### PR TITLE
feat: Phase 22 — pg_cron + pg_partman wrappers (Batch C, part 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `list_cron_jobs` tool — read pg_cron's `cron.job` catalog. Returns an
+  empty list when pg_cron is not installed (graceful degradation).
+- `schedule_cron_job` and `unschedule_cron_job` tools (write-gated) —
+  thin wrappers over `cron.schedule()` / `cron.unschedule()`. Raise
+  `CronError` when pg_cron is not installed.
+- `partman_create_parent`, `partman_run_maintenance`,
+  `partman_drop_partition` tools (write-gated) — pg_partman
+  partition-set creation, periodic maintenance (forward partitions +
+  retention drops), and explicit retention-based drops (time- or
+  id-controlled). `partition_type` is allowlisted to
+  range/list/native. Raise `PartmanError` when pg_partman is not
+  installed.
+- `pg_cron` and `pg_partman` added to `ENABLEABLE_EXTENSIONS` — agents
+  can request enabling them (still gated on unrestricted mode +
+  `MCPG_ALLOW_DDL`; pg_cron also requires server-side
+  `shared_preload_libraries`).
+
 ## [0.3.0] - 2026-05-23
 
 Twelve new MCP tools, closing Batch A of the post-0.2.0 roadmap

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -6,24 +6,20 @@
 
 ## Current state
 
-- **Phase:** 18 — Schema diff (Phases 0–18 complete; **Batch A done**;
-  v0.3.0 cut)
+- **Phase:** 22 — pg_cron + pg_partman wrappers (Phases 0–18 + 22
+  complete; v0.3.0 cut)
 - **Last updated:** 2026-05-23
 - **Branch:** `claude/postgresql-mcp-planning-8KssU`
-- **Tool count:** 45
+- **Tool count:** 51
 
 ## Next action
 
-> **v0.3.0 cut** — Batch A delivered (catalog completeness →
-> visualisation → diff). Awaiting direction on the next batch:
->
-> - **Batch B** — Advisors / lint (Phase 20) + audit trail (Phase 21);
-> - **Batch C** — extension power-tools (`pg_cron`/`pg_partman`/pgvector);
-> - **Batch G (USP)** — `generate_prisma_schema` then sibling ORM
->   bridges (Drizzle, SQLAlchemy, sqlc).
->
-> Batches D, E, F still require their ADRs first (subprocess policy,
-> NOTIFY model, migration shadowing).
+> Phase 22 (Batch C first half) complete — 6 new tools across pg_cron
+> and pg_partman, all gated on extension availability with graceful
+> degradation. Next: **Phase 23 — pgvector tuning**
+> (`tune_vector_index`, `vector_recall_at_k`) to finish Batch C, then
+> **Batch G (Phase 28 — `generate_prisma_schema`)** per the user's
+> sequencing direction.
 
 ## Phase 0 — Spike & foundation  ✅ COMPLETE
 
@@ -464,3 +460,18 @@
   integration (real-PG smoke across the matrix) — closes the one
   trust gap a fake driver couldn't reach. PROGRESS tool counts
   corrected (Phases 16/17/18 were drifting low).
+- 2026-05-23 — PR #7 merged to `main` (v0.3.0 release); branch
+  re-synced. Local `v0.3.0` tag created on `1c74b04` but `git push`
+  to the sandboxed remote returned 403; GitHub release to be cut
+  manually from `docs/release-notes-0.3.0.md`.
+- 2026-05-23 — Phase 22 (Batch C, first half): new `mcpg.cron` module
+  adds `list_cron_jobs` (read; returns `[]` when pg_cron absent),
+  `schedule_cron_job` and `unschedule_cron_job` (write-gated). New
+  `mcpg.partman` module adds `partman_create_parent`,
+  `partman_run_maintenance` (single parent or all), and
+  `partman_drop_partition` (time- or id-controlled retention). Both
+  extensions added to `ENABLEABLE_EXTENSIONS`. Tests: 24 new unit
+  tests covering graceful degradation + tool wiring matrix; new
+  integration tests gated on extension availability (CI image
+  doesn't ship either extension — skip path verified). Phase 22
+  complete (51 MCP tools total). 434 tests, 100% coverage.

--- a/src/mcpg/cron.py
+++ b/src/mcpg/cron.py
@@ -1,0 +1,111 @@
+"""pg_cron job-scheduling wrappers.
+
+pg_cron is a background-worker extension that runs scheduled SQL inside
+the database. MCPg exposes a thin read tool plus two write-gated tools
+that drive the extension's ``cron.schedule()`` / ``cron.unschedule()``
+functions. All write tools raise :class:`CronError` when the extension
+is not installed; the read tool returns an empty list.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mcpg._vendor.sql import SqlDriver
+from mcpg.extensions import extension_installed
+
+
+class CronError(Exception):
+    """Raised when a pg_cron operation cannot complete."""
+
+
+@dataclass(frozen=True, slots=True)
+class CronJob:
+    """A scheduled pg_cron job.
+
+    ``jobname`` is the user-supplied label (PG 14+ only; ``None`` on
+    older servers). ``active`` is ``True`` when the job will run.
+    """
+
+    jobid: int
+    schedule: str
+    command: str
+    database: str
+    username: str
+    active: bool
+    jobname: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class ScheduleResult:
+    """The outcome of scheduling a new cron job."""
+
+    jobid: int
+    name: str
+
+
+async def list_cron_jobs(driver: SqlDriver) -> list[CronJob]:
+    """List the pg_cron jobs registered in the database.
+
+    Returns an empty list when pg_cron is not installed — callers can
+    treat absence as "no jobs" rather than a hard error.
+    """
+    if not await extension_installed(driver, "pg_cron"):
+        return []
+    rows = await driver.execute_query(
+        "SELECT jobid, schedule, command, database, username, active, jobname FROM cron.job ORDER BY jobid",
+        force_readonly=True,
+    )
+    return [
+        CronJob(
+            jobid=row.cells["jobid"],
+            schedule=row.cells["schedule"],
+            command=row.cells["command"],
+            database=row.cells["database"],
+            username=row.cells["username"],
+            active=row.cells["active"],
+            jobname=row.cells["jobname"],
+        )
+        for row in rows or []
+    ]
+
+
+async def schedule_cron_job(driver: SqlDriver, name: str, schedule: str, command: str) -> ScheduleResult:
+    """Register a new pg_cron job and return the assigned jobid.
+
+    ``schedule`` is a cron expression (e.g. ``"*/5 * * * *"``) or one of
+    pg_cron's interval shortcuts (e.g. ``"30 seconds"``). ``command``
+    is the SQL to execute, run with the privileges of the connected
+    role.
+
+    Raises:
+        CronError: pg_cron is not installed, or the scheduling call
+            failed (invalid schedule expression, name conflict, etc.).
+    """
+    if not await extension_installed(driver, "pg_cron"):
+        raise CronError("pg_cron extension is not installed in this database")
+    rows = await driver.execute_query(
+        "SELECT cron.schedule(%s, %s, %s) AS jobid",
+        params=[name, schedule, command],
+    )
+    if not rows:
+        raise CronError(f"cron.schedule did not return a jobid for {name!r}")
+    return ScheduleResult(jobid=rows[0].cells["jobid"], name=name)
+
+
+async def unschedule_cron_job(driver: SqlDriver, name: str) -> bool:
+    """Unschedule a pg_cron job by name.
+
+    Returns the boolean pg_cron returns from ``cron.unschedule(name)``
+    — ``True`` when the job existed and was removed.
+
+    Raises:
+        CronError: pg_cron is not installed.
+    """
+    if not await extension_installed(driver, "pg_cron"):
+        raise CronError("pg_cron extension is not installed in this database")
+    rows = await driver.execute_query(
+        "SELECT cron.unschedule(%s) AS removed",
+        params=[name],
+    )
+    return bool(rows and rows[0].cells["removed"])

--- a/src/mcpg/cron.py
+++ b/src/mcpg/cron.py
@@ -23,8 +23,11 @@ class CronError(Exception):
 class CronJob:
     """A scheduled pg_cron job.
 
-    ``jobname`` is the user-supplied label (PG 14+ only; ``None`` on
-    older servers). ``active`` is ``True`` when the job will run.
+    ``jobname`` is the user-supplied label, available from pg_cron 1.4
+    onwards (the column was added in that release). MCPg targets the
+    1.4+ schema; older pg_cron installations will surface as a query
+    error rather than silently filling ``None``. ``active`` is ``True``
+    when the job will run.
     """
 
     jobid: int

--- a/src/mcpg/extensions.py
+++ b/src/mcpg/extensions.py
@@ -36,6 +36,8 @@ ENABLEABLE_EXTENSIONS = frozenset(
         "earthdistance",
         "postgis",
         "postgres_fdw",
+        "pg_cron",
+        "pg_partman",
     }
 )
 

--- a/src/mcpg/partman.py
+++ b/src/mcpg/partman.py
@@ -1,0 +1,124 @@
+"""pg_partman partition-management wrappers.
+
+pg_partman drives PostgreSQL's declarative partitioning with helpers
+for creating partition sets, running periodic maintenance (adding
+forward partitions, dropping retired ones), and retention-based
+partition drops.
+
+All tools are write-gated. Each raises :class:`PartmanError` when the
+extension is not installed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mcpg._vendor.sql import SqlDriver
+from mcpg.extensions import extension_installed
+
+# pg_partman accepts these partition-type strings since version 5.x —
+# 'range' and 'list' for declarative partitioning, 'native' as a legacy
+# alias. The allowlist guards against arbitrary identifier injection.
+_PARTITION_TYPES = frozenset({"range", "list", "native"})
+
+
+class PartmanError(Exception):
+    """Raised when a pg_partman operation cannot complete."""
+
+
+@dataclass(frozen=True, slots=True)
+class PartmanResult:
+    """Generic outcome of a pg_partman call."""
+
+    parent_table: str
+    detail: str
+
+
+async def _ensure_installed(driver: SqlDriver) -> None:
+    if not await extension_installed(driver, "pg_partman"):
+        raise PartmanError("pg_partman extension is not installed in this database")
+
+
+async def partman_create_parent(
+    driver: SqlDriver,
+    parent_table: str,
+    control_column: str,
+    partition_interval: str,
+    *,
+    partition_type: str = "range",
+) -> PartmanResult:
+    """Register ``parent_table`` as a pg_partman-managed partition set.
+
+    ``parent_table`` must already exist as a partitioned table.
+    ``control_column`` is the column pg_partman uses to derive
+    partition bounds; ``partition_interval`` is a string accepted by
+    pg_partman (e.g. ``"daily"``, ``"1 month"``, ``"1000"``).
+
+    Raises:
+        PartmanError: pg_partman is not installed, ``partition_type``
+            is not in the allowlist, or the underlying create_parent
+            call returns false.
+    """
+    await _ensure_installed(driver)
+    if partition_type not in _PARTITION_TYPES:
+        raise PartmanError(f"unsupported partition_type {partition_type!r}; expected one of {sorted(_PARTITION_TYPES)}")
+    rows = await driver.execute_query(
+        "SELECT partman.create_parent("
+        "  p_parent_table := %s, "
+        "  p_control := %s, "
+        "  p_type := %s, "
+        "  p_interval := %s"
+        ") AS created",
+        params=[parent_table, control_column, partition_type, partition_interval],
+    )
+    created = bool(rows and rows[0].cells["created"])
+    if not created:
+        raise PartmanError(f"partman.create_parent returned false for {parent_table!r}")
+    return PartmanResult(parent_table=parent_table, detail="created")
+
+
+async def partman_run_maintenance(driver: SqlDriver, parent_table: str | None = None) -> PartmanResult:
+    """Run pg_partman maintenance — add forward partitions, drop retired ones.
+
+    When ``parent_table`` is ``None``, maintenance runs for every
+    pg_partman-managed parent in the database.
+    """
+    await _ensure_installed(driver)
+    if parent_table is None:
+        await driver.execute_query("SELECT partman.run_maintenance()")
+        return PartmanResult(parent_table="*", detail="ran maintenance across all parents")
+    await driver.execute_query(
+        "SELECT partman.run_maintenance(p_parent_table := %s)",
+        params=[parent_table],
+    )
+    return PartmanResult(parent_table=parent_table, detail="ran maintenance")
+
+
+async def partman_drop_partition(
+    driver: SqlDriver,
+    parent_table: str,
+    retention: str,
+    *,
+    control_is_time: bool = True,
+) -> list[str]:
+    """Drop pg_partman partitions older than ``retention``.
+
+    For time-controlled parents (the default), ``retention`` is a
+    PostgreSQL interval (``"30 days"``, ``"1 year"``). For id-controlled
+    parents, set ``control_is_time=False`` and pass an integer-like
+    string (``"1000000"``).
+
+    Returns the qualified names of the dropped partitions.
+    """
+    await _ensure_installed(driver)
+    if control_is_time:
+        rows = await driver.execute_query(
+            "SELECT partman.drop_partition_time(  p_parent_table := %s,   p_retention := %s) AS dropped",
+            params=[parent_table, retention],
+        )
+    else:
+        rows = await driver.execute_query(
+            "SELECT partman.drop_partition_id(  p_parent_table := %s,   p_retention := %s::bigint) AS dropped",
+            params=[parent_table, retention],
+        )
+    return [row.cells["dropped"] for row in rows or [] if row.cells["dropped"]]

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -15,6 +15,7 @@ from mcp.server.session import ServerSession
 
 from mcpg import (
     __version__,
+    cron,
     diagrams,
     extensions,
     health,
@@ -22,6 +23,7 @@ from mcpg import (
     introspection,
     liveops,
     maintenance,
+    partman,
     query,
     schema_diff,
     textsearch,
@@ -462,6 +464,100 @@ def _register_liveops(server: FastMCP[AppContext]) -> None:
         queries = await liveops.list_active_queries(_driver(ctx))
         return [asdict(active) for active in queries]
 
+    @server.tool(
+        name="list_cron_jobs",
+        description=(
+            "List the pg_cron jobs registered in the database. Returns an empty list when pg_cron is not installed."
+        ),
+    )
+    async def list_cron_jobs(ctx: _Ctx) -> list[dict[str, Any]]:
+        jobs = await cron.list_cron_jobs(_driver(ctx))
+        return [asdict(job) for job in jobs]
+
+
+def _register_scheduling(server: FastMCP[AppContext]) -> None:
+    @server.tool(
+        name="schedule_cron_job",
+        description=(
+            "Register a pg_cron job. ``schedule`` is a cron expression or "
+            "pg_cron interval shortcut (e.g. '30 seconds'). Available only "
+            "in unrestricted mode; requires pg_cron installed."
+        ),
+    )
+    async def schedule_cron_job(ctx: _Ctx, name: str, schedule: str, command: str) -> dict[str, Any]:
+        result = await cron.schedule_cron_job(_driver(ctx), name, schedule, command)
+        return asdict(result)
+
+    @server.tool(
+        name="unschedule_cron_job",
+        description=(
+            "Unschedule a pg_cron job by name. Returns ``removed=true`` when the "
+            "job existed. Available only in unrestricted mode."
+        ),
+    )
+    async def unschedule_cron_job(ctx: _Ctx, name: str) -> dict[str, Any]:
+        removed = await cron.unschedule_cron_job(_driver(ctx), name)
+        return {"name": name, "removed": removed}
+
+    @server.tool(
+        name="partman_create_parent",
+        description=(
+            "Register a partitioned table with pg_partman. ``partition_type`` "
+            "must be 'range', 'list', or 'native'. Available only in "
+            "unrestricted mode; requires pg_partman installed."
+        ),
+    )
+    async def partman_create_parent(
+        ctx: _Ctx,
+        parent_table: str,
+        control_column: str,
+        partition_interval: str,
+        partition_type: str = "range",
+    ) -> dict[str, Any]:
+        result = await partman.partman_create_parent(
+            _driver(ctx),
+            parent_table,
+            control_column,
+            partition_interval,
+            partition_type=partition_type,
+        )
+        return asdict(result)
+
+    @server.tool(
+        name="partman_run_maintenance",
+        description=(
+            "Run pg_partman maintenance — add forward partitions and drop "
+            "retired ones. Pass parent_table to scope to one parent; omit "
+            "to run for every managed parent. Unrestricted mode only."
+        ),
+    )
+    async def partman_run_maintenance(ctx: _Ctx, parent_table: str | None = None) -> dict[str, Any]:
+        result = await partman.partman_run_maintenance(_driver(ctx), parent_table)
+        return asdict(result)
+
+    @server.tool(
+        name="partman_drop_partition",
+        description=(
+            "Drop pg_partman partitions older than ``retention``. Time-controlled "
+            "parents take a PG interval (e.g. '30 days'); id-controlled parents "
+            "take an integer-like string with control_is_time=false. Returns the "
+            "dropped partition names. Unrestricted mode only."
+        ),
+    )
+    async def partman_drop_partition(
+        ctx: _Ctx,
+        parent_table: str,
+        retention: str,
+        control_is_time: bool = True,
+    ) -> dict[str, Any]:
+        dropped = await partman.partman_drop_partition(
+            _driver(ctx),
+            parent_table,
+            retention,
+            control_is_time=control_is_time,
+        )
+        return {"parent_table": parent_table, "dropped": dropped}
+
 
 def _register_write(server: FastMCP[AppContext]) -> None:
     @server.tool(
@@ -560,5 +656,6 @@ def register_tools(server: FastMCP[AppContext], settings: Settings) -> None:
         _register_write(server)
         _register_maintenance(server)
         _register_backend_control(server)
+        _register_scheduling(server)
     if is_permitted(settings.access_mode, Capability.DDL) and settings.allow_ddl:
         _register_ddl(server)

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -475,7 +475,7 @@ def _register_liveops(server: FastMCP[AppContext]) -> None:
         return [asdict(job) for job in jobs]
 
 
-def _register_scheduling(server: FastMCP[AppContext]) -> None:
+def _register_cron_write(server: FastMCP[AppContext]) -> None:
     @server.tool(
         name="schedule_cron_job",
         description=(
@@ -499,12 +499,14 @@ def _register_scheduling(server: FastMCP[AppContext]) -> None:
         removed = await cron.unschedule_cron_job(_driver(ctx), name)
         return {"name": name, "removed": removed}
 
+
+def _register_partman(server: FastMCP[AppContext]) -> None:
     @server.tool(
         name="partman_create_parent",
         description=(
             "Register a partitioned table with pg_partman. ``partition_type`` "
-            "must be 'range', 'list', or 'native'. Available only in "
-            "unrestricted mode; requires pg_partman installed."
+            "must be 'range', 'list', or 'native'. Performs DDL — requires "
+            "unrestricted mode + MCPG_ALLOW_DDL; pg_partman installed."
         ),
     )
     async def partman_create_parent(
@@ -528,7 +530,8 @@ def _register_scheduling(server: FastMCP[AppContext]) -> None:
         description=(
             "Run pg_partman maintenance — add forward partitions and drop "
             "retired ones. Pass parent_table to scope to one parent; omit "
-            "to run for every managed parent. Unrestricted mode only."
+            "to run for every managed parent. Performs DDL — requires "
+            "unrestricted mode + MCPG_ALLOW_DDL."
         ),
     )
     async def partman_run_maintenance(ctx: _Ctx, parent_table: str | None = None) -> dict[str, Any]:
@@ -541,7 +544,8 @@ def _register_scheduling(server: FastMCP[AppContext]) -> None:
             "Drop pg_partman partitions older than ``retention``. Time-controlled "
             "parents take a PG interval (e.g. '30 days'); id-controlled parents "
             "take an integer-like string with control_is_time=false. Returns the "
-            "dropped partition names. Unrestricted mode only."
+            "dropped partition names. Performs DDL — requires unrestricted mode "
+            "+ MCPG_ALLOW_DDL."
         ),
     )
     async def partman_drop_partition(
@@ -656,6 +660,7 @@ def register_tools(server: FastMCP[AppContext], settings: Settings) -> None:
         _register_write(server)
         _register_maintenance(server)
         _register_backend_control(server)
-        _register_scheduling(server)
+        _register_cron_write(server)
     if is_permitted(settings.access_mode, Capability.DDL) and settings.allow_ddl:
         _register_ddl(server)
+        _register_partman(server)

--- a/tests/integration/test_cron_integration.py
+++ b/tests/integration/test_cron_integration.py
@@ -1,0 +1,44 @@
+"""Integration tests for pg_cron wrappers — gated on the extension."""
+
+import pytest
+
+from mcpg.cron import list_cron_jobs, schedule_cron_job, unschedule_cron_job
+from mcpg.database import Database
+from mcpg.extensions import enable_extension
+from mcpg.introspection import list_available_extensions
+
+
+async def test_list_cron_jobs_returns_empty_when_extension_absent(
+    connected_database: Database,
+) -> None:
+    # pg_cron typically requires shared_preload_libraries and isn't on the
+    # CI image; the read function must still answer without erroring.
+    available = {extension.name for extension in await list_available_extensions(connected_database.driver())}
+    if "pg_cron" in available:
+        pytest.skip("pg_cron is available — covered by the schedule-roundtrip test")
+
+    assert await list_cron_jobs(connected_database.driver()) == []
+
+
+async def test_schedule_then_unschedule_roundtrip(connected_database: Database) -> None:
+    driver = connected_database.driver()
+    available = {extension.name for extension in await list_available_extensions(driver)}
+    if "pg_cron" not in available:
+        pytest.skip("pg_cron is not available on this PostgreSQL server")
+    await enable_extension(driver, "pg_cron")
+
+    job_name = "mcpg_cron_it_heartbeat"
+    # Best-effort cleanup if a prior run left the job behind.
+    try:
+        await unschedule_cron_job(driver, job_name)
+    except Exception:
+        pass
+
+    scheduled = await schedule_cron_job(driver, job_name, "*/5 * * * *", "SELECT 1")
+    try:
+        names = {job.jobname for job in await list_cron_jobs(driver)}
+        assert job_name in names
+        assert scheduled.jobid > 0
+    finally:
+        removed = await unschedule_cron_job(driver, job_name)
+        assert removed is True

--- a/tests/integration/test_partman_integration.py
+++ b/tests/integration/test_partman_integration.py
@@ -1,0 +1,43 @@
+"""Integration test for pg_partman wrappers — gated on the extension."""
+
+from collections.abc import AsyncIterator
+
+import pytest
+
+from mcpg.database import Database
+from mcpg.extensions import enable_extension
+from mcpg.introspection import list_available_extensions
+from mcpg.partman import partman_create_parent, partman_run_maintenance
+
+_SCHEMA = "mcpg_partman_it"
+
+
+@pytest.fixture
+async def partman_schema(connected_database: Database) -> AsyncIterator[Database]:
+    """Build a partitioned table pg_partman can manage; skip if extension absent."""
+    driver = connected_database.driver()
+    available = {extension.name for extension in await list_available_extensions(driver)}
+    if "pg_partman" not in available:
+        pytest.skip("pg_partman is not available on this PostgreSQL server")
+    await enable_extension(driver, "pg_partman")
+    await driver.execute_query(f"DROP SCHEMA IF EXISTS {_SCHEMA} CASCADE")
+    await driver.execute_query(f"CREATE SCHEMA {_SCHEMA}")
+    await driver.execute_query(
+        f"CREATE TABLE {_SCHEMA}.event (  id bigserial,   created timestamp NOT NULL) PARTITION BY RANGE (created)"
+    )
+    try:
+        yield connected_database
+    finally:
+        await driver.execute_query(f"DROP SCHEMA IF EXISTS {_SCHEMA} CASCADE")
+
+
+async def test_partman_create_parent_and_run_maintenance(partman_schema: Database) -> None:
+    driver = partman_schema.driver()
+    parent = f"{_SCHEMA}.event"
+
+    created = await partman_create_parent(driver, parent, "created", "1 day")
+    assert created.parent_table == parent
+
+    # Maintenance on a freshly-created parent should succeed without raising.
+    swept = await partman_run_maintenance(driver, parent)
+    assert swept.parent_table == parent

--- a/tests/unit/test_cron.py
+++ b/tests/unit/test_cron.py
@@ -1,0 +1,133 @@
+"""Tests for pg_cron job-scheduling wrappers."""
+
+import pytest
+from _fakes import FakeDatabase, FakeDriver, FakeRoutingDriver
+from mcp.shared.memory import create_connected_server_and_client_session
+
+from mcpg.config import load_settings
+from mcpg.cron import CronError, CronJob, ScheduleResult, list_cron_jobs, schedule_cron_job, unschedule_cron_job
+from mcpg.server import create_server
+
+_UNRESTRICTED = load_settings(
+    {"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db", "MCPG_ACCESS_MODE": "unrestricted"}
+)
+_READ_ONLY = load_settings({"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db"})
+
+
+# --- list_cron_jobs --------------------------------------------------------
+
+
+async def test_list_cron_jobs_returns_empty_when_extension_absent() -> None:
+    driver = FakeRoutingDriver({"pg_extension": []})
+
+    assert await list_cron_jobs(driver) == []  # type: ignore[arg-type]
+
+
+async def test_list_cron_jobs_maps_rows_when_extension_present() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "FROM cron.job": [
+                {
+                    "jobid": 7,
+                    "schedule": "*/5 * * * *",
+                    "command": "SELECT 1",
+                    "database": "app",
+                    "username": "app_owner",
+                    "active": True,
+                    "jobname": "heartbeat",
+                }
+            ],
+        }
+    )
+
+    assert await list_cron_jobs(driver) == [  # type: ignore[arg-type]
+        CronJob(7, "*/5 * * * *", "SELECT 1", "app", "app_owner", True, "heartbeat")
+    ]
+
+
+# --- schedule_cron_job -----------------------------------------------------
+
+
+async def test_schedule_cron_job_returns_assigned_jobid() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "cron.schedule": [{"jobid": 42}],
+        }
+    )
+
+    result = await schedule_cron_job(driver, "heartbeat", "*/5 * * * *", "SELECT 1")  # type: ignore[arg-type]
+
+    assert result == ScheduleResult(jobid=42, name="heartbeat")
+
+
+async def test_schedule_cron_job_raises_when_extension_absent() -> None:
+    driver = FakeRoutingDriver({"pg_extension": []})
+
+    with pytest.raises(CronError, match="not installed"):
+        await schedule_cron_job(driver, "h", "* * * * *", "SELECT 1")  # type: ignore[arg-type]
+
+
+async def test_schedule_cron_job_raises_when_extension_returns_no_jobid() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}], "cron.schedule": []})
+
+    with pytest.raises(CronError, match="did not return a jobid"):
+        await schedule_cron_job(driver, "h", "* * * * *", "SELECT 1")  # type: ignore[arg-type]
+
+
+# --- unschedule_cron_job --------------------------------------------------
+
+
+async def test_unschedule_cron_job_returns_true_when_job_removed() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "cron.unschedule": [{"removed": True}],
+        }
+    )
+
+    assert await unschedule_cron_job(driver, "heartbeat") is True  # type: ignore[arg-type]
+
+
+async def test_unschedule_cron_job_returns_false_when_no_row() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "cron.unschedule": [],
+        }
+    )
+
+    assert await unschedule_cron_job(driver, "heartbeat") is False  # type: ignore[arg-type]
+
+
+async def test_unschedule_cron_job_raises_when_extension_absent() -> None:
+    driver = FakeRoutingDriver({"pg_extension": []})
+
+    with pytest.raises(CronError, match="not installed"):
+        await unschedule_cron_job(driver, "h")  # type: ignore[arg-type]
+
+
+# --- tool wiring -----------------------------------------------------------
+
+
+async def test_list_cron_jobs_tool_is_registered_in_read_mode() -> None:
+    server = create_server(_READ_ONLY, database=FakeDatabase(FakeDriver()))  # type: ignore[arg-type]
+    async with create_connected_server_and_client_session(server) as client:
+        listed = {tool.name for tool in (await client.list_tools()).tools}
+    assert "list_cron_jobs" in listed
+
+
+async def test_schedule_tools_require_unrestricted_mode() -> None:
+    server = create_server(_READ_ONLY, database=FakeDatabase(FakeDriver()))  # type: ignore[arg-type]
+    async with create_connected_server_and_client_session(server) as client:
+        listed = {tool.name for tool in (await client.list_tools()).tools}
+    assert "schedule_cron_job" not in listed
+    assert "unschedule_cron_job" not in listed
+
+
+async def test_schedule_tools_are_registered_in_unrestricted_mode() -> None:
+    server = create_server(_UNRESTRICTED, database=FakeDatabase(FakeDriver()))  # type: ignore[arg-type]
+    async with create_connected_server_and_client_session(server) as client:
+        listed = {tool.name for tool in (await client.list_tools()).tools}
+    assert {"schedule_cron_job", "unschedule_cron_job"} <= listed

