### PR TITLE
Phases 12–15: deeper introspection, partitioning, access control, live ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ adheres to [Semantic Versioning](https://semver.org/).
 - `list_triggers` tool — the user-defined triggers on a table.
 - `list_sequences` tool — the sequences in a schema, with each sequence's
   data type, range, increment, cycle flag, and last value.
+- `list_partitions` tool — how a table is partitioned (range, list, or
+  hash) and its partitions, each with its bound expression.
 
 ## [0.2.0] - 2026-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ adheres to [Semantic Versioning](https://semver.org/).
 - `check_database_health` gains two checks — replication lag (how far
   connected standbys trail) and table bloat (tables far larger than their
   estimated minimum size).
+- `run_maintenance` tool — runs `VACUUM` or `ANALYZE` against one table;
+  requires unrestricted mode. Runs on an autocommit connection, since
+  `VACUUM` cannot run inside a transaction.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ adheres to [Semantic Versioning](https://semver.org/).
 - `run_maintenance` tool — runs `VACUUM` or `ANALYZE` against one table;
   requires unrestricted mode. Runs on an autocommit connection, since
   `VACUUM` cannot run inside a transaction.
+- `cancel_query` and `terminate_backend` tools — signal a backend PID to
+  cancel its current query or close its connection; require unrestricted
+  mode.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ adheres to [Semantic Versioning](https://semver.org/).
 - `list_roles` tool — the database roles and their attributes (superuser,
   create-role/db, login, replication, bypass-RLS, connection limit, and
   role membership).
+- `list_grants` tool — the privileges granted on a table, with each
+  grant's grantee, privilege, grantable flag, and grantor.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 - `list_tables` now flags each table with `partitioned` (a partitioned
   parent) and `is_partition` (itself a partition).
+- `list_indexes` now flags each index with `partitioned` (a
+  partitioned-index template).
+- `recommend_indexes` now rolls a flagged partition up to its partitioned
+  parent — summing scan and row counts and setting a `partitioned` flag —
+  since an index created on the parent propagates to every partition.
 
 ## [0.2.0] - 2026-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ adheres to [Semantic Versioning](https://semver.org/).
   check, and exclusion constraints.
 - `list_views` tool — the views and materialized views in a schema, with
   their definitions.
+- `list_functions` tool — the functions and procedures in a schema, with
+  kind, arguments, return type, and language.
 
 ## [0.2.0] - 2026-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `list_constraints` tool — a table's primary-key, foreign-key, unique,
+  check, and exclusion constraints.
+
 ## [0.2.0] - 2026-05-21
 
 Extension support: index-method intelligence, extension management, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ adheres to [Semantic Versioning](https://semver.org/).
   data type, range, increment, cycle flag, and last value.
 - `list_partitions` tool — how a table is partitioned (range, list, or
   hash) and its partitions, each with its bound expression.
+- `list_policies` tool — the Row-Level-Security policies on a table, with
+  each policy's command, permissive flag, roles, and predicates, plus
+  whether row security is enabled on the table.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ tools, each degrading gracefully when its extension is absent.
 - `enable_extension` tool — enables an allowlisted PostgreSQL extension;
   requires unrestricted mode and `MCPG_ALLOW_DDL`.
 - `fuzzy_search` tool — ranks a text column by `pg_trgm` trigram similarity
-  to a search term.
+  to a search term, with a `word` mode (fragment matching, the default) and
+  a `full` mode (whole-string comparison).
 - `full_text_search` tool — ranks documents with PostgreSQL's built-in
   `tsvector`/`tsquery` full-text search.
 - `vector_search` tool — finds the rows nearest to a query vector by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ adheres to [Semantic Versioning](https://semver.org/).
 - `list_policies` tool — the Row-Level-Security policies on a table, with
   each policy's command, permissive flag, roles, and predicates, plus
   whether row security is enabled on the table.
+- `list_roles` tool — the database roles and their attributes (superuser,
+  create-role/db, login, replication, bypass-RLS, connection limit, and
+  role membership).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ adheres to [Semantic Versioning](https://semver.org/).
   grant's grantee, privilege, grantable flag, and grantor.
 - `list_active_queries` tool — the queries currently running on the
   server, each with its wait event, duration, and blocking PIDs.
+- `check_database_health` gains two checks — replication lag (how far
+  connected standbys trail) and table bloat (tables far larger than their
+  estimated minimum size).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ adheres to [Semantic Versioning](https://semver.org/).
 - `list_partitions` tool — how a table is partitioned (range, list, or
   hash) and its partitions, each with its bound expression.
 
+### Changed
+
+- `list_tables` now flags each table with `partitioned` (a partitioned
+  parent) and `is_partition` (itself a partition).
+
 ## [0.2.0] - 2026-05-21
 
 Extension support: index-method intelligence, extension management, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ adheres to [Semantic Versioning](https://semver.org/).
   their definitions.
 - `list_functions` tool — the functions and procedures in a schema, with
   kind, arguments, return type, and language.
+- `list_triggers` tool — the user-defined triggers on a table.
 
 ## [0.2.0] - 2026-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 - `list_constraints` tool — a table's primary-key, foreign-key, unique,
   check, and exclusion constraints.
+- `list_views` tool — the views and materialized views in a schema, with
+  their definitions.
 
 ## [0.2.0] - 2026-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ adheres to [Semantic Versioning](https://semver.org/).
   role membership).
 - `list_grants` tool — the privileges granted on a table, with each
   grant's grantee, privilege, grantable flag, and grantor.
+- `list_active_queries` tool — the queries currently running on the
+  server, each with its wait event, duration, and blocking PIDs.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ adheres to [Semantic Versioning](https://semver.org/).
 - `list_functions` tool — the functions and procedures in a schema, with
   kind, arguments, return type, and language.
 - `list_triggers` tool — the user-defined triggers on a table.
+- `list_sequences` tool — the sequences in a schema, with each sequence's
+  data type, range, increment, cycle flag, and last value.
 
 ## [0.2.0] - 2026-05-21
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -248,6 +248,45 @@ degrades gracefully when its extension is absent.
 > trigram): Phase 8 (index intelligence) → 9 (text/trigram) → 10 (pgvector)
 > → 11 (PostGIS). Re-orderable; revisit before starting Phase 8.
 
+## 7b. Capability gap analysis — Phases 12–15 (post-extension)
+
+After the extension phases, MCPg still lacks introspection and operations for
+several core PostgreSQL areas. Partition DDL already runs via `run_ddl`, but
+nothing is partition-*aware*; similarly there is no view of constraints,
+non-table objects, RLS policies, roles, or live activity.
+
+### Phase 12 — Deeper schema introspection
+- `list_constraints` — primary keys, foreign keys, unique, check, exclusion.
+- `list_views` (+ definitions), `list_functions`, `list_triggers`,
+  `list_sequences`.
+- Deliverable: an agent can see a table's full structure, not just columns.
+
+### Phase 13 — Partitioning
+- `list_partitions` — partition strategy (range/list/hash), bounds,
+  parent↔partition links; flag partitioned tables in `list_tables`.
+- Make `list_indexes` / `recommend_indexes` partition-aware (parent vs
+  per-partition indexes; aggregate partition scan stats).
+- Deliverable: partitioned schemas are correctly understood, including the
+  index interaction.
+
+### Phase 14 — Access-control introspection
+- `list_policies` — Row-Level-Security policies on a table (supports the
+  multi-tenant / partition-per-tenant story).
+- `list_roles`, `list_grants` — roles and table/object privileges.
+- Deliverable: "who can access what", and RLS visibility.
+
+### Phase 15 — Live ops & maintenance
+- `list_active_queries`, lock / blocking inspection (`pg_stat_activity`,
+  `pg_locks`).
+- Replication-lag and table/index bloat health checks (extends
+  `check_database_health`).
+- Gated maintenance: `run_maintenance` (`VACUUM`/`ANALYZE`),
+  `cancel_query` / `terminate_backend`.
+- Deliverable: diagnose and act on a running database.
+
+Each phase is TDD'd with unit + real-PostgreSQL integration tests, like
+Phases 0–11. Ordering 12 → 15; re-orderable.
+
 ## 8. Resume protocol (work across session limits)
 
 To resume at any time, a new session must:

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -12,8 +12,8 @@
 
 ## Next action
 
-> Phase 12, Task 12.4 — TDD a `list_triggers` tool reporting triggers on a
-> table.
+> Phase 12, Task 12.5 — TDD a `list_sequences` tool reporting sequences in a
+> schema.
 
 ## Phase 0 — Spike & foundation  ✅ COMPLETE
 
@@ -143,7 +143,7 @@
 - [x] 12.1 `list_constraints` — PK, FK, unique, check, exclusion (`mcpg/introspection.py`, TDD)
 - [x] 12.2 `list_views` (+ view definitions) (`mcpg/introspection.py`, TDD)
 - [x] 12.3 `list_functions` — functions and procedures (`mcpg/introspection.py`, TDD)
-- [ ] 12.4 `list_triggers` (TDD)
+- [x] 12.4 `list_triggers` (`mcpg/introspection.py`, TDD)
 - [ ] 12.5 `list_sequences` (TDD)
 
 ## Phase 13 — Partitioning
@@ -368,3 +368,5 @@
 - 2026-05-21 — Task 12.3: added `list_functions` — functions and procedures
   in a schema (kind, arguments, return type, language), via `pg_proc`.
   313 tests, 100% coverage.
+- 2026-05-21 — Task 12.4: added `list_triggers` — user-defined triggers on a
+  table (function + definition), via `pg_trigger`. 315 tests, 100% coverage.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -12,8 +12,8 @@
 
 ## Next action
 
-> Phase 14, Task 14.2 — TDD a `list_roles` tool reporting the database
-> roles and their attributes.
+> Phase 14, Task 14.3 — TDD a `list_grants` tool reporting table/object
+> privileges.
 
 ## Phase 0 — Spike & foundation  ✅ COMPLETE
 
@@ -155,7 +155,7 @@
 ## Phase 14 — Access-control introspection
 
 - [x] 14.1 `list_policies` — Row-Level-Security policies on a table (`mcpg/introspection.py`, TDD)
-- [ ] 14.2 `list_roles` (TDD)
+- [x] 14.2 `list_roles` (`mcpg/introspection.py`, TDD)
 - [ ] 14.3 `list_grants` — table/object privileges (TDD)
 
 ## Phase 15 — Live ops & maintenance
@@ -384,3 +384,7 @@
 - 2026-05-22 — Task 14.1: added `list_policies` — Row-Level-Security
   policies on a table (command, permissive, roles, predicates) plus the
   table's RLS-enabled flag, via `pg_policies`. 334 tests, 100% coverage.
+- 2026-05-22 — Task 14.2: added `list_roles` — database roles and their
+  attributes (superuser, create-role/db, login, replication, bypass-RLS,
+  connection limit, membership), via `pg_roles` and `pg_auth_members`.
+  340 tests, 100% coverage.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -12,8 +12,8 @@
 
 ## Next action
 
-> Phase 13, Task 13.1 — TDD a `list_partitions` tool reporting a partitioned
-> table's strategy, bounds, and parent↔partition links.
+> Phase 13, Task 13.2 — TDD flagging partitioned tables and partitions in
+> `list_tables`.
 
 ## Phase 0 — Spike & foundation  ✅ COMPLETE
 
@@ -148,7 +148,7 @@
 
 ## Phase 13 — Partitioning
 
-- [ ] 13.1 `list_partitions` — strategy, bounds, parent↔partition links (TDD)
+- [x] 13.1 `list_partitions` — strategy, bounds, parent↔partition links (`mcpg/introspection.py`, TDD)
 - [ ] 13.2 Flag partitioned tables / partitions in `list_tables` (TDD)
 - [ ] 13.3 Partition-aware `list_indexes` and `recommend_indexes` (TDD)
 
@@ -373,3 +373,6 @@
 - 2026-05-22 — Task 12.5: added `list_sequences` — sequences in a schema
   (data type, range, increment, cycle, last value), via `pg_sequences`.
   Phase 12 complete. 318 tests, 100% coverage.
+- 2026-05-22 — Task 13.1: added `list_partitions` — a table's partitioning
+  strategy and partitions with bound expressions, via `pg_partitioned_table`
+  and `pg_inherits`. 323 tests, 100% coverage.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -12,8 +12,7 @@
 
 ## Next action
 
-> Phase 15, Task 15.1 — TDD a `list_active_queries` tool reporting the
-> currently-running queries from `pg_stat_activity`.
+> Phase 15, Task 15.2 — TDD replication-lag and bloat health checks.
 
 ## Phase 0 — Spike & foundation  ✅ COMPLETE
 
@@ -160,7 +159,7 @@
 
 ## Phase 15 — Live ops & maintenance
 
-- [ ] 15.1 `list_active_queries` + lock / blocking inspection (TDD)
+- [x] 15.1 `list_active_queries` + lock / blocking inspection (`mcpg/liveops.py`, TDD)
 - [ ] 15.2 Replication-lag and bloat health checks (TDD)
 - [ ] 15.3 Gated `run_maintenance` (VACUUM/ANALYZE) (TDD)
 - [ ] 15.4 Gated `cancel_query` / `terminate_backend` (TDD)
@@ -392,3 +391,7 @@
   table (grantee, privilege, grantable, grantor), via
   `information_schema.table_privileges`. Phase 14 complete. 342 tests,
   100% coverage.
+- 2026-05-22 — Task 15.1: added `list_active_queries` (new `mcpg/liveops`
+  module) — in-flight queries with wait events, duration, and blocking
+  PIDs, via `pg_stat_activity` and `pg_blocking_pids`. 346 tests, 100%
+  coverage.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -12,7 +12,8 @@
 
 ## Next action
 
-> Phase 15, Task 15.2 — TDD replication-lag and bloat health checks.
+> Phase 15, Task 15.3 — TDD a gated `run_maintenance` tool (VACUUM /
+> ANALYZE).
 
 ## Phase 0 — Spike & foundation  ✅ COMPLETE
 
@@ -160,7 +161,7 @@
 ## Phase 15 — Live ops & maintenance
 
 - [x] 15.1 `list_active_queries` + lock / blocking inspection (`mcpg/liveops.py`, TDD)
-- [ ] 15.2 Replication-lag and bloat health checks (TDD)
+- [x] 15.2 Replication-lag and bloat health checks (`mcpg/health.py`, TDD)
 - [ ] 15.3 Gated `run_maintenance` (VACUUM/ANALYZE) (TDD)
 - [ ] 15.4 Gated `cancel_query` / `terminate_backend` (TDD)
 
@@ -395,3 +396,6 @@
   module) — in-flight queries with wait events, duration, and blocking
   PIDs, via `pg_stat_activity` and `pg_blocking_pids`. 346 tests, 100%
   coverage.
+- 2026-05-22 — Task 15.2: `check_database_health` gains `replication_lag`
+  (via `pg_stat_replication`) and `table_bloat` (catalog-only size
+  estimate) checks. 349 tests, 100% coverage.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -12,8 +12,8 @@
 
 ## Next action
 
-> Phase 13, Task 13.3 — TDD partition-aware `list_indexes` and
-> `recommend_indexes`.
+> Phase 14, Task 14.1 — TDD a `list_policies` tool reporting the
+> Row-Level-Security policies on a table.
 
 ## Phase 0 — Spike & foundation  ✅ COMPLETE
 
@@ -150,7 +150,7 @@
 
 - [x] 13.1 `list_partitions` — strategy, bounds, parent↔partition links (`mcpg/introspection.py`, TDD)
 - [x] 13.2 Flag partitioned tables / partitions in `list_tables` (`mcpg/introspection.py`, TDD)
-- [ ] 13.3 Partition-aware `list_indexes` and `recommend_indexes` (TDD)
+- [x] 13.3 Partition-aware `list_indexes` and `recommend_indexes` (TDD)
 
 ## Phase 14 — Access-control introspection
 
@@ -378,3 +378,6 @@
   and `pg_inherits`. 323 tests, 100% coverage.
 - 2026-05-22 — Task 13.2: `list_tables` now reads `pg_class` and flags each
   table with `partitioned` and `is_partition`. 325 tests, 100% coverage.
+- 2026-05-22 — Task 13.3: `list_indexes` flags partitioned-index templates;
+  `recommend_indexes` rolls partition stats up to the partitioned parent.
+  Phase 13 complete. 328 tests, 100% coverage.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -12,8 +12,8 @@
 
 ## Next action
 
-> Phase 14, Task 14.1 — TDD a `list_policies` tool reporting the
-> Row-Level-Security policies on a table.
+> Phase 14, Task 14.2 — TDD a `list_roles` tool reporting the database
+> roles and their attributes.
 
 ## Phase 0 — Spike & foundation  ✅ COMPLETE
 
@@ -154,7 +154,7 @@
 
 ## Phase 14 — Access-control introspection
 
-- [ ] 14.1 `list_policies` — Row-Level-Security policies on a table (TDD)
+- [x] 14.1 `list_policies` — Row-Level-Security policies on a table (`mcpg/introspection.py`, TDD)
 - [ ] 14.2 `list_roles` (TDD)
 - [ ] 14.3 `list_grants` — table/object privileges (TDD)
 
@@ -381,3 +381,6 @@
 - 2026-05-22 — Task 13.3: `list_indexes` flags partitioned-index templates;
   `recommend_indexes` rolls partition stats up to the partitioned parent.
   Phase 13 complete. 328 tests, 100% coverage.
+- 2026-05-22 — Task 14.1: added `list_policies` — Row-Level-Security
+  policies on a table (command, permissive, roles, predicates) plus the
+  table's RLS-enabled flag, via `pg_policies`. 334 tests, 100% coverage.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -12,8 +12,8 @@
 
 ## Next action
 
-> Phase 12, Task 12.1 — TDD a `list_constraints` tool: primary keys, foreign
-> keys, unique, check, and exclusion constraints on a table.
+> Phase 12, Task 12.2 — TDD a `list_views` tool reporting views (and
+> materialized views) in a schema with their definitions.
 
 ## Phase 0 — Spike & foundation  ✅ COMPLETE
 
@@ -140,7 +140,7 @@
 
 ## Phase 12 — Deeper schema introspection
 
-- [ ] 12.1 `list_constraints` — PK, FK, unique, check, exclusion (TDD)
+- [x] 12.1 `list_constraints` — PK, FK, unique, check, exclusion (`mcpg/introspection.py`, TDD)
 - [ ] 12.2 `list_views` (+ view definitions) (TDD)
 - [ ] 12.3 `list_functions` — functions and procedures (TDD)
 - [ ] 12.4 `list_triggers` (TDD)
@@ -360,3 +360,5 @@
 - 2026-05-21 — Capability gap analysis (`PLAN.md` §7b): added Phases 12–15 to
   the roadmap — deeper schema introspection, partitioning, access-control
   introspection, and live ops & maintenance.
+- 2026-05-21 — Task 12.1: added `list_constraints` — PK/FK/unique/check/
+  exclusion constraints on a table, via `pg_constraint`. 309 tests, 100% cov.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -12,8 +12,8 @@
 
 ## Next action
 
-> Phase 12, Task 12.5 — TDD a `list_sequences` tool reporting sequences in a
-> schema.
+> Phase 13, Task 13.1 — TDD a `list_partitions` tool reporting a partitioned
+> table's strategy, bounds, and parent↔partition links.
 
 ## Phase 0 — Spike & foundation  ✅ COMPLETE
 
@@ -144,7 +144,7 @@
 - [x] 12.2 `list_views` (+ view definitions) (`mcpg/introspection.py`, TDD)
 - [x] 12.3 `list_functions` — functions and procedures (`mcpg/introspection.py`, TDD)
 - [x] 12.4 `list_triggers` (`mcpg/introspection.py`, TDD)
-- [ ] 12.5 `list_sequences` (TDD)
+- [x] 12.5 `list_sequences` (`mcpg/introspection.py`, TDD)
 
 ## Phase 13 — Partitioning
 
@@ -370,3 +370,6 @@
   313 tests, 100% coverage.
 - 2026-05-21 — Task 12.4: added `list_triggers` — user-defined triggers on a
   table (function + definition), via `pg_trigger`. 315 tests, 100% coverage.
+- 2026-05-22 — Task 12.5: added `list_sequences` — sequences in a schema
+  (data type, range, increment, cycle, last value), via `pg_sequences`.
+  Phase 12 complete. 318 tests, 100% coverage.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -12,8 +12,8 @@
 
 ## Next action
 
-> Phase 15, Task 15.3 — TDD a gated `run_maintenance` tool (VACUUM /
-> ANALYZE).
+> Phase 15, Task 15.4 — TDD gated `cancel_query` / `terminate_backend`
+> tools.
 
 ## Phase 0 — Spike & foundation  ✅ COMPLETE
 
@@ -162,7 +162,7 @@
 
 - [x] 15.1 `list_active_queries` + lock / blocking inspection (`mcpg/liveops.py`, TDD)
 - [x] 15.2 Replication-lag and bloat health checks (`mcpg/health.py`, TDD)
-- [ ] 15.3 Gated `run_maintenance` (VACUUM/ANALYZE) (TDD)
+- [x] 15.3 Gated `run_maintenance` (VACUUM/ANALYZE) (`mcpg/maintenance.py`, TDD)
 - [ ] 15.4 Gated `cancel_query` / `terminate_backend` (TDD)
 
 > Phases 12–15 cover deeper introspection and live ops; see `PLAN.md` §7b for
@@ -399,3 +399,6 @@
 - 2026-05-22 — Task 15.2: `check_database_health` gains `replication_lag`
   (via `pg_stat_replication`) and `table_bloat` (catalog-only size
   estimate) checks. 349 tests, 100% coverage.
+- 2026-05-22 — Task 15.3: added gated `run_maintenance` (new
+  `mcpg/maintenance` module) — VACUUM/ANALYZE on one table via a new
+  autocommit `Database.run_unmanaged` path. 357 tests, 100% coverage.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -12,8 +12,8 @@
 
 ## Next action
 
-> Phase 13, Task 13.2 — TDD flagging partitioned tables and partitions in
-> `list_tables`.
+> Phase 13, Task 13.3 — TDD partition-aware `list_indexes` and
+> `recommend_indexes`.
 
 ## Phase 0 — Spike & foundation  ✅ COMPLETE
 
@@ -149,7 +149,7 @@
 ## Phase 13 — Partitioning
 
 - [x] 13.1 `list_partitions` — strategy, bounds, parent↔partition links (`mcpg/introspection.py`, TDD)
-- [ ] 13.2 Flag partitioned tables / partitions in `list_tables` (TDD)
+- [x] 13.2 Flag partitioned tables / partitions in `list_tables` (`mcpg/introspection.py`, TDD)
 - [ ] 13.3 Partition-aware `list_indexes` and `recommend_indexes` (TDD)
 
 ## Phase 14 — Access-control introspection
@@ -376,3 +376,5 @@
 - 2026-05-22 — Task 13.1: added `list_partitions` — a table's partitioning
   strategy and partitions with bound expressions, via `pg_partitioned_table`
   and `pg_inherits`. 323 tests, 100% coverage.
+- 2026-05-22 — Task 13.2: `list_tables` now reads `pg_class` and flags each
+  table with `partitioned` and `is_partition`. 325 tests, 100% coverage.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -12,8 +12,8 @@
 
 ## Next action
 
-> Phase 12, Task 12.2 — TDD a `list_views` tool reporting views (and
-> materialized views) in a schema with their definitions.
+> Phase 12, Task 12.3 — TDD a `list_functions` tool reporting functions and
+> procedures in a schema.
 
 ## Phase 0 — Spike & foundation  ✅ COMPLETE
 
@@ -141,7 +141,7 @@
 ## Phase 12 — Deeper schema introspection
 
 - [x] 12.1 `list_constraints` — PK, FK, unique, check, exclusion (`mcpg/introspection.py`, TDD)
-- [ ] 12.2 `list_views` (+ view definitions) (TDD)
+- [x] 12.2 `list_views` (+ view definitions) (`mcpg/introspection.py`, TDD)
 - [ ] 12.3 `list_functions` — functions and procedures (TDD)
 - [ ] 12.4 `list_triggers` (TDD)
 - [ ] 12.5 `list_sequences` (TDD)
@@ -362,3 +362,6 @@
   introspection, and live ops & maintenance.
 - 2026-05-21 — Task 12.1: added `list_constraints` — PK/FK/unique/check/
   exclusion constraints on a table, via `pg_constraint`. 309 tests, 100% cov.
+- 2026-05-21 — PR #2 (v0.2.0 + Phase 12 start) merged to `main`; branch
+  re-synced. Task 12.2: added `list_views` — views and materialized views in
+  a schema with definitions, via `pg_class`. 311 tests, 100% coverage.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -6,15 +6,14 @@
 
 ## Current state
 
-- **Phase:** all 11 phases complete — extension support fully delivered
+- **Phase:** 12 — Deeper schema introspection (Phases 0–11 complete)
 - **Last updated:** 2026-05-21
 - **Branch:** `claude/postgresql-mcp-planning-8KssU`
 
 ## Next action
 
-> All eleven planned phases are complete (20 MCP tools). Version bumped to
-> 0.2.0; the extension work (Phases 8–11) is being merged to `main` via a
-> second PR. Tagging `v0.2.0` awaits user sign-off.
+> Phase 12, Task 12.1 — TDD a `list_constraints` tool: primary keys, foreign
+> keys, unique, check, and exclusion constraints on a table.
 
 ## Phase 0 — Spike & foundation  ✅ COMPLETE
 
@@ -138,6 +137,36 @@
 
 > Phases 8–11 cover PostgreSQL extension and advanced-feature support; see
 > `PLAN.md` §7a for the capability inventory and per-extension priorities.
+
+## Phase 12 — Deeper schema introspection
+
+- [ ] 12.1 `list_constraints` — PK, FK, unique, check, exclusion (TDD)
+- [ ] 12.2 `list_views` (+ view definitions) (TDD)
+- [ ] 12.3 `list_functions` — functions and procedures (TDD)
+- [ ] 12.4 `list_triggers` (TDD)
+- [ ] 12.5 `list_sequences` (TDD)
+
+## Phase 13 — Partitioning
+
+- [ ] 13.1 `list_partitions` — strategy, bounds, parent↔partition links (TDD)
+- [ ] 13.2 Flag partitioned tables / partitions in `list_tables` (TDD)
+- [ ] 13.3 Partition-aware `list_indexes` and `recommend_indexes` (TDD)
+
+## Phase 14 — Access-control introspection
+
+- [ ] 14.1 `list_policies` — Row-Level-Security policies on a table (TDD)
+- [ ] 14.2 `list_roles` (TDD)
+- [ ] 14.3 `list_grants` — table/object privileges (TDD)
+
+## Phase 15 — Live ops & maintenance
+
+- [ ] 15.1 `list_active_queries` + lock / blocking inspection (TDD)
+- [ ] 15.2 Replication-lag and bloat health checks (TDD)
+- [ ] 15.3 Gated `run_maintenance` (VACUUM/ANALYZE) (TDD)
+- [ ] 15.4 Gated `cancel_query` / `terminate_backend` (TDD)
+
+> Phases 12–15 cover deeper introspection and live ops; see `PLAN.md` §7b for
+> the capability gap analysis behind them.
 
 ## Decisions log
 
@@ -326,3 +355,8 @@
   distance to a lon/lat point) to `mcpg/textsearch.py`. 296 tests (4
   extension integration tests run in CI), 100% coverage. **Phase 11 complete
   — all eleven planned phases delivered; 20 MCP tools.**
+- 2026-05-21 — Live-test of the real server surfaced a `fuzzy_search` UX gap;
+  added a `word`/`full` `mode` (default `word`). 306 tests.
+- 2026-05-21 — Capability gap analysis (`PLAN.md` §7b): added Phases 12–15 to
+  the roadmap — deeper schema introspection, partitioning, access-control
+  introspection, and live ops & maintenance.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -12,8 +12,8 @@
 
 ## Next action
 
-> Phase 15, Task 15.4 — TDD gated `cancel_query` / `terminate_backend`
-> tools.
+> Phases 12–15 complete. No task in progress — pick the next initiative
+> from `PLAN.md` or await direction.
 
 ## Phase 0 — Spike & foundation  ✅ COMPLETE
 
@@ -163,7 +163,7 @@
 - [x] 15.1 `list_active_queries` + lock / blocking inspection (`mcpg/liveops.py`, TDD)
 - [x] 15.2 Replication-lag and bloat health checks (`mcpg/health.py`, TDD)
 - [x] 15.3 Gated `run_maintenance` (VACUUM/ANALYZE) (`mcpg/maintenance.py`, TDD)
-- [ ] 15.4 Gated `cancel_query` / `terminate_backend` (TDD)
+- [x] 15.4 Gated `cancel_query` / `terminate_backend` (`mcpg/liveops.py`, TDD)
 
 > Phases 12–15 cover deeper introspection and live ops; see `PLAN.md` §7b for
 > the capability gap analysis behind them.
@@ -402,3 +402,7 @@
 - 2026-05-22 — Task 15.3: added gated `run_maintenance` (new
   `mcpg/maintenance` module) — VACUUM/ANALYZE on one table via a new
   autocommit `Database.run_unmanaged` path. 357 tests, 100% coverage.
+- 2026-05-22 — Task 15.4: added gated `cancel_query` and
+  `terminate_backend` — signal a backend PID via `pg_cancel_backend` /
+  `pg_terminate_backend`. Phases 12–15 complete. 365 tests, 100%
+  coverage.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -12,8 +12,8 @@
 
 ## Next action
 
-> Phase 12, Task 12.3 — TDD a `list_functions` tool reporting functions and
-> procedures in a schema.
+> Phase 12, Task 12.4 — TDD a `list_triggers` tool reporting triggers on a
+> table.
 
 ## Phase 0 — Spike & foundation  ✅ COMPLETE
 
@@ -142,7 +142,7 @@
 
 - [x] 12.1 `list_constraints` — PK, FK, unique, check, exclusion (`mcpg/introspection.py`, TDD)
 - [x] 12.2 `list_views` (+ view definitions) (`mcpg/introspection.py`, TDD)
-- [ ] 12.3 `list_functions` — functions and procedures (TDD)
+- [x] 12.3 `list_functions` — functions and procedures (`mcpg/introspection.py`, TDD)
 - [ ] 12.4 `list_triggers` (TDD)
 - [ ] 12.5 `list_sequences` (TDD)
 
@@ -365,3 +365,6 @@
 - 2026-05-21 — PR #2 (v0.2.0 + Phase 12 start) merged to `main`; branch
   re-synced. Task 12.2: added `list_views` — views and materialized views in
   a schema with definitions, via `pg_class`. 311 tests, 100% coverage.
+- 2026-05-21 — Task 12.3: added `list_functions` — functions and procedures
+  in a schema (kind, arguments, return type, language), via `pg_proc`.
+  313 tests, 100% coverage.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -12,8 +12,8 @@
 
 ## Next action
 
-> Phase 14, Task 14.3 — TDD a `list_grants` tool reporting table/object
-> privileges.
+> Phase 15, Task 15.1 — TDD a `list_active_queries` tool reporting the
+> currently-running queries from `pg_stat_activity`.
 
 ## Phase 0 — Spike & foundation  ✅ COMPLETE
 
@@ -156,7 +156,7 @@
 
 - [x] 14.1 `list_policies` — Row-Level-Security policies on a table (`mcpg/introspection.py`, TDD)
 - [x] 14.2 `list_roles` (`mcpg/introspection.py`, TDD)
-- [ ] 14.3 `list_grants` — table/object privileges (TDD)
+- [x] 14.3 `list_grants` — table/object privileges (`mcpg/introspection.py`, TDD)
 
 ## Phase 15 — Live ops & maintenance
 
@@ -388,3 +388,7 @@
   attributes (superuser, create-role/db, login, replication, bypass-RLS,
   connection limit, membership), via `pg_roles` and `pg_auth_members`.
   340 tests, 100% coverage.
+- 2026-05-22 — Task 14.3: added `list_grants` — privileges granted on a
+  table (grantee, privilege, grantable, grantor), via
+  `information_schema.table_privileges`. Phase 14 complete. 342 tests,
+  100% coverage.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -28,7 +28,9 @@ Parameters: `schema`, `table` (strings).
 ### `list_indexes`
 Lists the indexes on a table, each with its access method — a built-in one
 (`btree`, `gin`, `gist`, `brin`, `hash`, `spgist`) or an extension's (e.g.
-`hnsw`/`ivfflat` from `pgvector`). Parameters: `schema`, `table` (strings).
+`hnsw`/`ivfflat` from `pgvector`) — and a `partitioned` flag (a
+partitioned-index template propagated to each partition). Parameters:
+`schema`, `table` (strings).
 
 ### `list_constraints`
 Lists a table's constraints — each with its `type` (`primary_key`,
@@ -98,8 +100,10 @@ Returns the slowest queries by mean execution time, via the
 ### `recommend_indexes`
 Flags large tables read mostly by sequential scan, and for each suggests
 per-column index types from the column's data type — GIN for `jsonb` and
-array columns, trigram GIN for text columns. Parameter: `min_live_tuples`
-(int, default 10000).
+array columns, trigram GIN for text columns. A flagged partition is rolled
+up to its partitioned parent (where the index belongs), with scan and row
+counts summed across partitions and a `partitioned` flag set. Parameter:
+`min_live_tuples` (int, default 10000).
 
 ### `fuzzy_search`
 Ranks a text column's values by `pg_trgm` trigram similarity to a search

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -16,7 +16,9 @@ Lists database schemas. Parameter: `include_system` (bool, default `false`) —
 include PostgreSQL's own schemas.
 
 ### `list_tables`
-Lists the tables and views in a schema. Parameter: `schema` (string).
+Lists the tables and views in a schema. Each entry carries a `partitioned`
+flag (the table is a partitioned parent) and an `is_partition` flag (the
+table is itself a partition). Parameter: `schema` (string).
 
 ### `describe_table`
 Describes a table's columns in ordinal order — name, data type, nullability,

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -47,6 +47,11 @@ Lists the user-defined triggers on a table — each with the function it calls
 and its definition. Internal (constraint-enforcement) triggers are excluded.
 Parameters: `schema`, `table` (strings).
 
+### `list_sequences`
+Lists the sequences defined in a schema — each with its data type, start
+value, range (`min_value`/`max_value`), increment, `cycle` flag, and
+`last_value` (`null` if unused or not readable). Parameter: `schema` (string).
+
 ### `list_extensions`
 Lists the extensions installed in the database.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -57,6 +57,12 @@ Describes how a table is partitioned and lists its partitions. Returns
 `partitions` — each with its `name` and `bounds` expression. Parameters:
 `schema`, `table` (strings).
 
+### `list_roles`
+Lists the database roles and their attributes — `superuser`, `create_role`,
+`create_db`, `can_login`, `replication`, `bypass_rls`, `connection_limit`,
+and `member_of` (roles each role belongs to). Parameter: `include_system`
+(bool, default `false`) — include PostgreSQL's own `pg_*` roles.
+
 ### `list_policies`
 Lists the Row-Level-Security policies on a table. Returns `rls_enabled`
 (bool — policies are inert while off) and `policies` — each with its

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -42,6 +42,11 @@ Lists the functions and procedures in a schema — each with its `kind`
 (`function`, `procedure`, `aggregate`, `window`, `other`), arguments, return
 type, and language. Parameter: `schema` (string).
 
+### `list_triggers`
+Lists the user-defined triggers on a table — each with the function it calls
+and its definition. Internal (constraint-enforcement) triggers are excluded.
+Parameters: `schema`, `table` (strings).
+
 ### `list_extensions`
 Lists the extensions installed in the database.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -28,6 +28,11 @@ Lists the indexes on a table, each with its access method — a built-in one
 (`btree`, `gin`, `gist`, `brin`, `hash`, `spgist`) or an extension's (e.g.
 `hnsw`/`ivfflat` from `pgvector`). Parameters: `schema`, `table` (strings).
 
+### `list_constraints`
+Lists a table's constraints — each with its `type` (`primary_key`,
+`foreign_key`, `unique`, `check`, `exclusion`, or `other`) and definition.
+Parameters: `schema`, `table` (strings).
+
 ### `list_extensions`
 Lists the extensions installed in the database.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -37,6 +37,11 @@ Parameters: `schema`, `table` (strings).
 Lists the views and materialized views in a schema — each with a
 `materialized` flag and its definition. Parameter: `schema` (string).
 
