### PR TITLE
feat: Phase 16 — introspection gaps (enums, domains, composites, FDWs, replication)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,17 @@ adheres to [Semantic Versioning](https://semver.org/).
 - `cancel_query` and `terminate_backend` tools — signal a backend PID to
   cancel its current query or close its connection; require unrestricted
   mode.
+- `list_enums`, `list_domains`, `list_composite_types` tools — the
+  user-defined types in a schema. Composite types report each attribute
+  with its rendered type; the catalog's implicit table row-types are
+  excluded.
+- `list_foreign_data_wrappers`, `list_foreign_servers`,
+  `list_foreign_tables`, `list_user_mappings` tools — the FDW catalog,
+  with each entry's options array parsed into a typed dict.
+- `list_publications` and `list_subscriptions` tools — read-only view of
+  logical-replication publications (with the tables and operations they
+  cover) and subscriptions; reading subscriptions requires superuser, by
+  PostgreSQL design.
 
 ### Changed
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -358,7 +358,7 @@ opens its own feature branch and pull request.
 - **Phase 25** — Logical replication management: replication slots and
   publication/subscription create+drop wrappers (write-gated).
 - **Phase 26** — `LISTEN`/`NOTIFY` bridge. ADR-0005 picks between a
-  tool-poll model (recommended) and MCP notifications.
+  polling model (recommended) and MCP notifications.
 
 ### Batch F — Migrations with shadow workflow (LARGEST — gated on ADR-0006)
 - **Phase 27** — `prepare_migration`/`complete_migration` driven by the

--- a/PLAN.md
+++ b/PLAN.md
@@ -313,3 +313,60 @@ never lost when limits are hit.
 - Telemetry/observability scope (OpenTelemetry?) — revisit in Phase 6.
 
 These are tracked and resolved via ADRs as phases reach them.
+
+## 11. Post-Phase-15 roadmap (Phases 16–27)
+
+After Phases 12–15 closed (365 tests, 100% coverage), a second round of
+capability selection picked eleven themes spanning catalog completeness,
+advisors, extension wrappers, data movement, replication, events, and
+migrations. The work is grouped into six deliverable batches; each batch
+opens its own feature branch and pull request.
+
+### Batch A — Catalog completeness & visualisation
+- **Phase 16** — Introspection gaps: `list_enums`, `list_domains`,
+  `list_composite_types`, `list_foreign_data_wrappers`,
+  `list_foreign_servers`, `list_foreign_tables`, `list_user_mappings`,
+  `list_publications`, `list_subscriptions`.
+- **Phase 17** — Schema visualisation: `generate_schema_diagram`
+  returning a Mermaid ER diagram (tables, columns, PK/FK, partitions).
+- **Phase 18** — Schema diff: `compare_schemas(left, right)` returning a
+  structured diff. Foundation for Batch F.
+- **Phase 19** — Storage & cost telemetry: `analyze_storage`;
+  `wal_volume` health check.
+
+### Batch B — Advisors & trust
+- **Phase 20** — Advisors / lint layer: `run_advisors` with codified
+  rules (missing PKs, unindexed FKs, RLS gaps, duplicate indexes, etc).
+- **Phase 21** — Audit trail with semantic diff: `run_write`/`run_ddl`
+  emit a structured diff alongside their result; optional persistence
+  to an `mcpg_audit` schema (off by default).
+
+### Batch C — Extension power-tools
+- **Phase 22** — `pg_cron` + `pg_partman` wrappers: list / schedule /
+  unschedule / create-parent / run-maintenance / drop-partition.
+- **Phase 23** — pgvector tuning: `tune_vector_index`,
+  `vector_recall_at_k`.
+
+### Batch D — Data movement (LARGE — gated on ADR-0004)
+- **Phase 24** — Export/import: `export_query`, `export_table`,
+  `import_csv`/`import_json`, `dump_database`/`restore_database`,
+  `copy_table_between_databases`. Subprocess execution is a new attack
+  surface; ADR-0004 must define the allowlist / opt-in / redaction
+  policy before any code is written.
+
+### Batch E — Replication & event streams (LARGE — gated on ADR-0005)
+- **Phase 25** — Logical replication management: replication slots and
+  publication/subscription create+drop wrappers (write-gated).
+- **Phase 26** — `LISTEN`/`NOTIFY` bridge. ADR-0005 picks between a
+  tool-poll model (recommended) and MCP notifications.
+
+### Batch F — Migrations with shadow workflow (LARGEST — gated on ADR-0006)
+- **Phase 27** — `prepare_migration`/`complete_migration` driven by the
+  Phase-18 schema diff. ADR-0006 picks between same-DB shadow schema
+  (Option 1, recommended) and side-channel `CREATE DATABASE ... TEMPLATE`
+  (Option 2, heavyweight).
+
+Cadence: per-task TDD; 90% coverage gate (current 100%); ruff / mypy /
+PG 14–17 CI matrix must be green before each commit. Batches D, E, F
+require their ADR to be merged and signed off before implementation
+begins.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -6,14 +6,15 @@
 
 ## Current state
 
-- **Phase:** 12 — Deeper schema introspection (Phases 0–11 complete)
-- **Last updated:** 2026-05-21
+- **Phase:** 16 — Introspection gaps (Phases 0–15 complete)
+- **Last updated:** 2026-05-23
 - **Branch:** `claude/postgresql-mcp-planning-8KssU`
 
 ## Next action
 
-> Phases 12–15 complete. No task in progress — pick the next initiative
-> from `PLAN.md` or await direction.
+> Phase 16 complete (Tasks 16.1–16.3, nine new introspection tools).
+> Awaiting direction before starting Phase 17 (schema visualisation /
+> Mermaid ER) — the next item in Batch A of the post-Phase-15 roadmap.
 
 ## Phase 0 — Spike & foundation  ✅ COMPLETE
 
@@ -406,3 +407,19 @@
   `terminate_backend` — signal a backend PID via `pg_cancel_backend` /
   `pg_terminate_backend`. Phases 12–15 complete. 365 tests, 100%
   coverage.
+- 2026-05-23 — Post-Phase-15 roadmap (`PLAN.md` §11) captured: Phases
+  16–27 grouped into six batches (catalog completeness, advisors,
+  extension wrappers, data movement, replication/events, migrations).
+- 2026-05-23 — Task 16.1: added `list_enums`, `list_domains`,
+  `list_composite_types` — user-defined types via `pg_type`/`pg_enum`/
+  `pg_constraint` and `pg_attribute`. Composite types filter on
+  `relkind='c'` to exclude table row-types. 251 unit tests.
+- 2026-05-23 — Task 16.2: added `list_foreign_data_wrappers`,
+  `list_foreign_servers`, `list_foreign_tables`, `list_user_mappings` —
+  postgres_fdw and other wrappers via `pg_foreign_data_wrapper`,
+  `pg_foreign_server`, `pg_foreign_table`, `pg_user_mappings`. Text[]
+  options parsed into typed dicts. 255 unit tests.
+- 2026-05-23 — Task 16.3: added `list_publications` and
+  `list_subscriptions` — read-only logical-replication catalog via
+  `pg_publication`/`pg_publication_tables` and `pg_subscription`.
+  Phase 16 complete (29 MCP tools total). 257 unit tests, 100% coverage.

--- a/src/mcpg/extensions.py
+++ b/src/mcpg/extensions.py
@@ -35,6 +35,7 @@ ENABLEABLE_EXTENSIONS = frozenset(
         "cube",
         "earthdistance",
         "postgis",
+        "postgres_fdw",
     }
 )
 