--- a/tests/unit/test_partman.py
+++ b/tests/unit/test_partman.py
@@ -1,0 +1,152 @@
+"""Tests for pg_partman partition-management wrappers."""
+
+import pytest
+from _fakes import FakeDatabase, FakeDriver, FakeRoutingDriver
+from mcp.shared.memory import create_connected_server_and_client_session
+
+from mcpg.config import load_settings
+from mcpg.partman import (
+    PartmanError,
+    PartmanResult,
+    partman_create_parent,
+    partman_drop_partition,
+    partman_run_maintenance,
+)
+from mcpg.server import create_server
+
+_UNRESTRICTED = load_settings(
+    {"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db", "MCPG_ACCESS_MODE": "unrestricted"}
+)
+_READ_ONLY = load_settings({"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db"})
+
+
+# --- partman_create_parent -------------------------------------------------
+
+
+async def test_partman_create_parent_succeeds_when_extension_returns_true() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "partman.create_parent": [{"created": True}],
+        }
+    )
+
+    result = await partman_create_parent(driver, "app.event", "created", "1 day")  # type: ignore[arg-type]
+
+    assert result == PartmanResult(parent_table="app.event", detail="created")
+
+
+async def test_partman_create_parent_raises_when_extension_absent() -> None:
+    driver = FakeRoutingDriver({"pg_extension": []})
+
+    with pytest.raises(PartmanError, match="not installed"):
+        await partman_create_parent(driver, "app.event", "created", "1 day")  # type: ignore[arg-type]
+
+
+async def test_partman_create_parent_raises_on_unsupported_type() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(PartmanError, match="unsupported partition_type"):
+        await partman_create_parent(  # type: ignore[arg-type]
+            driver, "app.event", "created", "1 day", partition_type="hash"
+        )
+
+
+async def test_partman_create_parent_raises_when_create_returns_false() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "partman.create_parent": [{"created": False}],
+        }
+    )
+
+    with pytest.raises(PartmanError, match="returned false"):
+        await partman_create_parent(driver, "app.event", "created", "1 day")  # type: ignore[arg-type]
+
+
+# --- partman_run_maintenance ----------------------------------------------
+
+
+async def test_partman_run_maintenance_runs_for_all_parents_when_table_omitted() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}], "partman.run_maintenance": []})
+
+    result = await partman_run_maintenance(driver)  # type: ignore[arg-type]
+
+    assert result.parent_table == "*"
+
+
+async def test_partman_run_maintenance_scoped_to_one_parent() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}], "partman.run_maintenance": []})
+
+    result = await partman_run_maintenance(driver, "app.event")  # type: ignore[arg-type]
+
+    assert result.parent_table == "app.event"
+
+
+async def test_partman_run_maintenance_raises_when_extension_absent() -> None:
+    driver = FakeRoutingDriver({"pg_extension": []})
+
+    with pytest.raises(PartmanError, match="not installed"):
+        await partman_run_maintenance(driver)  # type: ignore[arg-type]
+
+
+# --- partman_drop_partition -----------------------------------------------
+
+
+async def test_partman_drop_partition_returns_dropped_names_for_time_retention() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "partman.drop_partition_time": [{"dropped": "app.event_2024_01"}, {"dropped": "app.event_2024_02"}],
+        }
+    )
+
+    dropped = await partman_drop_partition(driver, "app.event", "30 days")  # type: ignore[arg-type]
+
+    assert dropped == ["app.event_2024_01", "app.event_2024_02"]
+
+
+async def test_partman_drop_partition_filters_empty_dropped_rows() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}], "partman.drop_partition_time": [{"dropped": None}]})
+
+    assert await partman_drop_partition(driver, "app.event", "30 days") == []  # type: ignore[arg-type]
+
+
+async def test_partman_drop_partition_uses_id_branch_when_control_is_not_time() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "partman.drop_partition_id": [{"dropped": "app.event_id_900000"}],
+        }
+    )
+
+    dropped = await partman_drop_partition(  # type: ignore[arg-type]
+        driver, "app.event", "1000000", control_is_time=False
+    )
+
+    assert dropped == ["app.event_id_900000"]
+
+
+async def test_partman_drop_partition_raises_when_extension_absent() -> None:
+    driver = FakeRoutingDriver({"pg_extension": []})
+
+    with pytest.raises(PartmanError, match="not installed"):
+        await partman_drop_partition(driver, "app.event", "30 days")  # type: ignore[arg-type]
+
+
+# --- tool wiring -----------------------------------------------------------
+
+
+async def test_partman_tools_require_unrestricted_mode() -> None:
+    server = create_server(_READ_ONLY, database=FakeDatabase(FakeDriver()))  # type: ignore[arg-type]
+    async with create_connected_server_and_client_session(server) as client:
+        listed = {tool.name for tool in (await client.list_tools()).tools}
+    for name in ("partman_create_parent", "partman_run_maintenance", "partman_drop_partition"):
+        assert name not in listed
+
+
+async def test_partman_tools_registered_in_unrestricted_mode() -> None:
+    server = create_server(_UNRESTRICTED, database=FakeDatabase(FakeDriver()))  # type: ignore[arg-type]
+    async with create_connected_server_and_client_session(server) as client:
+        listed = {tool.name for tool in (await client.list_tools()).tools}
+    assert {"partman_create_parent", "partman_run_maintenance", "partman_drop_partition"} <= listed