+### `list_functions`
+Lists the functions and procedures in a schema — each with its `kind`
+(`function`, `procedure`, `aggregate`, `window`, `other`), arguments, return
+type, and language. Parameter: `schema` (string).
+
 ### `list_extensions`
 Lists the extensions installed in the database.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -33,6 +33,10 @@ Lists a table's constraints — each with its `type` (`primary_key`,
 `foreign_key`, `unique`, `check`, `exclusion`, or `other`) and definition.
 Parameters: `schema`, `table` (strings).
 
+### `list_views`
+Lists the views and materialized views in a schema — each with a
+`materialized` flag and its definition. Parameter: `schema` (string).
+
 ### `list_extensions`
 Lists the extensions installed in the database.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -173,6 +173,16 @@ Runs `VACUUM` or `ANALYZE` against one table. Parameters: `operation`
 Requires `unrestricted` mode. The schema and table are quoted identifiers,
 not parameters; both are escaped before reaching SQL.
 
+### `cancel_query`
+Cancels the query running on a backend PID (`pg_cancel_backend`); the
+connection stays open. Parameter: `pid` (int). Returns `succeeded` —
+`false` if no such backend exists. Requires `unrestricted` mode.
+
+### `terminate_backend`
+Terminates a backend PID (`pg_terminate_backend`), closing its connection.
+Parameter: `pid` (int). Returns `succeeded` — `false` if no such backend
+exists. Requires `unrestricted` mode.
+
 ### `run_ddl`
 Executes a single DDL statement (`CREATE`/`ALTER`/`DROP` and related).
 Requires `unrestricted` mode **and** `MCPG_ALLOW_DDL=true`. Parameter: `sql`

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -150,6 +150,15 @@ Finds the rows nearest to a lon/lat point by PostGIS distance. Parameters:
 column) plus its `distance`. Reports `available: false` if `postgis` is not
 installed.
 
+## Live operations (read)
+
+### `list_active_queries`
+Lists the queries currently running on the server, from `pg_stat_activity`.
+Each entry carries the backend `pid`, `username`, `application`, `state`,
+`wait_event` (`type:event` when waiting), `duration_seconds`, `query`, and
+`blocked_by` — the PIDs holding locks it waits on. Idle connections,
+PostgreSQL's background processes, and MCPg's own backend are excluded.
+
 ## Write (unrestricted mode only)
 
 ### `run_write`

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -70,9 +70,10 @@ array columns, trigram GIN for text columns. Parameter: `min_live_tuples`
 (int, default 10000).
 
 ### `fuzzy_search`
-Ranks a text column's values by trigram similarity to a search term, via the
-`pg_trgm` extension. Parameters: `schema`, `table`, `column`, `term`
-(strings), `limit` (int, default 10), `threshold` (float, default 0.3).
+Ranks a text column's values by `pg_trgm` trigram similarity to a search
+term. Parameters: `schema`, `table`, `column`, `term` (strings), `mode`
+(`word` — default — matches fragments within longer text; `full` compares
+whole strings), `limit` (int, default 10), `threshold` (float, default 0.3).
 Reports `available: false` if `pg_trgm` is not installed.
 
 ### `full_text_search`

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -57,6 +57,12 @@ Describes how a table is partitioned and lists its partitions. Returns
 `partitions` — each with its `name` and `bounds` expression. Parameters:
 `schema`, `table` (strings).
 
+### `list_policies`
+Lists the Row-Level-Security policies on a table. Returns `rls_enabled`
+(bool — policies are inert while off) and `policies` — each with its
+`command`, `permissive` flag, `roles`, and `using`/`check` expressions.
+Parameters: `schema`, `table` (strings).
+
 ### `list_sequences`
 Lists the sequences defined in a schema — each with its data type, start
 value, range (`min_value`/`max_value`), increment, `cycle` flag, and

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -63,6 +63,11 @@ Lists the database roles and their attributes — `superuser`, `create_role`,
 and `member_of` (roles each role belongs to). Parameter: `include_system`
 (bool, default `false`) — include PostgreSQL's own `pg_*` roles.
 
+### `list_grants`
+Lists the privileges granted on a table — each with its `grantee`,
+`privilege` (`SELECT`, `INSERT`, `UPDATE`, ...), `grantable` flag (`WITH
+GRANT OPTION`), and `grantor`. Parameters: `schema`, `table` (strings).
+
 ### `list_policies`
 Lists the Row-Level-Security policies on a table. Returns `rls_enabled`
 (bool — policies are inert while off) and `policies` — each with its

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -47,6 +47,12 @@ Lists the user-defined triggers on a table — each with the function it calls
 and its definition. Internal (constraint-enforcement) triggers are excluded.
 Parameters: `schema`, `table` (strings).
 
+### `list_partitions`
+Describes how a table is partitioned and lists its partitions. Returns
+`partitioned` (bool), `strategy` (`range`, `list`, `hash`, or `null`), and
+`partitions` — each with its `name` and `bounds` expression. Parameters:
+`schema`, `table` (strings).
+
 ### `list_sequences`
 Lists the sequences defined in a schema — each with its data type, start
 value, range (`min_value`/`max_value`), increment, `cycle` flag, and

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -167,6 +167,12 @@ Executes a single `INSERT`, `UPDATE`, or `DELETE` in a read-write transaction
 committed on success. Multiple statements and non-DML are rejected. Add a
 `RETURNING` clause to receive affected rows. Parameter: `sql` (string).
 
+### `run_maintenance`
+Runs `VACUUM` or `ANALYZE` against one table. Parameters: `operation`
+(`vacuum`, `analyze`, or `vacuum_analyze`), `schema`, `table` (strings).
+Requires `unrestricted` mode. The schema and table are quoted identifiers,
+not parameters; both are escaped before reaching SQL.
+
 ### `run_ddl`
 Executes a single DDL statement (`CREATE`/`ALTER`/`DROP` and related).
 Requires `unrestricted` mode **and** `MCPG_ALLOW_DDL=true`. Parameter: `sql`

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -106,8 +106,9 @@ and sequentially-scanned tables. Parameter: `sql` (string).
 
 ### `check_database_health`
 Runs health checks: connection utilisation, buffer cache hit ratio, tables
-needing vacuum, and invalid indexes. Returns an overall `status` plus
-per-check results.
+needing vacuum, invalid indexes, replication lag (how far connected
+standbys trail), and table bloat (tables far larger than their estimated
+minimum size). Returns an overall `status` plus per-check results.
 
 ### `analyze_workload`
 Returns the slowest queries by mean execution time, via the

--- a/src/mcpg/database.py
+++ b/src/mcpg/database.py
@@ -67,6 +67,25 @@ class Database:
             raise DatabaseError("database is not connected; call connect() first")
         return SqlDriver(conn=self._pool)
 
+    async def run_unmanaged(self, sql: str) -> None:
+        """Execute a statement on an autocommit connection — no transaction.
+
+        For maintenance commands such as ``VACUUM`` that cannot run inside a
+        transaction block. The caller is responsible for SQL safety.
+
+        Raises:
+            DatabaseError: If called before :meth:`connect`.
+        """
+        if not self._connected:
+            raise DatabaseError("database is not connected; call connect() first")
+        pool = await self._pool.pool_connect()
+        async with pool.connection() as connection:
+            await connection.set_autocommit(True)
+            try:
+                await connection.execute(sql)
+            finally:
+                await connection.set_autocommit(False)
+
     async def __aenter__(self) -> Database:
         await self.connect()
         return self

--- a/src/mcpg/health.py
+++ b/src/mcpg/health.py
@@ -14,6 +14,9 @@ from mcpg._vendor.sql import SqlDriver
 # Classification thresholds.
 _CONNECTION_WARN_RATIO = 0.8  # warn above 80% of max_connections
 _CACHE_HIT_WARN_RATIO = 0.99  # warn below a 99% buffer cache hit ratio
+_REPLICATION_LAG_WARN_BYTES = 64 * 1024 * 1024  # warn above 64 MiB of standby lag
+_BLOAT_RATIO_WARN = 2.0  # warn when a table occupies 2x its estimated minimum
+_BLOAT_MIN_PAGES = 128  # ignore tables smaller than ~1 MiB
 
 _OK = "ok"
 _WARNING = "warning"
@@ -86,6 +89,50 @@ async def check_invalid_indexes(driver: SqlDriver) -> HealthCheck:
     return HealthCheck("invalid_indexes", status, f"{invalid} invalid indexes")
 
 
