### PR TITLE
feat: Phase 28 — generate_prisma_schema (Batch G first cut, USP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `generate_prisma_schema` tool — read a PostgreSQL schema and emit a
+  valid Prisma `.prisma` schema string, mirroring `prisma db pull` but
+  driven by MCPg. Covers tables, columns, primary/foreign keys
+  (including composite), unique constraints, secondary indexes, and
+  enums; standard defaults (`nextval(...)` → `autoincrement()`, `now()`
+  → `now()`, `gen_random_uuid()` → `uuid()`, literals) and array types
+  are mapped; unmappable types (vectors, custom domains) fall back to
+  `Unsupported("...")` exactly like `prisma db pull`. Views, foreign
+  tables, partitions, triggers, functions, policies, and composite
+  types are out of scope for v1. **First USP-tier tool — no other PG
+  MCP server bridges to an ORM schema DSL.**
 - `tune_vector_index` tool — recommends an `ivfflat` or `hnsw`
   configuration for a pgvector column. Reads the live row count
   (`pg_class.reltuples`) and column dimension, applies the standard

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -6,18 +6,20 @@
 
 ## Current state
 
-- **Phase:** 23 — pgvector tuning (Phases 0–18 + 22–23 complete;
-  **Batch C done**)
+- **Phase:** 28 — `generate_prisma_schema` (Phases 0–18 + 22–23 + 28
+  complete; **Batch G first cut done**)
 - **Last updated:** 2026-05-24
 - **Branch:** `claude/postgresql-mcp-planning-8KssU`
-- **Tool count:** 53
+- **Tool count:** 54
 
 ## Next action
 
-> Phase 23 complete — `tune_vector_index` and `vector_recall_at_k`
-> finish Batch C. Next per the agreed sequencing: **Batch G — the
-> Prisma USP** (Phase 28 `generate_prisma_schema`), then **Batch B**
-> (Advisors / lint + audit). Batches D, E, F remain ADR-gated.
+> Phase 28 (Batch G first cut) complete — `generate_prisma_schema`
+> ships the marketable USP move: no other PG MCP server bridges to an
+> ORM schema DSL. Next per the agreed sequencing: **Batch B** —
+> advisors / lint (Phase 20) + audit trail (Phase 21). Batch G
+> follow-ons (Drizzle, SQLAlchemy, sqlc exporters) and Batches D, E,
+> F (ADR-gated) come after.
 
 ## Phase 0 — Spike & foundation  ✅ COMPLETE
 
@@ -493,3 +495,27 @@
   hnsw index (seeded with well-separated vectors → recall ~= 1.0).
   **Batch C complete.** Phase 23 complete (53 MCP tools total).
   456 tests, 100% coverage.
+- 2026-05-24 — PR #9 review fix: Sourcery + Gemini flagged identifier
+  injection across 6 SQL sites in vector_tuning.py plus an unbounded
+  `sample_size` DoS in `vector_recall_at_k`. Added a local `_quoted`
+  helper (allowlist `[A-Za-z_][A-Za-z0-9_]*` + double-quote) and a
+  `_MAX_SAMPLE_SIZE = 100` cap. New tests pin the gates.
+- 2026-05-24 — PR #9 merged to `main`; branch re-synced. Batch C
+  closed.
+- 2026-05-24 — Phase 28 (Batch G first cut): new `mcpg.prisma` module
+  exposes `generate_prisma_schema` — read a PG schema and emit a valid
+  Prisma `.prisma` schema string. Mirrors `prisma db pull` for the
+  most-used surface: tables → models with PK/FK/composite-PK/composite-
+  unique/secondary indexes; enums → top-level Prisma enums; standard
+  defaults (`nextval(...)` → `autoincrement()`, `now()`/`CURRENT_
+  TIMESTAMP` → `now()`, `gen_random_uuid()` → `uuid()`, literals)
+  mapped; unmappable types (vectors, custom domains) fall back to
+  `Unsupported("...")`. Identifiers must match `[A-Za-z_][A-Za-z0-9_]*`
+  and the schema-qualified prefix is stripped for enum / scalar lookup.
+  19 new unit tests cover the type/default mapping, FK back-relations,
+  composite-PK + composite-unique rendering, index deduplication, and
+  the Unsupported fallback; 1 integration test end-to-ends a real
+  schema with serial PKs, an enum-typed column, an FK, and a secondary
+  index. **First USP-tier tool** — no other PG MCP server bridges to
+  an ORM schema DSL. Phase 28 complete (54 MCP tools total). 482
+  tests, 100% coverage.

--- a/src/mcpg/prisma.py
+++ b/src/mcpg/prisma.py
@@ -1,0 +1,401 @@
+"""PostgreSQL → Prisma schema exporter.
+
+``generate_prisma_schema`` reads a PG schema via the existing
+introspection primitives and emits a valid ``.prisma`` schema string
+that an agent can drop into a Prisma project — mirroring what
+``prisma db pull`` would write, but driven by MCPg instead of the
+Prisma CLI.
+
+Coverage (first cut):
+* Tables → ``model`` blocks with columns, primary keys, foreign keys,
+  composite unique constraints, and single-column ``@unique`` /
+  multi-column ``@@index`` from the actual catalog.
+* Enums → top-level Prisma ``enum`` blocks; enum-typed columns reference
+  the Prisma enum directly.
+* Standard column defaults — ``nextval('seq')`` → ``autoincrement()``,
+  ``now()`` / ``CURRENT_TIMESTAMP`` → ``now()``,
+  ``gen_random_uuid()`` → ``uuid()``, literals → ``@default(...)``.
+* Types Prisma doesn't model (composite types, vectors, custom domains,
+  …) fall back to ``Unsupported("…")`` exactly like ``prisma db pull``.
+
+Out of scope for v1: views, foreign tables, partitions, triggers,
+functions, RLS policies, composite types. Identifiers must match the
+plain PG identifier pattern (no quoted/case-sensitive names) — the
+output is not re-mapped via ``@@map`` / ``@map`` in this first cut.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+
+from mcpg._vendor.sql import SqlDriver
+from mcpg.introspection import (
+    ColumnInfo,
+    EnumInfo,
+    ForeignKeyInfo,
+    IndexInfo,
+    describe_table,
+    list_constraints,
+    list_enums,
+    list_foreign_keys,
+    list_indexes,
+    list_tables,
+)
+
+# Generic PG types → Prisma scalar types. Types with parameters (e.g.
+# ``character varying(255)``, ``numeric(10,2)``, ``vector(384)``) are
+# stripped to the base name before lookup.
+_PRISMA_SCALAR_TYPES = {
+    "integer": "Int",
+    "int4": "Int",
+    "smallint": "Int",
+    "int2": "Int",
+    "bigint": "BigInt",
+    "int8": "BigInt",
+    "text": "String",
+    "character varying": "String",
+    "varchar": "String",
+    "character": "String",
+    "char": "String",
+    "bpchar": "String",
+    "boolean": "Boolean",
+    "bool": "Boolean",
+    "real": "Float",
+    "float4": "Float",
+    "double precision": "Float",
+    "float8": "Float",
+    "numeric": "Decimal",
+    "decimal": "Decimal",
+    "date": "DateTime",
+    "timestamp": "DateTime",
+    "timestamp without time zone": "DateTime",
+    "timestamp with time zone": "DateTime",
+    "timestamptz": "DateTime",
+    "time": "DateTime",
+    "time without time zone": "DateTime",
+    "time with time zone": "DateTime",
+    "json": "Json",
+    "jsonb": "Json",
+    "uuid": "String",
+    "bytea": "Bytes",
+}
+
+# Same prefix as mcpg.textsearch / mcpg.vector_tuning — refuse names
+# that need PG's delimited-identifier quoting; pass plain ones through.
+_IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
+
+_PRIMARY_KEY_COLUMNS = re.compile(r"PRIMARY KEY \(([^)]+)\)", re.IGNORECASE)
+_UNIQUE_COLUMNS = re.compile(r"UNIQUE \(([^)]+)\)", re.IGNORECASE)
+_LITERAL_DEFAULT = re.compile(r"^'((?:[^']|'')*)'::")
+
+
+class PrismaError(Exception):
+    """Raised when a Prisma schema cannot be emitted."""
+
+
+def _check_identifier(name: str, kind: str) -> None:
+    if not _IDENTIFIER.match(name):
+        raise PrismaError(f"invalid {kind} name {name!r}; Prisma export requires plain SQL identifiers")
+
+
+def _parse_pk_columns(definition: str) -> list[str]:
+    match = _PRIMARY_KEY_COLUMNS.search(definition)
+    if not match:
+        return []
+    return [column.strip().strip('"') for column in match.group(1).split(",")]
+
+
+def _parse_unique_columns(definition: str) -> list[str]:
+    match = _UNIQUE_COLUMNS.search(definition)
+    if not match:
+        return []
+    return [column.strip().strip('"') for column in match.group(1).split(",")]
+
+
+def _strip_type_parameters(data_type: str) -> str:
+    """Return the base PG type name without ``(...)`` modifiers, array suffix, or schema prefix."""
+    base = data_type.split("(", 1)[0].strip()
+    if base.endswith("[]"):
+        base = base[:-2].strip()
+    # User-defined types (enums, domains, composites) come back schema-
+    # qualified from format_type when they are not on the search_path —
+    # strip the schema prefix so the lookup table and enum-name set both
+    # match the bare type name.
+    if "." in base:
+        base = base.rsplit(".", 1)[1]
+    return base.lower()
+
+
+def _is_array_type(data_type: str) -> bool:
+    return data_type.rstrip().endswith("[]")
+
+
+def _prisma_type(column: ColumnInfo, enum_names: set[str]) -> tuple[str, list[str]]:
+    """Map a ``ColumnInfo`` to a Prisma type token + the attribute list.
+
+    The attribute list is the inline ``@db.X`` modifiers (e.g.
+    ``@db.VarChar(255)``) that fine-tune the Prisma type back to the
+    original PG shape; empty when no modifier applies.
+    """
+    base = _strip_type_parameters(column.data_type)
+    array = _is_array_type(column.data_type)
+    attrs: list[str] = []
+    if base in enum_names:
+        token = base
+    elif base in _PRISMA_SCALAR_TYPES:
+        token = _PRISMA_SCALAR_TYPES[base]
+    else:
+        # vector(384), custom domains, unmapped types — preserve the
+        # full PG type so prisma generate emits the same Unsupported.
+        return (f'Unsupported("{column.data_type}")', [])
+
+    if array:
+        token = f"{token}[]"
+    return token, attrs
+
+
+def _prisma_default(default: str | None) -> str | None:
+    if default is None:
+        return None
+    lowered = default.strip().lower()
+    if lowered.startswith("nextval("):
+        return "autoincrement()"
+    if lowered in {"now()", "current_timestamp"}:
+        return "now()"
+    if "gen_random_uuid()" in lowered or "uuid_generate_v4()" in lowered:
+        return "uuid()"
+    if lowered in {"true", "false"}:
+        return lowered
+    # PG renders bare numeric defaults without a cast — accept ints and
+    # decimals plus an optional sign.
+    if re.match(r"^-?\d+(\.\d+)?$", default.strip()):
+        return default.strip()
+    # Quoted text literal: ``'value'::type`` — extract the inner string,
+    # un-double single quotes, re-quote with double quotes for Prisma.
+    literal = _LITERAL_DEFAULT.match(default)
+    if literal:
+        return '"' + literal.group(1).replace("''", "'").replace('"', '\\"') + '"'
+    return None
+
+
+def _render_field(
+    column: ColumnInfo,
+    *,
+    pk_columns: set[str],
+    fk_columns_to_relation: dict[str, str],
+    unique_columns: set[str],
+    enum_names: set[str],
+) -> str:
+    _check_identifier(column.name, "column")
+    type_token, type_attrs = _prisma_type(column, enum_names)
+    nullable = "?" if column.nullable and not type_token.endswith("[]") else ""
+    attrs: list[str] = list(type_attrs)
+    if column.name in pk_columns and len(pk_columns) == 1:
+        attrs.append("@id")
+    if column.name in unique_columns:
+        attrs.append("@unique")
+    default = _prisma_default(column.default)
+    if default is not None:
+        attrs.append(f"@default({default})")
+    suffix = (" " + " ".join(attrs)) if attrs else ""
+    return f"  {column.name} {type_token}{nullable}{suffix}"
+
+
+def _render_relation_field(name: str, target_model: str, fk: ForeignKeyInfo) -> str:
+    fields = ", ".join(fk.from_columns)
+    references = ", ".join(fk.to_columns)
+    return f'  {name} {target_model} @relation("{fk.name}", fields: [{fields}], references: [{references}])'
+
+
+def _render_back_relation(name: str, source_model: str, fk_name: str) -> str:
+    return f'  {name} {source_model}[] @relation("{fk_name}")'
+
+
+def _render_composite_pk(pk_columns: list[str]) -> str:
+    cols = ", ".join(pk_columns)
+    return f"  @@id([{cols}])"
+
+
+def _render_unique_constraint(cols: list[str]) -> str:
+    if len(cols) == 1:
+        # single-column UNIQUE is emitted inline on the field as @unique
+        return ""
+    return f"  @@unique([{', '.join(cols)}])"
+
+
+def _render_index(index: IndexInfo) -> str:
+    # Best-effort parse: pg_get_indexdef -> CREATE [UNIQUE] INDEX ... USING method (col1, col2)
+    columns_match = re.search(r"\(([^)]+)\)", index.definition)
+    if not columns_match:
+        return ""
+    raw_columns = [
+        column.strip().strip('"').split(" ")[0]  # drop any ASC/DESC suffix
+        for column in columns_match.group(1).split(",")
+    ]
+    # Skip indexes whose expressions Prisma can't model.
+    if any(not _IDENTIFIER.match(column) for column in raw_columns):
+        return ""
+    is_unique = "UNIQUE" in index.definition.upper()
+    keyword = "@@unique" if is_unique else "@@index"
+    return f"  {keyword}([{', '.join(raw_columns)}])"
+
+
+def _render_enum(enum: EnumInfo) -> str:
+    _check_identifier(enum.name, "enum")
+    for value in enum.values:
+        _check_identifier(value, "enum value")
+    lines = [f"enum {enum.name} {{"]
+    lines.extend(f"  {value}" for value in enum.values)
+    lines.append("}")
+    return "\n".join(lines)
+
+
+def _datasource_header() -> str:
+    return (
+        "datasource db {\n"
+        '  provider = "postgresql"\n'
+        '  url      = env("DATABASE_URL")\n'
+        "}\n\n"
+        "generator client {\n"
+        '  provider = "prisma-client-js"\n'
+        "}"
+    )
+
+
+async def _foreign_keys_indexed(driver: SqlDriver, schema: str) -> dict[str, list[ForeignKeyInfo]]:
+    result: dict[str, list[ForeignKeyInfo]] = {}
+    for fk in await list_foreign_keys(driver, schema):
+        result.setdefault(fk.from_table, []).append(fk)
+    return result
+
+
+def _back_relations_by_target(
+    fks_by_source: dict[str, list[ForeignKeyInfo]], entity_names: set[str]
+) -> dict[str, list[tuple[str, ForeignKeyInfo]]]:
+    """Index back-relations as ``target_table → [(source_table, fk), ...]``."""
+    result: dict[str, list[tuple[str, ForeignKeyInfo]]] = {}
+    for source, fks in fks_by_source.items():
+        for fk in fks:
+            if fk.to_table not in entity_names:
+                continue
+            result.setdefault(fk.to_table, []).append((source, fk))
+    return result
+
+
+def _disambiguate_relation_names(pairs: Iterable[tuple[str, ForeignKeyInfo]]) -> dict[str, str]:
+    """Build ``fk.name → field_name`` so duplicate sources get unique names."""
+    counts: dict[str, int] = {}
+    chosen: dict[str, str] = {}
+    materialised = list(pairs)
+    for source, _fk in materialised:
+        counts[source] = counts.get(source, 0) + 1
+    seen: dict[str, int] = {}
+    for source, fk in materialised:
+        seen[source] = seen.get(source, 0) + 1
+        if counts[source] == 1:
+            chosen[fk.name] = source
+        else:
+            chosen[fk.name] = f"{source}_{seen[source]}"
+    return chosen
+
+
+async def generate_prisma_schema(driver: SqlDriver, schema: str) -> str:
+    """Emit a Prisma schema string covering the base tables of ``schema``.
+
+    Views, foreign tables, partitions, triggers, functions, policies,
+    and composite types are out of scope for v1. Identifiers must be
+    plain PG identifiers (``[A-Za-z_][A-Za-z0-9_]*``); a name that
+    needs PG's delimited-identifier quoting raises :class:`PrismaError`.
+    """
+    _check_identifier(schema, "schema")
+    tables = [
+        table for table in await list_tables(driver, schema) if table.type == "BASE TABLE" and not table.is_partition
+    ]
+    entity_names = {table.name for table in tables}
+    enums = await list_enums(driver, schema)
+    enum_names = {enum.name for enum in enums}
+
+    fks_by_source = await _foreign_keys_indexed(driver, schema)
+    back_relations = _back_relations_by_target(fks_by_source, entity_names)
+
+    blocks: list[str] = [_datasource_header()]
+
+    for table in tables:
+        _check_identifier(table.name, "table")
+        columns = await describe_table(driver, schema, table.name)
+        constraints = await list_constraints(driver, schema, table.name)
+        indexes = await list_indexes(driver, schema, table.name)
+
+        pk_columns: list[str] = []
+        single_column_uniques: set[str] = set()
+        composite_uniques: list[list[str]] = []
+        for constraint in constraints:
+            if constraint.type == "primary_key":
+                pk_columns = _parse_pk_columns(constraint.definition)
+            elif constraint.type == "unique":
+                cols = _parse_unique_columns(constraint.definition)
+                if len(cols) == 1:
+                    single_column_uniques.update(cols)
+                elif cols:
+                    composite_uniques.append(cols)
+
+        outgoing_fks = fks_by_source.get(table.name, [])
+        fk_columns_to_relation = {fk.from_columns[0]: fk.name for fk in outgoing_fks if len(fk.from_columns) == 1}
+
+        lines = [f"model {table.name} {{"]
+        for column in columns:
+            lines.append(
+                _render_field(
+                    column,
+                    pk_columns=set(pk_columns),
+                    fk_columns_to_relation=fk_columns_to_relation,
+                    unique_columns=single_column_uniques,
+                    enum_names=enum_names,
+                )
+            )
+
+        for fk in outgoing_fks:
+            if fk.to_table not in entity_names:
+                # Cross-schema FK — Prisma can't model it cleanly; the
+                # scalar columns are already emitted.
+                continue
+            relation_field = fk.name
+            lines.append(_render_relation_field(relation_field, fk.to_table, fk))
+
+        if table.name in back_relations:
+            relation_names = _disambiguate_relation_names(back_relations[table.name])
+            for source, fk in back_relations[table.name]:
+                if fk.from_table not in entity_names:
+                    continue
+                lines.append(_render_back_relation(relation_names[fk.name], source, fk.name))
+
+        if len(pk_columns) > 1:
+            lines.append(_render_composite_pk(pk_columns))
+        for unique_cols in composite_uniques:
+            lines.append(_render_unique_constraint(unique_cols))
+        emitted: set[tuple[str, ...]] = set()
+        # @@id and @@unique already declare their column sets; skip an
+        # @@index that duplicates them.
+        if pk_columns:
+            emitted.add(tuple(pk_columns))
+        for unique_cols in composite_uniques:
+            emitted.add(tuple(unique_cols))
+        for index in indexes:
+            rendered = _render_index(index)
+            if not rendered:
+                continue
+            cols_match = re.search(r"\[([^\]]+)\]", rendered)
+            if cols_match:
+                cols_key = tuple(part.strip() for part in cols_match.group(1).split(","))
+                if cols_key in emitted:
+                    continue
+                emitted.add(cols_key)
+            lines.append(rendered)
+        lines.append("}")
+        blocks.append("\n".join(lines))
+
+    for enum in enums:
+        blocks.append(_render_enum(enum))
+
+    return "\n\n".join(blocks) + "\n"

--- a/src/mcpg/prisma.py
+++ b/src/mcpg/prisma.py
@@ -359,12 +359,22 @@ async def generate_prisma_schema(driver: SqlDriver, schema: str) -> str:
                 )
             )
 
+        column_names = {column.name for column in columns}
+
         for fk in outgoing_fks:
             if fk.to_table not in entity_names:
                 # Cross-schema FK — Prisma can't model it cleanly; the
                 # scalar columns are already emitted.
                 continue
             relation_field = fk.name
+            if relation_field in column_names:
+                # A FK constraint named after an existing column would
+                # produce a duplicate-field Prisma model; surface it as
+                # a hard error rather than emit broken DSL.
+                raise PrismaError(
+                    f"foreign-key constraint {fk.name!r} on table {table.name!r} collides with column "
+                    f"of the same name; rename the constraint and re-run."
+                )
             lines.append(_render_relation_field(relation_field, fk.to_table, fk))
 
         if table.name in back_relations:

--- a/src/mcpg/prisma.py
+++ b/src/mcpg/prisma.py
@@ -131,16 +131,10 @@ def _is_array_type(data_type: str) -> bool:
     return data_type.rstrip().endswith("[]")
 
 
-def _prisma_type(column: ColumnInfo, enum_names: set[str]) -> tuple[str, list[str]]:
-    """Map a ``ColumnInfo`` to a Prisma type token + the attribute list.
-
-    The attribute list is the inline ``@db.X`` modifiers (e.g.
-    ``@db.VarChar(255)``) that fine-tune the Prisma type back to the
-    original PG shape; empty when no modifier applies.
-    """
+def _prisma_type(column: ColumnInfo, enum_names: set[str]) -> str:
+    """Map a ``ColumnInfo`` to the Prisma type token (without ``?`` modifier)."""
     base = _strip_type_parameters(column.data_type)
     array = _is_array_type(column.data_type)
-    attrs: list[str] = []
     if base in enum_names:
         token = base
     elif base in _PRISMA_SCALAR_TYPES:
@@ -148,11 +142,14 @@ def _prisma_type(column: ColumnInfo, enum_names: set[str]) -> tuple[str, list[st
     else:
         # vector(384), custom domains, unmapped types — preserve the
         # full PG type so prisma generate emits the same Unsupported.
-        return (f'Unsupported("{column.data_type}")', [])
+        # Escape embedded double quotes so a pathological type name
+        # can't produce a syntactically broken Prisma string literal.
+        escaped = column.data_type.replace("\\", "\\\\").replace('"', '\\"')
+        return f'Unsupported("{escaped}")'
 
     if array:
         token = f"{token}[]"
-    return token, attrs
+    return token
 
 
 def _prisma_default(default: str | None) -> str | None:
@@ -183,14 +180,16 @@ def _render_field(
     column: ColumnInfo,
     *,
     pk_columns: set[str],
-    fk_columns_to_relation: dict[str, str],
     unique_columns: set[str],
     enum_names: set[str],
 ) -> str:
     _check_identifier(column.name, "column")
-    type_token, type_attrs = _prisma_type(column, enum_names)
+    type_token = _prisma_type(column, enum_names)
+    # Prisma treats SQL arrays as inherently optional: an empty array is
+    # equivalent to "no value", so the schema can't carry ``?`` on a list
+    # type even when the underlying column is nullable. Don't append it.
     nullable = "?" if column.nullable and not type_token.endswith("[]") else ""
-    attrs: list[str] = list(type_attrs)
+    attrs: list[str] = []
     if column.name in pk_columns and len(pk_columns) == 1:
         attrs.append("@id")
     if column.name in unique_columns:
@@ -203,12 +202,19 @@ def _render_field(
 
 
 def _render_relation_field(name: str, target_model: str, fk: ForeignKeyInfo) -> str:
+    # ``name`` and ``fk.name`` are both interpolated into Prisma text —
+    # validate them against the identifier allowlist so a constraint
+    # name with spaces or quotes can't produce broken Prisma.
+    _check_identifier(name, "relation field")
+    _check_identifier(fk.name, "relation name")
     fields = ", ".join(fk.from_columns)
     references = ", ".join(fk.to_columns)
     return f'  {name} {target_model} @relation("{fk.name}", fields: [{fields}], references: [{references}])'
 
 
 def _render_back_relation(name: str, source_model: str, fk_name: str) -> str:
+    _check_identifier(name, "back-relation field")
+    _check_identifier(fk_name, "relation name")
     return f'  {name} {source_model}[] @relation("{fk_name}")'
 
 
@@ -284,20 +290,20 @@ def _back_relations_by_target(
 
 
 def _disambiguate_relation_names(pairs: Iterable[tuple[str, ForeignKeyInfo]]) -> dict[str, str]:
-    """Build ``fk.name → field_name`` so duplicate sources get unique names."""
-    counts: dict[str, int] = {}
-    chosen: dict[str, str] = {}
-    materialised = list(pairs)
-    for source, _fk in materialised:
-        counts[source] = counts.get(source, 0) + 1
-    seen: dict[str, int] = {}
-    for source, fk in materialised:
-        seen[source] = seen.get(source, 0) + 1
-        if counts[source] == 1:
-            chosen[fk.name] = source
-        else:
-            chosen[fk.name] = f"{source}_{seen[source]}"
-    return chosen
+    """Build ``fk.name → field_name`` so duplicate sources get unique names.
+
+    Single pass: the first time we see a source we record the bare name;
+    subsequent appearances are suffixed with their ordinal index. Order
+    is preserved from the input iterable, which makes the chosen names
+    stable across runs.
+    """
+    names: dict[str, str] = {}
+    per_source: dict[str, int] = {}
+    for source, fk in pairs:
+        ordinal = per_source.get(source, 0) + 1
+        per_source[source] = ordinal
+        names[fk.name] = source if ordinal == 1 else f"{source}_{ordinal}"
+    return names
 
 
 async def generate_prisma_schema(driver: SqlDriver, schema: str) -> str:
@@ -341,7 +347,6 @@ async def generate_prisma_schema(driver: SqlDriver, schema: str) -> str:
                     composite_uniques.append(cols)
 
         outgoing_fks = fks_by_source.get(table.name, [])
-        fk_columns_to_relation = {fk.from_columns[0]: fk.name for fk in outgoing_fks if len(fk.from_columns) == 1}
 
         lines = [f"model {table.name} {{"]
         for column in columns:
@@ -349,7 +354,6 @@ async def generate_prisma_schema(driver: SqlDriver, schema: str) -> str:
                 _render_field(
                     column,
                     pk_columns=set(pk_columns),
-                    fk_columns_to_relation=fk_columns_to_relation,
                     unique_columns=single_column_uniques,
                     enum_names=enum_names,
                 )

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -24,6 +24,7 @@ from mcpg import (
     liveops,
     maintenance,
     partman,
+    prisma,
     query,
     schema_diff,
     textsearch,
@@ -349,6 +350,21 @@ def _register_vector_tuning(server: FastMCP[AppContext]) -> None:
             metric=metric,
         )
         return asdict(report)
+
+
+def _register_prisma(server: FastMCP[AppContext]) -> None:
+    @server.tool(
+        name="generate_prisma_schema",
+        description=(
+            "Read a PostgreSQL schema and emit a valid Prisma `.prisma` schema string "
+            "(mirrors `prisma db pull`). Covers tables, columns, primary/foreign keys, "
+            "unique constraints, indexes, and enums. Views, foreign tables, partitions, "
+            "triggers, functions, and policies are out of scope; unmappable types fall "
+            'back to `Unsupported("...")`.'
+        ),
+    )
+    async def generate_prisma_schema(ctx: _Ctx, schema: str) -> str:
+        return await prisma.generate_prisma_schema(_driver(ctx), schema)
 
 
 def _register_query(server: FastMCP[AppContext]) -> None:
@@ -710,6 +726,7 @@ def register_tools(server: FastMCP[AppContext], settings: Settings) -> None:
         _register_diagrams(server)
         _register_schema_diff(server)
         _register_vector_tuning(server)
+        _register_prisma(server)
         _register_query(server)
         _register_health(server)
         _register_liveops(server)

--- a/tests/integration/test_prisma_integration.py
+++ b/tests/integration/test_prisma_integration.py
@@ -1,0 +1,66 @@
+"""Integration test for the PG → Prisma schema exporter."""
+
+from collections.abc import AsyncIterator
+
+import pytest
+
+from mcpg.database import Database
+from mcpg.prisma import generate_prisma_schema
+
+_SCHEMA = "mcpg_prisma_it"
+
+
+@pytest.fixture
+async def prisma_schema(connected_database: Database) -> AsyncIterator[str]:
+    """Build a small real schema covering tables, FK, enum, and an index."""
+    driver = connected_database.driver()
+    await driver.execute_query(f"DROP SCHEMA IF EXISTS {_SCHEMA} CASCADE")
+    await driver.execute_query(f"CREATE SCHEMA {_SCHEMA}")
+    await driver.execute_query(f"CREATE TYPE {_SCHEMA}.status AS ENUM ('draft', 'live', 'archived')")
+    await driver.execute_query(
+        f"CREATE TABLE {_SCHEMA}.widget ("
+        f"  id serial PRIMARY KEY, "
+        f"  name text NOT NULL, "
+        f"  state {_SCHEMA}.status NOT NULL DEFAULT 'draft'"
+        f")"
+    )
+    await driver.execute_query(
+        f"CREATE TABLE {_SCHEMA}.order_item ("
+        f"  id serial PRIMARY KEY, "
+        f"  widget_id integer NOT NULL REFERENCES {_SCHEMA}.widget(id), "
+        f"  quantity integer NOT NULL DEFAULT 1"
+        f")"
+    )
+    await driver.execute_query(f"CREATE INDEX widget_name_idx ON {_SCHEMA}.widget (name)")
+    try:
+        yield _SCHEMA
+    finally:
+        await driver.execute_query(f"DROP SCHEMA IF EXISTS {_SCHEMA} CASCADE")
+
+
+async def test_generate_prisma_schema_renders_a_real_schema_end_to_end(
+    connected_database: Database, prisma_schema: str
+) -> None:
+    out = await generate_prisma_schema(connected_database.driver(), prisma_schema)
+
+    # Preamble is unconditional.
+    assert 'provider = "postgresql"' in out
+    assert 'provider = "prisma-client-js"' in out
+
+    # Both models are present.
+    assert "model widget {" in out
+    assert "model order_item {" in out
+
+    # serial PKs map to Int @id @default(autoincrement()).
+    assert "id Int @id @default(autoincrement())" in out
+
+    # The enum block appears and is referenced from the column type.
+    assert "enum status {" in out
+    assert "state status" in out and '@default("draft")' in out
+
+    # FK renders on both sides with the same named relation.
+    assert '@relation("order_item_widget_id_fkey"' in out
+    assert "order_item[]" in out
+
+    # The secondary index materialises as @@index.
+    assert "@@index([name])" in out

--- a/tests/unit/test_prisma.py
+++ b/tests/unit/test_prisma.py
@@ -361,6 +361,39 @@ async def test_generate_prisma_schema_rejects_foreign_key_constraint_with_invali
         await generate_prisma_schema(driver, "app")  # type: ignore[arg-type]
 
 
+async def test_generate_prisma_schema_rejects_fk_name_colliding_with_a_column() -> None:
+    # If a FK constraint shares a name with an existing column in the
+    # same table, the relation field would shadow the scalar field —
+    # Prisma rejects models with duplicate field names. Surface it as a
+    # hard error so the agent renames the constraint.
+    routes: dict[tuple[str, tuple[Any, ...] | None], list[dict[str, Any]]] = {
+        (_LIST_TABLES, ("app",)): [
+            {"name": "widget", "relkind": "r", "is_partition": False},
+            {"name": "order_item", "relkind": "r", "is_partition": False},
+        ],
+        (_DESCRIBE, ("app", "widget")): [_column_row("id", "integer")],
+        (_DESCRIBE, ("app", "order_item")): [_column_row("id", "integer"), _column_row("widget_id", "integer")],
+        (_LIST_CONSTRAINTS, None): [],
+        (_LIST_INDEXES, None): [],
+        (_LIST_FKS, ("app",)): [
+            {
+                # Constraint name collides with the widget_id column.
+                "name": "widget_id",
+                "from_table": "order_item",
+                "to_schema": "app",
+                "to_table": "widget",
+                "from_columns": ["widget_id"],
+                "to_columns": ["id"],
+            }
+        ],
+        (_LIST_ENUMS, ("app",)): [],
+    }
+    driver = FakeParamRoutingDriver(routes)
+
+    with pytest.raises(PrismaError, match="collides with column"):
+        await generate_prisma_schema(driver, "app")  # type: ignore[arg-type]
+
+
 async def test_generate_prisma_schema_renders_composite_pk_and_composite_unique() -> None:
     routes: dict[tuple[str, tuple[Any, ...] | None], list[dict[str, Any]]] = {
         (_LIST_TABLES, ("app",)): [{"name": "shard", "relkind": "r", "is_partition": False}],

--- a/tests/unit/test_prisma.py
+++ b/tests/unit/test_prisma.py
@@ -1,0 +1,365 @@
+"""Tests for the PostgreSQL → Prisma schema exporter."""
+
+from typing import Any
+
+import pytest
+from _fakes import FakeDatabase, FakeDriver, FakeParamRoutingDriver
+from mcp.shared.memory import create_connected_server_and_client_session
+
+from mcpg.config import load_settings
+from mcpg.introspection import ColumnInfo
+from mcpg.prisma import (
+    PrismaError,
+    _parse_pk_columns,
+    _prisma_default,
+    _prisma_type,
+    _strip_type_parameters,
+    generate_prisma_schema,
+)
+from mcpg.server import create_server
+
+_SETTINGS = load_settings({"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db"})
+
+
+# --- pure helpers ----------------------------------------------------------
+
+
+def test_strip_type_parameters_handles_modifiers_and_array() -> None:
+    assert _strip_type_parameters("integer") == "integer"
+    assert _strip_type_parameters("character varying(255)") == "character varying"
+    assert _strip_type_parameters("numeric(10,2)") == "numeric"
+    assert _strip_type_parameters("vector(384)") == "vector"
+    assert _strip_type_parameters("text[]") == "text"
+    assert _strip_type_parameters("INTEGER") == "integer"
+    # User-defined types come back schema-qualified from format_type when
+    # the schema is not on the search_path — the schema prefix is stripped.
+    assert _strip_type_parameters("mcpg_prisma_it.status") == "status"
+
+
+def test_parse_pk_columns_extracts_quoted_and_unquoted() -> None:
+    assert _parse_pk_columns("PRIMARY KEY (id)") == ["id"]
+    assert _parse_pk_columns('PRIMARY KEY ("user_id", tenant)') == ["user_id", "tenant"]
+    assert _parse_pk_columns("CHECK (x > 0)") == []
+
+
+def _column(
+    name: str,
+    data_type: str,
+    *,
+    nullable: bool = False,
+    default: str | None = None,
+    vector_dimension: int | None = None,
+) -> ColumnInfo:
+    return ColumnInfo(
+        name=name,
+        data_type=data_type,
+        nullable=nullable,
+        default=default,
+        vector_dimension=vector_dimension,
+    )
+
+
+def test_prisma_type_maps_common_scalars() -> None:
+    assert _prisma_type(_column("a", "integer"), set()) == ("Int", [])
+    assert _prisma_type(_column("a", "bigint"), set()) == ("BigInt", [])
+    assert _prisma_type(_column("a", "text"), set()) == ("String", [])
+    assert _prisma_type(_column("a", "boolean"), set()) == ("Boolean", [])
+    assert _prisma_type(_column("a", "jsonb"), set()) == ("Json", [])
+    assert _prisma_type(_column("a", "timestamp with time zone"), set()) == ("DateTime", [])
+    assert _prisma_type(_column("a", "uuid"), set()) == ("String", [])
+    assert _prisma_type(_column("a", "bytea"), set()) == ("Bytes", [])
+
+
+def test_prisma_type_strips_modifiers_for_lookup() -> None:
+    assert _prisma_type(_column("a", "character varying(255)"), set()) == ("String", [])
+    assert _prisma_type(_column("a", "numeric(10,2)"), set()) == ("Decimal", [])
+
+
+def test_prisma_type_handles_array_suffix() -> None:
+    token, _ = _prisma_type(_column("tags", "text[]"), set())
+    assert token == "String[]"
+
+
+def test_prisma_type_resolves_enum_columns_to_the_enum_name() -> None:
+    token, _ = _prisma_type(_column("status", "status"), {"status"})
+    assert token == "status"
+
+
+def test_prisma_type_falls_back_to_unsupported_for_unknown_pg_types() -> None:
+    token, _ = _prisma_type(_column("embedding", "vector(384)"), set())
+    assert token == 'Unsupported("vector(384)")'
+
+
+def test_prisma_default_maps_sequences_to_autoincrement() -> None:
+    assert _prisma_default("nextval('widgets_id_seq'::regclass)") == "autoincrement()"
+
+
+def test_prisma_default_maps_timestamps_and_uuid_generators() -> None:
+    assert _prisma_default("now()") == "now()"
+    assert _prisma_default("CURRENT_TIMESTAMP") == "now()"
+    assert _prisma_default("gen_random_uuid()") == "uuid()"
+    assert _prisma_default("uuid_generate_v4()") == "uuid()"
+
+
+def test_prisma_default_maps_literals_with_un_doubled_quotes() -> None:
+    assert _prisma_default("'draft'::text") == '"draft"'
+    assert _prisma_default("'it''s'::text") == '"it\'s"'
+    assert _prisma_default("42") == "42"
+    assert _prisma_default("-3.14") == "-3.14"
+    assert _prisma_default("true") == "true"
+    assert _prisma_default("false") == "false"
+
+
+def test_prisma_default_returns_none_for_unknown_expressions() -> None:
+    assert _prisma_default(None) is None
+    assert _prisma_default("some_function(1, 2)") is None
+    assert _prisma_default("'unterminated") is None  # no ::cast, no match
+
+
+# --- full generate_prisma_schema via parameter-routing fake driver ---------
+
+
+def _column_row(
+    name: str,
+    data_type: str = "integer",
+    *,
+    nullable: bool = False,
+    default: str | None = None,
+    type_name: str = "int4",
+    type_mod: int = -1,
+) -> dict[str, Any]:
+    return {
+        "column_name": name,
+        "data_type": data_type,
+        "nullable": nullable,
+        "column_default": default,
+        "type_name": type_name,
+        "type_mod": type_mod,
+    }
+
+
+_LIST_TABLES = "FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = %s AND c.relkind"
+_DESCRIBE = "format_type(a.atttypid, a.atttypmod) AS data_type"
+_LIST_INDEXES = "FROM pg_class t JOIN pg_namespace n ON n.oid = t.relnamespace JOIN pg_index"
+_LIST_CONSTRAINTS = "FROM pg_constraint con JOIN pg_class c ON c.oid = con.conrelid"
+_LIST_FKS = "FROM pg_constraint c JOIN pg_class cl ON cl.oid = c.conrelid"
+_LIST_ENUMS = "FROM pg_type t JOIN pg_namespace n ON n.oid = t.typnamespace JOIN pg_enum"
+
+
+async def test_generate_prisma_schema_renders_models_with_pk_fk_and_back_relation() -> None:
+    routes: dict[tuple[str, tuple[Any, ...] | None], list[dict[str, Any]]] = {
+        (_LIST_TABLES, ("app",)): [
+            {"name": "widget", "relkind": "r", "is_partition": False},
+            {"name": "order_item", "relkind": "r", "is_partition": False},
+        ],
+        (_DESCRIBE, ("app", "widget")): [
+            _column_row("id", "integer", nullable=False, default="nextval('widgets_id_seq'::regclass)"),
+            _column_row("name", "text", nullable=False, type_name="text"),
+        ],
+        (_DESCRIBE, ("app", "order_item")): [
+            _column_row("id", "integer", nullable=False, default="nextval('order_id_seq'::regclass)"),
+            _column_row("widget_id", "integer", nullable=False),
+        ],
+        (_LIST_CONSTRAINTS, ("app", "widget")): [
+            {"name": "widget_pkey", "type_code": "p", "definition": "PRIMARY KEY (id)"}
+        ],
+        (_LIST_CONSTRAINTS, ("app", "order_item")): [
+            {"name": "order_item_pkey", "type_code": "p", "definition": "PRIMARY KEY (id)"}
+        ],
+        (_LIST_INDEXES, None): [],
+        (_LIST_FKS, ("app",)): [
+            {
+                "name": "order_widget_fk",
+                "from_table": "order_item",
+                "to_schema": "app",
+                "to_table": "widget",
+                "from_columns": ["widget_id"],
+                "to_columns": ["id"],
+            }
+        ],
+        (_LIST_ENUMS, ("app",)): [],
+    }
+    driver = FakeParamRoutingDriver(routes)
+
+    out = await generate_prisma_schema(driver, "app")  # type: ignore[arg-type]
+
+    # Datasource + generator preamble is always present.
+    assert 'provider = "postgresql"' in out
+    assert 'provider = "prisma-client-js"' in out
+
+    # Models include the PK marker on a single-column PK and an
+    # autoincrement default lifted from nextval(...).
+    assert "model widget {" in out
+    assert "id Int @id @default(autoincrement())" in out
+    assert "name String" in out
+
+    # Outgoing FK on the child side renders the relation field;
+    # back-relation appears on the parent side.
+    assert "model order_item {" in out
+    assert "widget_id Int" in out
+    assert '@relation("order_widget_fk", fields: [widget_id], references: [id])' in out
+    assert 'order_item[] @relation("order_widget_fk")' in out
+
+
+async def test_generate_prisma_schema_emits_enum_blocks_and_uses_them_in_columns() -> None:
+    routes: dict[tuple[str, tuple[Any, ...] | None], list[dict[str, Any]]] = {
+        (_LIST_TABLES, ("app",)): [{"name": "post", "relkind": "r", "is_partition": False}],
+        (_DESCRIBE, ("app", "post")): [
+            _column_row("id", "integer", nullable=False),
+            _column_row("status", "status", nullable=False, type_name="status"),
+        ],
+        (_LIST_CONSTRAINTS, ("app", "post")): [
+            {"name": "post_pkey", "type_code": "p", "definition": "PRIMARY KEY (id)"}
+        ],
+        (_LIST_INDEXES, None): [],
+        (_LIST_FKS, ("app",)): [],
+        (_LIST_ENUMS, ("app",)): [{"name": "status", "values": ["draft", "live", "archived"]}],
+    }
+    driver = FakeParamRoutingDriver(routes)
+
+    out = await generate_prisma_schema(driver, "app")  # type: ignore[arg-type]
+
+    assert "status status" in out  # field references the enum type
+    assert "enum status {" in out
+    assert "  draft" in out and "  live" in out and "  archived" in out
+
+
+async def test_generate_prisma_schema_renders_composite_pk_and_composite_unique() -> None:
+    routes: dict[tuple[str, tuple[Any, ...] | None], list[dict[str, Any]]] = {
+        (_LIST_TABLES, ("app",)): [{"name": "shard", "relkind": "r", "is_partition": False}],
+        (_DESCRIBE, ("app", "shard")): [
+            _column_row("tenant", "integer"),
+            _column_row("shard_no", "integer"),
+            _column_row("region", "text", type_name="text"),
+            _column_row("zone", "text", type_name="text"),
+        ],
+        (_LIST_CONSTRAINTS, ("app", "shard")): [
+            {"name": "shard_pkey", "type_code": "p", "definition": "PRIMARY KEY (tenant, shard_no)"},
+            {"name": "shard_region_zone_uq", "type_code": "u", "definition": "UNIQUE (region, zone)"},
+        ],
+        (_LIST_INDEXES, None): [],
+        (_LIST_FKS, ("app",)): [],
+        (_LIST_ENUMS, ("app",)): [],
+    }
+    driver = FakeParamRoutingDriver(routes)
+
+    out = await generate_prisma_schema(driver, "app")  # type: ignore[arg-type]
+
+    # Composite PK uses @@id since no single column is @id; UNIQUE renders as @@unique.
+    assert "@@id([tenant, shard_no])" in out
+    assert "@@unique([region, zone])" in out
+    # No standalone @id should appear because PK is composite.
+    assert " @id" not in out
+
+
+async def test_generate_prisma_schema_emits_index_blocks_without_duplicating_pk() -> None:
+    routes: dict[tuple[str, tuple[Any, ...] | None], list[dict[str, Any]]] = {
+        (_LIST_TABLES, ("app",)): [{"name": "widget", "relkind": "r", "is_partition": False}],
+        (_DESCRIBE, ("app", "widget")): [
+            _column_row("id", "integer"),
+            _column_row("name", "text", type_name="text"),
+        ],
+        (_LIST_CONSTRAINTS, ("app", "widget")): [
+            {"name": "widget_pkey", "type_code": "p", "definition": "PRIMARY KEY (id)"}
+        ],
+        (_LIST_INDEXES, ("app", "widget")): [
+            # The PK's implicit index — should be suppressed.
+            {
+                "name": "widget_pkey",
+                "method": "btree",
+                "relkind": "i",
+                "definition": "CREATE UNIQUE INDEX widget_pkey ON widget USING btree (id)",
+            },
+            # A real secondary index — should render.
+            {
+                "name": "widget_name_idx",
+                "method": "btree",
+                "relkind": "i",
+                "definition": "CREATE INDEX widget_name_idx ON widget USING btree (name)",
+            },
+        ],
+        (_LIST_FKS, ("app",)): [],
+        (_LIST_ENUMS, ("app",)): [],
+    }
+    driver = FakeParamRoutingDriver(routes)
+
+    out = await generate_prisma_schema(driver, "app")  # type: ignore[arg-type]
+
+    assert "@@index([name])" in out
+    # The (id) index is the PK and must not appear as a separate @@index/@@unique.
+    assert "@@index([id])" not in out and "@@unique([id])" not in out
+
+
+async def test_generate_prisma_schema_falls_back_to_unsupported_for_vector_columns() -> None:
+    routes: dict[tuple[str, tuple[Any, ...] | None], list[dict[str, Any]]] = {
+        (_LIST_TABLES, ("app",)): [{"name": "doc", "relkind": "r", "is_partition": False}],
+        (_DESCRIBE, ("app", "doc")): [
+            _column_row("id", "integer"),
+            _column_row("embedding", "vector(384)", nullable=True, type_name="vector", type_mod=384),
+        ],
+        (_LIST_CONSTRAINTS, ("app", "doc")): [{"name": "doc_pkey", "type_code": "p", "definition": "PRIMARY KEY (id)"}],
+        (_LIST_INDEXES, None): [],
+        (_LIST_FKS, ("app",)): [],
+        (_LIST_ENUMS, ("app",)): [],
+    }
+    driver = FakeParamRoutingDriver(routes)
+
+    out = await generate_prisma_schema(driver, "app")  # type: ignore[arg-type]
+
+    assert 'embedding Unsupported("vector(384)")?' in out
+
+
+async def test_generate_prisma_schema_skips_cross_schema_fk_relation_fields() -> None:
+    routes: dict[tuple[str, tuple[Any, ...] | None], list[dict[str, Any]]] = {
+        (_LIST_TABLES, ("app",)): [{"name": "order_item", "relkind": "r", "is_partition": False}],
+        (_DESCRIBE, ("app", "order_item")): [
+            _column_row("id", "integer"),
+            _column_row("widget_id", "integer"),
+        ],
+        (_LIST_CONSTRAINTS, ("app", "order_item")): [
+            {"name": "order_pkey", "type_code": "p", "definition": "PRIMARY KEY (id)"}
+        ],
+        (_LIST_INDEXES, None): [],
+        (_LIST_FKS, ("app",)): [
+            {
+                "name": "cross_fk",
+                "from_table": "order_item",
+                "to_schema": "other_schema",
+                "to_table": "widget",
+                "from_columns": ["widget_id"],
+                "to_columns": ["id"],
+            }
+        ],
+        (_LIST_ENUMS, ("app",)): [],
+    }
+    driver = FakeParamRoutingDriver(routes)
+
+    out = await generate_prisma_schema(driver, "app")  # type: ignore[arg-type]
+
+    # Scalar column stays, but no relation field is emitted (target not in
+    # the rendered model set).
+    assert "widget_id Int" in out
+    assert "@relation" not in out
+
+
+async def test_generate_prisma_schema_rejects_invalid_schema_identifier() -> None:
+    driver = FakeParamRoutingDriver({})
+    with pytest.raises(PrismaError, match="invalid schema name"):
+        await generate_prisma_schema(driver, 'app"; DROP TABLE x; --')  # type: ignore[arg-type]
+
+
+# --- MCP tool wiring -------------------------------------------------------
+
+
+async def test_generate_prisma_schema_tool_is_registered_and_callable() -> None:
+    server = create_server(_SETTINGS, database=FakeDatabase(FakeDriver()))  # type: ignore[arg-type]
+    async with create_connected_server_and_client_session(server) as client:
+        listed = {tool.name for tool in (await client.list_tools()).tools}
+        assert "generate_prisma_schema" in listed
+
+        result = await client.call_tool("generate_prisma_schema", {"schema": "public"})
+
+    assert result.isError is False
+    # Empty FakeDriver returns no tables / enums, but the preamble is
+    # always present.
+    assert 'provider = "postgresql"' in result.content[0].text  # type: ignore[union-attr]

--- a/tests/unit/test_prisma.py
+++ b/tests/unit/test_prisma.py
@@ -60,34 +60,48 @@ def _column(
 
 
 def test_prisma_type_maps_common_scalars() -> None:
-    assert _prisma_type(_column("a", "integer"), set()) == ("Int", [])
-    assert _prisma_type(_column("a", "bigint"), set()) == ("BigInt", [])
-    assert _prisma_type(_column("a", "text"), set()) == ("String", [])
-    assert _prisma_type(_column("a", "boolean"), set()) == ("Boolean", [])
-    assert _prisma_type(_column("a", "jsonb"), set()) == ("Json", [])
-    assert _prisma_type(_column("a", "timestamp with time zone"), set()) == ("DateTime", [])
-    assert _prisma_type(_column("a", "uuid"), set()) == ("String", [])
-    assert _prisma_type(_column("a", "bytea"), set()) == ("Bytes", [])
+    assert _prisma_type(_column("a", "integer"), set()) == "Int"
+    assert _prisma_type(_column("a", "bigint"), set()) == "BigInt"
+    assert _prisma_type(_column("a", "text"), set()) == "String"
+    assert _prisma_type(_column("a", "boolean"), set()) == "Boolean"
+    assert _prisma_type(_column("a", "jsonb"), set()) == "Json"
+    assert _prisma_type(_column("a", "timestamp with time zone"), set()) == "DateTime"
+    assert _prisma_type(_column("a", "uuid"), set()) == "String"
+    assert _prisma_type(_column("a", "bytea"), set()) == "Bytes"
 
 
 def test_prisma_type_strips_modifiers_for_lookup() -> None:
-    assert _prisma_type(_column("a", "character varying(255)"), set()) == ("String", [])
-    assert _prisma_type(_column("a", "numeric(10,2)"), set()) == ("Decimal", [])
+    assert _prisma_type(_column("a", "character varying(255)"), set()) == "String"
+    assert _prisma_type(_column("a", "numeric(10,2)"), set()) == "Decimal"
 
 
 def test_prisma_type_handles_array_suffix() -> None:
-    token, _ = _prisma_type(_column("tags", "text[]"), set())
-    assert token == "String[]"
+    assert _prisma_type(_column("tags", "text[]"), set()) == "String[]"
 
 
 def test_prisma_type_resolves_enum_columns_to_the_enum_name() -> None:
-    token, _ = _prisma_type(_column("status", "status"), {"status"})
-    assert token == "status"
+    assert _prisma_type(_column("status", "status"), {"status"}) == "status"
+
+
+def test_prisma_type_resolves_schema_qualified_enum_columns_to_the_bare_name() -> None:
+    # format_type emits qualified names when the type's schema isn't on
+    # the search_path — Prisma can only reference the bare enum name.
+    assert _prisma_type(_column("status", "mcpg_it.status"), {"status"}) == "status"
+
+
+def test_prisma_type_renders_enum_arrays_as_enum_lists() -> None:
+    assert _prisma_type(_column("tags", "status[]"), {"status"}) == "status[]"
 
 
 def test_prisma_type_falls_back_to_unsupported_for_unknown_pg_types() -> None:
-    token, _ = _prisma_type(_column("embedding", "vector(384)"), set())
-    assert token == 'Unsupported("vector(384)")'
+    assert _prisma_type(_column("embedding", "vector(384)"), set()) == 'Unsupported("vector(384)")'
+
+
+def test_prisma_type_escapes_embedded_quotes_in_unsupported_fallback() -> None:
+    # A pathological type name with quotes would otherwise break the
+    # generated Prisma string literal; ensure they're escaped.
+    rendered = _prisma_type(_column("x", 'weird"name'), set())
+    assert rendered == 'Unsupported("weird\\"name")'
 
 
 def test_prisma_default_maps_sequences_to_autoincrement() -> None:
@@ -222,6 +236,129 @@ async def test_generate_prisma_schema_emits_enum_blocks_and_uses_them_in_columns
     assert "status status" in out  # field references the enum type
     assert "enum status {" in out
     assert "  draft" in out and "  live" in out and "  archived" in out
+
+
+async def test_generate_prisma_schema_renders_single_column_unique_as_field_attribute() -> None:
+    # Single-column UNIQUE should fold into the field as ``@unique`` and
+    # NOT generate a separate ``@@unique([name])`` block.
+    routes: dict[tuple[str, tuple[Any, ...] | None], list[dict[str, Any]]] = {
+        (_LIST_TABLES, ("app",)): [{"name": "project", "relkind": "r", "is_partition": False}],
+        (_DESCRIBE, ("app", "project")): [
+            _column_row("id", "integer"),
+            _column_row("name", "text", type_name="text"),
+        ],
+        (_LIST_CONSTRAINTS, ("app", "project")): [
+            {"name": "project_pkey", "type_code": "p", "definition": "PRIMARY KEY (id)"},
+            {"name": "project_name_key", "type_code": "u", "definition": "UNIQUE (name)"},
+        ],
+        (_LIST_INDEXES, None): [],
+        (_LIST_FKS, ("app",)): [],
+        (_LIST_ENUMS, ("app",)): [],
+    }
+    driver = FakeParamRoutingDriver(routes)
+
+    out = await generate_prisma_schema(driver, "app")  # type: ignore[arg-type]
+
+    assert "name String @unique" in out
+    assert "@@unique([name])" not in out
+
+
+async def test_generate_prisma_schema_renders_nullable_array_without_optional_marker() -> None:
+    # Prisma's SQL data model treats arrays as inherently optional (empty
+    # == null), so even a nullable text[] column must render as
+    # ``String[]`` rather than ``String[]?`` — Prisma rejects the latter.
+    routes: dict[tuple[str, tuple[Any, ...] | None], list[dict[str, Any]]] = {
+        (_LIST_TABLES, ("app",)): [{"name": "post", "relkind": "r", "is_partition": False}],
+        (_DESCRIBE, ("app", "post")): [
+            _column_row("id", "integer"),
+            _column_row("tags", "text[]", nullable=True, type_name="text"),
+        ],
+        (_LIST_CONSTRAINTS, ("app", "post")): [
+            {"name": "post_pkey", "type_code": "p", "definition": "PRIMARY KEY (id)"}
+        ],
+        (_LIST_INDEXES, None): [],
+        (_LIST_FKS, ("app",)): [],
+        (_LIST_ENUMS, ("app",)): [],
+    }
+    driver = FakeParamRoutingDriver(routes)
+
+    out = await generate_prisma_schema(driver, "app")  # type: ignore[arg-type]
+
+    assert "tags String[]" in out
+    assert "String[]?" not in out
+
+
+async def test_generate_prisma_schema_skips_expression_indexes_and_emits_unique_secondary() -> None:
+    # _render_index should:
+    # - de-duplicate the PK-backing index (already covered above)
+    # - render a non-constraint UNIQUE INDEX as @@unique([cols])
+    # - skip an expression-based index (lower(name)) since the indexed
+    #   "column" isn't a bare identifier.
+    routes: dict[tuple[str, tuple[Any, ...] | None], list[dict[str, Any]]] = {
+        (_LIST_TABLES, ("app",)): [{"name": "widget", "relkind": "r", "is_partition": False}],
+        (_DESCRIBE, ("app", "widget")): [
+            _column_row("id", "integer"),
+            _column_row("name", "text", type_name="text"),
+        ],
+        (_LIST_CONSTRAINTS, ("app", "widget")): [
+            {"name": "widget_pkey", "type_code": "p", "definition": "PRIMARY KEY (id)"}
+        ],
+        (_LIST_INDEXES, ("app", "widget")): [
+            {
+                "name": "widget_name_key",
+                "method": "btree",
+                "relkind": "i",
+                "definition": "CREATE UNIQUE INDEX widget_name_key ON app.widget USING btree (name)",
+            },
+            {
+                "name": "widget_lower_name_idx",
+                "method": "btree",
+                "relkind": "i",
+                "definition": "CREATE INDEX widget_lower_name_idx ON app.widget USING btree (lower(name))",
+            },
+        ],
+        (_LIST_FKS, ("app",)): [],
+        (_LIST_ENUMS, ("app",)): [],
+    }
+    driver = FakeParamRoutingDriver(routes)
+
+    out = await generate_prisma_schema(driver, "app")  # type: ignore[arg-type]
+
+    assert "@@unique([name])" in out
+    # Expression index isn't representable as @@index — must be dropped.
+    assert "lower(name)" not in out
+    assert "@@index([lower" not in out
+
+
+async def test_generate_prisma_schema_rejects_foreign_key_constraint_with_invalid_name() -> None:
+    # FK constraint names are interpolated into Prisma text; an invalid
+    # one (spaces, quotes, etc.) must fail up-front instead of producing
+    # broken DSL.
+    routes: dict[tuple[str, tuple[Any, ...] | None], list[dict[str, Any]]] = {
+        (_LIST_TABLES, ("app",)): [
+            {"name": "widget", "relkind": "r", "is_partition": False},
+            {"name": "order_item", "relkind": "r", "is_partition": False},
+        ],
+        (_DESCRIBE, ("app", "widget")): [_column_row("id", "integer")],
+        (_DESCRIBE, ("app", "order_item")): [_column_row("id", "integer"), _column_row("widget_id", "integer")],
+        (_LIST_CONSTRAINTS, None): [],
+        (_LIST_INDEXES, None): [],
+        (_LIST_FKS, ("app",)): [
+            {
+                "name": "weird name with spaces",
+                "from_table": "order_item",
+                "to_schema": "app",
+                "to_table": "widget",
+                "from_columns": ["widget_id"],
+                "to_columns": ["id"],
+            }
+        ],
+        (_LIST_ENUMS, ("app",)): [],
+    }
+    driver = FakeParamRoutingDriver(routes)
+
+    with pytest.raises(PrismaError, match="invalid relation"):
+        await generate_prisma_schema(driver, "app")  # type: ignore[arg-type]
 
 
 async def test_generate_prisma_schema_renders_composite_pk_and_composite_unique() -> None:


### PR DESCRIPTION
## Summary

**Batch G first cut — the marketable USP move.** New `mcpg.prisma`
module ships one read-only tool:

  `generate_prisma_schema(schema) → str`

Read a PostgreSQL schema and emit a valid Prisma `.prisma` schema
string an agent can drop straight into a Prisma project. Mirrors
`prisma db pull` for the most-used surface but is driven by MCPg, not
the Prisma CLI — **no Node.js dependency, no subprocess**.

No other PG MCP server bridges to an ORM schema DSL today. This is the
first USP-tier tool in MCPg.

Tool surface 53 → 54.

### Coverage

| Group | What's emitted |
| --- | --- |
| Tables | `model` blocks with columns, single-column `@id`, composite `@@id`, single-column `@unique`, composite `@@unique`, secondary `@@index` (deduplicated against PK / UNIQUE indexes), array types (`text[]` → `String[]`) |
| Foreign keys | Named `@relation` on the child + matching back-relation field on the parent; collisions auto-disambiguated when one parent has multiple FKs from the same source |
| Enums | Top-level `enum` blocks; enum-typed columns reference the enum directly. Schema-qualified type names (`mcpg_it.status`) are stripped to the bare name for lookup |
| Defaults | `nextval('seq')` → `autoincrement()`, `now()`/`CURRENT_TIMESTAMP` → `now()`, `gen_random_uuid()`/`uuid_generate_v4()` → `uuid()`, numeric and text literals → `@default(...)`, booleans → `true`/`false`. Unknown defaults are silently dropped |
| Unmappable types | pgvector, custom domains, composite types fall back to `Unsupported("vector(384)")` exactly like `prisma db pull` |

### Out of scope for v1

Views, foreign tables, partitions, triggers, functions, RLS policies,
composite types. Identifiers must match `[A-Za-z_][A-Za-z0-9_]*`;
quoted/case-sensitive names raise `PrismaError` up-front. `@@map` /
`@map` re-mapping is deferred — output uses the PG names verbatim,
matching `prisma db pull`'s default.

## Test plan

- [ ] CI: ruff, mypy --strict, full unit + integration suites green
- [ ] CI matrix: PG 14/15/16/17 — the integration test builds a real
      schema (serial PKs, enum-typed column, FK with back-relation,
      secondary index) and asserts every shape in the output
- [ ] 19 unit tests cover every helper (type / default mapping with
      modifiers, arrays, schema-prefix stripping, every default form +
      unknown defaults) and the end-to-end render through a fake
      driver: PK/FK/back-relation happy path, enum reference + emission,
      composite PK + composite UNIQUE, index dedup, Unsupported
      fallback, cross-schema FK skip, invalid-schema rejection
- [ ] Coverage gate (90%) maintained; locally 482 pass / 9 skipped

## What's next after merge

Per the agreed sequencing: **Batch B** — advisors / lint (Phase 20) +
audit trail (Phase 21). Batch G follow-ons (Drizzle / SQLAlchemy /
sqlc exporters under the same `schema → ORM DSL` umbrella) and
Batches D, E, F (ADR-gated) come after.

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Introduce a Prisma schema generation tool that exports PostgreSQL schemas to Prisma DSL and wire it into the MCPg toolset, along with comprehensive unit and integration tests and documentation updates.

New Features:
- Add a `generate_prisma_schema` MCP tool that reads a PostgreSQL schema and emits a Prisma `.prisma` schema string mirroring `prisma db pull` for core tables, keys, indexes, and enums.

Enhancements:
- Implement a `mcpg.prisma` module that maps PostgreSQL types, defaults, and relationships to Prisma models, enums, and Unsupported fallbacks while enforcing safe identifier rules.
- Wire the new Prisma exporter into the server tool registration so it is available when running against a live database.
- Extend project progress tracking and changelog documentation to capture Phase 28 completion, tool count increase, and the new USP-tier capability.

Tests:
- Add focused unit tests for Prisma type/default mapping helpers and composite key/index rendering, plus an end-to-end schema export test using a fake driver.
- Add an integration test that builds a real PostgreSQL schema and verifies the generated Prisma schema models, relations, enums, and indexes.