### PR TITLE
feat: Phase 17 — Mermaid ER diagrams + structured FK introspection (+ Batch G roadmap)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `list_foreign_keys` tool — every foreign key in a schema, resolved to
+  its from-columns, referenced schema, referenced table, and
+  to-columns. The two column arrays are aligned by ordinal position.
+- `generate_schema_diagram` tool — renders a Mermaid ER diagram for a
+  schema (entities with PK/FK column markers, edges parent → child).
+  Views and foreign tables are excluded; partitions are excluded by
+  default and can be included with ``include_partitions=true``.
 - `list_constraints` tool — a table's primary-key, foreign-key, unique,
   check, and exclusion constraints.
 - `list_views` tool — the views and materialized views in a schema, with

--- a/PLAN.md
+++ b/PLAN.md
@@ -360,6 +360,14 @@ opens its own feature branch and pull request.
 - **Phase 26** — `LISTEN`/`NOTIFY` bridge. ADR-0005 picks between a
   polling model (recommended) and MCP notifications.
 
+### Batch G — ORM bridges (USP)
+- **Phase 28** — `generate_prisma_schema`: read the PG catalog and emit a
+  valid `.prisma` schema (mirrors `prisma db pull`). High-leverage
+  differentiator for TS/JS agentic workflows; sibling tools for Drizzle,
+  SQLAlchemy, and sqlc can follow under the same "schema → ORM DSL"
+  umbrella. Scope is deliberately narrow: catalog → DSL only, no
+  `.prisma` → DDL parsing and no `prisma migrate` subprocess driving.
+
 ### Batch F — Migrations with shadow workflow (LARGEST — gated on ADR-0006)
 - **Phase 27** — `prepare_migration`/`complete_migration` driven by the
   Phase-18 schema diff. ADR-0006 picks between same-DB shadow schema

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -6,15 +6,17 @@
 
 ## Current state
 
-- **Phase:** 16 — Introspection gaps (Phases 0–15 complete)
+- **Phase:** 17 — Schema visualisation (Phases 0–16 complete)
 - **Last updated:** 2026-05-23
 - **Branch:** `claude/postgresql-mcp-planning-8KssU`
 
 ## Next action
 
-> Phase 16 complete (Tasks 16.1–16.3, nine new introspection tools).
-> Awaiting direction before starting Phase 17 (schema visualisation /
-> Mermaid ER) — the next item in Batch A of the post-Phase-15 roadmap.
+> Phase 17 complete (`generate_schema_diagram` + `list_foreign_keys`).
+> Next: Phase 18 — schema diff (`compare_schemas`) — last item in
+> Batch A. `PLAN.md` §11 also gained Batch G (ORM bridges) starting
+> with Phase 28 `generate_prisma_schema` — a deliberate USP move; not
+> in flight yet.
 
 ## Phase 0 — Spike & foundation  ✅ COMPLETE
 
@@ -423,3 +425,14 @@
   `list_subscriptions` — read-only logical-replication catalog via
   `pg_publication`/`pg_publication_tables` and `pg_subscription`.
   Phase 16 complete (29 MCP tools total). 257 unit tests, 100% coverage.
+- 2026-05-23 — PR #4 merged to `main` (Phase 16); branch re-synced.
+- 2026-05-23 — Phase 17: added `list_foreign_keys` (structured FK
+  introspection via `pg_constraint`/`pg_attribute` aligned by ordinal)
+  and `generate_schema_diagram` (new `mcpg.diagrams` module) — a
+  Mermaid ER renderer with PK/FK column markers, parent→child edges,
+  cross-schema edge filtering, and an `include_partitions` knob.
+  Phase 17 complete (31 MCP tools total). 396 tests, 100% coverage.
+- 2026-05-23 — `PLAN.md` §11 gained Batch G (ORM bridges): Phase 28
+  `generate_prisma_schema` flagged as a deliberate USP. Sibling tools
+  for Drizzle, SQLAlchemy, sqlc may follow; scope deliberately narrow
+  (catalog → DSL only, no DSL→DDL parsing, no `prisma migrate` driving).

