### PR TITLE
feat: Phase 23 — pgvector tuning advisors (closes Batch C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `tune_vector_index` tool — recommends an `ivfflat` or `hnsw`
+  configuration for a pgvector column. Reads the live row count
+  (`pg_class.reltuples`) and column dimension, applies the standard
+  pgvector heuristics (lists ≈ rows/1000 or sqrt for ivfflat; m
+  scales with size, ef_construction with size for hnsw), and returns
+  the parameters plus a ready-to-run `CREATE INDEX` statement.
+- `vector_recall_at_k` tool — measures recall@k of an existing
+  pgvector index by comparing its top-k results against a brute-force
+  ground truth for the same query vectors. Uses pgvector's distance
+  functions (`l2_distance` / `cosine_distance` / `inner_product`) as
+  the non-indexed baseline; the operator form (`<->`, `<=>`, `<#>`)
+  triggers the ANN index.
 - `list_cron_jobs` tool — read pg_cron's `cron.job` catalog. Returns an
   empty list when pg_cron is not installed (graceful degradation).
 - `schedule_cron_job` and `unschedule_cron_job` tools (write-gated) —

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -6,20 +6,18 @@
 
 ## Current state
 
-- **Phase:** 22 — pg_cron + pg_partman wrappers (Phases 0–18 + 22
-  complete; v0.3.0 cut)
-- **Last updated:** 2026-05-23
+- **Phase:** 23 — pgvector tuning (Phases 0–18 + 22–23 complete;
+  **Batch C done**)
+- **Last updated:** 2026-05-24
 - **Branch:** `claude/postgresql-mcp-planning-8KssU`
-- **Tool count:** 51
+- **Tool count:** 53
 
 ## Next action
 
-> Phase 22 (Batch C first half) complete — 6 new tools across pg_cron
-> and pg_partman, all gated on extension availability with graceful
-> degradation. Next: **Phase 23 — pgvector tuning**
-> (`tune_vector_index`, `vector_recall_at_k`) to finish Batch C, then
-> **Batch G (Phase 28 — `generate_prisma_schema`)** per the user's
-> sequencing direction.
+> Phase 23 complete — `tune_vector_index` and `vector_recall_at_k`
+> finish Batch C. Next per the agreed sequencing: **Batch G — the
+> Prisma USP** (Phase 28 `generate_prisma_schema`), then **Batch B**
+> (Advisors / lint + audit). Batches D, E, F remain ADR-gated.
 
 ## Phase 0 — Spike & foundation  ✅ COMPLETE
 
@@ -475,3 +473,23 @@
   integration tests gated on extension availability (CI image
   doesn't ship either extension — skip path verified). Phase 22
   complete (51 MCP tools total). 434 tests, 100% coverage.
+- 2026-05-23 — PR #8 review fix: Gemini flagged that partman tools
+  perform DDL (CREATE/DROP partitions) but were registered under
+  Capability.WRITE, bypassing the MCPG_ALLOW_DDL guardrail. Split
+  `_register_scheduling` into `_register_cron_write` (WRITE, cron
+  DML) and `_register_partman` (DDL, alongside run_ddl /
+  enable_extension). New unit test pins the gate.
+- 2026-05-23 — PR #8 merged to `main`; branch re-synced.
+- 2026-05-24 — Phase 23 (Batch C second half): new `mcpg.vector_tuning`
+  module adds `tune_vector_index` — recommends ivfflat/hnsw
+  parameters from row count (via pg_class.reltuples) and column
+  dimension, emits a ready-to-run CREATE INDEX statement — and
+  `vector_recall_at_k` which compares the ANN operator path
+  (`<->`/`<=>`/`<#>`, index-using) against the brute-force function
+  path (`l2_distance`/`cosine_distance`/`inner_product`, documented
+  by pgvector as non-indexed) to report mean recall over a row
+  sample. Both raise VectorTuningError when pgvector is absent.
+  21 new unit tests + 3 integration tests against a real pgvector
+  hnsw index (seeded with well-separated vectors → recall ~= 1.0).
+  **Batch C complete.** Phase 23 complete (53 MCP tools total).
+  456 tests, 100% coverage.

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -27,6 +27,7 @@ from mcpg import (
     query,
     schema_diff,
     textsearch,
+    vector_tuning,
     workload,
     write,
 )
@@ -293,6 +294,61 @@ def _register_schema_diff(server: FastMCP[AppContext]) -> None:
     async def compare_schemas(ctx: _Ctx, left_schema: str, right_schema: str) -> dict[str, Any]:
         diff = await schema_diff.compare_schemas(_driver(ctx), left_schema, right_schema)
         return asdict(diff)
+
+
+def _register_vector_tuning(server: FastMCP[AppContext]) -> None:
+    @server.tool(
+        name="tune_vector_index",
+        description=(
+            "Recommend an ivfflat or hnsw configuration for a pgvector column. "
+            "Reads the live row count and column dimension, applies the standard "
+            "pgvector heuristics, and returns the parameters plus a ready-to-run "
+            "CREATE INDEX statement. Requires the vector extension."
+        ),
+    )
+    async def tune_vector_index(
+        ctx: _Ctx,
+        schema: str,
+        table: str,
+        column: str,
+        index_type: str = "hnsw",
+        metric: str = "l2",
+    ) -> dict[str, Any]:
+        result = await vector_tuning.tune_vector_index(
+            _driver(ctx), schema, table, column, index_type=index_type, metric=metric
+        )
+        return asdict(result)
+
+    @server.tool(
+        name="vector_recall_at_k",
+        description=(
+            "Measure recall@k of an existing pgvector index against a brute-force "
+            "ground truth (function-form distance, which pgvector documents as "
+            "non-indexed). Returns the mean overlap over a sample of rows from the "
+            "table. Requires the vector extension."
+        ),
+    )
+    async def vector_recall_at_k(
+        ctx: _Ctx,
+        schema: str,
+        table: str,
+        column: str,
+        id_column: str,
+        k: int = 10,
+        sample_size: int = 20,
+        metric: str = "l2",
+    ) -> dict[str, Any]:
+        report = await vector_tuning.vector_recall_at_k(
+            _driver(ctx),
+            schema,
+            table,
+            column,
+            id_column,
+            k=k,
+            sample_size=sample_size,
+            metric=metric,
+        )
+        return asdict(report)
 
 
 def _register_query(server: FastMCP[AppContext]) -> None:
@@ -653,6 +709,7 @@ def register_tools(server: FastMCP[AppContext], settings: Settings) -> None:
         _register_introspection(server)
         _register_diagrams(server)
         _register_schema_diff(server)
+        _register_vector_tuning(server)
         _register_query(server)
         _register_health(server)
         _register_liveops(server)

--- a/src/mcpg/vector_tuning.py
+++ b/src/mcpg/vector_tuning.py
@@ -1,0 +1,234 @@
+"""pgvector index-tuning advisors.
+
+Two read-only tools that help agents make sensible pgvector choices:
+
+* ``tune_vector_index`` recommends ``ivfflat`` or ``hnsw`` parameters
+  from the live row count and column dimension, and emits a ready-to-run
+  ``CREATE INDEX`` snippet.
+* ``vector_recall_at_k`` probes an existing pgvector index by comparing
+  its top-k results against a brute-force ground truth for the same
+  query vectors, reporting mean recall@k.
+
+Both require the ``vector`` extension; both raise :class:`VectorTuningError`
+when it is absent.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from mcpg._vendor.sql import SqlDriver
+from mcpg.extensions import extension_installed
+from mcpg.introspection import describe_table
+
+# pgvector supports these index access methods today; the allowlist
+# guards against arbitrary identifier injection in CREATE INDEX text.
+_INDEX_TYPES = frozenset({"ivfflat", "hnsw"})
+
+# Per pgvector docs: distance functions bypass the index in the planner,
+# giving us a reliable brute-force baseline without SET LOCAL gymnastics.
+_DISTANCE_FUNCTIONS = {"l2": "l2_distance", "cosine": "cosine_distance", "inner_product": "inner_product"}
+# Their operator counterparts trigger the ANN index when one exists.
+_DISTANCE_OPERATORS = {"l2": "<->", "cosine": "<=>", "inner_product": "<#>"}
+
+
+class VectorTuningError(Exception):
+    """Raised when a pgvector tuning operation cannot complete."""
+
+
+@dataclass(frozen=True, slots=True)
+class TuningRecommendation:
+    """A recommended pgvector index configuration."""
+
+    index_type: str
+    parameters: dict[str, int]
+    rationale: str
+    create_index_sql: str
+    row_count: int
+    dimension: int
+
+
+@dataclass(frozen=True, slots=True)
+class RecallReport:
+    """Recall@k probed against an existing pgvector index."""
+
+    metric: str
+    k: int
+    sample_size: int
+    mean_recall: float
+
+
+async def _ensure_installed(driver: SqlDriver) -> None:
+    if not await extension_installed(driver, "vector"):
+        raise VectorTuningError("vector extension is not installed in this database")
+
+
+async def _row_count(driver: SqlDriver, schema: str, table: str) -> int:
+    rows = await driver.execute_query(
+        # Catalog estimate from pg_class.reltuples — accurate enough for
+        # tuning heuristics and orders of magnitude faster than COUNT(*).
+        "SELECT GREATEST(c.reltuples, 0)::bigint AS estimate "
+        "FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace "
+        "WHERE n.nspname = %s AND c.relname = %s",
+        params=[schema, table],
+        force_readonly=True,
+    )
+    if not rows:
+        raise VectorTuningError(f"table {schema}.{table} not found")
+    return int(rows[0].cells["estimate"])
+
+
+async def _column_dimension(driver: SqlDriver, schema: str, table: str, column: str) -> int:
+    columns = await describe_table(driver, schema, table)
+    for info in columns:
+        if info.name == column:
+            if info.vector_dimension is None:
+                raise VectorTuningError(f"column {schema}.{table}.{column} is not a pgvector vector(N)")
+            return info.vector_dimension
+    raise VectorTuningError(f"column {schema}.{table}.{column} not found")
+
+
+def _recommend_ivfflat(row_count: int) -> tuple[dict[str, int], str]:
+    # pgvector docs: start with rows/1000 up to 1M rows, sqrt(rows)
+    # above 1M. Clamp at 100 — fewer lists than that gives little
+    # benefit over a seqscan.
+    if row_count > 1_000_000:
+        lists = max(100, int(math.sqrt(row_count)))
+        rationale = f"row_count={row_count:,} > 1M → lists = sqrt(rows) ≈ {lists}"
+    else:
+        lists = max(100, row_count // 1000)
+        rationale = f"row_count={row_count:,} → lists = rows/1000, floored at 100 = {lists}"
+    return {"lists": lists}, rationale
+
+
+def _recommend_hnsw(row_count: int) -> tuple[dict[str, int], str]:
+    # m controls graph degree (memory + recall trade-off); ef_construction
+    # controls build-time quality. Both ramp with size.
+    m = 16 if row_count <= 1_000_000 else 24
+    ef_construction = 64 if row_count <= 100_000 else 128
+    m_note = "baseline" if m == 16 else "denser graph for >1M rows"
+    ef_note = "default" if ef_construction == 64 else "wider candidate pool for >100k rows"
+    rationale = f"row_count={row_count:,} → m={m} ({m_note}), ef_construction={ef_construction} ({ef_note})"
+    return {"m": m, "ef_construction": ef_construction}, rationale
+
+
+def _format_create_index(
+    index_type: str, schema: str, table: str, column: str, ops: str, parameters: dict[str, int]
+) -> str:
+    params_text = ", ".join(f"{name} = {value}" for name, value in parameters.items())
+    return f"CREATE INDEX ON {schema}.{table} USING {index_type} ({column} {ops}) WITH ({params_text});"
+
+
+_DEFAULT_OPS_FOR_METRIC = {"l2": "vector_l2_ops", "cosine": "vector_cosine_ops", "inner_product": "vector_ip_ops"}
+
+
+async def tune_vector_index(
+    driver: SqlDriver,
+    schema: str,
+    table: str,
+    column: str,
+    *,
+    index_type: str = "hnsw",
+    metric: str = "l2",
+) -> TuningRecommendation:
+    """Recommend an ``ivfflat`` or ``hnsw`` configuration for a vector column.
+
+    Reads the live row count (from ``pg_class.reltuples``) and column
+    dimension, applies the standard pgvector heuristics, and returns the
+    parameters plus a ready-to-run ``CREATE INDEX`` statement.
+
+    Raises:
+        VectorTuningError: pgvector is not installed, ``index_type`` or
+            ``metric`` is not in the allowlist, or the column is not a
+            ``vector(N)`` column.
+    """
+    await _ensure_installed(driver)
+    if index_type not in _INDEX_TYPES:
+        raise VectorTuningError(f"unsupported index_type {index_type!r}; expected one of {sorted(_INDEX_TYPES)}")
+    if metric not in _DEFAULT_OPS_FOR_METRIC:
+        raise VectorTuningError(f"unknown metric {metric!r}; expected l2, cosine, or inner_product")
+
+    row_count = await _row_count(driver, schema, table)
+    dimension = await _column_dimension(driver, schema, table, column)
+
+    if index_type == "ivfflat":
+        parameters, rationale = _recommend_ivfflat(row_count)
+    else:
+        parameters, rationale = _recommend_hnsw(row_count)
+
+    ops = _DEFAULT_OPS_FOR_METRIC[metric]
+    sql = _format_create_index(index_type, schema, table, column, ops, parameters)
+    return TuningRecommendation(
+        index_type=index_type,
+        parameters=parameters,
+        rationale=rationale,
+        create_index_sql=sql,
+        row_count=row_count,
+        dimension=dimension,
+    )
+
+
+async def vector_recall_at_k(
+    driver: SqlDriver,
+    schema: str,
+    table: str,
+    column: str,
+    id_column: str,
+    *,
+    k: int = 10,
+    sample_size: int = 20,
+    metric: str = "l2",
+) -> RecallReport:
+    """Measure recall@k of an existing pgvector index against brute-force truth.
+
+    Picks ``sample_size`` rows in id order, treats each row's vector as
+    a query, runs the top-k search through the index (operator form,
+    which the planner routes to the ANN index) and via the brute-force
+    function form (``l2_distance`` / ``cosine_distance`` / ``inner_product``
+    — pgvector documents these as non-indexed alternatives), and reports
+    the mean overlap.
+
+    Raises:
+        VectorTuningError: pgvector is not installed, ``metric`` is
+            unknown, or the table / id column does not exist.
+    """
+    await _ensure_installed(driver)
+    if metric not in _DISTANCE_OPERATORS:
+        raise VectorTuningError(f"unknown metric {metric!r}; expected l2, cosine, or inner_product")
+    if k <= 0 or sample_size <= 0:
+        raise VectorTuningError("k and sample_size must be positive")
+
+    operator = _DISTANCE_OPERATORS[metric]
+    function = _DISTANCE_FUNCTIONS[metric]
+
+    sample_rows = await driver.execute_query(
+        f"SELECT {id_column} AS id, {column}::text AS vec FROM {schema}.{table} "
+        f"WHERE {column} IS NOT NULL ORDER BY {id_column} LIMIT %s",
+        params=[sample_size],
+        force_readonly=True,
+    )
+    samples = sample_rows or []
+    if not samples:
+        return RecallReport(metric=metric, k=k, sample_size=0, mean_recall=0.0)
+
+    recalls: list[float] = []
+    for sample in samples:
+        query_vec = sample.cells["vec"]
+        ann_rows = await driver.execute_query(
+            f"SELECT {id_column} AS id FROM {schema}.{table} ORDER BY {column} {operator} %s::vector LIMIT %s",
+            params=[query_vec, k],
+            force_readonly=True,
+        )
+        truth_rows = await driver.execute_query(
+            f"SELECT {id_column} AS id FROM {schema}.{table} ORDER BY {function}({column}, %s::vector) LIMIT %s",
+            params=[query_vec, k],
+            force_readonly=True,
+        )
+        ann_ids = {row.cells["id"] for row in ann_rows or []}
+        truth_ids = {row.cells["id"] for row in truth_rows or []}
+        if truth_ids:
+            recalls.append(len(ann_ids & truth_ids) / len(truth_ids))
+
+    mean = sum(recalls) / len(recalls) if recalls else 0.0
+    return RecallReport(metric=metric, k=k, sample_size=len(samples), mean_recall=mean)

--- a/src/mcpg/vector_tuning.py
+++ b/src/mcpg/vector_tuning.py
@@ -16,6 +16,7 @@ when it is absent.
 from __future__ import annotations
 
 import math
+import re
 from dataclasses import dataclass
 
 from mcpg._vendor.sql import SqlDriver
@@ -32,9 +33,26 @@ _DISTANCE_FUNCTIONS = {"l2": "l2_distance", "cosine": "cosine_distance", "inner_
 # Their operator counterparts trigger the ANN index when one exists.
 _DISTANCE_OPERATORS = {"l2": "<->", "cosine": "<=>", "inner_product": "<#>"}
 
+# Recall sampling triggers 2N+1 queries per call; cap N to prevent
+# accidental DoS via a runaway sample_size argument.
+_MAX_SAMPLE_SIZE = 100
+
+# Plain unquoted PostgreSQL identifier — letters, digits, underscores,
+# starting with a letter or underscore. We refuse anything that requires
+# quoting at the catalog level (delimited identifiers, case-sensitive
+# names) rather than try to parse them out of an agent's string.
+_IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
+
 
 class VectorTuningError(Exception):
     """Raised when a pgvector tuning operation cannot complete."""
+
+
+def _quoted(name: str, kind: str) -> str:
+    """Validate a SQL identifier against the allowlist and return it double-quoted."""
+    if not _IDENTIFIER.match(name):
+        raise VectorTuningError(f"invalid {kind} name: {name!r}")
+    return f'"{name}"'
 
 
 @dataclass(frozen=True, slots=True)
@@ -65,6 +83,9 @@ async def _ensure_installed(driver: SqlDriver) -> None:
 
 
 async def _row_count(driver: SqlDriver, schema: str, table: str) -> int:
+    # schema/table are matched against the catalog via parameters, so no
+    # quoting is needed here — _quoted is applied only where identifiers
+    # are interpolated into SQL text.
     rows = await driver.execute_query(
         # Catalog estimate from pg_class.reltuples — accurate enough for
         # tuning heuristics and orders of magnitude faster than COUNT(*).
@@ -117,7 +138,9 @@ def _format_create_index(
     index_type: str, schema: str, table: str, column: str, ops: str, parameters: dict[str, int]
 ) -> str:
     params_text = ", ".join(f"{name} = {value}" for name, value in parameters.items())
-    return f"CREATE INDEX ON {schema}.{table} USING {index_type} ({column} {ops}) WITH ({params_text});"
+    relation = f"{_quoted(schema, 'schema')}.{_quoted(table, 'table')}"
+    col = _quoted(column, "column")
+    return f"CREATE INDEX ON {relation} USING {index_type} ({col} {ops}) WITH ({params_text});"
 
 
 _DEFAULT_OPS_FOR_METRIC = {"l2": "vector_l2_ops", "cosine": "vector_cosine_ops", "inner_product": "vector_ip_ops"}
@@ -198,13 +221,19 @@ async def vector_recall_at_k(
         raise VectorTuningError(f"unknown metric {metric!r}; expected l2, cosine, or inner_product")
     if k <= 0 or sample_size <= 0:
         raise VectorTuningError("k and sample_size must be positive")
+    if sample_size > _MAX_SAMPLE_SIZE:
+        # Each probed row triggers two extra catalog queries; cap to
+        # keep an over-eager caller from accidentally DoSing the DB.
+        raise VectorTuningError(f"sample_size cannot exceed {_MAX_SAMPLE_SIZE}")
 
     operator = _DISTANCE_OPERATORS[metric]
     function = _DISTANCE_FUNCTIONS[metric]
+    relation = f"{_quoted(schema, 'schema')}.{_quoted(table, 'table')}"
+    col = _quoted(column, "column")
+    id_col = _quoted(id_column, "id_column")
 
     sample_rows = await driver.execute_query(
-        f"SELECT {id_column} AS id, {column}::text AS vec FROM {schema}.{table} "
-        f"WHERE {column} IS NOT NULL ORDER BY {id_column} LIMIT %s",
+        f"SELECT {id_col} AS id, {col}::text AS vec FROM {relation} WHERE {col} IS NOT NULL ORDER BY {id_col} LIMIT %s",
         params=[sample_size],
         force_readonly=True,
     )
@@ -216,12 +245,12 @@ async def vector_recall_at_k(
     for sample in samples:
         query_vec = sample.cells["vec"]
         ann_rows = await driver.execute_query(
-            f"SELECT {id_column} AS id FROM {schema}.{table} ORDER BY {column} {operator} %s::vector LIMIT %s",
+            f"SELECT {id_col} AS id FROM {relation} ORDER BY {col} {operator} %s::vector LIMIT %s",
             params=[query_vec, k],
             force_readonly=True,
         )
         truth_rows = await driver.execute_query(
-            f"SELECT {id_column} AS id FROM {schema}.{table} ORDER BY {function}({column}, %s::vector) LIMIT %s",
+            f"SELECT {id_col} AS id FROM {relation} ORDER BY {function}({col}, %s::vector) LIMIT %s",
             params=[query_vec, k],
             force_readonly=True,
         )

--- a/tests/integration/test_vector_tuning_integration.py
+++ b/tests/integration/test_vector_tuning_integration.py
@@ -1,0 +1,78 @@
+"""Integration tests for pgvector tuning advisors — gated on the extension."""
+
+from collections.abc import AsyncIterator
+
+import pytest
+
+from mcpg.database import Database
+from mcpg.extensions import enable_extension
+from mcpg.introspection import list_available_extensions
+from mcpg.vector_tuning import tune_vector_index, vector_recall_at_k
+
+_TABLE = "mcpg_vector_tuning_it"
+
+
+@pytest.fixture
+async def vector_table(connected_database: Database) -> AsyncIterator[Database]:
+    """Build a small pgvector table with an hnsw index; skip if extension absent."""
+    driver = connected_database.driver()
+    available = {extension.name for extension in await list_available_extensions(driver)}
+    if "vector" not in available:
+        pytest.skip("pgvector is not available on this PostgreSQL server")
+    await enable_extension(driver, "vector")
+    await driver.execute_query(f"DROP TABLE IF EXISTS {_TABLE}")
+    await driver.execute_query(f"CREATE TABLE {_TABLE} (id integer PRIMARY KEY, embedding vector(3))")
+    # Seed a handful of vectors that cluster — the index should agree
+    # with brute force on a small dataset of this shape.
+    for i, vec in enumerate(
+        [
+            "[0.1, 0.1, 0.1]",
+            "[0.2, 0.2, 0.2]",
+            "[0.3, 0.3, 0.3]",
+            "[0.9, 0.9, 0.9]",
+            "[1.0, 1.0, 1.0]",
+            "[5.0, 5.0, 5.0]",
+            "[5.1, 5.1, 5.1]",
+            "[5.2, 5.2, 5.2]",
+        ],
+        start=1,
+    ):
+        await driver.execute_query(
+            f"INSERT INTO {_TABLE} (id, embedding) VALUES (%s, %s::vector)",
+            params=[i, vec],
+        )
+    await driver.execute_query(f"CREATE INDEX {_TABLE}_idx ON {_TABLE} USING hnsw (embedding vector_l2_ops)")
+    await driver.execute_query(f"ANALYZE {_TABLE}")
+    try:
+        yield connected_database
+    finally:
+        await driver.execute_query(f"DROP TABLE IF EXISTS {_TABLE}")
+
+
+async def test_tune_vector_index_reads_real_catalog(vector_table: Database) -> None:
+    rec = await tune_vector_index(vector_table.driver(), "public", _TABLE, "embedding", index_type="hnsw")
+
+    assert rec.dimension == 3
+    assert rec.row_count >= 0  # pg_class.reltuples after ANALYZE is non-negative
+    assert rec.parameters == {"m": 16, "ef_construction": 64}
+    assert "CREATE INDEX" in rec.create_index_sql
+    assert "vector_l2_ops" in rec.create_index_sql
+
+
+async def test_tune_vector_index_emits_ivfflat_parameters(vector_table: Database) -> None:
+    rec = await tune_vector_index(vector_table.driver(), "public", _TABLE, "embedding", index_type="ivfflat")
+
+    assert rec.index_type == "ivfflat"
+    assert "lists" in rec.parameters
+    assert rec.parameters["lists"] >= 100  # always floored
+
+
+async def test_vector_recall_at_k_against_real_index(vector_table: Database) -> None:
+    report = await vector_recall_at_k(vector_table.driver(), "public", _TABLE, "embedding", "id", k=3, sample_size=4)
+
+    assert report.metric == "l2"
+    assert report.k == 3
+    assert report.sample_size == 4
+    # For 8 well-separated vectors with k=3, the hnsw index should match
+    # brute force exactly — recall should be 1.0 (or extremely close).
+    assert report.mean_recall >= 0.9

--- a/tests/unit/test_vector_tuning.py
+++ b/tests/unit/test_vector_tuning.py
@@ -39,6 +39,16 @@ def test_recommend_ivfflat_uses_sqrt_above_one_million() -> None:
     assert "sqrt" in rationale
 
 
+def test_recommend_ivfflat_boundary_at_exactly_one_million() -> None:
+    # row_count == 1M sits on the "<=" branch — rows/1000 = 1000 lists.
+    params, _ = _recommend_ivfflat(1_000_000)
+    assert params == {"lists": 1000}
+    # The first row above the boundary flips to the sqrt branch.
+    params_above, rationale_above = _recommend_ivfflat(1_000_001)
+    assert params_above["lists"] == int(1_000_001**0.5)
+    assert "sqrt" in rationale_above
+
+
 def test_recommend_hnsw_uses_baseline_under_one_million() -> None:
     params, rationale = _recommend_hnsw(500_000)
     assert params == {"m": 16, "ef_construction": 128}  # 500k > 100k → ef bumped
@@ -53,6 +63,24 @@ def test_recommend_hnsw_denser_graph_for_large_tables() -> None:
 def test_recommend_hnsw_default_ef_for_tiny_tables() -> None:
     params, _ = _recommend_hnsw(10_000)
     assert params == {"m": 16, "ef_construction": 64}
+
+
+def test_recommend_hnsw_boundary_at_exactly_100k_rows() -> None:
+    # row_count == 100k sits on the "<=" branch — ef_construction stays at 64.
+    params, _ = _recommend_hnsw(100_000)
+    assert params == {"m": 16, "ef_construction": 64}
+    # First row above flips the construction bump.
+    params_above, _ = _recommend_hnsw(100_001)
+    assert params_above == {"m": 16, "ef_construction": 128}
+
+
+def test_recommend_hnsw_boundary_at_exactly_one_million_rows() -> None:
+    # row_count == 1M sits on the "<=" branch — m stays at 16.
+    params, _ = _recommend_hnsw(1_000_000)
+    assert params == {"m": 16, "ef_construction": 128}
+    # First row above flips m to 24.
+    params_above, _ = _recommend_hnsw(1_000_001)
+    assert params_above == {"m": 24, "ef_construction": 128}
 
 
 # --- tune_vector_index -----------------------------------------------------
@@ -237,6 +265,34 @@ async def test_vector_recall_at_k_rejects_non_positive_arguments() -> None:
     driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
     with pytest.raises(VectorTuningError, match="must be positive"):
         await vector_recall_at_k(driver, "app", "docs", "embedding", "id", k=0)  # type: ignore[arg-type]
+    with pytest.raises(VectorTuningError, match="must be positive"):
+        await vector_recall_at_k(driver, "app", "docs", "embedding", "id", sample_size=0)  # type: ignore[arg-type]
+
+
+async def test_vector_recall_at_k_caps_sample_size_to_prevent_dos() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+    with pytest.raises(VectorTuningError, match="sample_size cannot exceed"):
+        await vector_recall_at_k(driver, "app", "docs", "embedding", "id", sample_size=101)  # type: ignore[arg-type]
+
+
+async def test_tune_vector_index_rejects_invalid_identifier_characters() -> None:
+    # Identifier injection guard — anything not matching the [A-Za-z_][...]
+    # allowlist is rejected before the SQL is built.
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "GREATEST(c.reltuples": [{"estimate": 1000}],
+            "format_type(a.atttypid": [_vector_column_row("embedding", 3)],
+        }
+    )
+    with pytest.raises(VectorTuningError, match="invalid schema name"):
+        await tune_vector_index(driver, 'app"; DROP TABLE x; --', "docs", "embedding")  # type: ignore[arg-type]
+
+
+async def test_vector_recall_at_k_rejects_invalid_identifier_characters() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}], "WHERE": []})
+    with pytest.raises(VectorTuningError, match="invalid id_column name"):
+        await vector_recall_at_k(driver, "app", "docs", "embedding", 'id"; DROP TABLE x; --')  # type: ignore[arg-type]
 
 
 # --- tool wiring -----------------------------------------------------------

--- a/tests/unit/test_vector_tuning.py
+++ b/tests/unit/test_vector_tuning.py
@@ -1,0 +1,249 @@
+"""Tests for pgvector tuning advisors."""
+
+import pytest
+from _fakes import FakeDatabase, FakeDriver, FakeRoutingDriver
+from mcp.shared.memory import create_connected_server_and_client_session
+
+from mcpg.config import load_settings
+from mcpg.server import create_server
+from mcpg.vector_tuning import (
+    RecallReport,
+    TuningRecommendation,
+    VectorTuningError,
+    _recommend_hnsw,
+    _recommend_ivfflat,
+    tune_vector_index,
+    vector_recall_at_k,
+)
+
+_SETTINGS = load_settings({"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db"})
+
+
+# --- heuristic helpers -----------------------------------------------------
+
+
+def test_recommend_ivfflat_uses_rows_over_1000_for_small_tables() -> None:
+    params, rationale = _recommend_ivfflat(50_000)
+    assert params == {"lists": 100}  # 50_000 // 1000 = 50, clamped to 100
+    assert "row_count=50,000" in rationale
+
+
+def test_recommend_ivfflat_uses_rows_over_1000_at_moderate_size() -> None:
+    params, _ = _recommend_ivfflat(500_000)
+    assert params == {"lists": 500}
+
+
+def test_recommend_ivfflat_uses_sqrt_above_one_million() -> None:
+    params, rationale = _recommend_ivfflat(4_000_000)
+    assert params == {"lists": 2000}  # sqrt(4M) = 2000
+    assert "sqrt" in rationale
+
+
+def test_recommend_hnsw_uses_baseline_under_one_million() -> None:
+    params, rationale = _recommend_hnsw(500_000)
+    assert params == {"m": 16, "ef_construction": 128}  # 500k > 100k → ef bumped
+    assert "baseline" in rationale
+
+
+def test_recommend_hnsw_denser_graph_for_large_tables() -> None:
+    params, _ = _recommend_hnsw(5_000_000)
+    assert params == {"m": 24, "ef_construction": 128}
+
+
+def test_recommend_hnsw_default_ef_for_tiny_tables() -> None:
+    params, _ = _recommend_hnsw(10_000)
+    assert params == {"m": 16, "ef_construction": 64}
+
+
+# --- tune_vector_index -----------------------------------------------------
+
+
+def _vector_column_row(name: str, dimension: int, nullable: bool = True) -> dict[str, object]:
+    return {
+        "column_name": name,
+        "data_type": f"vector({dimension})",
+        "nullable": nullable,
+        "column_default": None,
+        "type_name": "vector",
+        "type_mod": dimension,
+    }
+
+
+async def test_tune_vector_index_emits_hnsw_with_ready_to_run_sql() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "GREATEST(c.reltuples": [{"estimate": 250_000}],
+            "format_type(a.atttypid": [_vector_column_row("embedding", 384, nullable=False)],
+        }
+    )
+
+    rec = await tune_vector_index(driver, "app", "docs", "embedding")  # type: ignore[arg-type]
+
+    assert isinstance(rec, TuningRecommendation)
+    assert rec.index_type == "hnsw"
+    assert rec.parameters == {"m": 16, "ef_construction": 128}
+    assert rec.row_count == 250_000
+    assert rec.dimension == 384
+    assert "vector_l2_ops" in rec.create_index_sql
+    assert "m = 16" in rec.create_index_sql and "ef_construction = 128" in rec.create_index_sql
+
+
+async def test_tune_vector_index_supports_ivfflat_and_alternative_metric() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "GREATEST(c.reltuples": [{"estimate": 8_000_000}],
+            "format_type(a.atttypid": [_vector_column_row("v", 1536)],
+        }
+    )
+
+    rec = await tune_vector_index(  # type: ignore[arg-type]
+        driver, "app", "items", "v", index_type="ivfflat", metric="cosine"
+    )
+
+    assert rec.index_type == "ivfflat"
+    assert rec.parameters == {"lists": int(8_000_000**0.5)}  # 2828
+    assert "vector_cosine_ops" in rec.create_index_sql
+
+
+async def test_tune_vector_index_raises_when_extension_absent() -> None:
+    driver = FakeRoutingDriver({"pg_extension": []})
+
+    with pytest.raises(VectorTuningError, match="not installed"):
+        await tune_vector_index(driver, "app", "docs", "embedding")  # type: ignore[arg-type]
+
+
+async def test_tune_vector_index_rejects_unknown_index_type() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+    with pytest.raises(VectorTuningError, match="unsupported index_type"):
+        await tune_vector_index(driver, "app", "docs", "embedding", index_type="bogus")  # type: ignore[arg-type]
+
+
+async def test_tune_vector_index_rejects_unknown_metric() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+    with pytest.raises(VectorTuningError, match="unknown metric"):
+        await tune_vector_index(driver, "app", "docs", "embedding", metric="bogus")  # type: ignore[arg-type]
+
+
+async def test_tune_vector_index_raises_when_table_missing() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "GREATEST(c.reltuples": [],
+        }
+    )
+    with pytest.raises(VectorTuningError, match="not found"):
+        await tune_vector_index(driver, "app", "missing", "embedding")  # type: ignore[arg-type]
+
+
+async def test_tune_vector_index_raises_when_column_not_vector() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "GREATEST(c.reltuples": [{"estimate": 1000}],
+            "format_type(a.atttypid": [
+                {
+                    "column_name": "embedding",
+                    "data_type": "text",
+                    "nullable": True,
+                    "column_default": None,
+                    "type_name": "text",
+                    "type_mod": -1,
+                }
+            ],
+        }
+    )
+    with pytest.raises(VectorTuningError, match="not a pgvector"):
+        await tune_vector_index(driver, "app", "docs", "embedding")  # type: ignore[arg-type]
+
+
+async def test_tune_vector_index_raises_when_column_missing() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "GREATEST(c.reltuples": [{"estimate": 1000}],
+            "format_type(a.atttypid": [],
+        }
+    )
+    with pytest.raises(VectorTuningError, match="not found"):
+        await tune_vector_index(driver, "app", "docs", "missing")  # type: ignore[arg-type]
+
+
+# --- vector_recall_at_k ----------------------------------------------------
+
+
+async def test_vector_recall_at_k_perfect_recall_when_ann_matches_truth() -> None:
+    # Both the ANN (operator) and brute-force (function) paths return the
+    # same id sets for every sample row → recall = 1.0.
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "WHERE": [
+                {"id": 1, "vec": "[0.1,0.2,0.3]"},
+                {"id": 2, "vec": "[0.4,0.5,0.6]"},
+            ],
+            "<->": [{"id": 10}, {"id": 11}, {"id": 12}],
+            "l2_distance": [{"id": 10}, {"id": 11}, {"id": 12}],
+        }
+    )
+
+    report = await vector_recall_at_k(driver, "app", "docs", "embedding", "id", k=3, sample_size=2)  # type: ignore[arg-type]
+
+    assert isinstance(report, RecallReport)
+    assert report.sample_size == 2
+    assert report.k == 3
+    assert report.mean_recall == 1.0
+
+
+async def test_vector_recall_at_k_reports_partial_recall_for_imperfect_index() -> None:
+    # ANN returns {10, 11, 99}; truth is {10, 11, 12} → 2/3 overlap.
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "WHERE": [{"id": 1, "vec": "[1,2,3]"}],
+            "<->": [{"id": 10}, {"id": 11}, {"id": 99}],
+            "l2_distance": [{"id": 10}, {"id": 11}, {"id": 12}],
+        }
+    )
+
+    report = await vector_recall_at_k(driver, "app", "docs", "embedding", "id", k=3, sample_size=1)  # type: ignore[arg-type]
+
+    assert report.mean_recall == pytest.approx(2 / 3)
+
+
+async def test_vector_recall_at_k_returns_zero_recall_when_no_samples() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}], "WHERE": []})
+
+    report = await vector_recall_at_k(driver, "app", "docs", "embedding", "id")  # type: ignore[arg-type]
+
+    assert report.sample_size == 0
+    assert report.mean_recall == 0.0
+
+
+async def test_vector_recall_at_k_raises_when_extension_absent() -> None:
+    driver = FakeRoutingDriver({"pg_extension": []})
+    with pytest.raises(VectorTuningError, match="not installed"):
+        await vector_recall_at_k(driver, "app", "docs", "embedding", "id")  # type: ignore[arg-type]
+
+
+async def test_vector_recall_at_k_rejects_unknown_metric() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+    with pytest.raises(VectorTuningError, match="unknown metric"):
+        await vector_recall_at_k(driver, "app", "docs", "embedding", "id", metric="bogus")  # type: ignore[arg-type]
+
+
+async def test_vector_recall_at_k_rejects_non_positive_arguments() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+    with pytest.raises(VectorTuningError, match="must be positive"):
+        await vector_recall_at_k(driver, "app", "docs", "embedding", "id", k=0)  # type: ignore[arg-type]
+
+
+# --- tool wiring -----------------------------------------------------------
+
+
+async def test_vector_tuning_tools_are_registered_in_read_mode() -> None:
+    server = create_server(_SETTINGS, database=FakeDatabase(FakeDriver()))  # type: ignore[arg-type]
+    async with create_connected_server_and_client_session(server) as client:
+        listed = {tool.name for tool in (await client.list_tools()).tools}
+    assert {"tune_vector_index", "vector_recall_at_k"} <= listed


### PR DESCRIPTION
## Summary

Second (and final) half of Batch C (`PLAN.md` §11). Two new read-only
pgvector advisors in a new `mcpg.vector_tuning` module. Tool surface
51 → 53; Batch C complete.

### `tune_vector_index`

Reads live `pg_class.reltuples` and the column dimension, applies the
standard pgvector heuristics, returns parameters + a ready-to-run
`CREATE INDEX` statement:

- **ivfflat**: `lists = max(100, rows/1000)` up to 1M; `max(100,
  sqrt(rows))` above 1M.
- **hnsw**: `m=16` baseline, `m=24` above 1M rows; `ef_construction=64`
  baseline, `128` above 100k rows.

`index_type` allowlisted to `{ivfflat, hnsw}`; `metric` allowlisted to
`{l2, cosine, inner_product}` (mapped to the right `vector_*_ops`
opclass).

### `vector_recall_at_k`

Samples `sample_size` rows in id order, treats each vector as a query,
and compares two top-k searches:

- **ANN path** — operator form (`<->`/`<=>`/`<#>`) which pgvector
  documents as index-eligible.
- **Brute-force ground truth** — function form (`l2_distance` /
  `cosine_distance` / `inner_product`) which pgvector documents as a
  non-indexed alternative.

Reports `mean recall = mean(|ANN ∩ truth| / k)` over the sample. This
sidesteps `SET LOCAL` transaction gymnastics (each driver call is
independent) while still giving an honest accuracy probe.

Both tools raise `VectorTuningError` when pgvector is absent and are
exposed under the **READ** capability (advisory; no writes).

## Test plan

- [ ] CI: ruff, mypy --strict, full unit + integration suites green
- [ ] CI matrix: PG 14 / 15 / 16 / 17 — pgvector ships in the matrix
      image, so the 3 integration tests actually probe a real `hnsw`
      index across every version
- [ ] 21 unit tests cover heuristic boundary cases (100k / 1M rows),
      CREATE INDEX shape, every error path (missing extension,
      allowlist failure, missing table, non-vector column), and the
      recall arithmetic (perfect / partial / empty-sample)
- [ ] Integration: 8 well-separated 3-d vectors → ANN and brute-force
      agree exactly → assert `recall >= 0.9`
- [ ] Coverage gate maintained; locally 456 pass / 9 skipped

## What's next after merge

Per the agreed sequencing: **Batch G (Phase 28 — `generate_prisma_schema`)**,
then **Batch B** (Advisors / lint + audit). Batches D, E, F remain
ADR-gated.

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Add read-only pgvector tuning advisors and wire them into the MCP tool registry to complete Phase 23 Batch C.

New Features:
- Introduce a `tune_vector_index` advisor that recommends ivfflat or hnsw index configurations for pgvector columns and returns a ready-to-run CREATE INDEX statement.
- Introduce a `vector_recall_at_k` advisor that measures recall@k of an existing pgvector index by comparing index results against a brute-force ground truth.

Documentation:
- Update progress documentation to reflect completion of Phase 23 (pgvector tuning), increased tool count, and next planned phases.
- Document the new pgvector tuning tools in the changelog with high-level behavior descriptions.

Tests:
- Add unit tests covering pgvector tuning heuristics, error cases, and tool registration in read-only mode.
- Add integration tests that exercise the new pgvector tuning tools against a real pgvector-enabled PostgreSQL instance.