--- a/src/mcpg/introspection.py
+++ b/src/mcpg/introspection.py
@@ -277,6 +277,52 @@ class CompositeTypeInfo:
 
 
 @dataclass(frozen=True, slots=True)
+class ForeignDataWrapperInfo:
+    """A foreign-data wrapper installed in the database.
+
+    ``handler`` and ``validator`` are the qualified function names, or
+    ``None`` when the FDW does not define one.
+    """
+
+    name: str
+    handler: str | None
+    validator: str | None
+    options: dict[str, str]
+
+
+@dataclass(frozen=True, slots=True)
+class ForeignServerInfo:
+    """A foreign server defined for an FDW."""
+
+    name: str
+    wrapper: str
+    type: str | None
+    version: str | None
+    options: dict[str, str]
+
+
+@dataclass(frozen=True, slots=True)
+class ForeignTableInfo:
+    """A foreign table within a schema."""
+
+    name: str
+    server: str
+    options: dict[str, str]
+
+
+@dataclass(frozen=True, slots=True)
+class UserMappingInfo:
+    """A role-to-foreign-server mapping.
+
+    ``user`` is ``"public"`` for the catch-all mapping.
+    """
+
+    user: str
+    server: str
+    options: dict[str, str]
+
+
+@dataclass(frozen=True, slots=True)
 class ExtensionInfo:
     """An installed PostgreSQL extension."""
 
@@ -296,6 +342,16 @@ class AvailableExtension:
 
 def _is_system_schema(name: str) -> bool:
     return name in _SYSTEM_SCHEMAS or name.startswith("pg_")
+
+
+def _parse_options(raw: list[str] | None) -> dict[str, str]:
+    """Parse a PostgreSQL ``text[]`` of ``"key=value"`` entries into a dict."""
+    options: dict[str, str] = {}
+    for item in raw or []:
+        key, sep, value = item.partition("=")
+        if sep:
+            options[key] = value
+    return options
 
 
 async def list_schemas(driver: SqlDriver, *, include_system: bool = False) -> list[SchemaInfo]:
@@ -717,6 +773,92 @@ async def list_composite_types(driver: SqlDriver, schema: str) -> list[Composite
             CompositeAttribute(name=row.cells["attr_name"], data_type=row.cells["attr_type"])
         )
     return [CompositeTypeInfo(name=name, attributes=attrs) for name, attrs in grouped.items()]
+
+
+async def list_foreign_data_wrappers(driver: SqlDriver) -> list[ForeignDataWrapperInfo]:
+    """List the foreign-data wrappers installed in the database."""
+    rows = await driver.execute_query(
+        "SELECT fdwname AS name, "
+        "  CASE WHEN fdwhandler = 0 THEN NULL ELSE fdwhandler::regproc::text END AS handler, "
+        "  CASE WHEN fdwvalidator = 0 THEN NULL ELSE fdwvalidator::regproc::text END AS validator, "
+        "  fdwoptions AS options "
+        "FROM pg_foreign_data_wrapper ORDER BY fdwname",
+        force_readonly=True,
+    )
+    return [
+        ForeignDataWrapperInfo(
+            name=row.cells["name"],
+            handler=row.cells["handler"],
+            validator=row.cells["validator"],
+            options=_parse_options(row.cells["options"]),
+        )
+        for row in rows or []
+    ]
+
+
+async def list_foreign_servers(driver: SqlDriver) -> list[ForeignServerInfo]:
+    """List the foreign servers defined in the database."""
+    rows = await driver.execute_query(
+        "SELECT s.srvname AS name, fdw.fdwname AS wrapper, "
+        "  s.srvtype AS type, s.srvversion AS version, s.srvoptions AS options "
+        "FROM pg_foreign_server s "
+        "JOIN pg_foreign_data_wrapper fdw ON fdw.oid = s.srvfdw "
+        "ORDER BY s.srvname",
+        force_readonly=True,
+    )
+    return [
+        ForeignServerInfo(
+            name=row.cells["name"],
+            wrapper=row.cells["wrapper"],
+            type=row.cells["type"],
+            version=row.cells["version"],
+            options=_parse_options(row.cells["options"]),
+        )
+        for row in rows or []
+    ]
+
+
+async def list_foreign_tables(driver: SqlDriver, schema: str) -> list[ForeignTableInfo]:
+    """List the foreign tables in a schema, with their server and options."""
+    rows = await driver.execute_query(
+        "SELECT c.relname AS name, s.srvname AS server, ft.ftoptions AS options "
+        "FROM pg_foreign_table ft "
+        "JOIN pg_class c ON c.oid = ft.ftrelid "
+        "JOIN pg_namespace n ON n.oid = c.relnamespace "
+        "JOIN pg_foreign_server s ON s.oid = ft.ftserver "
+        "WHERE n.nspname = %s ORDER BY c.relname",
+        params=[schema],
+        force_readonly=True,
+    )
+    return [
+        ForeignTableInfo(
+            name=row.cells["name"],
+            server=row.cells["server"],
+            options=_parse_options(row.cells["options"]),
+        )
+        for row in rows or []
+    ]
+
+
+async def list_user_mappings(driver: SqlDriver) -> list[UserMappingInfo]:
+    """List the role-to-foreign-server mappings defined in the database.
+
+    The catch-all ``PUBLIC`` mapping appears with ``user = "public"``.
+    """
+    rows = await driver.execute_query(
+        "SELECT COALESCE(usename, 'public') AS user_name, srvname AS server, "
+        "  umoptions AS options "
+        "FROM pg_user_mappings ORDER BY srvname, user_name",
+        force_readonly=True,
+    )
+    return [
+        UserMappingInfo(
+            user=row.cells["user_name"],
+            server=row.cells["server"],
+            options=_parse_options(row.cells["options"]),
+        )
+        for row in rows or []
+    ]
 
 
 async def list_extensions(driver: SqlDriver) -> list[ExtensionInfo]:

--- a/src/mcpg/introspection.py
+++ b/src/mcpg/introspection.py
@@ -379,10 +379,17 @@ def _is_system_schema(name: str) -> bool:
     return name in _SYSTEM_SCHEMAS or name.startswith("pg_")
 
 