+async def check_replication_lag(driver: SqlDriver) -> HealthCheck:
+    """Measure how far connected standbys trail in replaying WAL."""
+    rows = await driver.execute_query(
+        "SELECT count(*) AS standbys, "
+        "COALESCE(max(pg_wal_lsn_diff("
+        "CASE WHEN pg_is_in_recovery() THEN pg_last_wal_replay_lsn() "
+        "ELSE pg_current_wal_lsn() END, replay_lsn)), 0) AS max_lag_bytes "
+        "FROM pg_stat_replication",
+        force_readonly=True,
+    )
+    cells = (rows or [])[0].cells
+    standbys, max_lag = cells["standbys"], int(cells["max_lag_bytes"])
+    if standbys == 0:
+        return HealthCheck("replication_lag", _OK, "no replication standbys connected")
+    status = _WARNING if max_lag > _REPLICATION_LAG_WARN_BYTES else _OK
+    return HealthCheck("replication_lag", status, f"{standbys} standby(s), max lag {max_lag} bytes")
+
+
+async def check_table_bloat(driver: SqlDriver) -> HealthCheck:
+    """Count tables far larger than their estimated minimum size.
+
+    The estimate is catalog-only — ``relpages`` against a size derived from
+    ``reltuples`` and the average row width — so the check stays cheap.
+    """
+    rows = await driver.execute_query(
+        "WITH table_stats AS ("
+        "SELECT c.relpages, c.reltuples, "
+        "(SELECT sum(COALESCE(s.avg_width, 0)) FROM pg_stats s "
+        "WHERE s.schemaname = n.nspname AND s.tablename = c.relname) AS row_width "
+        "FROM pg_class c "
+        "JOIN pg_namespace n ON n.oid = c.relnamespace "
+        "WHERE c.relkind = 'r' AND n.nspname NOT IN ('pg_catalog', 'information_schema')"
+        ") "
+        "SELECT count(*) AS bloated FROM table_stats "
+        "WHERE relpages > %s AND reltuples > 0 AND row_width > 0 "
+        "AND relpages::numeric / GREATEST(ceil(reltuples * (row_width + 24) / (8192 - 24)), 1) > %s",
+        params=[_BLOAT_MIN_PAGES, _BLOAT_RATIO_WARN],
+        force_readonly=True,
+    )
+    bloated = (rows or [])[0].cells["bloated"]
+    status = _WARNING if bloated > 0 else _OK
+    return HealthCheck("table_bloat", status, f"{bloated} tables appear bloated")
+
+
 async def check_database_health(driver: SqlDriver) -> HealthReport:
     """Run every health check and summarise the overall status."""
     checks = [
@@ -93,6 +140,8 @@ async def check_database_health(driver: SqlDriver) -> HealthReport:
         await check_cache_hit_ratio(driver),
         await check_dead_tuples(driver),
         await check_invalid_indexes(driver),
+        await check_replication_lag(driver),
+        await check_table_bloat(driver),
     ]
     status = _OK if all(check.status == _OK for check in checks) else _WARNING
     return HealthReport(status=status, checks=checks)

--- a/src/mcpg/indexing.py
+++ b/src/mcpg/indexing.py
@@ -30,7 +30,12 @@ class IndexSuggestion:
 
 @dataclass(frozen=True, slots=True)
 class IndexRecommendation:
-    """A table that may benefit from indexing, with per-column suggestions."""
+    """A table that may benefit from indexing, with per-column suggestions.
+
+    For a partitioned table, ``partitioned`` is ``True`` and the scan and row
+    counts are summed across its partitions — an index created on the parent
+    propagates to them all.
+    """
 
     schema: str
     table: str
@@ -38,6 +43,7 @@ class IndexRecommendation:
     live_tuples: int
     reason: str
     suggestions: list[IndexSuggestion]
+    partitioned: bool
 
 
 def _suggest(column: str, data_type: str) -> IndexSuggestion | None:
@@ -58,7 +64,9 @@ async def recommend_indexes(
 
     Heuristic: large tables (at least ``min_live_tuples`` rows) read more
     often by sequential scan than by index scan. For each, columns with
-    GIN-friendly types yield an :class:`IndexSuggestion`.
+    GIN-friendly types yield an :class:`IndexSuggestion`. A flagged partition
+    is rolled up to its partitioned parent, since an index belongs on the
+    parent; scan and row counts are summed across the partitions.
 
     Args:
         driver: The SQL driver to query through.
@@ -66,10 +74,15 @@ async def recommend_indexes(
     """
     rows = await driver.execute_query(
         "SELECT s.schemaname, s.relname, s.seq_scan, s.n_live_tup, "
-        "c.column_name, c.data_type "
+        "c.column_name, c.data_type, "
+        "pn.nspname AS parent_schema, parent.relname AS parent_table "
         "FROM pg_stat_user_tables s "
         "JOIN information_schema.columns c "
         "  ON c.table_schema = s.schemaname AND c.table_name = s.relname "
+        "LEFT JOIN pg_inherits inh ON inh.inhrelid = s.relid "
+        "LEFT JOIN pg_class parent "
+        "  ON parent.oid = inh.inhparent AND parent.relkind = 'p' "
+        "LEFT JOIN pg_namespace pn ON pn.oid = parent.relnamespace "
         "WHERE s.n_live_tup >= %s AND s.seq_scan > COALESCE(s.idx_scan, 0) "
         "ORDER BY s.seq_scan DESC, s.relname, c.ordinal_position",
         params=[min_live_tuples],
@@ -77,16 +90,33 @@ async def recommend_indexes(
     )
 
     order: list[tuple[str, str]] = []
-    stats: dict[tuple[str, str], tuple[int, int]] = {}
+    stats: dict[tuple[str, str], list[int]] = {}
+    partitioned: dict[tuple[str, str], bool] = {}
     suggestions: dict[tuple[str, str], list[IndexSuggestion]] = {}
+    suggested_columns: dict[tuple[str, str], set[str]] = {}
+    counted: set[tuple[str, str]] = set()
     for row in rows or []:
-        key = (row.cells["schemaname"], row.cells["relname"])
+        parent_table = row.cells["parent_table"]
+        is_partition = parent_table is not None
+        if is_partition:
+            key = (row.cells["parent_schema"], parent_table)
+        else:
+            key = (row.cells["schemaname"], row.cells["relname"])
         if key not in stats:
             order.append(key)
-            stats[key] = (row.cells["seq_scan"], row.cells["n_live_tup"])
+            stats[key] = [0, 0]
+            partitioned[key] = False
             suggestions[key] = []
+            suggested_columns[key] = set()
+        physical = (row.cells["schemaname"], row.cells["relname"])
+        if physical not in counted:
+            counted.add(physical)
+            stats[key][0] += row.cells["seq_scan"]
+            stats[key][1] += row.cells["n_live_tup"]
+            partitioned[key] = partitioned[key] or is_partition
         suggestion = _suggest(row.cells["column_name"], row.cells["data_type"])
-        if suggestion is not None:
+        if suggestion is not None and suggestion.column not in suggested_columns[key]:
+            suggested_columns[key].add(suggestion.column)
             suggestions[key].append(suggestion)
 
     return [
@@ -95,8 +125,13 @@ async def recommend_indexes(
             table=table,
             seq_scans=stats[(schema, table)][0],
             live_tuples=stats[(schema, table)][1],
-            reason="large table read mostly by sequential scan",
+            reason=(
+                "partitioned table whose partitions are read mostly by sequential scan"
+                if partitioned[(schema, table)]
+                else "large table read mostly by sequential scan"
+            ),
             suggestions=suggestions[(schema, table)],
+            partitioned=partitioned[(schema, table)],
         )
         for schema, table in order
     ]

--- a/src/mcpg/indexing.py
+++ b/src/mcpg/indexing.py
@@ -66,7 +66,9 @@ async def recommend_indexes(
     often by sequential scan than by index scan. For each, columns with
     GIN-friendly types yield an :class:`IndexSuggestion`. A flagged partition
     is rolled up to its partitioned parent, since an index belongs on the
-    parent; scan and row counts are summed across the partitions.
+    parent; scan and row counts are summed across the partitions. The
+    partitioned parent's own (empty) stats row is excluded from the
+    aggregation so partition stats are not double-counted.
 
     Args:
         driver: The SQL driver to query through.
@@ -77,6 +79,7 @@ async def recommend_indexes(
         "c.column_name, c.data_type, "
         "pn.nspname AS parent_schema, parent.relname AS parent_table "
         "FROM pg_stat_user_tables s "
+        "JOIN pg_class self ON self.oid = s.relid AND self.relkind <> 'p' "
         "JOIN information_schema.columns c "
         "  ON c.table_schema = s.schemaname AND c.table_name = s.relname "
         "LEFT JOIN pg_inherits inh ON inh.inhrelid = s.relid "

--- a/src/mcpg/indexing.py
+++ b/src/mcpg/indexing.py
@@ -8,7 +8,7 @@ workload filters on still needs query analysis (see ``analyze_workload``).
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from mcpg._vendor.sql import SqlDriver
 
@@ -44,6 +44,31 @@ class IndexRecommendation:
     reason: str
     suggestions: list[IndexSuggestion]
     partitioned: bool
+
+
+@dataclass(slots=True)
+class _TableAgg:
+    """Per-logical-table aggregator used while rolling up scan stats."""
+
+    seq_scans: int = 0
+    live_tuples: int = 0
+    partitioned: bool = False
+    suggestions: list[IndexSuggestion] = field(default_factory=list)
+    _seen_columns: set[str] = field(default_factory=set, repr=False)
+
+    def add_stats(self, seq_scan: int, live_tup: int, is_partition: bool) -> None:
+        self.seq_scans += seq_scan
+        self.live_tuples += live_tup
+        self.partitioned = self.partitioned or is_partition
+
+    def add_suggestion(self, column: str, data_type: str) -> None:
+        if column in self._seen_columns:
+            return
+        suggestion = _suggest(column, data_type)
+        if suggestion is None:
+            return
+        self._seen_columns.add(column)
+        self.suggestions.append(suggestion)
 
 
 def _suggest(column: str, data_type: str) -> IndexSuggestion | None:
@@ -93,10 +118,7 @@ async def recommend_indexes(
     )
 
     order: list[tuple[str, str]] = []
-    stats: dict[tuple[str, str], list[int]] = {}
-    partitioned: dict[tuple[str, str], bool] = {}
-    suggestions: dict[tuple[str, str], list[IndexSuggestion]] = {}
-    suggested_columns: dict[tuple[str, str], set[str]] = {}
+    tables: dict[tuple[str, str], _TableAgg] = {}
     counted: set[tuple[str, str]] = set()
     for row in rows or []:
         parent_table = row.cells["parent_table"]
@@ -105,36 +127,29 @@ async def recommend_indexes(
             key = (row.cells["parent_schema"], parent_table)
         else:
             key = (row.cells["schemaname"], row.cells["relname"])
-        if key not in stats:
+        if key not in tables:
+            tables[key] = _TableAgg()
             order.append(key)
-            stats[key] = [0, 0]
-            partitioned[key] = False
-            suggestions[key] = []
-            suggested_columns[key] = set()
+        agg = tables[key]
         physical = (row.cells["schemaname"], row.cells["relname"])
         if physical not in counted:
             counted.add(physical)
-            stats[key][0] += row.cells["seq_scan"]
-            stats[key][1] += row.cells["n_live_tup"]
-            partitioned[key] = partitioned[key] or is_partition
-        suggestion = _suggest(row.cells["column_name"], row.cells["data_type"])
-        if suggestion is not None and suggestion.column not in suggested_columns[key]:
-            suggested_columns[key].add(suggestion.column)
-            suggestions[key].append(suggestion)
+            agg.add_stats(row.cells["seq_scan"], row.cells["n_live_tup"], is_partition)
+        agg.add_suggestion(row.cells["column_name"], row.cells["data_type"])
 
     return [
         IndexRecommendation(
             schema=schema,
             table=table,
-            seq_scans=stats[(schema, table)][0],
-            live_tuples=stats[(schema, table)][1],
+            seq_scans=tables[(schema, table)].seq_scans,
+            live_tuples=tables[(schema, table)].live_tuples,
             reason=(
                 "partitioned table whose partitions are read mostly by sequential scan"
-                if partitioned[(schema, table)]
+                if tables[(schema, table)].partitioned
                 else "large table read mostly by sequential scan"
             ),
-            suggestions=suggestions[(schema, table)],
-            partitioned=partitioned[(schema, table)],
+            suggestions=tables[(schema, table)].suggestions,
+            partitioned=tables[(schema, table)].partitioned,
         )
         for schema, table in order
     ]

--- a/src/mcpg/introspection.py
+++ b/src/mcpg/introspection.py
@@ -26,6 +26,9 @@ _CONSTRAINT_TYPES = {
 # pg_proc.prokind codes -> readable routine kind.
 _ROUTINE_KINDS = {"f": "function", "p": "procedure", "a": "aggregate", "w": "window"}
 
+# pg_partitioned_table.partstrat codes -> readable partitioning strategy.
+_PARTITION_STRATEGIES = {"r": "range", "l": "list", "h": "hash"}
+
 
 @dataclass(frozen=True, slots=True)
 class SchemaInfo:
@@ -115,6 +118,31 @@ class ConstraintInfo:
     name: str
     type: str
     definition: str
+
+
+@dataclass(frozen=True, slots=True)
+class PartitionInfo:
+    """A partition of a partitioned table.
+
+    ``bounds`` is the partition's bound expression — e.g.
+    ``FOR VALUES FROM ('2026-01-01') TO ('2027-01-01')``.
+    """
+
+    name: str
+    bounds: str
+
+
+@dataclass(frozen=True, slots=True)
+class PartitionSet:
+    """How a table is partitioned, with its partitions.
+
+    ``partitioned`` is ``False`` for an ordinary table, in which case
+    ``strategy`` is ``None`` and ``partitions`` is empty.
+    """
+
+    partitioned: bool
+    strategy: str | None
+    partitions: list[PartitionInfo]
 
 
 @dataclass(frozen=True, slots=True)
@@ -331,6 +359,37 @@ async def list_constraints(driver: SqlDriver, schema: str, table: str) -> list[C
         )
         for row in rows or []
     ]
+
+
+async def list_partitions(driver: SqlDriver, schema: str, table: str) -> PartitionSet:
+    """Describe how a table is partitioned and list its partitions.
+
+    Returns ``partitioned=False`` when the table is not a partitioned table.
+    """
+    rows = await driver.execute_query(
+        "SELECT pt.partstrat AS strategy_code, "
+        "child.relname AS partition_name, "
+        "pg_get_expr(child.relpartbound, child.oid) AS bounds "
+        "FROM pg_class parent "
+        "JOIN pg_namespace n ON n.oid = parent.relnamespace "
+        "JOIN pg_partitioned_table pt ON pt.partrelid = parent.oid "
+        "LEFT JOIN pg_inherits i ON i.inhparent = parent.oid "
+        "LEFT JOIN pg_class child ON child.oid = i.inhrelid "
+        "WHERE n.nspname = %s AND parent.relname = %s "
+        "ORDER BY child.relname",
+        params=[schema, table],
+        force_readonly=True,
+    )
+    rows = rows or []
+    if not rows:
+        return PartitionSet(partitioned=False, strategy=None, partitions=[])
+    strategy = _PARTITION_STRATEGIES.get(rows[0].cells["strategy_code"])
+    partitions = [
+        PartitionInfo(name=row.cells["partition_name"], bounds=row.cells["bounds"])
+        for row in rows
+        if row.cells["partition_name"] is not None
+    ]
+    return PartitionSet(partitioned=True, strategy=strategy, partitions=partitions)
 
 
 async def list_sequences(driver: SqlDriver, schema: str) -> list[SequenceInfo]:

--- a/src/mcpg/introspection.py
+++ b/src/mcpg/introspection.py
@@ -96,6 +96,15 @@ class FunctionInfo:
 
 
 @dataclass(frozen=True, slots=True)
+class TriggerInfo:
+    """A user-defined trigger on a table."""
+
+    name: str
+    function: str
+    definition: str
+
+
+@dataclass(frozen=True, slots=True)
 class ConstraintInfo:
     """A constraint on a table.
 
@@ -252,6 +261,33 @@ async def list_functions(driver: SqlDriver, schema: str) -> list[FunctionInfo]:
             arguments=row.cells["arguments"],
             returns=row.cells["returns"],
             language=row.cells["language"],
+        )
+        for row in rows or []
+    ]
+
+
+async def list_triggers(driver: SqlDriver, schema: str, table: str) -> list[TriggerInfo]:
+    """List the user-defined triggers on a table.
+
+    Internal triggers (such as those enforcing foreign keys) are excluded.
+    """
+    rows = await driver.execute_query(
+        "SELECT t.tgname AS name, p.proname AS function, "
+        "pg_get_triggerdef(t.oid) AS definition "
+        "FROM pg_trigger t "
+        "JOIN pg_class c ON c.oid = t.tgrelid "
+        "JOIN pg_namespace n ON n.oid = c.relnamespace "
+        "JOIN pg_proc p ON p.oid = t.tgfoid "
+        "WHERE n.nspname = %s AND c.relname = %s AND NOT t.tgisinternal "
+        "ORDER BY t.tgname",
+        params=[schema, table],
+        force_readonly=True,
+    )
+    return [
+        TriggerInfo(
+            name=row.cells["name"],
+            function=row.cells["function"],
+            definition=row.cells["definition"],
         )
         for row in rows or []
     ]

--- a/src/mcpg/introspection.py
+++ b/src/mcpg/introspection.py
@@ -118,6 +118,24 @@ class ConstraintInfo:
 
 
 @dataclass(frozen=True, slots=True)
+class SequenceInfo:
+    """A sequence within a schema.
+
+    ``last_value`` is ``None`` when the sequence has not yet been used or is
+    not readable by the connected role.
+    """
+
+    name: str
+    data_type: str
+    start_value: int
+    min_value: int
+    max_value: int
+    increment: int
+    cycle: bool
+    last_value: int | None
+
+
+@dataclass(frozen=True, slots=True)
 class ExtensionInfo:
     """An installed PostgreSQL extension."""
 
@@ -310,6 +328,30 @@ async def list_constraints(driver: SqlDriver, schema: str, table: str) -> list[C
             name=row.cells["name"],
             type=_CONSTRAINT_TYPES.get(row.cells["type_code"], "other"),
             definition=row.cells["definition"],
+        )
+        for row in rows or []
+    ]
+
+
+async def list_sequences(driver: SqlDriver, schema: str) -> list[SequenceInfo]:
+    """List the sequences defined in a schema."""
+    rows = await driver.execute_query(
+        "SELECT sequencename AS name, data_type, start_value, min_value, "
+        "max_value, increment_by AS increment, cycle, last_value "
+        "FROM pg_sequences WHERE schemaname = %s ORDER BY sequencename",
+        params=[schema],
+        force_readonly=True,
+    )
+    return [
+        SequenceInfo(
+            name=row.cells["name"],
+            data_type=row.cells["data_type"],
+            start_value=row.cells["start_value"],
+            min_value=row.cells["min_value"],
+            max_value=row.cells["max_value"],
+            increment=row.cells["increment"],
+            cycle=row.cells["cycle"],
+            last_value=row.cells["last_value"],
         )
         for row in rows or []
     ]