--- a/src/mcpg/diagrams.py
+++ b/src/mcpg/diagrams.py
@@ -1,0 +1,89 @@
+"""Schema-visualisation helpers.
+
+``generate_schema_diagram`` builds a Mermaid ER diagram for a schema by
+combining the existing introspection primitives. The result is a single
+string in Mermaid's ``erDiagram`` syntax — agents can paste it into any
+Mermaid-aware renderer (GitHub, Mermaid Live, IDEs).
+"""
+
+from __future__ import annotations
+
+import re
+
+from mcpg._vendor.sql import SqlDriver
+from mcpg.introspection import (
+    describe_table,
+    list_constraints,
+    list_foreign_keys,
+    list_tables,
+)
+
+_PRIMARY_KEY_COLUMNS = re.compile(r"PRIMARY KEY \(([^)]+)\)", re.IGNORECASE)
+_NON_IDENT = re.compile(r"[^A-Za-z0-9]+")
+
+
+def _sanitize(text: str) -> str:
+    """Reduce arbitrary text to a Mermaid-friendly identifier-like token.
+
+    Mermaid ER attribute types and entity names must be alphanumeric-ish;
+    runs of non-alphanumeric characters are collapsed to a single
+    underscore and surrounding underscores stripped.
+    """
+    cleaned = _NON_IDENT.sub("_", text).strip("_")
+    return cleaned or "_"
+
+
+def _parse_pk_columns(definition: str) -> set[str]:
+    """Extract the column names from a ``PRIMARY KEY (...)`` clause."""
+    match = _PRIMARY_KEY_COLUMNS.search(definition)
+    if not match:
+        return set()
+    return {column.strip().strip('"') for column in match.group(1).split(",")}
+
+
+async def generate_schema_diagram(driver: SqlDriver, schema: str, *, include_partitions: bool = False) -> str:
+    """Render a Mermaid ER diagram for the tables in ``schema``.
+
+    Views and foreign tables are skipped. Partitions are skipped by
+    default — set ``include_partitions=True`` to draw each partition as
+    its own entity alongside the partitioned parent.
+    """
+    tables = [table for table in await list_tables(driver, schema) if table.type == "BASE TABLE"]
+    if not include_partitions:
+        tables = [table for table in tables if not table.is_partition]
+    entity_names = {table.name for table in tables}
+
+    lines = ["erDiagram"]
+    for table in tables:
+        columns = await describe_table(driver, schema, table.name)
+        constraints = await list_constraints(driver, schema, table.name)
+        pk_columns: set[str] = set()
+        for constraint in constraints:
+            if constraint.type == "primary_key":
+                pk_columns |= _parse_pk_columns(constraint.definition)
+
+        fk_columns: set[str] = set()
+        for fk in await list_foreign_keys(driver, schema):
+            if fk.from_table == table.name:
+                fk_columns |= set(fk.from_columns)
+
+        lines.append(f"    {_sanitize(table.name)} {{")
+        for column in columns:
+            attrs: list[str] = []
+            if column.name in pk_columns:
+                attrs.append("PK")
+            if column.name in fk_columns:
+                attrs.append("FK")
+            suffix = f" {' '.join(attrs)}" if attrs else ""
+            lines.append(f"        {_sanitize(column.data_type)} {_sanitize(column.name)}{suffix}")
+        lines.append("    }")
+
+    for fk in await list_foreign_keys(driver, schema):
+        if fk.from_table not in entity_names or fk.to_table not in entity_names:
+            # Cross-schema FK or pointing to a filtered-out table — skip the
+            # edge rather than emit a dangling reference.
+            continue
+        label = ",".join(fk.from_columns)
+        lines.append(f'    {_sanitize(fk.to_table)} ||--o{{ {_sanitize(fk.from_table)} : "{label}"')
+
+    return "\n".join(lines) + "\n"