-def _parse_options(raw: list[str] | None) -> dict[str, str]:
-    """Parse a PostgreSQL ``text[]`` of ``"key=value"`` entries into a dict."""
+def _parse_options(raw: list[str | None] | None) -> dict[str, str]:
+    """Parse a PostgreSQL ``text[]`` of ``"key=value"`` entries into a dict.
+
+    Tolerant of catalog quirks: ``NULL`` array elements are skipped, and
+    entries without an ``=`` separator are ignored. When a key appears more
+    than once the last occurrence wins.
+    """
     options: dict[str, str] = {}
     for item in raw or []:
+        if not isinstance(item, str):
+            continue
         key, sep, value = item.partition("=")
         if sep:
             options[key] = value

--- a/src/mcpg/introspection.py
+++ b/src/mcpg/introspection.py
@@ -238,6 +238,45 @@ class SequenceInfo:
 
 
 @dataclass(frozen=True, slots=True)
+class EnumInfo:
+    """An enum type within a schema and its labels in sort order."""
+
+    name: str
+    values: list[str]
+
+
+@dataclass(frozen=True, slots=True)
+class DomainInfo:
+    """A domain type within a schema.
+
+    ``constraints`` are the rendered ``CHECK`` constraint definitions
+    attached to the domain, in catalog order.
+    """
+
+    name: str
+    base_type: str
+    nullable: bool
+    default: str | None
+    constraints: list[str]
+
+
+@dataclass(frozen=True, slots=True)
+class CompositeAttribute:
+    """A column of a composite type."""
+
+    name: str
+    data_type: str
+
+
+@dataclass(frozen=True, slots=True)
+class CompositeTypeInfo:
+    """A standalone composite type within a schema (excludes table row-types)."""
+
+    name: str
+    attributes: list[CompositeAttribute]
+
+
+@dataclass(frozen=True, slots=True)
 class ExtensionInfo:
     """An installed PostgreSQL extension."""
 
@@ -603,6 +642,81 @@ async def list_sequences(driver: SqlDriver, schema: str) -> list[SequenceInfo]:
         )
         for row in rows or []
     ]
+
+
+async def list_enums(driver: SqlDriver, schema: str) -> list[EnumInfo]:
+    """List the enum types in a schema, with their labels in sort order."""
+    rows = await driver.execute_query(
+        "SELECT t.typname AS name, "
+        "array_agg(e.enumlabel ORDER BY e.enumsortorder) AS values "
+        "FROM pg_type t "
+        "JOIN pg_namespace n ON n.oid = t.typnamespace "
+        "JOIN pg_enum e ON e.enumtypid = t.oid "
+        "WHERE n.nspname = %s "
+        "GROUP BY t.typname ORDER BY t.typname",
+        params=[schema],
+        force_readonly=True,
+    )
+    return [EnumInfo(name=row.cells["name"], values=list(row.cells["values"])) for row in rows or []]
+
+
+async def list_domains(driver: SqlDriver, schema: str) -> list[DomainInfo]:
+    """List the domain types in a schema, with base type and check constraints."""
+    rows = await driver.execute_query(
+        "SELECT t.typname AS name, "
+        "format_type(t.typbasetype, t.typtypmod) AS base_type, "
+        "NOT t.typnotnull AS nullable, "
+        "t.typdefault AS default_value, "
+        "COALESCE("
+        "  array_agg(pg_get_constraintdef(con.oid) ORDER BY con.conname) "
+        "    FILTER (WHERE con.oid IS NOT NULL), "
+        "  '{}'"
+        ") AS constraints "
+        "FROM pg_type t "
+        "JOIN pg_namespace n ON n.oid = t.typnamespace "
+        "LEFT JOIN pg_constraint con ON con.contypid = t.oid "
+        "WHERE n.nspname = %s AND t.typtype = 'd' "
+        "GROUP BY t.typname, t.typbasetype, t.typtypmod, t.typnotnull, t.typdefault "
+        "ORDER BY t.typname",
+        params=[schema],
+        force_readonly=True,
+    )
+    return [
+        DomainInfo(
+            name=row.cells["name"],
+            base_type=row.cells["base_type"],
+            nullable=row.cells["nullable"],
+            default=row.cells["default_value"],
+            constraints=list(row.cells["constraints"]),
+        )
+        for row in rows or []
+    ]
+
+
+async def list_composite_types(driver: SqlDriver, schema: str) -> list[CompositeTypeInfo]:
+    """List the standalone composite types in a schema.
+
+    Implicit row-types of tables and views (which also live in ``pg_type``
+    with ``typtype = 'c'``) are excluded.
+    """
+    rows = await driver.execute_query(
+        "SELECT t.typname AS type_name, a.attname AS attr_name, "
+        "format_type(a.atttypid, a.atttypmod) AS attr_type, a.attnum AS attr_num "
+        "FROM pg_type t "
+        "JOIN pg_namespace n ON n.oid = t.typnamespace "
+        "JOIN pg_class c ON c.oid = t.typrelid "
+        "JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum > 0 AND NOT a.attisdropped "
+        "WHERE n.nspname = %s AND t.typtype = 'c' AND c.relkind = 'c' "
+        "ORDER BY t.typname, a.attnum",
+        params=[schema],
+        force_readonly=True,
+    )
+    grouped: dict[str, list[CompositeAttribute]] = {}
+    for row in rows or []:
+        grouped.setdefault(row.cells["type_name"], []).append(
+            CompositeAttribute(name=row.cells["attr_name"], data_type=row.cells["attr_type"])
+        )
+    return [CompositeTypeInfo(name=name, attributes=attrs) for name, attrs in grouped.items()]
 
 
 async def list_extensions(driver: SqlDriver) -> list[ExtensionInfo]:

--- a/src/mcpg/introspection.py
+++ b/src/mcpg/introspection.py
@@ -323,6 +323,41 @@ class UserMappingInfo:
 
 
 @dataclass(frozen=True, slots=True)
+class PublicationInfo:
+    """A logical-replication publication.
+
+    ``tables`` lists ``"schema.table"`` qualified names included in the
+    publication; empty when ``all_tables`` is true.
+    """
+
+    name: str
+    owner: str
+    all_tables: bool
+    publishes_insert: bool
+    publishes_update: bool
+    publishes_delete: bool
+    publishes_truncate: bool
+    tables: list[str]
+
+
+@dataclass(frozen=True, slots=True)
+class SubscriptionInfo:
+    """A logical-replication subscription.
+
+    ``publications`` lists the publication names this subscription consumes.
+    ``connection`` is the libpq connection string; password fields are
+    not redacted by PostgreSQL and the caller should treat the field as
+    sensitive.
+    """
+
+    name: str
+    owner: str
+    enabled: bool
+    connection: str
+    publications: list[str]
+
+
+@dataclass(frozen=True, slots=True)
 class ExtensionInfo:
     """An installed PostgreSQL extension."""
 
@@ -856,6 +891,64 @@ async def list_user_mappings(driver: SqlDriver) -> list[UserMappingInfo]:
             user=row.cells["user_name"],
             server=row.cells["server"],
             options=_parse_options(row.cells["options"]),