--- a/tests/unit/test_partman.py
+++ b/tests/unit/test_partman.py
@@ -14,7 +14,14 @@ from mcpg.partman import (
 )
 from mcpg.server import create_server
 
-_UNRESTRICTED = load_settings(
+_UNRESTRICTED_DDL = load_settings(
+    {
+        "MCPG_DATABASE_URL": "postgresql://u:p@localhost/db",
+        "MCPG_ACCESS_MODE": "unrestricted",
+        "MCPG_ALLOW_DDL": "true",
+    }
+)
+_UNRESTRICTED_NO_DDL = load_settings(
     {"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db", "MCPG_ACCESS_MODE": "unrestricted"}
 )
 _READ_ONLY = load_settings({"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db"})
@@ -137,16 +144,28 @@ async def test_partman_drop_partition_raises_when_extension_absent() -> None:
 # --- tool wiring -----------------------------------------------------------
 
 
-async def test_partman_tools_require_unrestricted_mode() -> None:
+_PARTMAN_TOOLS = {"partman_create_parent", "partman_run_maintenance", "partman_drop_partition"}
+
+
+async def test_partman_tools_hidden_in_read_only_mode() -> None:
     server = create_server(_READ_ONLY, database=FakeDatabase(FakeDriver()))  # type: ignore[arg-type]
     async with create_connected_server_and_client_session(server) as client:
         listed = {tool.name for tool in (await client.list_tools()).tools}
-    for name in ("partman_create_parent", "partman_run_maintenance", "partman_drop_partition"):
-        assert name not in listed
+    assert _PARTMAN_TOOLS.isdisjoint(listed)
 
 
-async def test_partman_tools_registered_in_unrestricted_mode() -> None:
-    server = create_server(_UNRESTRICTED, database=FakeDatabase(FakeDriver()))  # type: ignore[arg-type]
+async def test_partman_tools_hidden_in_unrestricted_without_allow_ddl() -> None:
+    # Partman creates and drops partitions — DDL. Per project policy
+    # (run_ddl, enable_extension) DDL tools require MCPG_ALLOW_DDL even
+    # in unrestricted mode. This test locks the gating in.
+    server = create_server(_UNRESTRICTED_NO_DDL, database=FakeDatabase(FakeDriver()))  # type: ignore[arg-type]
     async with create_connected_server_and_client_session(server) as client:
         listed = {tool.name for tool in (await client.list_tools()).tools}
-    assert {"partman_create_parent", "partman_run_maintenance", "partman_drop_partition"} <= listed
+    assert _PARTMAN_TOOLS.isdisjoint(listed)
+
+
+async def test_partman_tools_registered_in_unrestricted_mode_with_allow_ddl() -> None:
+    server = create_server(_UNRESTRICTED_DDL, database=FakeDatabase(FakeDriver()))  # type: ignore[arg-type]
+    async with create_connected_server_and_client_session(server) as client:
+        listed = {tool.name for tool in (await client.list_tools()).tools}
+    assert _PARTMAN_TOOLS <= listed


### PR DESCRIPTION
## Summary

First half of Batch C (`PLAN.md` §11). Six new tools across two
extension wrappers, all gated on extension availability with graceful
degradation. Brings the tool surface from 45 → 51.

### `mcpg.cron` (new module)

- **`list_cron_jobs`** (read) — pg_cron's `cron.job` catalog. Returns
  `[]` when pg_cron isn't installed; callers naturally treat absence
  as "no jobs" rather than a hard error.
- **`schedule_cron_job`** / **`unschedule_cron_job`** (write-gated) —
  thin wrappers over `cron.schedule()` / `cron.unschedule()`. Raise
  `CronError` when pg_cron isn't installed.

### `mcpg.partman` (new module)

- **`partman_create_parent`** — register a partitioned table with
  pg_partman. `partition_type` is allowlisted to `range`/`list`/
  `native` to guard against identifier injection.
- **`partman_run_maintenance`** — add forward partitions + drop
  retired ones. Targets one parent or all when `parent_table` is None.
- **`partman_drop_partition`** — explicit retention-based drop;
  time-controlled (PG interval like `"30 days"`) or id-controlled
  (`control_is_time=False`). Returns the dropped partition names.
- All three raise `PartmanError` when pg_partman isn't installed.

### Allowlist

`pg_cron` and `pg_partman` added to `ENABLEABLE_EXTENSIONS` so agents
can request enabling them via the existing path. Still gated on
unrestricted mode + `MCPG_ALLOW_DDL`. pg_cron additionally needs
server-side `shared_preload_libraries` which MCPg cannot set itself —
documented behaviour.

## Test plan

- [ ] CI: ruff, mypy --strict, full unit + integration suites green
- [ ] CI matrix: PG 14 / 15 / 16 / 17 — the new integration tests
      gracefully skip on the pgvector/pgvector image (neither extension
      ships there), exercising the skip path on every version
- [ ] 24 new unit tests cover: graceful-degradation paths, error
      paths (extension absent), partition-type allowlist, time- vs
      id-controlled retention branches, and the full access-mode
      wiring matrix (read mode hides write tools; unrestricted exposes
      them)
- [ ] Coverage gate (90%) maintained; locally 434 pass / 6 skipped

## Notes

- This is Batch C **part 1**; **Phase 23 — pgvector tuning** is next
  to close Batch C, then **Batch G (Prisma USP)** per the agreed
  sequencing.
- v0.3.0 was tagged locally on commit `1c74b04` but the sandboxed git
  remote returned 403 on tag push; the GitHub release still needs
  manual creation from `docs/release-notes-0.3.0.md`.

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Add pg_cron and pg_partman extension wrappers with new scheduling and partition-management tools, wiring them into the MCPg tool registry and extension allowlist.

New Features:
- Expose a read-only list_cron_jobs tool plus schedule_cron_job and unschedule_cron_job for managing pg_cron jobs.
- Introduce partman_create_parent, partman_run_maintenance, and partman_drop_partition tools for pg_partman-based partition management.
- Allow enabling pg_cron and pg_partman via the existing ENABLEABLE_EXTENSIONS mechanism.

Enhancements:
- Register new scheduling and partition-management tools only in unrestricted mode where appropriate, keeping list_cron_jobs available in read mode.
- Update project progress and changelog documentation to reflect Phase 22 completion, new tools, and release/tagging status.

Tests:
- Add unit tests covering pg_cron and pg_partman wrappers, including graceful degradation when extensions are absent and access-mode-based tool registration.
- Add integration tests for pg_cron and pg_partman that exercise extension-gated behavior and skip cleanly when extensions are unavailable.