--- a/src/mcpg/introspection.py
+++ b/src/mcpg/introspection.py
@@ -29,6 +29,9 @@ _ROUTINE_KINDS = {"f": "function", "p": "procedure", "a": "aggregate", "w": "win
 # pg_partitioned_table.partstrat codes -> readable partitioning strategy.
 _PARTITION_STRATEGIES = {"r": "range", "l": "list", "h": "hash"}
 
+# pg_class.relkind codes -> the table type reported by list_tables.
+_TABLE_TYPES = {"r": "BASE TABLE", "p": "BASE TABLE", "v": "VIEW", "f": "FOREIGN"}
+
 
 @dataclass(frozen=True, slots=True)
 class SchemaInfo:
@@ -39,10 +42,16 @@ class SchemaInfo:
 
 @dataclass(frozen=True, slots=True)
 class TableInfo:
-    """A table or view within a schema."""
+    """A table or view within a schema.
+
+    ``partitioned`` is ``True`` for a partitioned table (the parent);
+    ``is_partition`` is ``True`` when the table is itself a partition of one.
+    """
 
     name: str
     type: str
+    partitioned: bool
+    is_partition: bool
 
 
 @dataclass(frozen=True, slots=True)
@@ -198,13 +207,26 @@ async def list_schemas(driver: SqlDriver, *, include_system: bool = False) -> li
 
 
 async def list_tables(driver: SqlDriver, schema: str) -> list[TableInfo]:
-    """List the tables and views in a schema."""
+    """List the tables and views in a schema, flagging partitioning."""
     rows = await driver.execute_query(
-        "SELECT table_name, table_type FROM information_schema.tables WHERE table_schema = %s ORDER BY table_name",
+        "SELECT c.relname AS name, c.relkind AS relkind, "
+        "c.relispartition AS is_partition "
+        "FROM pg_class c "
+        "JOIN pg_namespace n ON n.oid = c.relnamespace "
+        "WHERE n.nspname = %s AND c.relkind IN ('r', 'p', 'v', 'f') "
+        "ORDER BY c.relname",
         params=[schema],
         force_readonly=True,
     )
-    return [TableInfo(name=row.cells["table_name"], type=row.cells["table_type"]) for row in rows or []]
+    return [
+        TableInfo(
+            name=row.cells["name"],
+            type=_TABLE_TYPES.get(row.cells["relkind"], "other"),
+            partitioned=row.cells["relkind"] == "p",
+            is_partition=row.cells["is_partition"],
+        )
+        for row in rows or []
+    ]
 
 
 async def describe_table(driver: SqlDriver, schema: str, table: str) -> list[ColumnInfo]:

--- a/src/mcpg/introspection.py
+++ b/src/mcpg/introspection.py
@@ -206,6 +206,20 @@ class RoleInfo:
 
 
 @dataclass(frozen=True, slots=True)
+class GrantInfo:
+    """A privilege granted on a table.
+
+    ``grantable`` is ``True`` when the grantee may pass the privilege on
+    (``WITH GRANT OPTION``).
+    """
+
+    grantee: str
+    privilege: str
+    grantable: bool
+    grantor: str
+
+
+@dataclass(frozen=True, slots=True)
 class SequenceInfo:
     """A sequence within a schema.
 
@@ -544,6 +558,27 @@ async def list_roles(driver: SqlDriver, *, include_system: bool = False) -> list
     if include_system:
         return roles
     return [role for role in roles if not role.name.startswith("pg_")]
+
+
+async def list_grants(driver: SqlDriver, schema: str, table: str) -> list[GrantInfo]:
+    """List the privileges granted on a table — who may do what to it."""
+    rows = await driver.execute_query(
+        "SELECT grantee, privilege_type AS privilege, is_grantable, grantor "
+        "FROM information_schema.table_privileges "
+        "WHERE table_schema = %s AND table_name = %s "
+        "ORDER BY grantee, privilege_type",
+        params=[schema, table],
+        force_readonly=True,
+    )
+    return [
+        GrantInfo(
+            grantee=row.cells["grantee"],
+            privilege=row.cells["privilege"],
+            grantable=row.cells["is_grantable"] == "YES",
+            grantor=row.cells["grantor"],
+        )
+        for row in rows or []
+    ]
 
 
 async def list_sequences(driver: SqlDriver, schema: str) -> list[SequenceInfo]:

--- a/src/mcpg/introspection.py
+++ b/src/mcpg/introspection.py
@@ -14,6 +14,15 @@ from mcpg._vendor.sql import SqlDriver
 # Schemas that belong to PostgreSQL itself rather than the user.
 _SYSTEM_SCHEMAS = frozenset({"pg_catalog", "information_schema", "pg_toast"})
 
+# pg_constraint.contype codes -> readable constraint type.
+_CONSTRAINT_TYPES = {
+    "p": "primary_key",
+    "f": "foreign_key",
+    "u": "unique",
+    "c": "check",
+    "x": "exclusion",
+}
+
 
 @dataclass(frozen=True, slots=True)
 class SchemaInfo:
@@ -56,6 +65,19 @@ class IndexInfo:
 
     name: str
     method: str
+    definition: str
+
+
+@dataclass(frozen=True, slots=True)
+class ConstraintInfo:
+    """A constraint on a table.
+
+    ``type`` is ``primary_key``, ``foreign_key``, ``unique``, ``check``,
+    ``exclusion``, or ``other``.
+    """
+
+    name: str
+    type: str
     definition: str
 
 
@@ -156,6 +178,28 @@ async def list_indexes(driver: SqlDriver, schema: str, table: str) -> list[Index
         IndexInfo(
             name=row.cells["name"],
             method=row.cells["method"],
+            definition=row.cells["definition"],
+        )
+        for row in rows or []
+    ]
+
+
+async def list_constraints(driver: SqlDriver, schema: str, table: str) -> list[ConstraintInfo]:
+    """List the constraints on a table — keys, unique, check, exclusion."""
+    rows = await driver.execute_query(
+        "SELECT con.conname AS name, con.contype AS type_code, "
+        "pg_get_constraintdef(con.oid) AS definition "
+        "FROM pg_constraint con "
+        "JOIN pg_class c ON c.oid = con.conrelid "
+        "JOIN pg_namespace n ON n.oid = c.relnamespace "
+        "WHERE n.nspname = %s AND c.relname = %s ORDER BY con.conname",
+        params=[schema, table],
+        force_readonly=True,
+    )
+    return [
+        ConstraintInfo(
+            name=row.cells["name"],
+            type=_CONSTRAINT_TYPES.get(row.cells["type_code"], "other"),
             definition=row.cells["definition"],
         )
         for row in rows or []

--- a/src/mcpg/introspection.py
+++ b/src/mcpg/introspection.py
@@ -23,6 +23,9 @@ _CONSTRAINT_TYPES = {
     "x": "exclusion",
 }
 
+# pg_proc.prokind codes -> readable routine kind.
+_ROUTINE_KINDS = {"f": "function", "p": "procedure", "a": "aggregate", "w": "window"}
+
 
 @dataclass(frozen=True, slots=True)
 class SchemaInfo:
@@ -75,6 +78,21 @@ class ViewInfo:
     name: str
     materialized: bool
     definition: str
+
+
+@dataclass(frozen=True, slots=True)
+class FunctionInfo:
+    """A function or procedure within a schema.
+
+    ``kind`` is ``function``, ``procedure``, ``aggregate``, ``window``, or
+    ``other``. ``returns`` is ``None`` for procedures.
+    """
+
+    name: str
+    kind: str
+    arguments: str
+    returns: str | None
+    language: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -209,6 +227,31 @@ async def list_views(driver: SqlDriver, schema: str) -> list[ViewInfo]:
             name=row.cells["name"],
             materialized=row.cells["materialized"],
             definition=row.cells["definition"],
+        )
+        for row in rows or []
+    ]
+
+
+async def list_functions(driver: SqlDriver, schema: str) -> list[FunctionInfo]:
+    """List the functions and procedures defined in a schema."""
+    rows = await driver.execute_query(
+        "SELECT p.proname AS name, p.prokind AS kind_code, "
+        "pg_get_function_arguments(p.oid) AS arguments, "
+        "pg_get_function_result(p.oid) AS returns, l.lanname AS language "
+        "FROM pg_proc p "
+        "JOIN pg_namespace n ON n.oid = p.pronamespace "
+        "JOIN pg_language l ON l.oid = p.prolang "
+        "WHERE n.nspname = %s ORDER BY p.proname, p.oid",
+        params=[schema],
+        force_readonly=True,
+    )
+    return [
+        FunctionInfo(
+            name=row.cells["name"],
+            kind=_ROUTINE_KINDS.get(row.cells["kind_code"], "other"),
+            arguments=row.cells["arguments"],
+            returns=row.cells["returns"],
+            language=row.cells["language"],
         )
         for row in rows or []
     ]

--- a/src/mcpg/introspection.py
+++ b/src/mcpg/introspection.py
@@ -69,6 +69,15 @@ class IndexInfo:
 
 
 @dataclass(frozen=True, slots=True)
+class ViewInfo:
+    """A view or materialized view within a schema."""
+
+    name: str
+    materialized: bool
+    definition: str
+
+
+@dataclass(frozen=True, slots=True)
 class ConstraintInfo:
     """A constraint on a table.
 
@@ -178,6 +187,27 @@ async def list_indexes(driver: SqlDriver, schema: str, table: str) -> list[Index
         IndexInfo(
             name=row.cells["name"],
             method=row.cells["method"],
+            definition=row.cells["definition"],
+        )
+        for row in rows or []
+    ]
+
+
+async def list_views(driver: SqlDriver, schema: str) -> list[ViewInfo]:
+    """List the views and materialized views in a schema, with definitions."""
+    rows = await driver.execute_query(
+        "SELECT c.relname AS name, (c.relkind = 'm') AS materialized, "
+        "pg_get_viewdef(c.oid, true) AS definition "
+        "FROM pg_class c "
+        "JOIN pg_namespace n ON n.oid = c.relnamespace "
+        "WHERE n.nspname = %s AND c.relkind IN ('v', 'm') ORDER BY c.relname",
+        params=[schema],
+        force_readonly=True,
+    )
+    return [
+        ViewInfo(
+            name=row.cells["name"],
+            materialized=row.cells["materialized"],
             definition=row.cells["definition"],
         )
         for row in rows or []

--- a/src/mcpg/introspection.py
+++ b/src/mcpg/introspection.py
@@ -157,6 +157,36 @@ class PartitionSet:
 
 
 @dataclass(frozen=True, slots=True)
+class PolicyInfo:
+    """A Row-Level-Security policy on a table.
+
+    ``permissive`` is ``True`` for a permissive policy, ``False`` for a
+    restrictive one. ``using_expression`` and ``check_expression`` are the
+    policy's ``USING`` and ``WITH CHECK`` predicates, or ``None``.
+    """
+
+    name: str
+    command: str
+    permissive: bool
+    roles: list[str]
+    using_expression: str | None
+    check_expression: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class PolicySet:
+    """The Row-Level-Security configuration of a table.
+
+    ``rls_enabled`` reflects whether row security is switched on for the
+    table — policies can exist while it is off, in which case they are
+    inert.
+    """
+
+    rls_enabled: bool
+    policies: list[PolicyInfo]
+
+
+@dataclass(frozen=True, slots=True)
 class SequenceInfo:
     """A sequence within a schema.
 
@@ -416,6 +446,43 @@ async def list_partitions(driver: SqlDriver, schema: str, table: str) -> Partiti
         if row.cells["partition_name"] is not None
     ]
     return PartitionSet(partitioned=True, strategy=strategy, partitions=partitions)
+
+
+async def list_policies(driver: SqlDriver, schema: str, table: str) -> PolicySet:
+    """List the Row-Level-Security policies on a table.
+
+    Also reports whether row security is enabled on the table; policies are
+    inert while it is off.
+    """
+    rows = await driver.execute_query(
+        "SELECT c.relrowsecurity AS rls_enabled, "
+        "p.policyname AS name, p.cmd AS command, p.permissive AS permissive, "
+        "p.roles AS roles, p.qual AS using_expression, "
+        "p.with_check AS check_expression "
+        "FROM pg_class c "
+        "JOIN pg_namespace n ON n.oid = c.relnamespace "
+        "LEFT JOIN pg_policies p ON p.schemaname = n.nspname AND p.tablename = c.relname "
+        "WHERE n.nspname = %s AND c.relname = %s "
+        "ORDER BY p.policyname",
+        params=[schema, table],
+        force_readonly=True,
+    )
+    rows = rows or []
+    if not rows:
+        return PolicySet(rls_enabled=False, policies=[])
+    policies = [
+        PolicyInfo(
+            name=row.cells["name"],
+            command=row.cells["command"],
+            permissive=row.cells["permissive"] == "PERMISSIVE",
+            roles=list(row.cells["roles"]),
+            using_expression=row.cells["using_expression"],
+            check_expression=row.cells["check_expression"],
+        )
+        for row in rows
+        if row.cells["name"] is not None
+    ]
+    return PolicySet(rls_enabled=rows[0].cells["rls_enabled"], policies=policies)
 
 
 async def list_sequences(driver: SqlDriver, schema: str) -> list[SequenceInfo]:

--- a/src/mcpg/introspection.py
+++ b/src/mcpg/introspection.py
@@ -75,12 +75,14 @@ class IndexInfo:
 
     ``method`` is the access method — a built-in one (``btree``, ``gin``,
     ``gist``, ``brin``, ``hash``, ``spgist``) or an extension's (e.g.
-    ``hnsw`` / ``ivfflat`` from ``pgvector``).
+    ``hnsw`` / ``ivfflat`` from ``pgvector``). ``partitioned`` is ``True``
+    for a partitioned index — the template propagated to each partition.
     """
 
     name: str
     method: str
     definition: str
+    partitioned: bool
 
 
 @dataclass(frozen=True, slots=True)
@@ -268,7 +270,8 @@ async def describe_table(driver: SqlDriver, schema: str, table: str) -> list[Col
 async def list_indexes(driver: SqlDriver, schema: str, table: str) -> list[IndexInfo]:
     """List the indexes defined on a table, with their access method."""
     rows = await driver.execute_query(
-        "SELECT i.relname AS name, am.amname AS method, pg_get_indexdef(i.oid) AS definition "
+        "SELECT i.relname AS name, am.amname AS method, i.relkind AS relkind, "
+        "pg_get_indexdef(i.oid) AS definition "
         "FROM pg_class t "
         "JOIN pg_namespace n ON n.oid = t.relnamespace "
         "JOIN pg_index ix ON ix.indrelid = t.oid "
@@ -283,6 +286,7 @@ async def list_indexes(driver: SqlDriver, schema: str, table: str) -> list[Index
             name=row.cells["name"],
             method=row.cells["method"],
             definition=row.cells["definition"],
+            partitioned=row.cells["relkind"] == "I",
         )
         for row in rows or []
     ]

--- a/src/mcpg/introspection.py
+++ b/src/mcpg/introspection.py
@@ -187,6 +187,25 @@ class PolicySet:
 
 
 @dataclass(frozen=True, slots=True)
+class RoleInfo:
+    """A database role and its attributes.
+
+    ``connection_limit`` is ``-1`` when the role has no connection cap.
+    ``member_of`` lists the roles this role is a direct member of.
+    """
+
+    name: str
+    superuser: bool
+    create_role: bool
+    create_db: bool
+    can_login: bool
+    replication: bool
+    bypass_rls: bool
+    connection_limit: int
+    member_of: list[str]
+
+
+@dataclass(frozen=True, slots=True)
 class SequenceInfo:
     """A sequence within a schema.
 
@@ -483,6 +502,48 @@ async def list_policies(driver: SqlDriver, schema: str, table: str) -> PolicySet
         if row.cells["name"] is not None
     ]
     return PolicySet(rls_enabled=rows[0].cells["rls_enabled"], policies=policies)
+
+
+async def list_roles(driver: SqlDriver, *, include_system: bool = False) -> list[RoleInfo]:
+    """List the database roles and their attributes.
+
+    PostgreSQL's own predefined roles (named ``pg_*``) are excluded unless
+    ``include_system`` is set.
+    """
+    rows = await driver.execute_query(
+        "SELECT r.rolname AS name, r.rolsuper AS superuser, "
+        "r.rolcreaterole AS create_role, r.rolcreatedb AS create_db, "
+        "r.rolcanlogin AS can_login, r.rolreplication AS replication, "
+        "r.rolbypassrls AS bypass_rls, r.rolconnlimit AS connection_limit, "
+        "COALESCE("
+        "  array_agg(m.rolname ORDER BY m.rolname) FILTER (WHERE m.rolname IS NOT NULL), "
+        "  '{}'"
+        ") AS member_of "
+        "FROM pg_roles r "
+        "LEFT JOIN pg_auth_members am ON am.member = r.oid "
+        "LEFT JOIN pg_roles m ON m.oid = am.roleid "
+        "GROUP BY r.oid, r.rolname, r.rolsuper, r.rolcreaterole, r.rolcreatedb, "
+        "r.rolcanlogin, r.rolreplication, r.rolbypassrls, r.rolconnlimit "
+        "ORDER BY r.rolname",
+        force_readonly=True,
+    )
+    roles = [
+        RoleInfo(
+            name=row.cells["name"],
+            superuser=row.cells["superuser"],
+            create_role=row.cells["create_role"],
+            create_db=row.cells["create_db"],
+            can_login=row.cells["can_login"],
+            replication=row.cells["replication"],
+            bypass_rls=row.cells["bypass_rls"],
+            connection_limit=row.cells["connection_limit"],
+            member_of=list(row.cells["member_of"]),
+        )
+        for row in rows or []
+    ]
+    if include_system:
+        return roles
+    return [role for role in roles if not role.name.startswith("pg_")]
 
 
 async def list_sequences(driver: SqlDriver, schema: str) -> list[SequenceInfo]:

--- a/src/mcpg/liveops.py
+++ b/src/mcpg/liveops.py
@@ -1,0 +1,65 @@
+"""Live-operations introspection: in-flight queries, waits, and blocking.
+
+Reads ``pg_stat_activity`` to report what the server is doing right now.
+Every query is read-only and parameterless.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mcpg._vendor.sql import SqlDriver
+
+
+@dataclass(frozen=True, slots=True)
+class ActiveQuery:
+    """A query currently executing on the server.
+
+    ``wait_event`` is ``type:event`` when the backend is waiting, else
+    ``None``. ``blocked_by`` lists the PIDs holding locks this backend
+    waits on — empty when the query is not blocked.
+    """
+
+    pid: int
+    username: str | None
+    application: str | None
+    state: str | None
+    wait_event: str | None
+    duration_seconds: float | None
+    query: str
+    blocked_by: list[int]
+
+
+async def list_active_queries(driver: SqlDriver) -> list[ActiveQuery]:
+    """List the queries currently running on the server.
+
+    Idle connections, PostgreSQL's background processes, and MCPg's own
+    backend are excluded; the result is the work other clients are doing.
+    """
+    rows = await driver.execute_query(
+        "SELECT pid, usename AS username, application_name AS application, "
+        "state, "
+        "CASE WHEN wait_event_type IS NULL THEN NULL "
+        "ELSE wait_event_type || ':' || COALESCE(wait_event, '') END AS wait_event, "
+        "EXTRACT(EPOCH FROM (now() - query_start))::double precision AS duration_seconds, "
+        "query, pg_blocking_pids(pid) AS blocked_by "
+        "FROM pg_stat_activity "
+        "WHERE backend_type = 'client backend' "
+        "AND pid <> pg_backend_pid() "
+        "AND state IS DISTINCT FROM 'idle' "
+        "ORDER BY query_start NULLS LAST",
+        force_readonly=True,
+    )
+    return [
+        ActiveQuery(
+            pid=row.cells["pid"],
+            username=row.cells["username"],
+            application=row.cells["application"],
+            state=row.cells["state"],
+            wait_event=row.cells["wait_event"],
+            duration_seconds=row.cells["duration_seconds"],
+            query=row.cells["query"],
+            blocked_by=list(row.cells["blocked_by"]),
+        )
+        for row in rows or []
+    ]

--- a/src/mcpg/liveops.py
+++ b/src/mcpg/liveops.py
@@ -12,6 +12,19 @@ from mcpg._vendor.sql import SqlDriver
 
 
 @dataclass(frozen=True, slots=True)
+class BackendActionResult:
+    """The outcome of cancelling a query or terminating a backend.
+
+    ``succeeded`` is ``False`` when PostgreSQL could not act on the PID —
+    most often because no such backend exists.
+    """
+
+    pid: int
+    action: str
+    succeeded: bool
+
+
+@dataclass(frozen=True, slots=True)
 class ActiveQuery:
     """A query currently executing on the server.
 
@@ -63,3 +76,33 @@ async def list_active_queries(driver: SqlDriver) -> list[ActiveQuery]:
         )
         for row in rows or []
     ]
+
+
+async def cancel_query(driver: SqlDriver, pid: int) -> BackendActionResult:
+    """Cancel the query currently running on a backend.
+
+    Sends a cancel signal via ``pg_cancel_backend``; the connection itself
+    stays open. ``succeeded`` is ``False`` if no such backend exists.
+    """
+    rows = await driver.execute_query(
+        "SELECT pg_cancel_backend(%s) AS ok",
+        params=[pid],
+        force_readonly=True,
+    )
+    succeeded = bool((rows or [])[0].cells["ok"])
+    return BackendActionResult(pid=pid, action="cancel_query", succeeded=succeeded)
+
+
+async def terminate_backend(driver: SqlDriver, pid: int) -> BackendActionResult:
+    """Terminate a backend, closing its connection.
+
+    Sends a terminate signal via ``pg_terminate_backend``. ``succeeded`` is
+    ``False`` if no such backend exists.
+    """
+    rows = await driver.execute_query(
+        "SELECT pg_terminate_backend(%s) AS ok",
+        params=[pid],
+        force_readonly=True,
+    )
+    succeeded = bool((rows or [])[0].cells["ok"])
+    return BackendActionResult(pid=pid, action="terminate_backend", succeeded=succeeded)

--- a/src/mcpg/maintenance.py
+++ b/src/mcpg/maintenance.py
@@ -58,8 +58,9 @@ async def run_maintenance(database: Database, operation: str, schema: str, table
         expected = ", ".join(sorted(_OPERATIONS))
         raise MaintenanceError(f"unknown operation {operation!r}; expected one of {expected}")
     target = f"{_quote_identifier(schema)}.{_quote_identifier(table)}"
+    label = f"{schema}.{table}"
     try:
         await database.run_unmanaged(f"{command} {target}")
     except Exception as exc:
-        raise MaintenanceError(str(exc)) from exc
-    return MaintenanceResult(operation=operation, target=f"{schema}.{table}")
+        raise MaintenanceError(f"{operation} on {label} failed: {exc}") from exc
+    return MaintenanceResult(operation=operation, target=label)

--- a/src/mcpg/maintenance.py
+++ b/src/mcpg/maintenance.py
@@ -1,0 +1,65 @@
+"""Maintenance operations: gated VACUUM and ANALYZE.
+
+``VACUUM`` cannot run inside a transaction block, so maintenance runs on an
+autocommit connection (:meth:`Database.run_unmanaged`) rather than through
+the transactional ``SqlDriver``. The target table is named, not parameterised
+— PostgreSQL takes an identifier here — so the schema and table are quoted
+defensively before they reach SQL.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mcpg.database import Database
+
+# Accepted operation -> the SQL command it maps to.
+_OPERATIONS = {
+    "vacuum": "VACUUM",
+    "analyze": "ANALYZE",
+    "vacuum_analyze": "VACUUM (ANALYZE)",
+}
+
+
+class MaintenanceError(Exception):
+    """Raised when a maintenance request is rejected or fails."""
+
+
+@dataclass(frozen=True, slots=True)
+class MaintenanceResult:
+    """The outcome of a maintenance run."""
+
+    operation: str
+    target: str
+
+
+def _quote_identifier(name: str) -> str:
+    """Quote a SQL identifier, escaping embedded double-quotes."""
+    if not name or "\x00" in name:
+        raise MaintenanceError(f"invalid identifier: {name!r}")
+    return '"' + name.replace('"', '""') + '"'
+
+
+async def run_maintenance(database: Database, operation: str, schema: str, table: str) -> MaintenanceResult:
+    """Run ``VACUUM`` or ``ANALYZE`` against one table.
+
+    Args:
+        database: The connected database to run maintenance on.
+        operation: ``vacuum``, ``analyze``, or ``vacuum_analyze``.
+        schema: The target table's schema.
+        table: The target table.
+
+    Raises:
+        MaintenanceError: If the operation is unknown, an identifier is
+            invalid, or the command fails.
+    """
+    command = _OPERATIONS.get(operation)
+    if command is None:
+        expected = ", ".join(sorted(_OPERATIONS))
+        raise MaintenanceError(f"unknown operation {operation!r}; expected one of {expected}")
+    target = f"{_quote_identifier(schema)}.{_quote_identifier(table)}"
+    try:
+        await database.run_unmanaged(f"{command} {target}")
+    except Exception as exc:
+        raise MaintenanceError(str(exc)) from exc
+    return MaintenanceResult(operation=operation, target=f"{schema}.{table}")

--- a/src/mcpg/textsearch.py
+++ b/src/mcpg/textsearch.py
@@ -147,10 +147,10 @@ async def fuzzy_search(
     Raises:
         SearchError: If an identifier is invalid or ``mode`` is unknown.
     """
-    if not await extension_installed(driver, "pg_trgm"):
-        return FuzzySearchResult(available=False, matches=[])
     if mode not in _FUZZY_MODES:
         raise SearchError(f"unknown fuzzy mode: {mode!r}")
+    if not await extension_installed(driver, "pg_trgm"):
+        return FuzzySearchResult(available=False, matches=[])
 
     relation = f"{_quoted(schema, 'schema')}.{_quoted(table, 'table')}"
     col = _quoted(column, "column")

--- a/src/mcpg/textsearch.py
+++ b/src/mcpg/textsearch.py
@@ -28,6 +28,11 @@ _IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
 DEFAULT_LIMIT = 10
 DEFAULT_THRESHOLD = 0.3
 
+# Fuzzy-match mode: "word" matches the term against the best word window of
+# the value (good for fragments); "full" compares the whole strings.
+_FUZZY_MODES = frozenset({"word", "full"})
+DEFAULT_FUZZY_MODE = "word"
+
 # Default text-search configuration for full-text search.
 DEFAULT_TEXT_CONFIG = "english"
 
@@ -125,6 +130,7 @@ async def fuzzy_search(
     column: str,
     term: str,
     *,
+    mode: str = DEFAULT_FUZZY_MODE,
     limit: int = DEFAULT_LIMIT,
     threshold: float = DEFAULT_THRESHOLD,
 ) -> FuzzySearchResult:
@@ -133,18 +139,24 @@ async def fuzzy_search(
     Requires the ``pg_trgm`` extension; when absent the result is returned
     with ``available=False`` and no matches.
 
+    Args:
+        mode: ``word`` (default) scores the term against the best-matching
+            word window of each value — good for fragments and misspellings
+            within longer text. ``full`` compares the whole strings.
+
     Raises:
-        SearchError: If a schema/table/column name is not a valid identifier.
+        SearchError: If an identifier is invalid or ``mode`` is unknown.
     """
     if not await extension_installed(driver, "pg_trgm"):
         return FuzzySearchResult(available=False, matches=[])
+    if mode not in _FUZZY_MODES:
+        raise SearchError(f"unknown fuzzy mode: {mode!r}")
 
     relation = f"{_quoted(schema, 'schema')}.{_quoted(table, 'table')}"
     col = _quoted(column, "column")
+    score = f"similarity({col}, %s)" if mode == "full" else f"word_similarity(%s, {col})"
     rows = await driver.execute_query(
-        f"SELECT {col} AS value, similarity({col}, %s) AS score "
-        f"FROM {relation} WHERE similarity({col}, %s) >= %s "
-        f"ORDER BY score DESC LIMIT %s",
+        f"SELECT {col} AS value, {score} AS score FROM {relation} WHERE {score} >= %s ORDER BY score DESC LIMIT %s",
         params=[term, term, threshold, limit],
         force_readonly=True,
     )

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -124,6 +124,14 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
         return [asdict(trigger) for trigger in triggers]
 
     @server.tool(
+        name="list_partitions",
+        description="Describe how a table is partitioned (strategy and bounds) and list its partitions.",
+    )
+    async def list_partitions(ctx: _Ctx, schema: str, table: str) -> dict[str, Any]:
+        partition_set = await introspection.list_partitions(_driver(ctx), schema, table)
+        return asdict(partition_set)
+
+    @server.tool(
         name="list_sequences",
         description="List the sequences defined in a schema, with their range, increment, and last value.",
     )

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -115,6 +115,14 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
         functions = await introspection.list_functions(_driver(ctx), schema)
         return [asdict(function) for function in functions]
 
+    @server.tool(
+        name="list_triggers",
+        description="List the user-defined triggers on a table.",
+    )
+    async def list_triggers(ctx: _Ctx, schema: str, table: str) -> list[dict[str, Any]]:
+        triggers = await introspection.list_triggers(_driver(ctx), schema, table)
+        return [asdict(trigger) for trigger in triggers]
+
     @server.tool(name="list_extensions", description="List the extensions installed in the database.")
     async def list_extensions(ctx: _Ctx) -> list[dict[str, Any]]:
         extensions = await introspection.list_extensions(_driver(ctx))

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -177,9 +177,10 @@ def _register_health(server: FastMCP[AppContext]) -> None:
     @server.tool(
         name="fuzzy_search",
         description=(
-            "Rank a text column's values by trigram similarity to a search "
-            "term, via the pg_trgm extension. Reports available=false if "
-            "pg_trgm is not installed."
+            "Rank a text column's values by pg_trgm trigram similarity to a "
+            "search term. mode='word' (default) matches fragments within "
+            "longer text; mode='full' compares whole strings. Reports "
+            "available=false if pg_trgm is not installed."
         ),
     )
     async def fuzzy_search(
@@ -188,11 +189,12 @@ def _register_health(server: FastMCP[AppContext]) -> None:
         table: str,
         column: str,
         term: str,
+        mode: str = textsearch.DEFAULT_FUZZY_MODE,
         limit: int = textsearch.DEFAULT_LIMIT,
         threshold: float = textsearch.DEFAULT_THRESHOLD,
     ) -> dict[str, Any]:
         result = await textsearch.fuzzy_search(
-            _driver(ctx), schema, table, column, term, limit=limit, threshold=threshold
+            _driver(ctx), schema, table, column, term, mode=mode, limit=limit, threshold=threshold
         )
         return asdict(result)
 

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -135,6 +135,14 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
         return asdict(partition_set)
 
     @server.tool(
+        name="list_policies",
+        description="List the Row-Level-Security policies on a table, and whether row security is enabled.",
+    )
+    async def list_policies(ctx: _Ctx, schema: str, table: str) -> dict[str, Any]:
+        policy_set = await introspection.list_policies(_driver(ctx), schema, table)
+        return asdict(policy_set)
+
+    @server.tool(
         name="list_sequences",
         description="List the sequences defined in a schema, with their range, increment, and last value.",
     )

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -107,6 +107,14 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
         views = await introspection.list_views(_driver(ctx), schema)
         return [asdict(view) for view in views]
 
+    @server.tool(
+        name="list_functions",
+        description="List the functions and procedures defined in a schema.",
+    )
+    async def list_functions(ctx: _Ctx, schema: str) -> list[dict[str, Any]]:
+        functions = await introspection.list_functions(_driver(ctx), schema)
+        return [asdict(function) for function in functions]
+
     @server.tool(name="list_extensions", description="List the extensions installed in the database.")
     async def list_extensions(ctx: _Ctx) -> list[dict[str, Any]]:
         extensions = await introspection.list_extensions(_driver(ctx))

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -91,6 +91,14 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
         indexes = await introspection.list_indexes(_driver(ctx), schema, table)
         return [asdict(index) for index in indexes]
 
+    @server.tool(
+        name="list_constraints",
+        description="List a table's constraints — primary/foreign keys, unique, check, exclusion.",
+    )
+    async def list_constraints(ctx: _Ctx, schema: str, table: str) -> list[dict[str, Any]]:
+        constraints = await introspection.list_constraints(_driver(ctx), schema, table)
+        return [asdict(constraint) for constraint in constraints]
+
     @server.tool(name="list_extensions", description="List the extensions installed in the database.")
     async def list_extensions(ctx: _Ctx) -> list[dict[str, Any]]:
         extensions = await introspection.list_extensions(_driver(ctx))

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -20,6 +20,7 @@ from mcpg import (
     indexing,
     introspection,
     liveops,
+    maintenance,
     query,
     textsearch,
     workload,
@@ -366,6 +367,20 @@ def _register_write(server: FastMCP[AppContext]) -> None:
         return asdict(result)
 
 
+def _register_maintenance(server: FastMCP[AppContext]) -> None:
+    @server.tool(
+        name="run_maintenance",
+        description=(
+            "Run VACUUM or ANALYZE against one table (operation: vacuum, "
+            "analyze, or vacuum_analyze). Available only in unrestricted mode."
+        ),
+    )
+    async def run_maintenance(ctx: _Ctx, operation: str, schema: str, table: str) -> dict[str, Any]:
+        database = ctx.request_context.lifespan_context.database
+        result = await maintenance.run_maintenance(database, operation, schema, table)
+        return asdict(result)
+
+
 def _register_ddl(server: FastMCP[AppContext]) -> None:
     @server.tool(
         name="run_ddl",
@@ -407,5 +422,6 @@ def register_tools(server: FastMCP[AppContext], settings: Settings) -> None:
         _register_liveops(server)
     if is_permitted(settings.access_mode, Capability.WRITE):
         _register_write(server)
+        _register_maintenance(server)
     if is_permitted(settings.access_mode, Capability.DDL) and settings.allow_ddl:
         _register_ddl(server)

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -19,6 +19,7 @@ from mcpg import (
     health,
     indexing,
     introspection,
+    liveops,
     query,
     textsearch,
     workload,
@@ -338,6 +339,19 @@ def _register_health(server: FastMCP[AppContext]) -> None:
         return asdict(result)
 
 
+def _register_liveops(server: FastMCP[AppContext]) -> None:
+    @server.tool(
+        name="list_active_queries",
+        description=(
+            "List the queries currently running on the server, with each "
+            "backend's wait event, duration, and the PIDs blocking it."
+        ),
+    )
+    async def list_active_queries(ctx: _Ctx) -> list[dict[str, Any]]:
+        queries = await liveops.list_active_queries(_driver(ctx))
+        return [asdict(active) for active in queries]
+
+
 def _register_write(server: FastMCP[AppContext]) -> None:
     @server.tool(
         name="run_write",
@@ -390,6 +404,7 @@ def register_tools(server: FastMCP[AppContext], settings: Settings) -> None:
         _register_introspection(server)
         _register_query(server)
         _register_health(server)
+        _register_liveops(server)
     if is_permitted(settings.access_mode, Capability.WRITE):
         _register_write(server)
     if is_permitted(settings.access_mode, Capability.DDL) and settings.allow_ddl:

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -76,7 +76,10 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
         schemas = await introspection.list_schemas(_driver(ctx), include_system=include_system)
         return [asdict(schema) for schema in schemas]
 
-    @server.tool(name="list_tables", description="List the tables and views in a schema.")
+    @server.tool(
+        name="list_tables",
+        description="List the tables and views in a schema, flagging partitioned tables and partitions.",
+    )
     async def list_tables(ctx: _Ctx, schema: str) -> list[dict[str, Any]]:
         tables = await introspection.list_tables(_driver(ctx), schema)
         return [asdict(table) for table in tables]

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -135,6 +135,15 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
         return asdict(partition_set)
 
     @server.tool(
+        name="list_roles",
+        description="List the database roles and their attributes, excluding PostgreSQL's own roles "
+        "unless include_system is true.",
+    )
+    async def list_roles(ctx: _Ctx, include_system: bool = False) -> list[dict[str, Any]]:
+        roles = await introspection.list_roles(_driver(ctx), include_system=include_system)
+        return [asdict(role) for role in roles]
+
+    @server.tool(
         name="list_policies",
         description="List the Row-Level-Security policies on a table, and whether row security is enabled.",
     )

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -381,6 +381,30 @@ def _register_maintenance(server: FastMCP[AppContext]) -> None:
         return asdict(result)
 
 
+def _register_backend_control(server: FastMCP[AppContext]) -> None:
+    @server.tool(
+        name="cancel_query",
+        description=(
+            "Cancel the query running on a backend PID (pg_cancel_backend); "
+            "the connection stays open. Available only in unrestricted mode."
+        ),
+    )
+    async def cancel_query(ctx: _Ctx, pid: int) -> dict[str, Any]:
+        result = await liveops.cancel_query(_driver(ctx), pid)
+        return asdict(result)
+
+    @server.tool(
+        name="terminate_backend",
+        description=(
+            "Terminate a backend PID (pg_terminate_backend), closing its "
+            "connection. Available only in unrestricted mode."
+        ),
+    )
+    async def terminate_backend(ctx: _Ctx, pid: int) -> dict[str, Any]:
+        result = await liveops.terminate_backend(_driver(ctx), pid)
+        return asdict(result)
+
+
 def _register_ddl(server: FastMCP[AppContext]) -> None:
     @server.tool(
         name="run_ddl",
@@ -423,5 +447,6 @@ def register_tools(server: FastMCP[AppContext], settings: Settings) -> None:
     if is_permitted(settings.access_mode, Capability.WRITE):
         _register_write(server)
         _register_maintenance(server)
+        _register_backend_control(server)
     if is_permitted(settings.access_mode, Capability.DDL) and settings.allow_ddl:
         _register_ddl(server)

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -99,6 +99,14 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
         constraints = await introspection.list_constraints(_driver(ctx), schema, table)
         return [asdict(constraint) for constraint in constraints]
 
+    @server.tool(
+        name="list_views",
+        description="List the views and materialized views in a schema, with their definitions.",
+    )
+    async def list_views(ctx: _Ctx, schema: str) -> list[dict[str, Any]]:
+        views = await introspection.list_views(_driver(ctx), schema)
+        return [asdict(view) for view in views]
+
     @server.tool(name="list_extensions", description="List the extensions installed in the database.")
     async def list_extensions(ctx: _Ctx) -> list[dict[str, Any]]:
         extensions = await introspection.list_extensions(_driver(ctx))

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -144,6 +144,14 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
         return [asdict(role) for role in roles]
 
     @server.tool(
+        name="list_grants",
+        description="List the privileges granted on a table — who may do what to it.",
+    )
+    async def list_grants(ctx: _Ctx, schema: str, table: str) -> list[dict[str, Any]]:
+        grants = await introspection.list_grants(_driver(ctx), schema, table)
+        return [asdict(grant) for grant in grants]
+
+    @server.tool(
         name="list_policies",
         description="List the Row-Level-Security policies on a table, and whether row security is enabled.",
     )

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -123,6 +123,14 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
         triggers = await introspection.list_triggers(_driver(ctx), schema, table)
         return [asdict(trigger) for trigger in triggers]
 
+    @server.tool(
+        name="list_sequences",
+        description="List the sequences defined in a schema, with their range, increment, and last value.",
+    )
+    async def list_sequences(ctx: _Ctx, schema: str) -> list[dict[str, Any]]:
+        sequences = await introspection.list_sequences(_driver(ctx), schema)
+        return [asdict(sequence) for sequence in sequences]
+
     @server.tool(name="list_extensions", description="List the extensions installed in the database.")
     async def list_extensions(ctx: _Ctx) -> list[dict[str, Any]]:
         extensions = await introspection.list_extensions(_driver(ctx))

--- a/tests/integration/test_health_integration.py
+++ b/tests/integration/test_health_integration.py
@@ -13,6 +13,8 @@ async def test_check_database_health_against_real_postgres(connected_database: D
         "cache_hit_ratio",
         "dead_tuples",
         "invalid_indexes",
+        "replication_lag",
+        "table_bloat",
     }
     # A freshly created test database should have no invalid indexes.
     invalid = next(check for check in report.checks if check.name == "invalid_indexes")

--- a/tests/integration/test_introspection_integration.py
+++ b/tests/integration/test_introspection_integration.py
@@ -14,6 +14,7 @@ from mcpg.introspection import (
     list_extensions,
     list_functions,
     list_indexes,
+    list_partitions,
     list_schemas,
     list_sequences,
     list_tables,
@@ -33,6 +34,11 @@ async def sample_schema(connected_database: Database) -> AsyncIterator[str]:
     await driver.execute_query(f"CREATE TABLE {_SCHEMA}.widget (id integer PRIMARY KEY, name text NOT NULL, note text)")
     await driver.execute_query(f"CREATE INDEX widget_name_idx ON {_SCHEMA}.widget (name)")
     await driver.execute_query(f"CREATE SEQUENCE {_SCHEMA}.widget_seq")
+    await driver.execute_query(f"CREATE TABLE {_SCHEMA}.event (id integer, created date) PARTITION BY RANGE (created)")
+    await driver.execute_query(
+        f"CREATE TABLE {_SCHEMA}.event_2026 PARTITION OF {_SCHEMA}.event "
+        f"FOR VALUES FROM ('2026-01-01') TO ('2027-01-01')"
+    )
     await driver.execute_query(f"CREATE VIEW {_SCHEMA}.widget_names AS SELECT name FROM {_SCHEMA}.widget")
     await driver.execute_query(
         f"CREATE FUNCTION {_SCHEMA}.widget_count() RETURNS bigint LANGUAGE sql "
@@ -121,6 +127,22 @@ async def test_list_sequences_finds_the_sequence(connected_database: Database, s
 
     assert "widget_seq" in by_name
     assert by_name["widget_seq"].increment == 1
+
+
+async def test_list_partitions_describes_a_partitioned_table(connected_database: Database, sample_schema: str) -> None:
+    result = await list_partitions(connected_database.driver(), sample_schema, "event")
+
+    assert result.partitioned is True
+    assert result.strategy == "range"
+    assert "event_2026" in {partition.name for partition in result.partitions}
+
+
+async def test_list_partitions_reports_a_plain_table_as_not_partitioned(
+    connected_database: Database, sample_schema: str
+) -> None:
+    result = await list_partitions(connected_database.driver(), sample_schema, "widget")
+
+    assert result.partitioned is False
 
 
 async def test_describe_table_reports_pgvector_dimension(connected_database: Database) -> None:

--- a/tests/integration/test_introspection_integration.py
+++ b/tests/integration/test_introspection_integration.py
@@ -15,6 +15,7 @@ from mcpg.introspection import (
     list_functions,
     list_indexes,
     list_partitions,
+    list_policies,
     list_schemas,
     list_sequences,
     list_tables,
@@ -52,6 +53,8 @@ async def sample_schema(connected_database: Database) -> AsyncIterator[str]:
         f"CREATE TRIGGER widget_bi BEFORE INSERT ON {_SCHEMA}.widget "
         f"FOR EACH ROW EXECUTE FUNCTION {_SCHEMA}.widget_touch()"
     )
+    await driver.execute_query(f"ALTER TABLE {_SCHEMA}.widget ENABLE ROW LEVEL SECURITY")
+    await driver.execute_query(f"CREATE POLICY widget_select ON {_SCHEMA}.widget FOR SELECT USING (true)")
     try:
         yield _SCHEMA
     finally:
@@ -132,6 +135,20 @@ async def test_list_triggers_finds_the_trigger(connected_database: Database, sam
 
     assert "widget_bi" in by_name
     assert by_name["widget_bi"].function == "widget_touch"
+
+
+async def test_list_policies_finds_the_policy(connected_database: Database, sample_schema: str) -> None:
+    result = await list_policies(connected_database.driver(), sample_schema, "widget")
+
+    assert result.rls_enabled is True
+    assert "widget_select" in {policy.name for policy in result.policies}
+
+
+async def test_list_policies_reports_an_unsecured_table(connected_database: Database, sample_schema: str) -> None:
+    result = await list_policies(connected_database.driver(), sample_schema, "event")
+
+    assert result.rls_enabled is False
+    assert result.policies == []
 
 
 async def test_list_sequences_finds_the_sequence(connected_database: Database, sample_schema: str) -> None:

--- a/tests/integration/test_introspection_integration.py
+++ b/tests/integration/test_introspection_integration.py
@@ -10,6 +10,7 @@ from mcpg.introspection import (
     SchemaInfo,
     describe_table,
     list_available_extensions,
+    list_constraints,
     list_extensions,
     list_indexes,
     list_schemas,
@@ -63,6 +64,13 @@ async def test_list_indexes_finds_primary_key_and_secondary_index(
     # Both sample indexes are plain B-tree; the access method is reported.
     assert by_name["widget_pkey"].method == "btree"
     assert by_name["widget_name_idx"].method == "btree"
+
+
+async def test_list_constraints_finds_the_primary_key(connected_database: Database, sample_schema: str) -> None:
+    constraints = await list_constraints(connected_database.driver(), sample_schema, "widget")
+
+    by_type = {constraint.type for constraint in constraints}
+    assert "primary_key" in by_type
 
 
 async def test_describe_table_reports_pgvector_dimension(connected_database: Database) -> None:

--- a/tests/integration/test_introspection_integration.py
+++ b/tests/integration/test_introspection_integration.py
@@ -16,6 +16,7 @@ from mcpg.introspection import (
     list_indexes,
     list_partitions,
     list_policies,
+    list_roles,
     list_schemas,
     list_sequences,
     list_tables,
@@ -173,6 +174,19 @@ async def test_list_partitions_reports_a_plain_table_as_not_partitioned(
     result = await list_partitions(connected_database.driver(), sample_schema, "widget")
 
     assert result.partitioned is False
+
+
+async def test_list_roles_includes_a_login_capable_role(connected_database: Database) -> None:
+    roles = await list_roles(connected_database.driver())
+
+    assert roles  # every cluster has at least the bootstrap superuser
+    assert any(role.can_login for role in roles)
+
+
+async def test_list_roles_excludes_predefined_roles_by_default(connected_database: Database) -> None:
+    roles = await list_roles(connected_database.driver())
+
+    assert not any(role.name.startswith("pg_") for role in roles)
 
 
 async def test_describe_table_reports_pgvector_dimension(connected_database: Database) -> None:

--- a/tests/integration/test_introspection_integration.py
+++ b/tests/integration/test_introspection_integration.py
@@ -15,6 +15,7 @@ from mcpg.introspection import (
     list_indexes,
     list_schemas,
     list_tables,
+    list_views,
 )
 
 _SCHEMA = "mcpg_introspection_it"
@@ -28,6 +29,7 @@ async def sample_schema(connected_database: Database) -> AsyncIterator[str]:
     await driver.execute_query(f"CREATE SCHEMA {_SCHEMA}")
     await driver.execute_query(f"CREATE TABLE {_SCHEMA}.widget (id integer PRIMARY KEY, name text NOT NULL, note text)")
     await driver.execute_query(f"CREATE INDEX widget_name_idx ON {_SCHEMA}.widget (name)")
+    await driver.execute_query(f"CREATE VIEW {_SCHEMA}.widget_names AS SELECT name FROM {_SCHEMA}.widget")
     try:
         yield _SCHEMA
     finally:
@@ -71,6 +73,14 @@ async def test_list_constraints_finds_the_primary_key(connected_database: Databa
 
     by_type = {constraint.type for constraint in constraints}
     assert "primary_key" in by_type
+
+
+async def test_list_views_finds_the_view(connected_database: Database, sample_schema: str) -> None:
+    views = await list_views(connected_database.driver(), sample_schema)
+    by_name = {view.name: view for view in views}
+
+    assert "widget_names" in by_name
+    assert by_name["widget_names"].materialized is False
 
 
 async def test_describe_table_reports_pgvector_dimension(connected_database: Database) -> None:

--- a/tests/integration/test_introspection_integration.py
+++ b/tests/integration/test_introspection_integration.py
@@ -12,6 +12,7 @@ from mcpg.introspection import (
     list_available_extensions,
     list_constraints,
     list_extensions,
+    list_functions,
     list_indexes,
     list_schemas,
     list_tables,
@@ -30,6 +31,10 @@ async def sample_schema(connected_database: Database) -> AsyncIterator[str]:
     await driver.execute_query(f"CREATE TABLE {_SCHEMA}.widget (id integer PRIMARY KEY, name text NOT NULL, note text)")
     await driver.execute_query(f"CREATE INDEX widget_name_idx ON {_SCHEMA}.widget (name)")
     await driver.execute_query(f"CREATE VIEW {_SCHEMA}.widget_names AS SELECT name FROM {_SCHEMA}.widget")
+    await driver.execute_query(
+        f"CREATE FUNCTION {_SCHEMA}.widget_count() RETURNS bigint LANGUAGE sql "
+        f"AS 'SELECT count(*) FROM {_SCHEMA}.widget'"
+    )
     try:
         yield _SCHEMA
     finally:
@@ -81,6 +86,15 @@ async def test_list_views_finds_the_view(connected_database: Database, sample_sc
 
     assert "widget_names" in by_name
     assert by_name["widget_names"].materialized is False
+
+
+async def test_list_functions_finds_the_function(connected_database: Database, sample_schema: str) -> None:
+    functions = await list_functions(connected_database.driver(), sample_schema)
+    by_name = {function.name: function for function in functions}
+
+    assert "widget_count" in by_name
+    assert by_name["widget_count"].kind == "function"
+    assert by_name["widget_count"].returns == "bigint"
 
 
 async def test_describe_table_reports_pgvector_dimension(connected_database: Database) -> None:

--- a/tests/integration/test_introspection_integration.py
+++ b/tests/integration/test_introspection_integration.py
@@ -65,8 +65,12 @@ async def test_list_schemas_includes_a_user_schema(connected_database: Database,
 
 async def test_list_tables_finds_the_table(connected_database: Database, sample_schema: str) -> None:
     tables = await list_tables(connected_database.driver(), sample_schema)
+    by_name = {table.name: table for table in tables}
 
-    assert ("widget", "BASE TABLE") in {(table.name, table.type) for table in tables}
+    assert by_name["widget"].type == "BASE TABLE"
+    assert by_name["widget"].partitioned is False
+    assert by_name["event"].partitioned is True
+    assert by_name["event_2026"].is_partition is True
 
 
 async def test_describe_table_returns_typed_columns(connected_database: Database, sample_schema: str) -> None:

--- a/tests/integration/test_introspection_integration.py
+++ b/tests/integration/test_introspection_integration.py
@@ -15,6 +15,7 @@ from mcpg.introspection import (
     list_functions,
     list_indexes,
     list_schemas,
+    list_sequences,
     list_tables,
     list_triggers,
     list_views,
@@ -31,6 +32,7 @@ async def sample_schema(connected_database: Database) -> AsyncIterator[str]:
     await driver.execute_query(f"CREATE SCHEMA {_SCHEMA}")
     await driver.execute_query(f"CREATE TABLE {_SCHEMA}.widget (id integer PRIMARY KEY, name text NOT NULL, note text)")
     await driver.execute_query(f"CREATE INDEX widget_name_idx ON {_SCHEMA}.widget (name)")
+    await driver.execute_query(f"CREATE SEQUENCE {_SCHEMA}.widget_seq")
     await driver.execute_query(f"CREATE VIEW {_SCHEMA}.widget_names AS SELECT name FROM {_SCHEMA}.widget")
     await driver.execute_query(
         f"CREATE FUNCTION {_SCHEMA}.widget_count() RETURNS bigint LANGUAGE sql "
@@ -111,6 +113,14 @@ async def test_list_triggers_finds_the_trigger(connected_database: Database, sam
 
     assert "widget_bi" in by_name
     assert by_name["widget_bi"].function == "widget_touch"
+
+
+async def test_list_sequences_finds_the_sequence(connected_database: Database, sample_schema: str) -> None:
+    sequences = await list_sequences(connected_database.driver(), sample_schema)
+    by_name = {sequence.name: sequence for sequence in sequences}
+
+    assert "widget_seq" in by_name
+    assert by_name["widget_seq"].increment == 1
 
 
 async def test_describe_table_reports_pgvector_dimension(connected_database: Database) -> None:

--- a/tests/integration/test_introspection_integration.py
+++ b/tests/integration/test_introspection_integration.py
@@ -39,6 +39,7 @@ async def sample_schema(connected_database: Database) -> AsyncIterator[str]:
         f"CREATE TABLE {_SCHEMA}.event_2026 PARTITION OF {_SCHEMA}.event "
         f"FOR VALUES FROM ('2026-01-01') TO ('2027-01-01')"
     )
+    await driver.execute_query(f"CREATE INDEX event_created_idx ON {_SCHEMA}.event (created)")
     await driver.execute_query(f"CREATE VIEW {_SCHEMA}.widget_names AS SELECT name FROM {_SCHEMA}.widget")
     await driver.execute_query(
         f"CREATE FUNCTION {_SCHEMA}.widget_count() RETURNS bigint LANGUAGE sql "
@@ -91,6 +92,14 @@ async def test_list_indexes_finds_primary_key_and_secondary_index(
     # Both sample indexes are plain B-tree; the access method is reported.
     assert by_name["widget_pkey"].method == "btree"
     assert by_name["widget_name_idx"].method == "btree"
+    assert by_name["widget_pkey"].partitioned is False
+
+
+async def test_list_indexes_flags_a_partitioned_index(connected_database: Database, sample_schema: str) -> None:
+    indexes = await list_indexes(connected_database.driver(), sample_schema, "event")
+    by_name = {index.name: index for index in indexes}
+
+    assert by_name["event_created_idx"].partitioned is True
 
 
 async def test_list_constraints_finds_the_primary_key(connected_database: Database, sample_schema: str) -> None:

--- a/tests/integration/test_introspection_integration.py
+++ b/tests/integration/test_introspection_integration.py
@@ -13,6 +13,7 @@ from mcpg.introspection import (
     list_constraints,
     list_extensions,
     list_functions,
+    list_grants,
     list_indexes,
     list_partitions,
     list_policies,
@@ -174,6 +175,13 @@ async def test_list_partitions_reports_a_plain_table_as_not_partitioned(
     result = await list_partitions(connected_database.driver(), sample_schema, "widget")
 
     assert result.partitioned is False
+
+
+async def test_list_grants_finds_the_owner_privileges(connected_database: Database, sample_schema: str) -> None:
+    grants = await list_grants(connected_database.driver(), sample_schema, "widget")
+
+    assert grants  # the table owner always holds privileges on its own table
+    assert "SELECT" in {grant.privilege for grant in grants}
 
 
 async def test_list_roles_includes_a_login_capable_role(connected_database: Database) -> None:

--- a/tests/integration/test_introspection_integration.py
+++ b/tests/integration/test_introspection_integration.py
@@ -16,6 +16,7 @@ from mcpg.introspection import (
     list_indexes,
     list_schemas,
     list_tables,
+    list_triggers,
     list_views,
 )
 
@@ -34,6 +35,13 @@ async def sample_schema(connected_database: Database) -> AsyncIterator[str]:
     await driver.execute_query(
         f"CREATE FUNCTION {_SCHEMA}.widget_count() RETURNS bigint LANGUAGE sql "
         f"AS 'SELECT count(*) FROM {_SCHEMA}.widget'"
+    )
+    await driver.execute_query(
+        f"CREATE FUNCTION {_SCHEMA}.widget_touch() RETURNS trigger LANGUAGE plpgsql AS 'BEGIN RETURN NEW; END'"
+    )
+    await driver.execute_query(
+        f"CREATE TRIGGER widget_bi BEFORE INSERT ON {_SCHEMA}.widget "
+        f"FOR EACH ROW EXECUTE FUNCTION {_SCHEMA}.widget_touch()"
     )
     try:
         yield _SCHEMA
@@ -95,6 +103,14 @@ async def test_list_functions_finds_the_function(connected_database: Database, s
     assert "widget_count" in by_name
     assert by_name["widget_count"].kind == "function"
     assert by_name["widget_count"].returns == "bigint"
+
+
+async def test_list_triggers_finds_the_trigger(connected_database: Database, sample_schema: str) -> None:
+    triggers = await list_triggers(connected_database.driver(), sample_schema, "widget")
+    by_name = {trigger.name: trigger for trigger in triggers}
+
+    assert "widget_bi" in by_name
+    assert by_name["widget_bi"].function == "widget_touch"
 
 
 async def test_describe_table_reports_pgvector_dimension(connected_database: Database) -> None:

--- a/tests/integration/test_liveops_integration.py
+++ b/tests/integration/test_liveops_integration.py
@@ -1,0 +1,14 @@
+"""Integration tests for live-operations introspection against PostgreSQL."""
+
+from mcpg.database import Database
+from mcpg.liveops import ActiveQuery, list_active_queries
+
+
+async def test_list_active_queries_against_real_postgres(connected_database: Database) -> None:
+    # The querying backend excludes itself, so the result is whatever other
+    # clients are doing — possibly nothing. The catalog query is still
+    # exercised end to end.
+    queries = await list_active_queries(connected_database.driver())
+
+    assert isinstance(queries, list)
+    assert all(isinstance(active, ActiveQuery) for active in queries)

--- a/tests/integration/test_liveops_integration.py
+++ b/tests/integration/test_liveops_integration.py
@@ -1,7 +1,10 @@
 """Integration tests for live-operations introspection against PostgreSQL."""
 
 from mcpg.database import Database
-from mcpg.liveops import ActiveQuery, list_active_queries
+from mcpg.liveops import ActiveQuery, cancel_query, list_active_queries, terminate_backend
+
+# A PID well outside the range any real backend would use.
+_ABSENT_PID = 2147483647
 
 
 async def test_list_active_queries_against_real_postgres(connected_database: Database) -> None:
@@ -12,3 +15,19 @@ async def test_list_active_queries_against_real_postgres(connected_database: Dat
 
     assert isinstance(queries, list)
     assert all(isinstance(active, ActiveQuery) for active in queries)
+
+
+async def test_cancel_query_reports_failure_for_an_absent_backend(connected_database: Database) -> None:
+    # Cancelling a non-existent PID is a safe no-op that still exercises the
+    # pg_cancel_backend round trip.
+    result = await cancel_query(connected_database.driver(), _ABSENT_PID)
+
+    assert result.action == "cancel_query"
+    assert result.succeeded is False
+
+
+async def test_terminate_backend_reports_failure_for_an_absent_backend(connected_database: Database) -> None:
+    result = await terminate_backend(connected_database.driver(), _ABSENT_PID)
+
+    assert result.action == "terminate_backend"
+    assert result.succeeded is False

--- a/tests/integration/test_maintenance_integration.py
+++ b/tests/integration/test_maintenance_integration.py
@@ -1,0 +1,40 @@
+"""Integration tests for maintenance operations against a live PostgreSQL."""
+
+from collections.abc import AsyncIterator
+
+import pytest
+
+from mcpg.database import Database
+from mcpg.maintenance import MaintenanceResult, run_maintenance
+
+_TABLE = "mcpg_maintenance_it"
+
+
+@pytest.fixture
+async def maintenance_table(connected_database: Database) -> AsyncIterator[str]:
+    """Create a throwaway table to run maintenance against; drop it afterwards."""
+    driver = connected_database.driver()
+    await driver.execute_query(f"DROP TABLE IF EXISTS {_TABLE}", force_readonly=False)
+    await driver.execute_query(f"CREATE TABLE {_TABLE} (id integer)", force_readonly=False)
+    try:
+        yield _TABLE
+    finally:
+        await driver.execute_query(f"DROP TABLE IF EXISTS {_TABLE}", force_readonly=False)
+
+
+async def test_run_maintenance_vacuum_against_real_postgres(
+    connected_database: Database, maintenance_table: str
+) -> None:
+    # VACUUM cannot run inside a transaction block; this exercises the
+    # autocommit path end to end.
+    result = await run_maintenance(connected_database, "vacuum", "public", maintenance_table)
+
+    assert result == MaintenanceResult(operation="vacuum", target=f"public.{maintenance_table}")
+
+
+async def test_run_maintenance_analyze_against_real_postgres(
+    connected_database: Database, maintenance_table: str
+) -> None:
+    result = await run_maintenance(connected_database, "analyze", "public", maintenance_table)
+
+    assert result.operation == "analyze"

--- a/tests/integration/test_textsearch_integration.py
+++ b/tests/integration/test_textsearch_integration.py
@@ -23,7 +23,7 @@ async def trigram_table(connected_database: Database) -> AsyncIterator[str]:
     await driver.execute_query(f"DROP TABLE IF EXISTS {_TABLE}", force_readonly=False)
     await driver.execute_query(f"CREATE TABLE {_TABLE} (name text)", force_readonly=False)
     await driver.execute_query(
-        f"INSERT INTO {_TABLE} (name) VALUES ('alice'), ('alicia'), ('bob')",
+        f"INSERT INTO {_TABLE} (name) VALUES ('alice'), ('alicia'), ('bob'), ('Espresso Machine')",
         force_readonly=False,
     )
     try:
@@ -41,6 +41,18 @@ async def test_fuzzy_search_ranks_real_rows_by_similarity(connected_database: Da
     assert "bob" not in values
     # Matches are ordered by descending similarity.
     assert result.matches == sorted(result.matches, key=lambda m: m.score, reverse=True)
+
+
+async def test_fuzzy_search_word_mode_matches_a_fragment_full_mode_misses(
+    connected_database: Database, trigram_table: str
+) -> None:
+    driver = connected_database.driver()
+    # "expreso" is a misspelled fragment of "Espresso Machine".
+    word = await fuzzy_search(driver, "public", trigram_table, "name", "expreso", mode="word")
+    full = await fuzzy_search(driver, "public", trigram_table, "name", "expreso", mode="full")
+
+    assert "Espresso Machine" in [match.value for match in word.matches]
+    assert "Espresso Machine" not in [match.value for match in full.matches]
 
 
 async def test_full_text_search_against_real_postgres(connected_database: Database) -> None:

--- a/tests/unit/_fakes.py
+++ b/tests/unit/_fakes.py
@@ -69,9 +69,11 @@ class FakeRoutingDriver:
 class FakeDatabase:
     """Stand-in for Database whose driver() returns a supplied FakeDriver."""
 
-    def __init__(self, driver: FakeDriver) -> None:
+    def __init__(self, driver: FakeDriver, *, unmanaged_fail: bool = False) -> None:
         self._driver = driver
         self.is_connected = False
+        self.unmanaged_fail = unmanaged_fail
+        self.unmanaged: list[str] = []
 
     async def connect(self) -> None:
         self.is_connected = True
@@ -81,6 +83,11 @@ class FakeDatabase:
 
     def driver(self) -> FakeDriver:
         return self._driver
+
+    async def run_unmanaged(self, sql: str) -> None:
+        self.unmanaged.append(sql)
+        if self.unmanaged_fail:
+            raise RuntimeError("maintenance failed")
 
     async def __aenter__(self) -> FakeDatabase:
         await self.connect()

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -73,6 +73,67 @@ async def test_driver_after_connect_returns_a_sql_driver() -> None:
     assert isinstance(db.driver(), SqlDriver)
 
 
+class _FakeConnection:
+    """Stand-in for an async psycopg connection used by run_unmanaged."""
+
+    def __init__(self) -> None:
+        self.autocommit_calls: list[bool] = []
+        self.executed: list[str] = []
+
+    async def set_autocommit(self, value: bool) -> None:
+        self.autocommit_calls.append(value)
+
+    async def execute(self, sql: str) -> None:
+        self.executed.append(sql)
+
+
+class _FakeConnectionContext:
+    """Async context manager yielding a fake connection, like pool.connection()."""
+
+    def __init__(self, connection: _FakeConnection) -> None:
+        self._connection = connection
+
+    async def __aenter__(self) -> _FakeConnection:
+        return self._connection
+
+    async def __aexit__(self, *exc: object) -> None:
+        return None
+
+
+class _UnmanagedPool(FakePool):
+    """FakePool whose pool_connect yields a handle with a fake connection."""
+
+    def __init__(self, connection: _FakeConnection) -> None:
+        super().__init__()
+        self._connection = connection
+
+    async def pool_connect(self, connection_url: str | None = None) -> object:
+        await super().pool_connect(connection_url)
+        return self
+
+    def connection(self) -> _FakeConnectionContext:
+        return _FakeConnectionContext(self._connection)
+
+
+async def test_run_unmanaged_executes_on_an_autocommit_connection() -> None:
+    connection = _FakeConnection()
+    db = Database(_SETTINGS, pool=_UnmanagedPool(connection))  # type: ignore[arg-type]
+    await db.connect()
+
+    await db.run_unmanaged('VACUUM "app"."widget"')
+
+    assert connection.executed == ['VACUUM "app"."widget"']
+    # Autocommit is switched on for the statement, then restored.
+    assert connection.autocommit_calls == [True, False]
+
+
+async def test_run_unmanaged_before_connect_raises() -> None:
+    db = Database(_SETTINGS, pool=FakePool())  # type: ignore[arg-type]
+
+    with pytest.raises(DatabaseError, match="not connected"):
+        await db.run_unmanaged("VACUUM x")
+
+
 def test_database_builds_its_own_pool_from_settings() -> None:
     db = Database(_SETTINGS)
     # No pool injected: it should construct one from the settings URL.

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -10,6 +10,8 @@ from mcpg.health import (
     check_database_health,
     check_dead_tuples,
     check_invalid_indexes,
+    check_replication_lag,
+    check_table_bloat,
 )
 from mcpg.server import create_server
 
@@ -58,6 +60,29 @@ async def test_check_invalid_indexes_warns_when_any_are_invalid() -> None:
     assert broken.status == "warning"
 
 
+async def test_check_replication_lag_is_ok_with_no_standbys() -> None:
+    result = await check_replication_lag(FakeDriver([{"standbys": 0, "max_lag_bytes": 0}]))
+
+    assert result.status == "ok"
+    assert "no replication standbys" in result.detail
+
+
+async def test_check_replication_lag_warns_on_a_lagging_standby() -> None:
+    healthy = await check_replication_lag(FakeDriver([{"standbys": 2, "max_lag_bytes": 4096}]))
+    lagging = await check_replication_lag(FakeDriver([{"standbys": 1, "max_lag_bytes": 256 * 1024 * 1024}]))
+
+    assert healthy.status == "ok"
+    assert lagging.status == "warning"
+
+
+async def test_check_table_bloat_warns_when_tables_are_bloated() -> None:
+    clean = await check_table_bloat(FakeDriver([{"bloated": 0}]))
+    bloated = await check_table_bloat(FakeDriver([{"bloated": 5}]))
+
+    assert clean.status == "ok"
+    assert bloated.status == "warning"
+
+
 # --- aggregate report ------------------------------------------------------
 
 _HEALTHY_ROUTES: dict[str, list[dict[str, object]]] = {
@@ -65,6 +90,8 @@ _HEALTHY_ROUTES: dict[str, list[dict[str, object]]] = {
     "pg_stat_database": [{"hits": 999, "reads": 1}],
     "pg_stat_user_tables": [{"bloated": 0}],
     "pg_index": [{"invalid": 0}],
+    "pg_stat_replication": [{"standbys": 0, "max_lag_bytes": 0}],
+    "table_stats": [{"bloated": 0}],
 }
 
 
@@ -77,6 +104,8 @@ async def test_check_database_health_reports_ok_when_all_checks_pass() -> None:
         "cache_hit_ratio",
         "dead_tuples",
         "invalid_indexes",
+        "replication_lag",
+        "table_bloat",
     }
 
 

--- a/tests/unit/test_indexing.py
+++ b/tests/unit/test_indexing.py
@@ -59,6 +59,25 @@ async def test_recommend_indexes_groups_columns_into_one_table_recommendation() 
     ]
 
 
+async def test_recommend_indexes_deduplicates_suggestions_across_partitions() -> None:
+    # Both partitions expose the same GIN-friendly column. After roll-up, the
+    # parent should be flagged once with a single payload suggestion.
+    driver = FakeDriver(
+        [
+            _partition_row("event_2026", "event", "payload", "jsonb", seq_scan=4000, n_live_tup=120000),
+            _partition_row("event_2027", "event", "payload", "jsonb", seq_scan=3000, n_live_tup=90000),
+        ]
+    )
+
+    result = await recommend_indexes(driver)
+
+    assert len(result) == 1
+    assert result[0].table == "event"
+    assert result[0].suggestions == [
+        IndexSuggestion("payload", "gin", "GIN supports jsonb containment and key lookups")
+    ]
+
+
 async def test_recommend_indexes_rolls_partition_stats_up_to_the_parent() -> None:
     driver = FakeDriver(
         [

--- a/tests/unit/test_indexing.py
+++ b/tests/unit/test_indexing.py
@@ -20,6 +20,24 @@ def _row(column: str, data_type: str) -> dict[str, object]:
         "n_live_tup": 250000,
         "column_name": column,
         "data_type": data_type,
+        "parent_schema": None,
+        "parent_table": None,
+    }
+
+
+def _partition_row(
+    partition: str, parent: str, column: str, data_type: str, *, seq_scan: int, n_live_tup: int
+) -> dict[str, object]:
+    """One (partition x column) row whose parent partitioned table is ``parent``."""
+    return {
+        "schemaname": "app",
+        "relname": partition,
+        "seq_scan": seq_scan,
+        "n_live_tup": n_live_tup,
+        "column_name": column,
+        "data_type": data_type,
+        "parent_schema": "app",
+        "parent_table": parent,
     }
 
 
@@ -36,6 +54,30 @@ async def test_recommend_indexes_groups_columns_into_one_table_recommendation() 
             live_tuples=250000,
             reason="large table read mostly by sequential scan",
             suggestions=[IndexSuggestion("payload", "gin", "GIN supports jsonb containment and key lookups")],
+            partitioned=False,
+        )
+    ]
+
+
+async def test_recommend_indexes_rolls_partition_stats_up_to_the_parent() -> None:
+    driver = FakeDriver(
+        [
+            _partition_row("event_2026", "event", "id", "integer", seq_scan=4000, n_live_tup=120000),
+            _partition_row("event_2027", "event", "payload", "jsonb", seq_scan=3000, n_live_tup=90000),
+        ]
+    )
+
+    result = await recommend_indexes(driver)
+
+    assert result == [
+        IndexRecommendation(
+            schema="app",
+            table="event",
+            seq_scans=7000,
+            live_tuples=210000,
+            reason="partitioned table whose partitions are read mostly by sequential scan",
+            suggestions=[IndexSuggestion("payload", "gin", "GIN supports jsonb containment and key lookups")],
+            partitioned=True,
         )
     ]
 

--- a/tests/unit/test_introspection.py
+++ b/tests/unit/test_introspection.py
@@ -13,6 +13,7 @@ from mcpg.introspection import (
     IndexInfo,
     SchemaInfo,
     TableInfo,
+    TriggerInfo,
     ViewInfo,
     describe_table,
     list_available_extensions,
@@ -22,6 +23,7 @@ from mcpg.introspection import (
     list_indexes,
     list_schemas,
     list_tables,
+    list_triggers,
     list_views,
 )
 from mcpg.server import create_server
@@ -157,6 +159,16 @@ async def test_list_functions_maps_routines() -> None:
     ]
 
 
+async def test_list_triggers_maps_rows() -> None:
+    driver = FakeDriver(
+        [{"name": "widget_bi", "function": "widget_touch", "definition": "CREATE TRIGGER widget_bi ..."}]
+    )
+
+    assert await list_triggers(driver, "app", "widget") == [
+        TriggerInfo("widget_bi", "widget_touch", "CREATE TRIGGER widget_bi ...")
+    ]
+
+
 async def test_list_constraints_maps_constraint_types() -> None:
     driver = FakeDriver(
         [
@@ -209,6 +221,7 @@ _INTROSPECTION_TOOLS = {
     "list_constraints",
     "list_views",
     "list_functions",
+    "list_triggers",
     "list_extensions",
     "list_available_extensions",
 }
@@ -246,6 +259,10 @@ async def test_every_introspection_tool_is_callable_from_a_client() -> None:
         "list_functions": (
             {"schema": "app"},
             [{"name": "f", "kind_code": "f", "arguments": "", "returns": "void", "language": "sql"}],
+        ),
+        "list_triggers": (
+            {"schema": "app", "table": "w"},
+            [{"name": "t", "function": "fn", "definition": "CREATE TRIGGER t ..."}],
         ),
         "list_extensions": ({}, [{"extname": "plpgsql", "extversion": "1.0"}]),
         "list_available_extensions": (

--- a/tests/unit/test_introspection.py
+++ b/tests/unit/test_introspection.py
@@ -10,6 +10,7 @@ from mcpg.introspection import (
     ConstraintInfo,
     ExtensionInfo,
     FunctionInfo,
+    GrantInfo,
     IndexInfo,
     PartitionInfo,
     PartitionSet,
@@ -26,6 +27,7 @@ from mcpg.introspection import (
     list_constraints,
     list_extensions,
     list_functions,
+    list_grants,
     list_indexes,
     list_partitions,
     list_policies,
@@ -353,6 +355,21 @@ async def test_list_policies_reports_a_missing_table_as_unsecured() -> None:
     assert await list_policies(FakeDriver([]), "app", "missing") == PolicySet(rls_enabled=False, policies=[])
 
 
+async def test_list_grants_maps_rows() -> None:
+    driver = FakeDriver(
+        [
+            {"grantee": "app_user", "privilege": "SELECT", "is_grantable": "NO", "grantor": "app_owner"},
+            {"grantee": "app_admin", "privilege": "UPDATE", "is_grantable": "YES", "grantor": "app_owner"},
+        ]
+    )
+
+    assert await list_grants(driver, "app", "widget") == [
+        GrantInfo("app_user", "SELECT", grantable=False, grantor="app_owner"),
+        GrantInfo("app_admin", "UPDATE", grantable=True, grantor="app_owner"),
+    ]
+    assert driver.calls[0][1] == ["app", "widget"]
+
+
 def _role_row(name: str, **overrides: object) -> dict[str, object]:
     """A pg_roles catalog row with sensible non-privileged defaults."""
     row: dict[str, object] = {
@@ -478,6 +495,7 @@ _INTROSPECTION_TOOLS = {
     "list_partitions",
     "list_policies",
     "list_roles",
+    "list_grants",
     "list_sequences",
     "list_extensions",
     "list_available_extensions",
@@ -540,6 +558,10 @@ async def test_every_introspection_tool_is_callable_from_a_client() -> None:
             ],
         ),
         "list_roles": ({}, [_role_row("app_user")]),
+        "list_grants": (
+            {"schema": "app", "table": "w"},
+            [{"grantee": "app_user", "privilege": "SELECT", "is_grantable": "NO", "grantor": "app_owner"}],
+        ),
         "list_sequences": (
             {"schema": "app"},
             [

--- a/tests/unit/test_introspection.py
+++ b/tests/unit/test_introspection.py
@@ -63,13 +63,27 @@ async def test_list_schemas_includes_system_schemas_when_requested() -> None:
 
 
 async def test_list_tables_maps_rows_and_passes_schema_as_a_parameter() -> None:
-    driver = FakeDriver([{"table_name": "widget", "table_type": "BASE TABLE"}])
+    driver = FakeDriver([{"name": "widget", "relkind": "r", "is_partition": False}])
 
     result = await list_tables(driver, "app")
 
-    assert result == [TableInfo("widget", "BASE TABLE")]
+    assert result == [TableInfo("widget", "BASE TABLE", partitioned=False, is_partition=False)]
     # The schema must be bound as a parameter, never interpolated into SQL.
     assert driver.calls[0][1] == ["app"]
+
+
+async def test_list_tables_flags_partitioned_tables_and_partitions() -> None:
+    driver = FakeDriver(
+        [
+            {"name": "event", "relkind": "p", "is_partition": False},
+            {"name": "event_2026", "relkind": "r", "is_partition": True},
+        ]
+    )
+
+    assert await list_tables(driver, "app") == [
+        TableInfo("event", "BASE TABLE", partitioned=True, is_partition=False),
+        TableInfo("event_2026", "BASE TABLE", partitioned=False, is_partition=True),
+    ]
 
 
 def _column_row(name: str, data_type: str, **overrides: object) -> dict[str, object]:
@@ -332,7 +346,7 @@ async def test_introspection_tools_are_registered() -> None:
 async def test_every_introspection_tool_is_callable_from_a_client() -> None:
     cases: dict[str, tuple[dict[str, str], list[dict[str, object]]]] = {
         "list_schemas": ({}, [{"schema_name": "app"}]),
-        "list_tables": ({"schema": "app"}, [{"table_name": "w", "table_type": "BASE TABLE"}]),
+        "list_tables": ({"schema": "app"}, [{"name": "w", "relkind": "r", "is_partition": False}]),
         "describe_table": (
             {"schema": "app", "table": "w"},
             [_column_row("id", "integer", nullable=False, type_name="int4")],

--- a/tests/unit/test_introspection.py
+++ b/tests/unit/test_introspection.py
@@ -15,6 +15,7 @@ from mcpg.introspection import (
     PartitionSet,
     PolicyInfo,
     PolicySet,
+    RoleInfo,
     SchemaInfo,
     SequenceInfo,
     TableInfo,
@@ -28,6 +29,7 @@ from mcpg.introspection import (
     list_indexes,
     list_partitions,
     list_policies,
+    list_roles,
     list_schemas,
     list_sequences,
     list_tables,
@@ -351,6 +353,56 @@ async def test_list_policies_reports_a_missing_table_as_unsecured() -> None:
     assert await list_policies(FakeDriver([]), "app", "missing") == PolicySet(rls_enabled=False, policies=[])
 
 
+def _role_row(name: str, **overrides: object) -> dict[str, object]:
+    """A pg_roles catalog row with sensible non-privileged defaults."""
+    row: dict[str, object] = {
+        "name": name,
+        "superuser": False,
+        "create_role": False,
+        "create_db": False,
+        "can_login": True,
+        "replication": False,
+        "bypass_rls": False,
+        "connection_limit": -1,
+        "member_of": [],
+    }
+    row.update(overrides)
+    return row
+
+
+async def test_list_roles_maps_attributes_and_membership() -> None:
+    driver = FakeDriver([_role_row("app_user", create_db=True, member_of=["app_readers"])])
+
+    assert await list_roles(driver) == [
+        RoleInfo(
+            name="app_user",
+            superuser=False,
+            create_role=False,
+            create_db=True,
+            can_login=True,
+            replication=False,
+            bypass_rls=False,
+            connection_limit=-1,
+            member_of=["app_readers"],
+        )
+    ]
+
+
+async def test_list_roles_excludes_predefined_roles_by_default() -> None:
+    driver = FakeDriver([_role_row("app_user"), _role_row("pg_read_all_data")])
+
+    assert [role.name for role in await list_roles(driver)] == ["app_user"]
+
+
+async def test_list_roles_includes_predefined_roles_when_requested() -> None:
+    driver = FakeDriver([_role_row("app_user"), _role_row("pg_read_all_data")])
+
+    assert [role.name for role in await list_roles(driver, include_system=True)] == [
+        "app_user",
+        "pg_read_all_data",
+    ]
+
+
 async def test_list_sequences_maps_rows() -> None:
     driver = FakeDriver(
         [
@@ -425,6 +477,7 @@ _INTROSPECTION_TOOLS = {
     "list_triggers",
     "list_partitions",
     "list_policies",
+    "list_roles",
     "list_sequences",
     "list_extensions",
     "list_available_extensions",
@@ -486,6 +539,7 @@ async def test_every_introspection_tool_is_callable_from_a_client() -> None:
                 }
             ],
         ),
+        "list_roles": ({}, [_role_row("app_user")]),
         "list_sequences": (
             {"schema": "app"},
             [

--- a/tests/unit/test_introspection.py
+++ b/tests/unit/test_introspection.py
@@ -7,12 +7,14 @@ from mcpg.config import load_settings
 from mcpg.introspection import (
     AvailableExtension,
     ColumnInfo,
+    ConstraintInfo,
     ExtensionInfo,
     IndexInfo,
     SchemaInfo,
     TableInfo,
     describe_table,
     list_available_extensions,
+    list_constraints,
     list_extensions,
     list_indexes,
     list_schemas,
@@ -111,6 +113,28 @@ async def test_list_indexes_maps_rows_including_the_access_method() -> None:
     ]
 
 
+async def test_list_constraints_maps_constraint_types() -> None:
+    driver = FakeDriver(
+        [
+            {"name": "widget_pkey", "type_code": "p", "definition": "PRIMARY KEY (id)"},
+            {"name": "widget_cat_fk", "type_code": "f", "definition": "FOREIGN KEY (cat) REFERENCES c(id)"},
+            {"name": "widget_price_chk", "type_code": "c", "definition": "CHECK (price > 0)"},
+        ]
+    )
+
+    assert await list_constraints(driver, "app", "widget") == [
+        ConstraintInfo("widget_pkey", "primary_key", "PRIMARY KEY (id)"),
+        ConstraintInfo("widget_cat_fk", "foreign_key", "FOREIGN KEY (cat) REFERENCES c(id)"),
+        ConstraintInfo("widget_price_chk", "check", "CHECK (price > 0)"),
+    ]
+
+
+async def test_list_constraints_maps_an_unknown_type_code_to_other() -> None:
+    driver = FakeDriver([{"name": "x", "type_code": "z", "definition": "..."}])
+
+    assert (await list_constraints(driver, "app", "t"))[0].type == "other"
+
+
 async def test_list_extensions_maps_rows() -> None:
     driver = FakeDriver([{"extname": "plpgsql", "extversion": "1.0"}])
 
@@ -138,6 +162,7 @@ _INTROSPECTION_TOOLS = {
     "list_tables",
     "describe_table",
     "list_indexes",
+    "list_constraints",
     "list_extensions",
     "list_available_extensions",
 }
@@ -163,6 +188,10 @@ async def test_every_introspection_tool_is_callable_from_a_client() -> None:
         "list_indexes": (
             {"schema": "app", "table": "w"},
             [{"name": "i", "method": "btree", "definition": "d"}],
+        ),
+        "list_constraints": (
+            {"schema": "app", "table": "w"},
+            [{"name": "w_pkey", "type_code": "p", "definition": "PRIMARY KEY (id)"}],
         ),
         "list_extensions": ({}, [{"extname": "plpgsql", "extversion": "1.0"}]),
         "list_available_extensions": (

--- a/tests/unit/test_introspection.py
+++ b/tests/unit/test_introspection.py
@@ -127,14 +127,34 @@ async def test_describe_table_reports_pgvector_dimension() -> None:
 async def test_list_indexes_maps_rows_including_the_access_method() -> None:
     driver = FakeDriver(
         [
-            {"name": "widget_pkey", "method": "btree", "definition": "CREATE UNIQUE INDEX widget_pkey ..."},
-            {"name": "widget_doc_idx", "method": "gin", "definition": "CREATE INDEX widget_doc_idx ..."},
+            {
+                "name": "widget_pkey",
+                "method": "btree",
+                "relkind": "i",
+                "definition": "CREATE UNIQUE INDEX widget_pkey ...",
+            },
+            {
+                "name": "widget_doc_idx",
+                "method": "gin",
+                "relkind": "i",
+                "definition": "CREATE INDEX widget_doc_idx ...",
+            },
         ]
     )
 
     assert await list_indexes(driver, "app", "widget") == [
-        IndexInfo("widget_pkey", "btree", "CREATE UNIQUE INDEX widget_pkey ..."),
-        IndexInfo("widget_doc_idx", "gin", "CREATE INDEX widget_doc_idx ..."),
+        IndexInfo("widget_pkey", "btree", "CREATE UNIQUE INDEX widget_pkey ...", partitioned=False),
+        IndexInfo("widget_doc_idx", "gin", "CREATE INDEX widget_doc_idx ...", partitioned=False),
+    ]
+
+
+async def test_list_indexes_flags_a_partitioned_index() -> None:
+    driver = FakeDriver(
+        [{"name": "event_created_idx", "method": "btree", "relkind": "I", "definition": "CREATE INDEX ..."}]
+    )
+
+    assert await list_indexes(driver, "app", "event") == [
+        IndexInfo("event_created_idx", "btree", "CREATE INDEX ...", partitioned=True)
     ]
 
 
@@ -353,7 +373,7 @@ async def test_every_introspection_tool_is_callable_from_a_client() -> None:
         ),
         "list_indexes": (
             {"schema": "app", "table": "w"},
-            [{"name": "i", "method": "btree", "definition": "d"}],
+            [{"name": "i", "method": "btree", "relkind": "i", "definition": "d"}],
         ),
         "list_constraints": (
             {"schema": "app", "table": "w"},

--- a/tests/unit/test_introspection.py
+++ b/tests/unit/test_introspection.py
@@ -11,6 +11,8 @@ from mcpg.introspection import (
     ExtensionInfo,
     FunctionInfo,
     IndexInfo,
+    PartitionInfo,
+    PartitionSet,
     SchemaInfo,
     SequenceInfo,
     TableInfo,
@@ -22,6 +24,7 @@ from mcpg.introspection import (
     list_extensions,
     list_functions,
     list_indexes,
+    list_partitions,
     list_schemas,
     list_sequences,
     list_tables,
@@ -193,6 +196,51 @@ async def test_list_constraints_maps_an_unknown_type_code_to_other() -> None:
     assert (await list_constraints(driver, "app", "t"))[0].type == "other"
 
 
+async def test_list_partitions_describes_a_range_partitioned_table() -> None:
+    driver = FakeDriver(
+        [
+            {
+                "strategy_code": "r",
+                "partition_name": "event_2026",
+                "bounds": "FOR VALUES FROM ('2026-01-01') TO ('2027-01-01')",
+            },
+            {
+                "strategy_code": "r",
+                "partition_name": "event_2027",
+                "bounds": "FOR VALUES FROM ('2027-01-01') TO ('2028-01-01')",
+            },
+        ]
+    )
+
+    result = await list_partitions(driver, "app", "event")
+
+    assert result == PartitionSet(
+        partitioned=True,
+        strategy="range",
+        partitions=[
+            PartitionInfo("event_2026", "FOR VALUES FROM ('2026-01-01') TO ('2027-01-01')"),
+            PartitionInfo("event_2027", "FOR VALUES FROM ('2027-01-01') TO ('2028-01-01')"),
+        ],
+    )
+    assert driver.calls[0][1] == ["app", "event"]
+
+
+async def test_list_partitions_reports_a_partitioned_table_with_no_partitions() -> None:
+    driver = FakeDriver([{"strategy_code": "l", "partition_name": None, "bounds": None}])
+
+    result = await list_partitions(driver, "app", "event")
+
+    assert result == PartitionSet(partitioned=True, strategy="list", partitions=[])
+
+
+async def test_list_partitions_reports_a_plain_table_as_not_partitioned() -> None:
+    driver = FakeDriver([])
+
+    assert await list_partitions(driver, "app", "widget") == PartitionSet(
+        partitioned=False, strategy=None, partitions=[]
+    )
+
+
 async def test_list_sequences_maps_rows() -> None:
     driver = FakeDriver(
         [
@@ -265,6 +313,7 @@ _INTROSPECTION_TOOLS = {
     "list_views",
     "list_functions",
     "list_triggers",
+    "list_partitions",
     "list_sequences",
     "list_extensions",
     "list_available_extensions",
@@ -307,6 +356,10 @@ async def test_every_introspection_tool_is_callable_from_a_client() -> None:
         "list_triggers": (
             {"schema": "app", "table": "w"},
             [{"name": "t", "function": "fn", "definition": "CREATE TRIGGER t ..."}],
+        ),
+        "list_partitions": (
+            {"schema": "app", "table": "event"},
+            [{"strategy_code": "r", "partition_name": "event_2026", "bounds": "FOR VALUES ..."}],
         ),
         "list_sequences": (
             {"schema": "app"},

--- a/tests/unit/test_introspection.py
+++ b/tests/unit/test_introspection.py
@@ -13,6 +13,8 @@ from mcpg.introspection import (
     IndexInfo,
     PartitionInfo,
     PartitionSet,
+    PolicyInfo,
+    PolicySet,
     SchemaInfo,
     SequenceInfo,
     TableInfo,
@@ -25,6 +27,7 @@ from mcpg.introspection import (
     list_functions,
     list_indexes,
     list_partitions,
+    list_policies,
     list_schemas,
     list_sequences,
     list_tables,
@@ -275,6 +278,79 @@ async def test_list_partitions_reports_a_plain_table_as_not_partitioned() -> Non
     )
 
 
+async def test_list_policies_maps_rows() -> None:
+    driver = FakeDriver(
+        [
+            {
+                "rls_enabled": True,
+                "name": "widget_select",
+                "command": "SELECT",
+                "permissive": "PERMISSIVE",
+                "roles": ["app_reader"],
+                "using_expression": "(owner = current_user)",
+                "check_expression": None,
+            }
+        ]
+    )
+
+    result = await list_policies(driver, "app", "widget")
+
+    assert result == PolicySet(
+        rls_enabled=True,
+        policies=[
+            PolicyInfo(
+                name="widget_select",
+                command="SELECT",
+                permissive=True,
+                roles=["app_reader"],
+                using_expression="(owner = current_user)",
+                check_expression=None,
+            )
+        ],
+    )
+    assert driver.calls[0][1] == ["app", "widget"]
+
+
+async def test_list_policies_reports_a_restrictive_policy() -> None:
+    driver = FakeDriver(
+        [
+            {
+                "rls_enabled": True,
+                "name": "widget_block",
+                "command": "ALL",
+                "permissive": "RESTRICTIVE",
+                "roles": ["public"],
+                "using_expression": "false",
+                "check_expression": None,
+            }
+        ]
+    )
+
+    assert (await list_policies(driver, "app", "widget")).policies[0].permissive is False
+
+
+async def test_list_policies_reports_a_table_with_no_policies() -> None:
+    driver = FakeDriver(
+        [
+            {
+                "rls_enabled": False,
+                "name": None,
+                "command": None,
+                "permissive": None,
+                "roles": None,
+                "using_expression": None,
+                "check_expression": None,
+            }
+        ]
+    )
+
+    assert await list_policies(driver, "app", "widget") == PolicySet(rls_enabled=False, policies=[])
+
+
+async def test_list_policies_reports_a_missing_table_as_unsecured() -> None:
+    assert await list_policies(FakeDriver([]), "app", "missing") == PolicySet(rls_enabled=False, policies=[])
+
+
 async def test_list_sequences_maps_rows() -> None:
     driver = FakeDriver(
         [
@@ -348,6 +424,7 @@ _INTROSPECTION_TOOLS = {
     "list_functions",
     "list_triggers",
     "list_partitions",
+    "list_policies",
     "list_sequences",
     "list_extensions",
     "list_available_extensions",
@@ -394,6 +471,20 @@ async def test_every_introspection_tool_is_callable_from_a_client() -> None:
         "list_partitions": (
             {"schema": "app", "table": "event"},
             [{"strategy_code": "r", "partition_name": "event_2026", "bounds": "FOR VALUES ..."}],
+        ),
+        "list_policies": (
+            {"schema": "app", "table": "w"},
+            [
+                {
+                    "rls_enabled": True,
+                    "name": "p",
+                    "command": "SELECT",
+                    "permissive": "PERMISSIVE",
+                    "roles": ["public"],
+                    "using_expression": "true",
+                    "check_expression": None,
+                }
+            ],
         ),
         "list_sequences": (
             {"schema": "app"},

--- a/tests/unit/test_introspection.py
+++ b/tests/unit/test_introspection.py
@@ -12,6 +12,7 @@ from mcpg.introspection import (
     IndexInfo,
     SchemaInfo,
     TableInfo,
+    ViewInfo,
     describe_table,
     list_available_extensions,
     list_constraints,
@@ -19,6 +20,7 @@ from mcpg.introspection import (
     list_indexes,
     list_schemas,
     list_tables,
+    list_views,
 )
 from mcpg.server import create_server
 
@@ -113,6 +115,20 @@ async def test_list_indexes_maps_rows_including_the_access_method() -> None:
     ]
 
 
+async def test_list_views_maps_views_and_materialized_views() -> None:
+    driver = FakeDriver(
+        [
+            {"name": "active_users", "materialized": False, "definition": "SELECT * FROM users"},
+            {"name": "user_stats", "materialized": True, "definition": "SELECT count(*) FROM users"},
+        ]
+    )
+
+    assert await list_views(driver, "app") == [
+        ViewInfo("active_users", materialized=False, definition="SELECT * FROM users"),
+        ViewInfo("user_stats", materialized=True, definition="SELECT count(*) FROM users"),
+    ]
+
+
 async def test_list_constraints_maps_constraint_types() -> None:
     driver = FakeDriver(
         [
@@ -163,6 +179,7 @@ _INTROSPECTION_TOOLS = {
     "describe_table",
     "list_indexes",
     "list_constraints",
+    "list_views",
     "list_extensions",
     "list_available_extensions",
 }
@@ -192,6 +209,10 @@ async def test_every_introspection_tool_is_callable_from_a_client() -> None:
         "list_constraints": (
             {"schema": "app", "table": "w"},
             [{"name": "w_pkey", "type_code": "p", "definition": "PRIMARY KEY (id)"}],
+        ),
+        "list_views": (
+            {"schema": "app"},
+            [{"name": "v", "materialized": False, "definition": "SELECT 1"}],
         ),
         "list_extensions": ({}, [{"extname": "plpgsql", "extversion": "1.0"}]),
         "list_available_extensions": (

--- a/tests/unit/test_introspection.py
+++ b/tests/unit/test_introspection.py
@@ -12,6 +12,7 @@ from mcpg.introspection import (
     FunctionInfo,
     IndexInfo,
     SchemaInfo,
+    SequenceInfo,
     TableInfo,
     TriggerInfo,
     ViewInfo,
@@ -22,6 +23,7 @@ from mcpg.introspection import (
     list_functions,
     list_indexes,
     list_schemas,
+    list_sequences,
     list_tables,
     list_triggers,
     list_views,
@@ -191,6 +193,47 @@ async def test_list_constraints_maps_an_unknown_type_code_to_other() -> None:
     assert (await list_constraints(driver, "app", "t"))[0].type == "other"
 
 
+async def test_list_sequences_maps_rows() -> None:
+    driver = FakeDriver(
+        [
+            {
+                "name": "widget_id_seq",
+                "data_type": "bigint",
+                "start_value": 1,
+                "min_value": 1,
+                "max_value": 9223372036854775807,
+                "increment": 1,
+                "cycle": False,
+                "last_value": 42,
+            }
+        ]
+    )
+
+    assert await list_sequences(driver, "app") == [
+        SequenceInfo("widget_id_seq", "bigint", 1, 1, 9223372036854775807, 1, cycle=False, last_value=42)
+    ]
+    assert driver.calls[0][1] == ["app"]
+
+
+async def test_list_sequences_allows_a_null_last_value() -> None:
+    driver = FakeDriver(
+        [
+            {
+                "name": "fresh_seq",
+                "data_type": "integer",
+                "start_value": 1,
+                "min_value": 1,
+                "max_value": 2147483647,
+                "increment": 1,
+                "cycle": False,
+                "last_value": None,
+            }
+        ]
+    )
+
+    assert (await list_sequences(driver, "app"))[0].last_value is None
+
+
 async def test_list_extensions_maps_rows() -> None:
     driver = FakeDriver([{"extname": "plpgsql", "extversion": "1.0"}])
 
@@ -222,6 +265,7 @@ _INTROSPECTION_TOOLS = {
     "list_views",
     "list_functions",
     "list_triggers",
+    "list_sequences",
     "list_extensions",
     "list_available_extensions",
 }
@@ -263,6 +307,21 @@ async def test_every_introspection_tool_is_callable_from_a_client() -> None:
         "list_triggers": (
             {"schema": "app", "table": "w"},
             [{"name": "t", "function": "fn", "definition": "CREATE TRIGGER t ..."}],
+        ),
+        "list_sequences": (
+            {"schema": "app"},
+            [
+                {
+                    "name": "s",
+                    "data_type": "bigint",
+                    "start_value": 1,
+                    "min_value": 1,
+                    "max_value": 100,
+                    "increment": 1,
+                    "cycle": False,
+                    "last_value": None,
+                }
+            ],
         ),
         "list_extensions": ({}, [{"extname": "plpgsql", "extversion": "1.0"}]),
         "list_available_extensions": (

--- a/tests/unit/test_introspection.py
+++ b/tests/unit/test_introspection.py
@@ -9,6 +9,7 @@ from mcpg.introspection import (
     ColumnInfo,
     ConstraintInfo,
     ExtensionInfo,
+    FunctionInfo,
     IndexInfo,
     SchemaInfo,
     TableInfo,
@@ -17,6 +18,7 @@ from mcpg.introspection import (
     list_available_extensions,
     list_constraints,
     list_extensions,
+    list_functions,
     list_indexes,
     list_schemas,
     list_tables,
@@ -129,6 +131,32 @@ async def test_list_views_maps_views_and_materialized_views() -> None:
     ]
 
 
+async def test_list_functions_maps_routines() -> None:
+    driver = FakeDriver(
+        [
+            {
+                "name": "widget_count",
+                "kind_code": "f",
+                "arguments": "",
+                "returns": "bigint",
+                "language": "sql",
+            },
+            {
+                "name": "do_thing",
+                "kind_code": "p",
+                "arguments": "x integer",
+                "returns": None,
+                "language": "plpgsql",
+            },
+        ]
+    )
+
+    assert await list_functions(driver, "app") == [
+        FunctionInfo("widget_count", "function", "", "bigint", "sql"),
+        FunctionInfo("do_thing", "procedure", "x integer", None, "plpgsql"),
+    ]
+
+
 async def test_list_constraints_maps_constraint_types() -> None:
     driver = FakeDriver(
         [
@@ -180,6 +208,7 @@ _INTROSPECTION_TOOLS = {
     "list_indexes",
     "list_constraints",
     "list_views",
+    "list_functions",
     "list_extensions",
     "list_available_extensions",
 }
@@ -213,6 +242,10 @@ async def test_every_introspection_tool_is_callable_from_a_client() -> None:
         "list_views": (
             {"schema": "app"},
             [{"name": "v", "materialized": False, "definition": "SELECT 1"}],
+        ),
+        "list_functions": (
+            {"schema": "app"},
+            [{"name": "f", "kind_code": "f", "arguments": "", "returns": "void", "language": "sql"}],
         ),
         "list_extensions": ({}, [{"extname": "plpgsql", "extversion": "1.0"}]),
         "list_available_extensions": (

--- a/tests/unit/test_liveops.py
+++ b/tests/unit/test_liveops.py
@@ -4,10 +4,19 @@ from _fakes import FakeDatabase, FakeDriver
 from mcp.shared.memory import create_connected_server_and_client_session
 
 from mcpg.config import load_settings
-from mcpg.liveops import ActiveQuery, list_active_queries
+from mcpg.liveops import (
+    ActiveQuery,
+    BackendActionResult,
+    cancel_query,
+    list_active_queries,
+    terminate_backend,
+)
 from mcpg.server import create_server
 
 _SETTINGS = load_settings({"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db"})
+_UNRESTRICTED = load_settings(
+    {"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db", "MCPG_ACCESS_MODE": "unrestricted"}
+)
 
 
 def _row(pid: int, **overrides: object) -> dict[str, object]:
@@ -63,3 +72,38 @@ async def test_list_active_queries_tool_is_callable_from_a_client() -> None:
         result = await client.call_tool("list_active_queries", {})
 
     assert result.isError is False
+
+
+async def test_cancel_query_reports_the_signal_outcome() -> None:
+    driver = FakeDriver([{"ok": True}])
+
+    result = await cancel_query(driver, 4242)
+
+    assert result == BackendActionResult(pid=4242, action="cancel_query", succeeded=True)
+    assert driver.calls[0][1] == [4242]
+
+
+async def test_cancel_query_reports_failure_for_an_unknown_backend() -> None:
+    result = await cancel_query(FakeDriver([{"ok": False}]), 999999)
+
+    assert result.succeeded is False
+
+
+async def test_terminate_backend_reports_the_signal_outcome() -> None:
+    driver = FakeDriver([{"ok": True}])
+
+    result = await terminate_backend(driver, 7000)
+
+    assert result == BackendActionResult(pid=7000, action="terminate_backend", succeeded=True)
+    assert driver.calls[0][1] == [7000]
+
+
+async def test_backend_control_tools_are_callable_in_unrestricted_mode() -> None:
+    server = create_server(_UNRESTRICTED, database=FakeDatabase(FakeDriver([{"ok": True}])))  # type: ignore[arg-type]
+
+    async with create_connected_server_and_client_session(server) as client:
+        cancelled = await client.call_tool("cancel_query", {"pid": 100})
+        terminated = await client.call_tool("terminate_backend", {"pid": 100})
+
+    assert cancelled.isError is False
+    assert terminated.isError is False

--- a/tests/unit/test_liveops.py
+++ b/tests/unit/test_liveops.py
@@ -1,0 +1,65 @@
+"""Tests for live-operations introspection and the list_active_queries tool."""
+
+from _fakes import FakeDatabase, FakeDriver
+from mcp.shared.memory import create_connected_server_and_client_session
+
+from mcpg.config import load_settings
+from mcpg.liveops import ActiveQuery, list_active_queries
+from mcpg.server import create_server
+
+_SETTINGS = load_settings({"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db"})
+
+
+def _row(pid: int, **overrides: object) -> dict[str, object]:
+    """A pg_stat_activity row with sensible defaults for one active backend."""
+    row: dict[str, object] = {
+        "pid": pid,
+        "username": "app_user",
+        "application": "psql",
+        "state": "active",
+        "wait_event": None,
+        "duration_seconds": 1.5,
+        "query": "SELECT 1",
+        "blocked_by": [],
+    }
+    row.update(overrides)
+    return row
+
+
+async def test_list_active_queries_maps_rows() -> None:
+    driver = FakeDriver([_row(101, query="SELECT * FROM widget")])
+
+    assert await list_active_queries(driver) == [
+        ActiveQuery(
+            pid=101,
+            username="app_user",
+            application="psql",
+            state="active",
+            wait_event=None,
+            duration_seconds=1.5,
+            query="SELECT * FROM widget",
+            blocked_by=[],
+        )
+    ]
+
+
+async def test_list_active_queries_reports_a_blocked_backend() -> None:
+    driver = FakeDriver([_row(102, wait_event="Lock:relation", blocked_by=[101])])
+
+    result = await list_active_queries(driver)
+
+    assert result[0].wait_event == "Lock:relation"
+    assert result[0].blocked_by == [101]
+
+
+async def test_list_active_queries_returns_empty_when_the_server_is_idle() -> None:
+    assert await list_active_queries(FakeDriver([])) == []
+
+
+async def test_list_active_queries_tool_is_callable_from_a_client() -> None:
+    server = create_server(_SETTINGS, database=FakeDatabase(FakeDriver([])))  # type: ignore[arg-type]
+
+    async with create_connected_server_and_client_session(server) as client:
+        result = await client.call_tool("list_active_queries", {})
+
+    assert result.isError is False

--- a/tests/unit/test_maintenance.py
+++ b/tests/unit/test_maintenance.py
@@ -1,0 +1,78 @@
+"""Tests for maintenance operations and the run_maintenance tool."""
+
+import pytest
+from _fakes import FakeDatabase, FakeDriver
+from mcp.shared.memory import create_connected_server_and_client_session
+
+from mcpg.config import load_settings
+from mcpg.maintenance import MaintenanceError, MaintenanceResult, run_maintenance
+from mcpg.server import create_server
+
+
+def _database() -> FakeDatabase:
+    return FakeDatabase(FakeDriver())
+
+
+async def test_run_maintenance_issues_vacuum_for_a_table() -> None:
+    database = _database()
+
+    result = await run_maintenance(database, "vacuum", "app", "widget")
+
+    assert result == MaintenanceResult(operation="vacuum", target="app.widget")
+    assert database.unmanaged == ['VACUUM "app"."widget"']
+
+
+async def test_run_maintenance_issues_analyze() -> None:
+    database = _database()
+
+    await run_maintenance(database, "analyze", "app", "widget")
+
+    assert database.unmanaged == ['ANALYZE "app"."widget"']
+
+
+async def test_run_maintenance_issues_vacuum_analyze() -> None:
+    database = _database()
+
+    await run_maintenance(database, "vacuum_analyze", "app", "widget")
+
+    assert database.unmanaged == ['VACUUM (ANALYZE) "app"."widget"']
+
+
+async def test_run_maintenance_rejects_an_unknown_operation() -> None:
+    with pytest.raises(MaintenanceError, match="unknown operation"):
+        await run_maintenance(_database(), "reindex", "app", "widget")
+
+
+async def test_run_maintenance_quotes_identifiers_to_block_injection() -> None:
+    database = _database()
+
+    await run_maintenance(database, "analyze", "app", 'widget"; DROP TABLE x; --')
+
+    # The embedded quote is doubled, so the payload stays inside one identifier.
+    assert database.unmanaged == ['ANALYZE "app"."widget""; DROP TABLE x; --"']
+
+
+async def test_run_maintenance_rejects_an_empty_identifier() -> None:
+    with pytest.raises(MaintenanceError, match="invalid identifier"):
+        await run_maintenance(_database(), "vacuum", "app", "")
+
+
+async def test_run_maintenance_wraps_a_database_failure() -> None:
+    database = FakeDatabase(FakeDriver(), unmanaged_fail=True)
+
+    with pytest.raises(MaintenanceError, match="maintenance failed"):
+        await run_maintenance(database, "vacuum", "app", "widget")
+
+
+_UNRESTRICTED = load_settings(
+    {"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db", "MCPG_ACCESS_MODE": "unrestricted"}
+)
+
+
+async def test_run_maintenance_tool_is_callable_in_unrestricted_mode() -> None:
+    server = create_server(_UNRESTRICTED, database=_database())  # type: ignore[arg-type]
+
+    async with create_connected_server_and_client_session(server) as client:
+        result = await client.call_tool("run_maintenance", {"operation": "analyze", "schema": "app", "table": "w"})
+
+    assert result.isError is False

--- a/tests/unit/test_textsearch.py
+++ b/tests/unit/test_textsearch.py
@@ -61,6 +61,32 @@ async def test_fuzzy_search_rejects_invalid_identifiers(bad: str) -> None:
         await fuzzy_search(driver, bad, "users", "name", "alice")  # type: ignore[arg-type]
 
 
+async def test_fuzzy_search_word_mode_uses_word_similarity_by_default() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}], "similarity": []})
+
+    await fuzzy_search(driver, "app", "users", "name", "alice")  # type: ignore[arg-type]
+
+    search_call = next(call for call in driver.calls if "ORDER BY" in call[0])
+    assert "word_similarity(" in search_call[0]
+
+
+async def test_fuzzy_search_full_mode_uses_whole_string_similarity() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}], "similarity": []})
+
+    await fuzzy_search(driver, "app", "users", "name", "alice", mode="full")  # type: ignore[arg-type]
+
+    search_call = next(call for call in driver.calls if "ORDER BY" in call[0])
+    assert "word_similarity" not in search_call[0]
+    assert "similarity(" in search_call[0]
+
+
+async def test_fuzzy_search_rejects_an_unknown_mode() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(SearchError, match="mode"):
+        await fuzzy_search(driver, "app", "users", "name", "alice", mode="bogus")  # type: ignore[arg-type]
+
+
 async def test_fuzzy_search_tool_is_callable_from_a_client() -> None:
     database = FakeDatabase(FakeRoutingDriver({"pg_extension": []}))
     server = create_server(_SETTINGS, database=database)  # type: ignore[arg-type]

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -26,6 +26,7 @@ _READ_TOOLS = {
     "list_partitions",
     "list_policies",
     "list_roles",
+    "list_grants",
     "list_sequences",
     "list_extensions",
     "list_available_extensions",

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -25,6 +25,7 @@ _READ_TOOLS = {
     "list_triggers",
     "list_partitions",
     "list_policies",
+    "list_roles",
     "list_sequences",
     "list_extensions",
     "list_available_extensions",

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -19,6 +19,7 @@ _READ_TOOLS = {
     "list_tables",
     "describe_table",
     "list_indexes",
+    "list_constraints",
     "list_extensions",
     "list_available_extensions",
     "run_select",

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -116,6 +116,8 @@ async def test_write_tools_are_exposed_only_in_unrestricted_mode(access_mode: Ac
 
     assert ("run_write" in names) is (access_mode is AccessMode.UNRESTRICTED)
     assert ("run_maintenance" in names) is (access_mode is AccessMode.UNRESTRICTED)
+    assert ("cancel_query" in names) is (access_mode is AccessMode.UNRESTRICTED)
+    assert ("terminate_backend" in names) is (access_mode is AccessMode.UNRESTRICTED)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -36,6 +36,7 @@ _READ_TOOLS = {
     "check_database_health",
     "analyze_workload",
     "recommend_indexes",
+    "list_active_queries",
     "fuzzy_search",
     "full_text_search",
     "vector_search",

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -21,6 +21,7 @@ _READ_TOOLS = {
     "list_indexes",
     "list_constraints",
     "list_views",
+    "list_functions",
     "list_extensions",
     "list_available_extensions",
     "run_select",

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -24,6 +24,7 @@ _READ_TOOLS = {
     "list_functions",
     "list_triggers",
     "list_partitions",
+    "list_policies",
     "list_sequences",
     "list_extensions",
     "list_available_extensions",

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -22,6 +22,7 @@ _READ_TOOLS = {
     "list_constraints",
     "list_views",
     "list_functions",
+    "list_triggers",
     "list_extensions",
     "list_available_extensions",
     "run_select",

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -20,6 +20,7 @@ _READ_TOOLS = {
     "describe_table",
     "list_indexes",
     "list_constraints",
+    "list_views",
     "list_extensions",
     "list_available_extensions",
     "run_select",

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -23,6 +23,7 @@ _READ_TOOLS = {
     "list_views",
     "list_functions",
     "list_triggers",
+    "list_partitions",
     "list_sequences",
     "list_extensions",
     "list_available_extensions",

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -115,6 +115,7 @@ async def test_write_tools_are_exposed_only_in_unrestricted_mode(access_mode: Ac
         names = {tool.name for tool in (await client.list_tools()).tools}
 
     assert ("run_write" in names) is (access_mode is AccessMode.UNRESTRICTED)
+    assert ("run_maintenance" in names) is (access_mode is AccessMode.UNRESTRICTED)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -23,6 +23,7 @@ _READ_TOOLS = {
     "list_views",
     "list_functions",
     "list_triggers",
+    "list_sequences",
     "list_extensions",
     "list_available_extensions",
     "run_select",


### PR DESCRIPTION
## Summary

Adds 14 new MCP tools and 2 new health checks across four phases, plus a `word`/`full` mode toggle on `fuzzy_search`. Every task was developed TDD-first; 321 unit tests pass with 100% coverage of authored code, and CI exercises the integration suite against PostgreSQL 14–17.

### Phase 12 — Deeper schema introspection
- `list_constraints` — PK/FK/unique/check/exclusion (via `pg_constraint`)
- `list_views` — views and materialized views with definitions
- `list_functions` — functions and procedures (kind, args, return type, language)
- `list_triggers` — user-defined triggers, with the function each calls
- `list_sequences` — sequences with data type, range, increment, cycle, last value

### Phase 13 — Partitioning
- `list_partitions` — strategy (range/list/hash) and bound expressions
- `list_tables` now flags each table with `partitioned` and `is_partition`
- `list_indexes` flags partitioned-index templates
- `recommend_indexes` rolls partition stats up to the partitioned parent (where the index belongs), summing scan and row counts

### Phase 14 — Access-control introspection
- `list_policies` — Row-Level-Security policies on a table, plus RLS-enabled flag
- `list_roles` — database roles and their attributes (superuser, create-role/db, login, replication, bypass-RLS, connection limit, membership)
- `list_grants` — privileges granted on a table

### Phase 15 — Live ops & maintenance
- `list_active_queries` (new `mcpg.liveops` module) — in-flight queries with wait events, duration, and blocking PIDs
- `check_database_health` gains `replication_lag` and `table_bloat` checks
- `run_maintenance` (new `mcpg.maintenance` module) — gated `VACUUM` / `ANALYZE` / `VACUUM (ANALYZE)`, running on a new autocommit `Database.run_unmanaged` path since `VACUUM` cannot run in a transaction
- `cancel_query` and `terminate_backend` — gated `pg_cancel_backend` / `pg_terminate_backend`

### Earlier on the branch
- `fuzzy_search` gains a `mode` parameter (`word` matches fragments — the new default; `full` compares whole strings) to address misses on misspelled fragments
- PLAN.md §7b — capability gap analysis behind Phases 12–15

## Test plan
- [x] `uv run pytest -q --cov=mcpg` — 321 passed, 100% coverage (integration tests skip locally without DB)
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] `uv run mypy src` — clean
- [ ] CI integration suite green against PostgreSQL 14, 15, 16, 17 (will run on push)
- [ ] Smoke-check the new tools end-to-end through an MCP client against a live database (`list_partitions`, `list_policies`, `run_maintenance`, `cancel_query`)

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Add deeper PostgreSQL introspection, partition-awareness, access-control visibility, and live operations/maintenance tools, plus a more flexible fuzzy search mode and extra health checks.

New Features:
- Expose new introspection tools for constraints, views, functions, triggers, sequences, partitions, roles, grants, Row-Level-Security policies, and partition-aware table/index metadata.
- Add live operations tools to list active queries and to cancel or terminate backends, gated to unrestricted mode.
- Introduce a run_maintenance tool for VACUUM/ANALYZE operations using a new autocommit database execution path.
- Extend fuzzy_search with a configurable word/full matching mode to better handle fragments and misspellings.
- Augment database health reporting with replication lag and table bloat checks.

Enhancements:
- Make index recommendations partition-aware by aggregating partition statistics at the parent table level and marking partitioned recommendations.
- Document the new tools, extended health checks, and fuzzy_search behaviour in the user-facing tools and progress documentation, and record roadmap progress through Phases 12–15.

Tests:
- Add unit and integration tests covering the new introspection, liveops, maintenance, health, indexing, and fuzzy_search behaviours, including unmanaged execution and access-mode gating.