+        )
+        for row in rows or []
+    ]
+
+
+async def list_publications(driver: SqlDriver) -> list[PublicationInfo]:
+    """List the logical-replication publications in the database."""
+    rows = await driver.execute_query(
+        "SELECT p.pubname AS name, r.rolname AS owner, p.puballtables AS all_tables, "
+        "  p.pubinsert AS publishes_insert, p.pubupdate AS publishes_update, "
+        "  p.pubdelete AS publishes_delete, p.pubtruncate AS publishes_truncate, "
+        "  COALESCE("
+        "    (SELECT array_agg(pt.schemaname || '.' || pt.tablename ORDER BY pt.schemaname, pt.tablename) "
+        "       FROM pg_publication_tables pt WHERE pt.pubname = p.pubname), "
+        "    '{}'"
+        "  ) AS tables "
+        "FROM pg_publication p "
+        "JOIN pg_roles r ON r.oid = p.pubowner "
+        "ORDER BY p.pubname",
+        force_readonly=True,
+    )
+    return [
+        PublicationInfo(
+            name=row.cells["name"],
+            owner=row.cells["owner"],
+            all_tables=row.cells["all_tables"],
+            publishes_insert=row.cells["publishes_insert"],
+            publishes_update=row.cells["publishes_update"],
+            publishes_delete=row.cells["publishes_delete"],
+            publishes_truncate=row.cells["publishes_truncate"],
+            tables=list(row.cells["tables"]),
+        )
+        for row in rows or []
+    ]
+
+
+async def list_subscriptions(driver: SqlDriver) -> list[SubscriptionInfo]:
+    """List the logical-replication subscriptions in the database.
+
+    Reading ``pg_subscription`` requires superuser privileges; with a
+    non-privileged role the result will be empty even when subscriptions
+    exist.
+    """
+    rows = await driver.execute_query(
+        "SELECT s.subname AS name, r.rolname AS owner, s.subenabled AS enabled, "
+        "  s.subconninfo AS connection, s.subpublications AS publications "
+        "FROM pg_subscription s "
+        "JOIN pg_roles r ON r.oid = s.subowner "
+        "ORDER BY s.subname",
+        force_readonly=True,
+    )
+    return [
+        SubscriptionInfo(
+            name=row.cells["name"],
+            owner=row.cells["owner"],
+            enabled=row.cells["enabled"],
+            connection=row.cells["connection"],
+            publications=list(row.cells["publications"]),
         )
         for row in rows or []
     ]

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -225,6 +225,22 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
         mappings = await introspection.list_user_mappings(_driver(ctx))
         return [asdict(mapping) for mapping in mappings]
 
+    @server.tool(
+        name="list_publications",
+        description="List logical-replication publications with the tables and operations they include.",
+    )
+    async def list_publications(ctx: _Ctx) -> list[dict[str, Any]]:
+        publications = await introspection.list_publications(_driver(ctx))
+        return [asdict(publication) for publication in publications]
+
+    @server.tool(
+        name="list_subscriptions",
+        description="List logical-replication subscriptions; requires superuser to see any rows.",
+    )
+    async def list_subscriptions(ctx: _Ctx) -> list[dict[str, Any]]:
+        subscriptions = await introspection.list_subscriptions(_driver(ctx))
+        return [asdict(subscription) for subscription in subscriptions]
+
     @server.tool(name="list_extensions", description="List the extensions installed in the database.")
     async def list_extensions(ctx: _Ctx) -> list[dict[str, Any]]:
         extensions = await introspection.list_extensions(_driver(ctx))

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -169,6 +169,30 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
         sequences = await introspection.list_sequences(_driver(ctx), schema)
         return [asdict(sequence) for sequence in sequences]
 
+    @server.tool(
+        name="list_enums",
+        description="List the enum types in a schema, with their labels in sort order.",
+    )
+    async def list_enums(ctx: _Ctx, schema: str) -> list[dict[str, Any]]:
+        enums = await introspection.list_enums(_driver(ctx), schema)
+        return [asdict(enum) for enum in enums]
+
+    @server.tool(
+        name="list_domains",
+        description="List the domain types in a schema, with base type, default, and check constraints.",
+    )
+    async def list_domains(ctx: _Ctx, schema: str) -> list[dict[str, Any]]:
+        domains = await introspection.list_domains(_driver(ctx), schema)
+        return [asdict(domain) for domain in domains]
+
+    @server.tool(
+        name="list_composite_types",
+        description="List the standalone composite types in a schema with their attributes.",
+    )
+    async def list_composite_types(ctx: _Ctx, schema: str) -> list[dict[str, Any]]:
+        types = await introspection.list_composite_types(_driver(ctx), schema)
+        return [asdict(t) for t in types]
+
     @server.tool(name="list_extensions", description="List the extensions installed in the database.")
     async def list_extensions(ctx: _Ctx) -> list[dict[str, Any]]:
         extensions = await introspection.list_extensions(_driver(ctx))

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -193,6 +193,38 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
         types = await introspection.list_composite_types(_driver(ctx), schema)
         return [asdict(t) for t in types]
 
+    @server.tool(
+        name="list_foreign_data_wrappers",
+        description="List the foreign-data wrappers installed in the database.",
+    )
+    async def list_foreign_data_wrappers(ctx: _Ctx) -> list[dict[str, Any]]:
+        wrappers = await introspection.list_foreign_data_wrappers(_driver(ctx))
+        return [asdict(wrapper) for wrapper in wrappers]
+
+    @server.tool(
+        name="list_foreign_servers",
+        description="List the foreign servers defined in the database, with their FDW and options.",
+    )
+    async def list_foreign_servers(ctx: _Ctx) -> list[dict[str, Any]]:
+        servers = await introspection.list_foreign_servers(_driver(ctx))
+        return [asdict(server_info) for server_info in servers]
+
+    @server.tool(
+        name="list_foreign_tables",
+        description="List the foreign tables in a schema, with their server and options.",
+    )
+    async def list_foreign_tables(ctx: _Ctx, schema: str) -> list[dict[str, Any]]:
+        tables = await introspection.list_foreign_tables(_driver(ctx), schema)
+        return [asdict(table) for table in tables]
+
+    @server.tool(
+        name="list_user_mappings",
+        description="List role-to-foreign-server mappings; the catch-all appears as user='public'.",
+    )
+    async def list_user_mappings(ctx: _Ctx) -> list[dict[str, Any]]:
+        mappings = await introspection.list_user_mappings(_driver(ctx))
+        return [asdict(mapping) for mapping in mappings]
+
     @server.tool(name="list_extensions", description="List the extensions installed in the database.")
     async def list_extensions(ctx: _Ctx) -> list[dict[str, Any]]:
         extensions = await introspection.list_extensions(_driver(ctx))