--- a/src/mcpg/diagrams.py
+++ b/src/mcpg/diagrams.py
@@ -53,6 +53,11 @@ async def generate_schema_diagram(driver: SqlDriver, schema: str, *, include_par
         tables = [table for table in tables if not table.is_partition]
     entity_names = {table.name for table in tables}
 
+    foreign_keys = await list_foreign_keys(driver, schema)
+    fk_columns_by_table: dict[str, set[str]] = {}
+    for fk in foreign_keys:
+        fk_columns_by_table.setdefault(fk.from_table, set()).update(fk.from_columns)
+
     lines = ["erDiagram"]
     for table in tables:
         columns = await describe_table(driver, schema, table.name)
@@ -62,10 +67,7 @@ async def generate_schema_diagram(driver: SqlDriver, schema: str, *, include_par
             if constraint.type == "primary_key":
                 pk_columns |= _parse_pk_columns(constraint.definition)
 
-        fk_columns: set[str] = set()
-        for fk in await list_foreign_keys(driver, schema):
-            if fk.from_table == table.name:
-                fk_columns |= set(fk.from_columns)
+        fk_columns = fk_columns_by_table.get(table.name, set())
 
         lines.append(f"    {_sanitize(table.name)} {{")
         for column in columns:
@@ -78,7 +80,7 @@ async def generate_schema_diagram(driver: SqlDriver, schema: str, *, include_par
             lines.append(f"        {_sanitize(column.data_type)} {_sanitize(column.name)}{suffix}")
         lines.append("    }")
 
-    for fk in await list_foreign_keys(driver, schema):
+    for fk in foreign_keys:
         if fk.from_table not in entity_names or fk.to_table not in entity_names:
             # Cross-schema FK or pointing to a filtered-out table — skip the
             # edge rather than emit a dangling reference.

--- a/src/mcpg/introspection.py
+++ b/src/mcpg/introspection.py
@@ -132,6 +132,23 @@ class ConstraintInfo:
 
 
 @dataclass(frozen=True, slots=True)
+class ForeignKeyInfo:
+    """A foreign-key constraint resolved to its referenced columns.
+
+    ``from_columns`` and ``to_columns`` are aligned by ordinal position —
+    ``from_columns[i]`` references ``to_columns[i]`` of
+    ``to_schema.to_table``.
+    """
+
+    name: str
+    from_table: str
+    from_columns: list[str]
+    to_schema: str
+    to_table: str
+    to_columns: list[str]
+
+
+@dataclass(frozen=True, slots=True)
 class PartitionInfo:
     """A partition of a partitioned table.
 
@@ -582,6 +599,47 @@ async def list_constraints(driver: SqlDriver, schema: str, table: str) -> list[C
             name=row.cells["name"],
             type=_CONSTRAINT_TYPES.get(row.cells["type_code"], "other"),
             definition=row.cells["definition"],
+        )
+        for row in rows or []
+    ]
+
+
+async def list_foreign_keys(driver: SqlDriver, schema: str) -> list[ForeignKeyInfo]:
+    """List every foreign key in a schema, resolved to columns and referenced table.
+
+    ``from_columns`` and ``to_columns`` are aligned by ordinal position.
+    """
+    rows = await driver.execute_query(
+        "SELECT c.conname AS name, cl.relname AS from_table, "
+        "  nf.nspname AS to_schema, clf.relname AS to_table, "
+        "  ("
+        "    SELECT array_agg(att.attname ORDER BY u.ord) "
+        "    FROM unnest(c.conkey) WITH ORDINALITY u(num, ord) "
+        "    JOIN pg_attribute att ON att.attrelid = c.conrelid AND att.attnum = u.num"
+        "  ) AS from_columns, "
+        "  ("
+        "    SELECT array_agg(att.attname ORDER BY u.ord) "
+        "    FROM unnest(c.confkey) WITH ORDINALITY u(num, ord) "
+        "    JOIN pg_attribute att ON att.attrelid = c.confrelid AND att.attnum = u.num"
+        "  ) AS to_columns "
+        "FROM pg_constraint c "
+        "JOIN pg_class cl ON cl.oid = c.conrelid "
+        "JOIN pg_namespace n ON n.oid = cl.relnamespace "
+        "JOIN pg_class clf ON clf.oid = c.confrelid "
+        "JOIN pg_namespace nf ON nf.oid = clf.relnamespace "
+        "WHERE c.contype = 'f' AND n.nspname = %s "
+        "ORDER BY cl.relname, c.conname",
+        params=[schema],
+        force_readonly=True,
+    )
+    return [
+        ForeignKeyInfo(
+            name=row.cells["name"],
+            from_table=row.cells["from_table"],
+            from_columns=list(row.cells["from_columns"]),
+            to_schema=row.cells["to_schema"],
+            to_table=row.cells["to_table"],
+            to_columns=list(row.cells["to_columns"]),
         )
         for row in rows or []
     ]

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -15,6 +15,7 @@ from mcp.server.session import ServerSession
 
 from mcpg import (
     __version__,
+    diagrams,
     extensions,
     health,
     indexing,
@@ -103,6 +104,14 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
     async def list_constraints(ctx: _Ctx, schema: str, table: str) -> list[dict[str, Any]]:
         constraints = await introspection.list_constraints(_driver(ctx), schema, table)
         return [asdict(constraint) for constraint in constraints]
+
+    @server.tool(
+        name="list_foreign_keys",
+        description="List foreign keys in a schema, resolved to columns and referenced table.",
+    )
+    async def list_foreign_keys(ctx: _Ctx, schema: str) -> list[dict[str, Any]]:
+        fks = await introspection.list_foreign_keys(_driver(ctx), schema)
+        return [asdict(fk) for fk in fks]
 
     @server.tool(
         name="list_views",
@@ -253,6 +262,19 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
     async def list_available_extensions(ctx: _Ctx) -> list[dict[str, Any]]:
         extensions = await introspection.list_available_extensions(_driver(ctx))
         return [asdict(extension) for extension in extensions]
+
+
+def _register_diagrams(server: FastMCP[AppContext]) -> None:
+    @server.tool(
+        name="generate_schema_diagram",
+        description=(
+            "Render a Mermaid ER diagram for a schema. Views and foreign tables are "
+            "excluded; partitions are excluded by default — pass include_partitions=true "
+            "to draw each partition as its own entity."
+        ),
+    )
+    async def generate_schema_diagram(ctx: _Ctx, schema: str, include_partitions: bool = False) -> str:
+        return await diagrams.generate_schema_diagram(_driver(ctx), schema, include_partitions=include_partitions)
 
 
 def _register_query(server: FastMCP[AppContext]) -> None:
@@ -513,6 +535,7 @@ def register_tools(server: FastMCP[AppContext], settings: Settings) -> None:
     _register_server_info(server)
     if is_permitted(settings.access_mode, Capability.READ):
         _register_introspection(server)
+        _register_diagrams(server)
         _register_query(server)
         _register_health(server)
         _register_liveops(server)

--- a/tests/integration/test_diagrams_integration.py
+++ b/tests/integration/test_diagrams_integration.py
@@ -1,0 +1,42 @@
+"""Integration tests for the Mermaid ER diagram generator."""
+
+from collections.abc import AsyncIterator
+
+import pytest
+
+from mcpg.database import Database
+from mcpg.diagrams import generate_schema_diagram
+
+_SCHEMA = "mcpg_diagrams_it"
+
+
+@pytest.fixture
+async def diagram_schema(connected_database: Database) -> AsyncIterator[str]:
+    """Create a small two-table schema with a real foreign key."""
+    driver = connected_database.driver()
+    await driver.execute_query(f"DROP SCHEMA IF EXISTS {_SCHEMA} CASCADE")
+    await driver.execute_query(f"CREATE SCHEMA {_SCHEMA}")
+    await driver.execute_query(f"CREATE TABLE {_SCHEMA}.widget (id integer PRIMARY KEY, name text NOT NULL)")
+    await driver.execute_query(
+        f"CREATE TABLE {_SCHEMA}.order_item ("
+        f"  id integer PRIMARY KEY, "
+        f"  widget_id integer NOT NULL REFERENCES {_SCHEMA}.widget(id)"
+        f")"
+    )
+    try:
+        yield _SCHEMA
+    finally:
+        await driver.execute_query(f"DROP SCHEMA IF EXISTS {_SCHEMA} CASCADE")
+
+
+async def test_generate_schema_diagram_renders_entities_and_fk_edge(
+    connected_database: Database, diagram_schema: str
+) -> None:
+    rendered = await generate_schema_diagram(connected_database.driver(), diagram_schema)
+
+    assert rendered.startswith("erDiagram\n")
+    assert "widget {" in rendered
+    assert "order_item {" in rendered
+    assert "integer id PK" in rendered
+    assert "integer widget_id" in rendered and "FK" in rendered
+    assert "widget ||--o{ order_item" in rendered

--- a/tests/integration/test_diagrams_integration.py
+++ b/tests/integration/test_diagrams_integration.py
@@ -38,5 +38,5 @@ async def test_generate_schema_diagram_renders_entities_and_fk_edge(
     assert "widget {" in rendered
     assert "order_item {" in rendered
     assert "integer id PK" in rendered
-    assert "integer widget_id" in rendered and "FK" in rendered
+    assert "integer widget_id FK" in rendered
     assert "widget ||--o{ order_item" in rendered

--- a/tests/unit/test_diagrams.py
+++ b/tests/unit/test_diagrams.py
@@ -23,6 +23,8 @@ def test_sanitize_collapses_non_alphanumeric_runs_and_strips_edges() -> None:
     # Pathological all-punctuation input degrades to a placeholder rather
     # than producing an empty Mermaid token (which the parser would reject).
     assert _sanitize("---") == "_"
+    # Leading and trailing whitespace must not survive as separator underscores.
+    assert _sanitize("  text with spaces  ") == "text_with_spaces"
 
 
 def test_parse_pk_columns_extracts_quoted_and_unquoted_columns() -> None:
@@ -121,6 +123,47 @@ async def test_generate_schema_diagram_skips_edges_pointing_outside_the_schema()
     assert "||--o{" not in rendered
 
 
+async def test_generate_schema_diagram_includes_partitions_when_requested() -> None:
+    routes = _routes()
+    routes["FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = %s AND c.relkind"] = [
+        {"name": "event", "relkind": "p", "is_partition": False},
+        {"name": "event_2026", "relkind": "r", "is_partition": True},
+    ]
+    driver = FakeRoutingDriver(routes)
+
+    rendered = await generate_schema_diagram(driver, "app", include_partitions=True)
+
+    # Both the partitioned parent and the partition itself are drawn.
+    assert "    event {\n" in rendered
+    assert "    event_2026 {\n" in rendered
+
+
+async def test_generate_schema_diagram_skips_edges_pointing_to_filtered_partitions() -> None:
+    # Same-schema partner of the cross-schema test — the FK target table is
+    # filtered out (partition skipped by default), so no edge is emitted
+    # even though the FK has to_schema == 'app'.
+    routes = _routes()
+    routes["FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = %s AND c.relkind"] = [
+        {"name": "order", "relkind": "r", "is_partition": False},
+        {"name": "event_2026", "relkind": "r", "is_partition": True},
+    ]
+    routes["FROM pg_constraint c JOIN pg_class cl ON cl.oid = c.conrelid"] = [
+        {
+            "name": "order_event_fk",
+            "from_table": "order",
+            "to_schema": "app",
+            "to_table": "event_2026",
+            "from_columns": ["event_id"],
+            "to_columns": ["id"],
+        }
+    ]
+    driver = FakeRoutingDriver(routes)
+
+    rendered = await generate_schema_diagram(driver, "app", include_partitions=False)
+
+    assert "||--o{" not in rendered
+
+
 # --- MCP tool wiring -------------------------------------------------------
 
 
@@ -134,3 +177,6 @@ async def test_generate_schema_diagram_tool_is_registered_and_callable() -> None
         result = await client.call_tool("generate_schema_diagram", {"schema": "app"})
 
     assert result.isError is False
+    # The wiring should hand the raw Mermaid string straight through; an empty
+    # schema still produces the ``erDiagram`` preamble.
+    assert result.content[0].text.startswith("erDiagram\n")  # type: ignore[union-attr]

--- a/tests/unit/test_diagrams.py
+++ b/tests/unit/test_diagrams.py
@@ -1,0 +1,136 @@
+"""Tests for the Mermaid ER diagram generator and its MCP tool."""
+
+from typing import Any
+
+from _fakes import FakeDatabase, FakeDriver, FakeRoutingDriver
+from mcp.shared.memory import create_connected_server_and_client_session
+
+from mcpg.config import load_settings
+from mcpg.diagrams import _parse_pk_columns, _sanitize, generate_schema_diagram
+from mcpg.server import create_server
+
+_SETTINGS = load_settings({"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db"})
+
+
+# --- helpers ---------------------------------------------------------------
+
+
+def test_sanitize_collapses_non_alphanumeric_runs_and_strips_edges() -> None:
+    assert _sanitize("character varying(255)") == "character_varying_255"
+    assert _sanitize("timestamp with time zone") == "timestamp_with_time_zone"
+    assert _sanitize("numeric(10,2)") == "numeric_10_2"
+    assert _sanitize("int4") == "int4"
+    # Pathological all-punctuation input degrades to a placeholder rather
+    # than producing an empty Mermaid token (which the parser would reject).
+    assert _sanitize("---") == "_"
+
+
+def test_parse_pk_columns_extracts_quoted_and_unquoted_columns() -> None:
+    assert _parse_pk_columns("PRIMARY KEY (id)") == {"id"}
+    assert _parse_pk_columns('PRIMARY KEY ("user_id", tenant)') == {"user_id", "tenant"}
+    assert _parse_pk_columns("CHECK (x > 0)") == set()
+
+
+# --- generate_schema_diagram ----------------------------------------------
+
+
+def _routes() -> dict[str, list[dict[str, Any]]]:
+    """Routes that satisfy every catalog query the generator issues."""
+    return {
+        # list_tables — both tables, no partitions
+        "FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = %s AND c.relkind": [
+            {"name": "widget", "relkind": "r", "is_partition": False},
+            {"name": "order", "relkind": "r", "is_partition": False},
+        ],
+        # describe_table — keyed by AS column_name so both tables resolve
+        "format_type(a.atttypid, a.atttypmod) AS data_type": [
+            {
+                "column_name": "id",
+                "data_type": "integer",
+                "nullable": False,
+                "column_default": None,
+                "type_name": "int4",
+                "type_mod": -1,
+            },
+        ],
+        # list_constraints — widget has PK on id (the order's PK is omitted
+        # in this fake so we exercise an unannotated column too).
+        "FROM pg_constraint con JOIN pg_class c ON c.oid = con.conrelid": [
+            {"name": "widget_pkey", "type_code": "p", "definition": "PRIMARY KEY (id)"},
+        ],
+        # list_foreign_keys — order(widget_id) -> widget(id)
+        "FROM pg_constraint c JOIN pg_class cl ON cl.oid = c.conrelid": [
+            {
+                "name": "order_widget_fk",
+                "from_table": "order",
+                "to_schema": "app",
+                "to_table": "widget",
+                "from_columns": ["widget_id"],
+                "to_columns": ["id"],
+            },
+        ],
+    }
+
+
+async def test_generate_schema_diagram_emits_entities_and_fk_edges() -> None:
+    driver = FakeRoutingDriver(_routes())
+
+    rendered = await generate_schema_diagram(driver, "app")
+
+    assert rendered.startswith("erDiagram\n")
+    # Entities with PK and FK markers, sanitised types
+    assert "    widget {\n        integer id PK\n    }" in rendered
+    assert "    order {\n" in rendered
+    assert "        integer id PK" in rendered or "        integer id\n" in rendered
+    # The FK edge points from the parent (widget) to the child (order)
+    assert '    widget ||--o{ order : "widget_id"' in rendered
+
+
+async def test_generate_schema_diagram_skips_partitions_by_default() -> None:
+    routes = _routes()
+    routes["FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = %s AND c.relkind"] = [
+        {"name": "event", "relkind": "p", "is_partition": False},
+        {"name": "event_2026", "relkind": "r", "is_partition": True},
+    ]
+    driver = FakeRoutingDriver(routes)
+
+    rendered = await generate_schema_diagram(driver, "app")
+
+    # The partition child is filtered out; the partitioned parent is
+    # excluded too because it is reported as ``type=BASE TABLE`` only
+    # when ``relkind='p'`` — that mapping is exercised by list_tables.
+    assert "event_2026" not in rendered
+
+
+async def test_generate_schema_diagram_skips_edges_pointing_outside_the_schema() -> None:
+    routes = _routes()
+    routes["FROM pg_constraint c JOIN pg_class cl ON cl.oid = c.conrelid"] = [
+        {
+            "name": "cross_fk",
+            "from_table": "order",
+            "to_schema": "other",
+            "to_table": "absent",
+            "from_columns": ["x"],
+            "to_columns": ["y"],
+        }
+    ]
+    driver = FakeRoutingDriver(routes)
+
+    rendered = await generate_schema_diagram(driver, "app")
+
+    assert "||--o{" not in rendered
+
+
+# --- MCP tool wiring -------------------------------------------------------
+
+
+async def test_generate_schema_diagram_tool_is_registered_and_callable() -> None:
+    server = create_server(_SETTINGS, database=FakeDatabase(FakeDriver()))  # type: ignore[arg-type]
+
+    async with create_connected_server_and_client_session(server) as client:
+        listed = {tool.name for tool in (await client.list_tools()).tools}
+        assert "generate_schema_diagram" in listed
+
+        result = await client.call_tool("generate_schema_diagram", {"schema": "app"})
+
+    assert result.isError is False

--- a/tests/unit/test_introspection.py
+++ b/tests/unit/test_introspection.py
@@ -287,6 +287,10 @@ async def test_list_foreign_keys_maps_rows_aligned_by_ordinal() -> None:
     assert driver.calls[0][1] == ["app"]
 
 
+async def test_list_foreign_keys_returns_an_empty_list_when_no_foreign_keys() -> None:
+    assert await list_foreign_keys(FakeDriver([]), "app") == []
+
+
 async def test_list_partitions_describes_a_range_partitioned_table() -> None:
     driver = FakeDriver(
         [

--- a/tests/unit/test_introspection.py
+++ b/tests/unit/test_introspection.py
@@ -14,6 +14,7 @@ from mcpg.introspection import (
     EnumInfo,
     ExtensionInfo,
     ForeignDataWrapperInfo,
+    ForeignKeyInfo,
     ForeignServerInfo,
     ForeignTableInfo,
     FunctionInfo,
@@ -40,6 +41,7 @@ from mcpg.introspection import (
     list_enums,
     list_extensions,
     list_foreign_data_wrappers,
+    list_foreign_keys,
     list_foreign_servers,
     list_foreign_tables,
     list_functions,
@@ -254,6 +256,35 @@ async def test_list_constraints_maps_an_unknown_type_code_to_other() -> None:
     driver = FakeDriver([{"name": "x", "type_code": "z", "definition": "..."}])
 
     assert (await list_constraints(driver, "app", "t"))[0].type == "other"
+
+
+async def test_list_foreign_keys_maps_rows_aligned_by_ordinal() -> None:
+    driver = FakeDriver(
+        [
+            {
+                "name": "order_widget_fk",
+                "from_table": "order",
+                "to_schema": "app",
+                "to_table": "widget",
+                "from_columns": ["widget_id"],
+                "to_columns": ["id"],
+            },
+            {
+                "name": "order_composite_fk",
+                "from_table": "order",
+                "to_schema": "app",
+                "to_table": "shard",
+                "from_columns": ["tenant", "shard_no"],
+                "to_columns": ["tenant_id", "no"],
+            },
+        ]
+    )
+
+    assert await list_foreign_keys(driver, "app") == [
+        ForeignKeyInfo("order_widget_fk", "order", ["widget_id"], "app", "widget", ["id"]),
+        ForeignKeyInfo("order_composite_fk", "order", ["tenant", "shard_no"], "app", "shard", ["tenant_id", "no"]),
+    ]
+    assert driver.calls[0][1] == ["app"]
 
 
 async def test_list_partitions_describes_a_range_partitioned_table() -> None:
@@ -714,6 +745,7 @@ _INTROSPECTION_TOOLS = {
     "describe_table",
     "list_indexes",
     "list_constraints",
+    "list_foreign_keys",
     "list_views",
     "list_functions",
     "list_triggers",
@@ -760,6 +792,19 @@ async def test_every_introspection_tool_is_callable_from_a_client() -> None:
         "list_constraints": (
             {"schema": "app", "table": "w"},
             [{"name": "w_pkey", "type_code": "p", "definition": "PRIMARY KEY (id)"}],
+        ),
+        "list_foreign_keys": (
+            {"schema": "app"},
+            [
+                {
+                    "name": "fk",
+                    "from_table": "order",
+                    "to_schema": "app",
+                    "to_table": "widget",
+                    "from_columns": ["widget_id"],
+                    "to_columns": ["id"],
+                }
+            ],
         ),
         "list_views": (
             {"schema": "app"},


### PR DESCRIPTION
## Summary

Phase 17 of Batch A (`PLAN.md` §11). Adds the schema-visualisation
deliverable plus a piece of structured FK introspection the renderer
needed.

- **`generate_schema_diagram`** — new `mcpg.diagrams` module renders a
  schema as a Mermaid `erDiagram` block: entities with PK/FK markers
  and parent→child edges. Views and foreign tables are excluded;
  partitions are excluded by default and can be drawn with
  `include_partitions=true`. Edges pointing outside the rendered entity
  set (cross-schema or filtered-out tables) are skipped rather than
  left dangling. Output is a single string an agent can paste into any
  Mermaid-aware renderer.
- **`list_foreign_keys`** — new in `mcpg.introspection`. Gives the
  renderer structured FK data instead of regex'ing
  `pg_get_constraintdef`. The two column arrays are aligned by ordinal
  position, computed via `unnest(... WITH ORDINALITY)` joined to
  `pg_attribute` on both sides. Surfaced as a public tool — useful
  standalone for any "which columns reference what" question, and
  prerequisite for Phase 18 schema diff.

Two MCP tools registered (was 29 after Phase 16, now 31).

### Roadmap update — Batch G (ORM bridges) — also included

`PLAN.md` §11 gains **Batch G — ORM bridges** with **Phase 28
`generate_prisma_schema`** as a deliberate USP move. No other PG MCP
server bridges the catalog to an ORM's schema DSL; Prisma is the
highest-leverage starting point (~3M weekly downloads). Scope is
intentionally narrow: catalog → DSL only — no `.prisma` → DDL
parsing and no `prisma migrate` subprocess driving. Drizzle,
SQLAlchemy, and sqlc can follow as siblings under the same umbrella.

This commit only records the roadmap entry; Batch G is not in flight.

## Test plan

- [ ] CI: ruff, mypy --strict, full unit + integration suites green
- [ ] CI matrix: PG 14 / 15 / 16 / 17 — integration test renders a real
      two-table schema with a real FK and asserts the diagram output
- [ ] Coverage gate (fail_under = 90) on authored code; 100%
      maintained
- [ ] Unit tests exercise `_sanitize` edge cases (whitespace, parens,
      pathological all-punctuation), `_parse_pk_columns` (quoted +
      unquoted), partition filtering, cross-schema edge filtering, and
      MCP tool wiring via the in-process client

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Add a Mermaid-based schema diagram generator and structured foreign key introspection, and expose them as new MCP tools alongside roadmap and documentation updates.

New Features:
- Expose a list_foreign_keys introspection tool that returns structured foreign key metadata for all tables in a schema.
- Introduce a generate_schema_diagram tool that renders a Mermaid ER diagram from the database schema, with optional partition inclusion.

Enhancements:
- Add a ForeignKeyInfo data structure and query to resolve foreign key relationships with column-level detail.
- Wire the new diagram generator into the server tool registration flow so it is available in read-only access mode.

Documentation:
- Update PROGRESS.md and PLAN.md to reflect completion of Phase 17, the addition of the new tools, and the future Batch G ORM bridge roadmap.

Tests:
- Add unit tests for the diagram generator’s sanitisation, primary-key parsing, partition and cross-schema filtering, and MCP tool wiring.
- Add unit tests for list_foreign_keys to verify column alignment and MCP exposure.
- Add an integration test that renders a diagram from a real two-table schema with a foreign key edge.