--- a/tests/integration/test_introspection_integration.py
+++ b/tests/integration/test_introspection_integration.py
@@ -15,6 +15,9 @@ from mcpg.introspection import (
     list_domains,
     list_enums,
     list_extensions,
+    list_foreign_data_wrappers,
+    list_foreign_servers,
+    list_foreign_tables,
     list_functions,
     list_grants,
     list_indexes,
@@ -25,6 +28,7 @@ from mcpg.introspection import (
     list_sequences,
     list_tables,
     list_triggers,
+    list_user_mappings,
     list_views,
 )
 
@@ -224,6 +228,71 @@ async def test_list_composite_types_excludes_table_row_types(connected_database:
     assert {attr.name for attr in types["address"].attributes} == {"street", "city"}
     # Tables' implicit row-types must not appear.
     assert "widget" not in types
+
+
+@pytest.fixture
+async def foreign_data_setup(connected_database: Database) -> AsyncIterator[str]:
+    """Create a postgres_fdw server, mapping, and foreign table; clean up after."""
+    driver = connected_database.driver()
+    available = {extension.name for extension in await list_available_extensions(driver)}
+    if "postgres_fdw" not in available:
+        pytest.skip("postgres_fdw is not available on this PostgreSQL server")
+    schema = "mcpg_fdw_it"
+    await driver.execute_query("DROP SERVER IF EXISTS mcpg_fdw_server CASCADE")
+    await driver.execute_query(f"DROP SCHEMA IF EXISTS {schema} CASCADE")
+    await enable_extension(driver, "postgres_fdw")
+    await driver.execute_query(f"CREATE SCHEMA {schema}")
+    await driver.execute_query(
+        "CREATE SERVER mcpg_fdw_server FOREIGN DATA WRAPPER postgres_fdw OPTIONS (host 'localhost', dbname 'postgres')"
+    )
+    await driver.execute_query("CREATE USER MAPPING FOR PUBLIC SERVER mcpg_fdw_server OPTIONS (user 'postgres')")
+    await driver.execute_query(
+        f"CREATE FOREIGN TABLE {schema}.remote_widget (id integer, name text) "
+        "SERVER mcpg_fdw_server OPTIONS (schema_name 'public', table_name 'widget')"
+    )
+    try:
+        yield schema
+    finally:
+        await driver.execute_query("DROP SERVER IF EXISTS mcpg_fdw_server CASCADE")
+        await driver.execute_query(f"DROP SCHEMA IF EXISTS {schema} CASCADE")
+
+
+async def test_list_foreign_data_wrappers_finds_postgres_fdw(
+    connected_database: Database, foreign_data_setup: str
+) -> None:
+    wrappers = {w.name: w for w in await list_foreign_data_wrappers(connected_database.driver())}
+
+    assert "postgres_fdw" in wrappers
+    assert wrappers["postgres_fdw"].handler is not None
+
+
+async def test_list_foreign_servers_finds_the_server_and_options(
+    connected_database: Database, foreign_data_setup: str
+) -> None:
+    servers = {s.name: s for s in await list_foreign_servers(connected_database.driver())}
+
+    assert "mcpg_fdw_server" in servers
+    assert servers["mcpg_fdw_server"].wrapper == "postgres_fdw"
+    assert servers["mcpg_fdw_server"].options.get("host") == "localhost"
+
+
+async def test_list_foreign_tables_finds_the_foreign_table(
+    connected_database: Database, foreign_data_setup: str
+) -> None:
+    tables = {t.name: t for t in await list_foreign_tables(connected_database.driver(), foreign_data_setup)}
+
+    assert "remote_widget" in tables
+    assert tables["remote_widget"].server == "mcpg_fdw_server"
+    assert tables["remote_widget"].options.get("table_name") == "widget"
+
+
+async def test_list_user_mappings_finds_the_public_mapping(
+    connected_database: Database, foreign_data_setup: str
+) -> None:
+    mappings = await list_user_mappings(connected_database.driver())
+    by_server = {(m.user, m.server) for m in mappings}
+
+    assert ("public", "mcpg_fdw_server") in by_server
 
 
 async def test_describe_table_reports_pgvector_dimension(connected_database: Database) -> None:

--- a/tests/integration/test_introspection_integration.py
+++ b/tests/integration/test_introspection_integration.py
@@ -10,7 +10,10 @@ from mcpg.introspection import (
     SchemaInfo,
     describe_table,
     list_available_extensions,
+    list_composite_types,
     list_constraints,
+    list_domains,
+    list_enums,
     list_extensions,
     list_functions,
     list_grants,
@@ -57,6 +60,9 @@ async def sample_schema(connected_database: Database) -> AsyncIterator[str]:
     )
     await driver.execute_query(f"ALTER TABLE {_SCHEMA}.widget ENABLE ROW LEVEL SECURITY")
     await driver.execute_query(f"CREATE POLICY widget_select ON {_SCHEMA}.widget FOR SELECT USING (true)")
+    await driver.execute_query(f"CREATE TYPE {_SCHEMA}.status AS ENUM ('draft', 'live', 'archived')")
+    await driver.execute_query(f"CREATE DOMAIN {_SCHEMA}.positive_int AS integer NOT NULL DEFAULT 1 CHECK (VALUE > 0)")
+    await driver.execute_query(f"CREATE TYPE {_SCHEMA}.address AS (street text, city text)")
     try:
         yield _SCHEMA
     finally:
@@ -195,6 +201,29 @@ async def test_list_roles_excludes_predefined_roles_by_default(connected_databas
     roles = await list_roles(connected_database.driver())
 
     assert not any(role.name.startswith("pg_") for role in roles)
+
+
+async def test_list_enums_finds_an_enum_with_its_labels(connected_database: Database, sample_schema: str) -> None:
+    enums = {enum.name: enum for enum in await list_enums(connected_database.driver(), sample_schema)}
+
+    assert enums["status"].values == ["draft", "live", "archived"]
+
+
+async def test_list_domains_finds_a_domain_with_its_check(connected_database: Database, sample_schema: str) -> None:
+    domains = {domain.name: domain for domain in await list_domains(connected_database.driver(), sample_schema)}
+
+    assert domains["positive_int"].base_type == "integer"
+    assert domains["positive_int"].nullable is False
+    assert any("VALUE > 0" in constraint for constraint in domains["positive_int"].constraints)
+
+
+async def test_list_composite_types_excludes_table_row_types(connected_database: Database, sample_schema: str) -> None:
+    types = {t.name: t for t in await list_composite_types(connected_database.driver(), sample_schema)}
+
+    assert "address" in types
+    assert {attr.name for attr in types["address"].attributes} == {"street", "city"}
+    # Tables' implicit row-types must not appear.
+    assert "widget" not in types
 
 
 async def test_describe_table_reports_pgvector_dimension(connected_database: Database) -> None:

--- a/tests/integration/test_introspection_integration.py
+++ b/tests/integration/test_introspection_integration.py
@@ -23,9 +23,11 @@ from mcpg.introspection import (
     list_indexes,
     list_partitions,
     list_policies,
+    list_publications,
     list_roles,
     list_schemas,
     list_sequences,
+    list_subscriptions,
     list_tables,
     list_triggers,
     list_user_mappings,
@@ -293,6 +295,38 @@ async def test_list_user_mappings_finds_the_public_mapping(
     by_server = {(m.user, m.server) for m in mappings}
 
     assert ("public", "mcpg_fdw_server") in by_server
+
+
+@pytest.fixture
+async def publication_setup(connected_database: Database, sample_schema: str) -> AsyncIterator[str]:
+    """Create a logical-replication publication covering the sample widget table."""
+    driver = connected_database.driver()
+    await driver.execute_query("DROP PUBLICATION IF EXISTS mcpg_widget_pub")
+    await driver.execute_query(f"CREATE PUBLICATION mcpg_widget_pub FOR TABLE {sample_schema}.widget")
+    try:
+        yield "mcpg_widget_pub"
+    finally:
+        await driver.execute_query("DROP PUBLICATION IF EXISTS mcpg_widget_pub")
+
+
+async def test_list_publications_finds_the_publication_with_its_table(
+    connected_database: Database, publication_setup: str, sample_schema: str
+) -> None:
+    pubs = {p.name: p for p in await list_publications(connected_database.driver())}
+
+    assert publication_setup in pubs
+    assert pubs[publication_setup].all_tables is False
+    assert f"{sample_schema}.widget" in pubs[publication_setup].tables
+    assert pubs[publication_setup].publishes_insert is True
+
+
+async def test_list_subscriptions_returns_a_list(connected_database: Database) -> None:
+    # Subscriptions need a remote publisher and superuser to read; we only
+    # assert the call succeeds and returns a (possibly empty) list — the
+    # mapping is exercised in the unit tests.
+    subscriptions = await list_subscriptions(connected_database.driver())
+
+    assert isinstance(subscriptions, list)
 
 
 async def test_describe_table_reports_pgvector_dimension(connected_database: Database) -> None:

--- a/tests/integration/test_introspection_integration.py
+++ b/tests/integration/test_introspection_integration.py
@@ -217,10 +217,12 @@ async def test_list_enums_finds_an_enum_with_its_labels(connected_database: Data
 
 async def test_list_domains_finds_a_domain_with_its_check(connected_database: Database, sample_schema: str) -> None:
     domains = {domain.name: domain for domain in await list_domains(connected_database.driver(), sample_schema)}
+    positive_int = domains["positive_int"]
 
-    assert domains["positive_int"].base_type == "integer"
-    assert domains["positive_int"].nullable is False
-    assert any("VALUE > 0" in constraint for constraint in domains["positive_int"].constraints)
+    assert positive_int.base_type == "integer"
+    assert positive_int.nullable is False
+    assert positive_int.default == "1"
+    assert any("VALUE > 0" in constraint for constraint in positive_int.constraints)
 
 
 async def test_list_composite_types_excludes_table_row_types(connected_database: Database, sample_schema: str) -> None:

--- a/tests/unit/test_introspection.py
+++ b/tests/unit/test_introspection.py
@@ -495,6 +495,10 @@ async def test_list_enums_maps_rows() -> None:
     assert driver.calls[0][1] == ["app"]
 
 
+async def test_list_enums_returns_empty_for_a_schema_with_no_enums() -> None:
+    assert await list_enums(FakeDriver([]), "app") == []
+
+
 async def test_list_domains_maps_rows_including_constraints() -> None:
     driver = FakeDriver(
         [
@@ -565,6 +569,25 @@ async def test_list_foreign_data_wrappers_maps_rows() -> None:
             "postgres_fdw", "public.postgres_fdw_handler", "public.postgres_fdw_validator", {"debug": "true"}
         ),
         ForeignDataWrapperInfo("no_handler_fdw", None, None, {}),
+    ]
+
+
+async def test_options_parser_tolerates_catalog_quirks() -> None:
+    # text[] catalog columns can contain NULL elements and entries without
+    # a separator; duplicate keys collapse to the last value seen.
+    driver = FakeDriver(
+        [
+            {
+                "name": "quirky_fdw",
+                "handler": None,
+                "validator": None,
+                "options": ["debug=true", "no_equal_sign", None, "debug=false", "work_mem=64MB"],
+            }
+        ]
+    )
+
+    assert await list_foreign_data_wrappers(driver) == [
+        ForeignDataWrapperInfo("quirky_fdw", None, None, {"debug": "false", "work_mem": "64MB"}),
     ]
 
 

--- a/tests/unit/test_introspection.py
+++ b/tests/unit/test_introspection.py
@@ -13,6 +13,9 @@ from mcpg.introspection import (
     DomainInfo,
     EnumInfo,
     ExtensionInfo,
+    ForeignDataWrapperInfo,
+    ForeignServerInfo,
+    ForeignTableInfo,
     FunctionInfo,
     GrantInfo,
     IndexInfo,
@@ -25,6 +28,7 @@ from mcpg.introspection import (
     SequenceInfo,
     TableInfo,
     TriggerInfo,
+    UserMappingInfo,
     ViewInfo,
     describe_table,
     list_available_extensions,
@@ -33,6 +37,9 @@ from mcpg.introspection import (
     list_domains,
     list_enums,
     list_extensions,
+    list_foreign_data_wrappers,
+    list_foreign_servers,
+    list_foreign_tables,
     list_functions,
     list_grants,
     list_indexes,
@@ -43,6 +50,7 @@ from mcpg.introspection import (
     list_sequences,
     list_tables,
     list_triggers,
+    list_user_mappings,
     list_views,
 )
 from mcpg.server import create_server
@@ -535,6 +543,72 @@ async def test_list_composite_types_returns_empty_for_a_schema_with_no_types() -
     assert await list_composite_types(FakeDriver([]), "app") == []
 
 
+async def test_list_foreign_data_wrappers_maps_rows() -> None:
+    driver = FakeDriver(
+        [
+            {
+                "name": "postgres_fdw",
+                "handler": "public.postgres_fdw_handler",
+                "validator": "public.postgres_fdw_validator",
+                "options": ["debug=true"],
+            },
+            {"name": "no_handler_fdw", "handler": None, "validator": None, "options": None},
+        ]
+    )
+
+    assert await list_foreign_data_wrappers(driver) == [
+        ForeignDataWrapperInfo(
+            "postgres_fdw", "public.postgres_fdw_handler", "public.postgres_fdw_validator", {"debug": "true"}
+        ),
+        ForeignDataWrapperInfo("no_handler_fdw", None, None, {}),
+    ]
+
+
+async def test_list_foreign_servers_maps_rows() -> None:
+    driver = FakeDriver(
+        [
+            {
+                "name": "remote_db",
+                "wrapper": "postgres_fdw",
+                "type": None,
+                "version": None,
+                "options": ["host=remote", "dbname=app"],
+            }
+        ]
+    )
+
+    assert await list_foreign_servers(driver) == [
+        ForeignServerInfo("remote_db", "postgres_fdw", None, None, {"host": "remote", "dbname": "app"}),
+    ]
+
+
+async def test_list_foreign_tables_maps_rows() -> None:
+    driver = FakeDriver(
+        [
+            {"name": "remote_widget", "server": "remote_db", "options": ["schema_name=public", "table_name=widget"]},
+        ]
+    )
+
+    assert await list_foreign_tables(driver, "app") == [
+        ForeignTableInfo("remote_widget", "remote_db", {"schema_name": "public", "table_name": "widget"}),
+    ]
+    assert driver.calls[0][1] == ["app"]
+
+
+async def test_list_user_mappings_maps_rows() -> None:
+    driver = FakeDriver(
+        [
+            {"user_name": "public", "server": "remote_db", "options": []},
+            {"user_name": "app_user", "server": "remote_db", "options": ["user=app", "password=secret"]},
+        ]
+    )
+
+    assert await list_user_mappings(driver) == [
+        UserMappingInfo("public", "remote_db", {}),
+        UserMappingInfo("app_user", "remote_db", {"user": "app", "password": "secret"}),
+    ]
+
+
 async def test_list_extensions_maps_rows() -> None:
     driver = FakeDriver([{"extname": "plpgsql", "extversion": "1.0"}])
 
@@ -574,6 +648,10 @@ _INTROSPECTION_TOOLS = {
     "list_enums",
     "list_domains",
     "list_composite_types",
+    "list_foreign_data_wrappers",
+    "list_foreign_servers",
+    "list_foreign_tables",
+    "list_user_mappings",
     "list_extensions",
     "list_available_extensions",
 }
@@ -673,6 +751,22 @@ async def test_every_introspection_tool_is_callable_from_a_client() -> None:
         "list_composite_types": (
             {"schema": "app"},
             [{"type_name": "address", "attr_name": "street", "attr_type": "text", "attr_num": 1}],
+        ),
+        "list_foreign_data_wrappers": (
+            {},
+            [{"name": "postgres_fdw", "handler": None, "validator": None, "options": []}],
+        ),
+        "list_foreign_servers": (
+            {},
+            [{"name": "remote_db", "wrapper": "postgres_fdw", "type": None, "version": None, "options": []}],
+        ),
+        "list_foreign_tables": (
+            {"schema": "app"},
+            [{"name": "remote_widget", "server": "remote_db", "options": []}],
+        ),
+        "list_user_mappings": (
+            {},
+            [{"user_name": "public", "server": "remote_db", "options": []}],
         ),
         "list_extensions": ({}, [{"extname": "plpgsql", "extversion": "1.0"}]),
         "list_available_extensions": (

--- a/tests/unit/test_introspection.py
+++ b/tests/unit/test_introspection.py
@@ -7,7 +7,11 @@ from mcpg.config import load_settings
 from mcpg.introspection import (
     AvailableExtension,
     ColumnInfo,
+    CompositeAttribute,
+    CompositeTypeInfo,
     ConstraintInfo,
+    DomainInfo,
+    EnumInfo,
     ExtensionInfo,
     FunctionInfo,
     GrantInfo,
@@ -24,7 +28,10 @@ from mcpg.introspection import (
     ViewInfo,
     describe_table,
     list_available_extensions,
+    list_composite_types,
     list_constraints,
+    list_domains,
+    list_enums,
     list_extensions,
     list_functions,
     list_grants,
@@ -461,6 +468,73 @@ async def test_list_sequences_allows_a_null_last_value() -> None:
     assert (await list_sequences(driver, "app"))[0].last_value is None
 
 
+async def test_list_enums_maps_rows() -> None:
+    driver = FakeDriver(
+        [
+            {"name": "status", "values": ["draft", "live", "archived"]},
+            {"name": "tier", "values": ["bronze", "silver", "gold"]},
+        ]
+    )
+
+    assert await list_enums(driver, "app") == [
+        EnumInfo("status", ["draft", "live", "archived"]),
+        EnumInfo("tier", ["bronze", "silver", "gold"]),
+    ]
+    assert driver.calls[0][1] == ["app"]
+
+
+async def test_list_domains_maps_rows_including_constraints() -> None:
+    driver = FakeDriver(
+        [
+            {
+                "name": "positive_int",
+                "base_type": "integer",
+                "nullable": False,
+                "default_value": "0",
+                "constraints": ["CHECK ((VALUE > 0))"],
+            },
+            {
+                "name": "free_text",
+                "base_type": "text",
+                "nullable": True,
+                "default_value": None,
+                "constraints": [],
+            },
+        ]
+    )
+
+    assert await list_domains(driver, "app") == [
+        DomainInfo("positive_int", "integer", False, "0", ["CHECK ((VALUE > 0))"]),
+        DomainInfo("free_text", "text", True, None, []),
+    ]
+
+
+async def test_list_composite_types_groups_attributes_by_type() -> None:
+    driver = FakeDriver(
+        [
+            {"type_name": "address", "attr_name": "street", "attr_type": "text", "attr_num": 1},
+            {"type_name": "address", "attr_name": "city", "attr_type": "text", "attr_num": 2},
+            {"type_name": "money_range", "attr_name": "low", "attr_type": "numeric", "attr_num": 1},
+            {"type_name": "money_range", "attr_name": "high", "attr_type": "numeric", "attr_num": 2},
+        ]
+    )
+
+    assert await list_composite_types(driver, "app") == [
+        CompositeTypeInfo(
+            "address",
+            [CompositeAttribute("street", "text"), CompositeAttribute("city", "text")],
+        ),
+        CompositeTypeInfo(
+            "money_range",
+            [CompositeAttribute("low", "numeric"), CompositeAttribute("high", "numeric")],
+        ),
+    ]
+
+
+async def test_list_composite_types_returns_empty_for_a_schema_with_no_types() -> None:
+    assert await list_composite_types(FakeDriver([]), "app") == []
+
+
 async def test_list_extensions_maps_rows() -> None:
     driver = FakeDriver([{"extname": "plpgsql", "extversion": "1.0"}])
 
@@ -497,6 +571,9 @@ _INTROSPECTION_TOOLS = {
     "list_roles",
     "list_grants",
     "list_sequences",
+    "list_enums",
+    "list_domains",
+    "list_composite_types",
     "list_extensions",
     "list_available_extensions",
 }
@@ -576,6 +653,26 @@ async def test_every_introspection_tool_is_callable_from_a_client() -> None:
                     "last_value": None,
                 }
             ],
+        ),
+        "list_enums": (
+            {"schema": "app"},
+            [{"name": "status", "values": ["draft", "live"]}],
+        ),
+        "list_domains": (
+            {"schema": "app"},
+            [
+                {
+                    "name": "positive_int",
+                    "base_type": "integer",
+                    "nullable": False,
+                    "default_value": "0",
+                    "constraints": ["CHECK ((VALUE > 0))"],
+                }
+            ],
+        ),
+        "list_composite_types": (
+            {"schema": "app"},
+            [{"type_name": "address", "attr_name": "street", "attr_type": "text", "attr_num": 1}],
         ),
         "list_extensions": ({}, [{"extname": "plpgsql", "extversion": "1.0"}]),
         "list_available_extensions": (

--- a/tests/unit/test_introspection.py
+++ b/tests/unit/test_introspection.py
@@ -23,9 +23,11 @@ from mcpg.introspection import (
     PartitionSet,
     PolicyInfo,
     PolicySet,
+    PublicationInfo,
     RoleInfo,
     SchemaInfo,
     SequenceInfo,
+    SubscriptionInfo,
     TableInfo,
     TriggerInfo,
     UserMappingInfo,
@@ -45,9 +47,11 @@ from mcpg.introspection import (
     list_indexes,
     list_partitions,
     list_policies,
+    list_publications,
     list_roles,
     list_schemas,
     list_sequences,
+    list_subscriptions,
     list_tables,
     list_triggers,
     list_user_mappings,
@@ -609,6 +613,56 @@ async def test_list_user_mappings_maps_rows() -> None:
     ]
 
 
+async def test_list_publications_maps_rows_including_tables() -> None:
+    driver = FakeDriver(
+        [
+            {
+                "name": "widget_pub",
+                "owner": "app_owner",
+                "all_tables": False,
+                "publishes_insert": True,
+                "publishes_update": True,
+                "publishes_delete": False,
+                "publishes_truncate": False,
+                "tables": ["app.widget", "app.event"],
+            },
+            {
+                "name": "everything_pub",
+                "owner": "postgres",
+                "all_tables": True,
+                "publishes_insert": True,
+                "publishes_update": True,
+                "publishes_delete": True,
+                "publishes_truncate": True,
+                "tables": [],
+            },
+        ]
+    )
+
+    assert await list_publications(driver) == [
+        PublicationInfo("widget_pub", "app_owner", False, True, True, False, False, ["app.widget", "app.event"]),
+        PublicationInfo("everything_pub", "postgres", True, True, True, True, True, []),
+    ]
+
+
+async def test_list_subscriptions_maps_rows() -> None:
+    driver = FakeDriver(
+        [
+            {
+                "name": "widget_sub",
+                "owner": "app_owner",
+                "enabled": True,
+                "connection": "host=upstream dbname=app",
+                "publications": ["widget_pub"],
+            }
+        ]
+    )
+
+    assert await list_subscriptions(driver) == [
+        SubscriptionInfo("widget_sub", "app_owner", True, "host=upstream dbname=app", ["widget_pub"]),
+    ]
+
+
 async def test_list_extensions_maps_rows() -> None:
     driver = FakeDriver([{"extname": "plpgsql", "extversion": "1.0"}])
 
@@ -652,6 +706,8 @@ _INTROSPECTION_TOOLS = {
     "list_foreign_servers",
     "list_foreign_tables",
     "list_user_mappings",
+    "list_publications",
+    "list_subscriptions",
     "list_extensions",
     "list_available_extensions",
 }
@@ -767,6 +823,33 @@ async def test_every_introspection_tool_is_callable_from_a_client() -> None:
         "list_user_mappings": (
             {},
             [{"user_name": "public", "server": "remote_db", "options": []}],
+        ),
+        "list_publications": (
+            {},
+            [
+                {
+                    "name": "p",
+                    "owner": "postgres",
+                    "all_tables": False,
+                    "publishes_insert": True,
+                    "publishes_update": True,
+                    "publishes_delete": True,
+                    "publishes_truncate": False,
+                    "tables": ["app.widget"],
+                }
+            ],
+        ),
+        "list_subscriptions": (
+            {},
+            [
+                {
+                    "name": "s",
+                    "owner": "postgres",
+                    "enabled": True,
+                    "connection": "host=u",
+                    "publications": ["p"],
+                }
+            ],
         ),
         "list_extensions": ({}, [{"extname": "plpgsql", "extversion": "1.0"}]),
         "list_available_extensions": (


### PR DESCRIPTION
## Summary

Phase 16 of the post-Phase-15 roadmap (`PLAN.md` §11, Batch A). Adds nine
read-only catalog tools that close the long-standing introspection gaps —
user-defined types, the foreign-data-wrapper family, and a read-only view
of logical replication.

- **Task 16.1 — custom types**: `list_enums`, `list_domains`,
  `list_composite_types`. Composite types filter on `relkind = 'c'` so the
  catalog's implicit table row-types are excluded.
- **Task 16.2 — foreign data**: `list_foreign_data_wrappers`,
  `list_foreign_servers`, `list_foreign_tables`, `list_user_mappings`. The
  PostgreSQL `text[]` options arrays are parsed into typed dicts; the
  `PUBLIC` mapping surfaces as `user='public'`.
- **Task 16.3 — logical replication (read-only)**: `list_publications`
  (with per-publication operations + qualified table list) and
  `list_subscriptions` (gated by PostgreSQL to superuser).

Same TDD cadence as Phases 12–15: dataclass + parameterised catalog
query, unit tests with the existing fake driver, MCP tool registration
in `tools.py`, integration tests against a live PostgreSQL.
Extension-dependent fixtures (postgres_fdw) follow the existing skip-if-
unavailable pattern; publications use a throwaway fixture, subscriptions
get a "call succeeds" smoke test since they need a remote publisher.

Roadmap context (`PLAN.md` §11) added so a future session can resume
into Phase 17 (Mermaid ER visualisation) without re-deriving the plan.

## Test plan

- [ ] CI: ruff, mypy --strict, full unit suite (target: still 100% coverage)
- [ ] CI matrix: PG 14, 15, 16, 17 integration tests green (including the
      new FDW + publication fixtures)
- [ ] `pgvector + postgres_fdw` extension paths exercised by the
      integration tests (postgres_fdw available in the contrib package
      shipped with the official PG images)
- [ ] 29 MCP tools now registered (was 20 after Phase 15 + 12–15
      additions); `_INTROSPECTION_TOOLS` set in
      `tests/unit/test_introspection.py` updated to enforce the
      registration contract

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Add new read-only PostgreSQL catalog introspection tools covering user-defined types, foreign data wrappers, and logical replication metadata, and wire them into the MCP tool surface with full test and docs updates.

New Features:
- Expose schema-level introspection for enum, domain, and standalone composite types via new list_* tools and dataclasses.
- Provide tools to inspect foreign-data wrappers, servers, tables, and user mappings, including parsed options metadata.
- Add read-only tools to list logical replication publications and subscriptions with their associated tables and publications.

Enhancements:
- Extend introspection test harness and integration suite to cover the new catalog surfaces, including postgres_fdw and publication fixtures.
- Update planning and progress documentation to capture the post-Phase-15 roadmap and mark Phase 16 as complete.
- Expand the introspection tool registry so all new catalog tools are callable from clients.

Documentation:
- Update PLAN and PROGRESS documents to document the post-Phase-15 roadmap and the completion of Phase 16, plus changelog entries for the new introspection tools.

Tests:
- Add unit tests for each new introspection function and its MCP tool wrapper, ensuring registration and mapping from raw rows to dataclasses.
- Add integration tests exercising enums, domains, composite types, FDW objects, and publications against a live PostgreSQL instance.