### PR TITLE
feat: Phase 20 — run_advisors (Batch B, part 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `run_advisors` tool — runs a set of codified, catalog-driven lint
+  rules against a schema and returns a typed report of findings. First
+  cut covers: `missing_primary_key`, `unindexed_foreign_key` (leading-
+  column heuristic), `duplicate_indexes` (same column-keys + access
+  method), and `nullable_timestamp_without_tz`. Each finding carries a
+  rule id, severity (`warning`/`info`), a qualified object name, and a
+  human-readable message. Advisory only — no writes.
 - `generate_prisma_schema` tool — read a PostgreSQL schema and emit a
   valid Prisma `.prisma` schema string, mirroring `prisma db pull` but
   driven by MCPg. Covers tables, columns, primary/foreign keys

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -6,20 +6,20 @@
 
 ## Current state
 
-- **Phase:** 28 — `generate_prisma_schema` (Phases 0–18 + 22–23 + 28
-  complete; **Batch G first cut done**)
+- **Phase:** 20 — Advisors / lint (Phases 0–18 + 20 + 22–23 + 28
+  complete; **Batch B first half done**)
 - **Last updated:** 2026-05-24
 - **Branch:** `claude/postgresql-mcp-planning-8KssU`
-- **Tool count:** 54
+- **Tool count:** 55
 
 ## Next action
 
-> Phase 28 (Batch G first cut) complete — `generate_prisma_schema`
-> ships the marketable USP move: no other PG MCP server bridges to an
-> ORM schema DSL. Next per the agreed sequencing: **Batch B** —
-> advisors / lint (Phase 20) + audit trail (Phase 21). Batch G
-> follow-ons (Drizzle, SQLAlchemy, sqlc exporters) and Batches D, E,
-> F (ADR-gated) come after.
+> Phase 20 (Batch B first half) complete — `run_advisors` ships four
+> catalog-driven lint rules (missing PK, unindexed FK, duplicate
+> indexes, nullable timestamp without TZ). Next: **Phase 21 — audit
+> trail with semantic diff** to close Batch B. Batch G follow-ons
+> (Drizzle, SQLAlchemy, sqlc exporters) and Batches D, E, F (ADR-
+> gated) come after.
 
 ## Phase 0 — Spike & foundation  ✅ COMPLETE
 
@@ -519,3 +519,21 @@
   index. **First USP-tier tool** — no other PG MCP server bridges to
   an ORM schema DSL. Phase 28 complete (54 MCP tools total). 482
   tests, 100% coverage.
+- 2026-05-24 — PR #10 review fix: 12 Sourcery + Gemini comments
+  collapsing to FK-name validation, Unsupported() quote escaping, dead
+  `fk_columns_to_relation`, `_prisma_type` simplification, FK-name
+  vs column-name collision detection, and three test-gap fills.
+  Resolved across `f231bc9` and `11dcb9d`.
+- 2026-05-24 — PR #10 merged to `main`; branch re-synced. Batch G
+  first cut closed.
+- 2026-05-24 — Phase 20 (Batch B first half): new `mcpg.advisors`
+  module exposes one read-only tool, `run_advisors`, that runs four
+  codified catalog-driven rules and aggregates findings:
+  `missing_primary_key`, `unindexed_foreign_key` (leading-column
+  heuristic via `pg_constraint.conkey[1]` vs `pg_index.indkey[0]`),
+  `duplicate_indexes` (matching `indkey` + same `relam`, deduplicated
+  via `indexrelid` inequality), and `nullable_timestamp_without_tz`
+  (catches the common TZ-coercion source). 9 unit tests cover each
+  rule + aggregator; 1 integration test seeds one example violation
+  per rule plus a clean control table against real PG. Phase 20
+  complete (55 MCP tools total). 500 tests, 100% coverage.

--- a/src/mcpg/advisors.py
+++ b/src/mcpg/advisors.py
@@ -1,0 +1,195 @@
+"""Schema advisors — codified lint rules over the PG catalog.
+
+``run_advisors`` runs a set of catalog-driven checks and returns a
+typed report of findings. Each rule is a small function that yields
+:class:`Finding` instances; rules are pure SQL (no fix-up, no DDL) and
+the tool is exposed under the READ capability so an agent in any mode
+can request advice.
+
+First-cut rules:
+
+* ``missing_primary_key`` — base tables without a PRIMARY KEY constraint.
+* ``unindexed_foreign_key`` — FK constraints whose leading column lacks
+  an index whose first column matches; can produce slow joins and
+  ``DELETE CASCADE`` storms.
+* ``duplicate_indexes`` — two indexes on the same access method with
+  identical column keys; one is redundant.
+* ``nullable_timestamp_without_tz`` — nullable ``timestamp`` (without
+  time zone) columns; a frequent source of TZ-coercion bugs.
+
+Rules are deliberately conservative — the goal is "would a careful
+reviewer flag this?" rather than "is this provably wrong?".
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mcpg._vendor.sql import SqlDriver
+
+# Stable rule identifiers — agents may filter by these.
+RULE_MISSING_PRIMARY_KEY = "missing_primary_key"
+RULE_UNINDEXED_FOREIGN_KEY = "unindexed_foreign_key"
+RULE_DUPLICATE_INDEXES = "duplicate_indexes"
+RULE_NULLABLE_TIMESTAMP_WITHOUT_TZ = "nullable_timestamp_without_tz"
+
+_RULES = (
+    RULE_MISSING_PRIMARY_KEY,
+    RULE_UNINDEXED_FOREIGN_KEY,
+    RULE_DUPLICATE_INDEXES,
+    RULE_NULLABLE_TIMESTAMP_WITHOUT_TZ,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class Finding:
+    """A single advisor finding.
+
+    ``object`` is the qualified name of the thing the rule is about —
+    ``"schema.table"`` for table-level rules, ``"schema.table.column"``
+    for column-level rules, and ``"schema.index_a vs schema.index_b"``
+    for the duplicate-indexes rule.
+    """
+
+    rule: str
+    severity: str
+    object: str
+    message: str
+
+
+@dataclass(frozen=True, slots=True)
+class AdvisorReport:
+    """The aggregated result of running every advisor against a schema."""
+
+    schema: str
+    rules_run: list[str]
+    findings: list[Finding]
+
+
+async def _missing_primary_keys(driver: SqlDriver, schema: str) -> list[Finding]:
+    rows = await driver.execute_query(
+        "SELECT c.relname AS table_name "
+        "FROM pg_class c "
+        "JOIN pg_namespace n ON n.oid = c.relnamespace "
+        "WHERE n.nspname = %s AND c.relkind IN ('r', 'p') "
+        "AND NOT EXISTS ("
+        "  SELECT 1 FROM pg_constraint con "
+        "  WHERE con.conrelid = c.oid AND con.contype = 'p'"
+        ") ORDER BY c.relname",
+        params=[schema],
+        force_readonly=True,
+    )
+    return [
+        Finding(
+            rule=RULE_MISSING_PRIMARY_KEY,
+            severity="warning",
+            object=f"{schema}.{row.cells['table_name']}",
+            message="table has no PRIMARY KEY constraint",
+        )
+        for row in rows or []
+    ]
+
+
+async def _unindexed_foreign_keys(driver: SqlDriver, schema: str) -> list[Finding]:
+    rows = await driver.execute_query(
+        # Leading-column heuristic: a FK can use any index whose first
+        # column matches the FK's first column; reporting on that is
+        # close enough to "is this FK indexed?" for the common cases.
+        "SELECT con.conname AS fk_name, c.relname AS table_name, att.attname AS first_column "
+        "FROM pg_constraint con "
+        "JOIN pg_class c ON c.oid = con.conrelid "
+        "JOIN pg_namespace n ON n.oid = c.relnamespace "
+        "JOIN pg_attribute att ON att.attrelid = con.conrelid AND att.attnum = con.conkey[1] "
+        "WHERE n.nspname = %s AND con.contype = 'f' "
+        "AND NOT EXISTS ("
+        "  SELECT 1 FROM pg_index idx "
+        "  WHERE idx.indrelid = con.conrelid AND idx.indkey[0] = con.conkey[1]"
+        ") ORDER BY c.relname, con.conname",
+        params=[schema],
+        force_readonly=True,
+    )
+    return [
+        Finding(
+            rule=RULE_UNINDEXED_FOREIGN_KEY,
+            severity="warning",
+            object=f"{schema}.{row.cells['table_name']}.{row.cells['first_column']}",
+            message=(
+                f"foreign key {row.cells['fk_name']!r} has no index whose leading column "
+                f"is {row.cells['first_column']!r}; joins and cascading deletes will seq-scan"
+            ),
+        )
+        for row in rows or []
+    ]
+
+
+async def _duplicate_indexes(driver: SqlDriver, schema: str) -> list[Finding]:
+    rows = await driver.execute_query(
+        "SELECT i1.relname AS index_a, i2.relname AS index_b, c.relname AS table_name "
+        "FROM pg_index ix1 "
+        "JOIN pg_class i1 ON i1.oid = ix1.indexrelid "
+        "JOIN pg_class c ON c.oid = ix1.indrelid "
+        "JOIN pg_namespace n ON n.oid = c.relnamespace "
+        # Pair each index with every other index on the same table whose
+        # key vector matches and uses the same access method; the
+        # indexrelid inequality avoids reporting (a,b) and (b,a).
+        "JOIN pg_index ix2 ON ix2.indrelid = ix1.indrelid "
+        "  AND ix2.indkey = ix1.indkey "
+        "  AND ix2.indexrelid > ix1.indexrelid "
+        "JOIN pg_class i2 ON i2.oid = ix2.indexrelid "
+        "WHERE n.nspname = %s AND i1.relam = i2.relam "
+        "ORDER BY c.relname, i1.relname, i2.relname",
+        params=[schema],
+        force_readonly=True,
+    )
+    return [
+        Finding(
+            rule=RULE_DUPLICATE_INDEXES,
+            severity="warning",
+            object=f"{schema}.{row.cells['index_a']} vs {schema}.{row.cells['index_b']}",
+            message=(
+                f"indexes {row.cells['index_a']!r} and {row.cells['index_b']!r} on "
+                f"{row.cells['table_name']!r} cover identical columns with the same access method"
+            ),
+        )
+        for row in rows or []
+    ]
+
+
+async def _nullable_timestamps_without_tz(driver: SqlDriver, schema: str) -> list[Finding]:
+    rows = await driver.execute_query(
+        "SELECT c.relname AS table_name, att.attname AS column_name "
+        "FROM pg_attribute att "
+        "JOIN pg_class c ON c.oid = att.attrelid "
+        "JOIN pg_namespace n ON n.oid = c.relnamespace "
+        "JOIN pg_type t ON t.oid = att.atttypid "
+        "WHERE n.nspname = %s AND c.relkind IN ('r', 'p') "
+        "AND att.attnum > 0 AND NOT att.attisdropped "
+        # 'timestamp' is the internal name for 'timestamp without time
+        # zone'; the TZ-aware variant is 'timestamptz'.
+        "AND t.typname = 'timestamp' AND NOT att.attnotnull "
+        "ORDER BY c.relname, att.attnum",
+        params=[schema],
+        force_readonly=True,
+    )
+    return [
+        Finding(
+            rule=RULE_NULLABLE_TIMESTAMP_WITHOUT_TZ,
+            severity="info",
+            object=f"{schema}.{row.cells['table_name']}.{row.cells['column_name']}",
+            message=(
+                "nullable timestamp column without time zone — prefer 'timestamptz NOT NULL' "
+                "to avoid TZ-coercion surprises"
+            ),
+        )
+        for row in rows or []
+    ]
+
+
+async def run_advisors(driver: SqlDriver, schema: str) -> AdvisorReport:
+    """Run every advisor rule against ``schema`` and aggregate the findings."""
+    findings: list[Finding] = []
+    findings.extend(await _missing_primary_keys(driver, schema))
+    findings.extend(await _unindexed_foreign_keys(driver, schema))
+    findings.extend(await _duplicate_indexes(driver, schema))
+    findings.extend(await _nullable_timestamps_without_tz(driver, schema))
+    return AdvisorReport(schema=schema, rules_run=list(_RULES), findings=findings)

--- a/src/mcpg/advisors.py
+++ b/src/mcpg/advisors.py
@@ -129,12 +129,23 @@ async def _duplicate_indexes(driver: SqlDriver, schema: str) -> list[Finding]:
         "JOIN pg_class i1 ON i1.oid = ix1.indexrelid "
         "JOIN pg_class c ON c.oid = ix1.indrelid "
         "JOIN pg_namespace n ON n.oid = c.relnamespace "
-        # Pair each index with every other index on the same table whose
-        # key vector matches and uses the same access method; the
-        # indexrelid inequality avoids reporting (a,b) and (b,a).
+        # Pair each index with every other index on the same table that
+        # is functionally identical — same column keys, same operator
+        # classes, same sort options, same uniqueness, same partial
+        # predicate, same expression set, and not a primary-key
+        # backing index. Without these, a UNIQUE / partial / expression
+        # index would be falsely flagged as a duplicate of a plain
+        # index over the same columns, and an agent acting on the
+        # report could drop a constraint-enforcing index by mistake.
         "JOIN pg_index ix2 ON ix2.indrelid = ix1.indrelid "
-        "  AND ix2.indkey = ix1.indkey "
         "  AND ix2.indexrelid > ix1.indexrelid "
+        "  AND ix2.indkey = ix1.indkey "
+        "  AND ix2.indclass = ix1.indclass "
+        "  AND ix2.indoption = ix1.indoption "
+        "  AND ix2.indisunique = ix1.indisunique "
+        "  AND ix2.indisprimary = ix1.indisprimary "
+        "  AND ix2.indpred::text IS NOT DISTINCT FROM ix1.indpred::text "
+        "  AND ix2.indexprs::text IS NOT DISTINCT FROM ix1.indexprs::text "
         "JOIN pg_class i2 ON i2.oid = ix2.indexrelid "
         "WHERE n.nspname = %s AND i1.relam = i2.relam "
         "ORDER BY c.relname, i1.relname, i2.relname",

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -15,6 +15,7 @@ from mcp.server.session import ServerSession
 
 from mcpg import (
     __version__,
+    advisors,
     cron,
     diagrams,
     extensions,
@@ -365,6 +366,21 @@ def _register_prisma(server: FastMCP[AppContext]) -> None:
     )
     async def generate_prisma_schema(ctx: _Ctx, schema: str) -> str:
         return await prisma.generate_prisma_schema(_driver(ctx), schema)
+
+
+def _register_advisors(server: FastMCP[AppContext]) -> None:
+    @server.tool(
+        name="run_advisors",
+        description=(
+            "Run a set of catalog-driven advisor rules against a schema and return "
+            "the aggregated findings. Rules cover missing primary keys, unindexed "
+            "foreign keys, duplicate indexes, and nullable timestamps without time "
+            "zone. Advisory only — no writes."
+        ),
+    )
+    async def run_advisors(ctx: _Ctx, schema: str) -> dict[str, Any]:
+        report = await advisors.run_advisors(_driver(ctx), schema)
+        return asdict(report)
 
 
 def _register_query(server: FastMCP[AppContext]) -> None:
@@ -727,6 +743,7 @@ def register_tools(server: FastMCP[AppContext], settings: Settings) -> None:
         _register_schema_diff(server)
         _register_vector_tuning(server)
         _register_prisma(server)
+        _register_advisors(server)
         _register_query(server)
         _register_health(server)
         _register_liveops(server)

--- a/tests/integration/test_advisors_integration.py
+++ b/tests/integration/test_advisors_integration.py
@@ -65,5 +65,39 @@ async def test_run_advisors_reports_every_seeded_violation(connected_database: D
     # nullable_timestamp_without_tz — legacy.created_at.
     assert any(f.object == f"{advisors_schema}.legacy.created_at" for f in by_rule[RULE_NULLABLE_TIMESTAMP_WITHOUT_TZ])
 
-    # The clean control table must not show up under any rule.
-    assert all(advisors_schema + ".control" not in f.object.split(" vs ")[0] for f in report.findings)
+    # The clean control table must not show up under any rule. Inspect
+    # every side of " vs " findings so duplicate-index reports get
+    # both indexes checked, not just the first.
+    control_prefix = f"{advisors_schema}.control"
+    assert all(not obj_part.startswith(control_prefix) for f in report.findings for obj_part in f.object.split(" vs "))
+
+
+async def test_run_advisors_does_not_flag_indexes_that_differ_in_uniqueness_or_predicate(
+    connected_database: Database, advisors_schema: str
+) -> None:
+    # Two indexes covering the same column but with different semantics
+    # (plain vs UNIQUE, plain vs partial) must NOT be reported as
+    # duplicates — dropping one would lose the uniqueness or the
+    # WHERE-filtered selectivity.
+    driver = connected_database.driver()
+    await driver.execute_query(
+        f"CREATE TABLE {advisors_schema}.with_unique (id integer PRIMARY KEY, code text NOT NULL)"
+    )
+    await driver.execute_query(f"CREATE INDEX with_unique_code_idx ON {advisors_schema}.with_unique (code)")
+    await driver.execute_query(f"CREATE UNIQUE INDEX with_unique_code_uq ON {advisors_schema}.with_unique (code)")
+    await driver.execute_query(
+        f"CREATE TABLE {advisors_schema}.with_partial (id integer PRIMARY KEY, active boolean NOT NULL)"
+    )
+    await driver.execute_query(f"CREATE INDEX with_partial_full_idx ON {advisors_schema}.with_partial (active)")
+    await driver.execute_query(
+        f"CREATE INDEX with_partial_filtered_idx ON {advisors_schema}.with_partial (active) WHERE active"
+    )
+
+    report = await run_advisors(connected_database.driver(), advisors_schema)
+
+    duplicates = [f for f in report.findings if f.rule == RULE_DUPLICATE_INDEXES]
+    for finding in duplicates:
+        # Neither the unique/non-unique pair nor the partial/non-partial
+        # pair should appear — only genuinely-identical indexes should.
+        assert "with_unique_code" not in finding.object, finding
+        assert "with_partial" not in finding.object, finding

--- a/tests/integration/test_advisors_integration.py
+++ b/tests/integration/test_advisors_integration.py
@@ -1,0 +1,69 @@
+"""Integration test for the schema-advisor rules against a live PostgreSQL."""
+
+from collections.abc import AsyncIterator
+
+import pytest
+
+from mcpg.advisors import (
+    RULE_DUPLICATE_INDEXES,
+    RULE_MISSING_PRIMARY_KEY,
+    RULE_NULLABLE_TIMESTAMP_WITHOUT_TZ,
+    RULE_UNINDEXED_FOREIGN_KEY,
+    run_advisors,
+)
+from mcpg.database import Database
+
+_SCHEMA = "mcpg_advisors_it"
+
+
+@pytest.fixture
+async def advisors_schema(connected_database: Database) -> AsyncIterator[str]:
+    """Build one example violation per advisor rule, plus a clean control table."""
+    driver = connected_database.driver()
+    await driver.execute_query(f"DROP SCHEMA IF EXISTS {_SCHEMA} CASCADE")
+    await driver.execute_query(f"CREATE SCHEMA {_SCHEMA}")
+    # Clean control — has a PK, no FKs, no duplicates, no nullable
+    # timestamps. Should NOT produce any findings.
+    await driver.execute_query(f"CREATE TABLE {_SCHEMA}.control (id integer PRIMARY KEY, name text NOT NULL)")
+    # Violates missing_primary_key.
+    await driver.execute_query(f"CREATE TABLE {_SCHEMA}.no_pk (note text)")
+    # Violates nullable_timestamp_without_tz on created_at.
+    await driver.execute_query(f"CREATE TABLE {_SCHEMA}.legacy (id integer PRIMARY KEY, created_at timestamp)")
+    # Violates unindexed_foreign_key: order_item.control_id references
+    # control(id) but has no leading-column index.
+    await driver.execute_query(
+        f"CREATE TABLE {_SCHEMA}.order_item ("
+        f"  id integer PRIMARY KEY, "
+        f"  control_id integer NOT NULL REFERENCES {_SCHEMA}.control(id)"
+        f")"
+    )
+    # Violates duplicate_indexes: two btree indexes on widget(name).
+    await driver.execute_query(f"CREATE TABLE {_SCHEMA}.widget (id integer PRIMARY KEY, name text NOT NULL)")
+    await driver.execute_query(f"CREATE INDEX widget_name_a ON {_SCHEMA}.widget (name)")
+    await driver.execute_query(f"CREATE INDEX widget_name_b ON {_SCHEMA}.widget (name)")
+    try:
+        yield _SCHEMA
+    finally:
+        await driver.execute_query(f"DROP SCHEMA IF EXISTS {_SCHEMA} CASCADE")
+
+
+async def test_run_advisors_reports_every_seeded_violation(connected_database: Database, advisors_schema: str) -> None:
+    report = await run_advisors(connected_database.driver(), advisors_schema)
+
+    by_rule = {rule: [f for f in report.findings if f.rule == rule] for rule in report.rules_run}
+
+    # missing_primary_key — exactly the no_pk table.
+    assert {f.object for f in by_rule[RULE_MISSING_PRIMARY_KEY]} == {f"{advisors_schema}.no_pk"}
+
+    # unindexed_foreign_key — the order_item.control_id FK.
+    assert any(f.object == f"{advisors_schema}.order_item.control_id" for f in by_rule[RULE_UNINDEXED_FOREIGN_KEY])
+
+    # duplicate_indexes — the widget_name_a / widget_name_b pair.
+    duplicate_objects = {f.object for f in by_rule[RULE_DUPLICATE_INDEXES]}
+    assert any("widget_name_a" in obj and "widget_name_b" in obj for obj in duplicate_objects)
+
+    # nullable_timestamp_without_tz — legacy.created_at.
+    assert any(f.object == f"{advisors_schema}.legacy.created_at" for f in by_rule[RULE_NULLABLE_TIMESTAMP_WITHOUT_TZ])
+
+    # The clean control table must not show up under any rule.
+    assert all(advisors_schema + ".control" not in f.object.split(" vs ")[0] for f in report.findings)

--- a/tests/unit/test_advisors.py
+++ b/tests/unit/test_advisors.py
@@ -1,0 +1,168 @@
+"""Tests for the schema-advisor rules and their MCP tool."""
+
+from _fakes import FakeDatabase, FakeDriver, FakeRoutingDriver
+from mcp.shared.memory import create_connected_server_and_client_session
+
+from mcpg.advisors import (
+    RULE_DUPLICATE_INDEXES,
+    RULE_MISSING_PRIMARY_KEY,
+    RULE_NULLABLE_TIMESTAMP_WITHOUT_TZ,
+    RULE_UNINDEXED_FOREIGN_KEY,
+    AdvisorReport,
+    Finding,
+    _duplicate_indexes,
+    _missing_primary_keys,
+    _nullable_timestamps_without_tz,
+    _unindexed_foreign_keys,
+    run_advisors,
+)
+from mcpg.config import load_settings
+from mcpg.server import create_server
+
+_SETTINGS = load_settings({"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db"})
+
+
+# --- _missing_primary_keys -------------------------------------------------
+
+
+async def test_missing_primary_keys_flags_each_table_without_a_pk() -> None:
+    driver = FakeRoutingDriver({"FROM pg_class c": [{"table_name": "orphan_a"}, {"table_name": "orphan_b"}]})
+
+    findings = await _missing_primary_keys(driver, "app")  # type: ignore[arg-type]
+
+    assert findings == [
+        Finding(
+            rule=RULE_MISSING_PRIMARY_KEY,
+            severity="warning",
+            object="app.orphan_a",
+            message="table has no PRIMARY KEY constraint",
+        ),
+        Finding(
+            rule=RULE_MISSING_PRIMARY_KEY,
+            severity="warning",
+            object="app.orphan_b",
+            message="table has no PRIMARY KEY constraint",
+        ),
+    ]
+
+
+async def test_missing_primary_keys_returns_empty_list_when_every_table_has_a_pk() -> None:
+    assert await _missing_primary_keys(FakeRoutingDriver({}), "app") == []  # type: ignore[arg-type]
+
+
+# --- _unindexed_foreign_keys -----------------------------------------------
+
+
+async def test_unindexed_foreign_keys_flags_fk_without_a_leading_index() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "FROM pg_constraint con": [
+                {"fk_name": "order_widget_fk", "table_name": "order_item", "first_column": "widget_id"}
+            ]
+        }
+    )
+
+    findings = await _unindexed_foreign_keys(driver, "app")  # type: ignore[arg-type]
+
+    assert len(findings) == 1
+    assert findings[0].rule == RULE_UNINDEXED_FOREIGN_KEY
+    assert findings[0].severity == "warning"
+    assert findings[0].object == "app.order_item.widget_id"
+    assert "order_widget_fk" in findings[0].message
+    assert "widget_id" in findings[0].message
+
+
+async def test_unindexed_foreign_keys_returns_empty_when_every_fk_is_indexed() -> None:
+    assert await _unindexed_foreign_keys(FakeRoutingDriver({}), "app") == []  # type: ignore[arg-type]
+
+
+# --- _duplicate_indexes ----------------------------------------------------
+
+
+async def test_duplicate_indexes_flags_each_redundant_index_pair() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "FROM pg_index ix1": [
+                {"index_a": "widget_name_idx", "index_b": "widget_name_dup_idx", "table_name": "widget"}
+            ]
+        }
+    )
+
+    findings = await _duplicate_indexes(driver, "app")  # type: ignore[arg-type]
+
+    assert len(findings) == 1
+    assert findings[0].rule == RULE_DUPLICATE_INDEXES
+    assert findings[0].object == "app.widget_name_idx vs app.widget_name_dup_idx"
+    assert "identical columns" in findings[0].message
+
+
+# --- _nullable_timestamps_without_tz --------------------------------------
+
+
+async def test_nullable_timestamps_without_tz_flags_each_column() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "FROM pg_attribute att": [
+                {"table_name": "widget", "column_name": "created"},
+                {"table_name": "widget", "column_name": "updated"},
+            ]
+        }
+    )
+
+    findings = await _nullable_timestamps_without_tz(driver, "app")  # type: ignore[arg-type]
+
+    assert {finding.object for finding in findings} == {"app.widget.created", "app.widget.updated"}
+    assert all(finding.rule == RULE_NULLABLE_TIMESTAMP_WITHOUT_TZ for finding in findings)
+    assert all(finding.severity == "info" for finding in findings)
+
+
+# --- run_advisors aggregator + tool wiring --------------------------------
+
+
+async def test_run_advisors_aggregates_every_rule_and_records_them_in_rules_run() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "FROM pg_class c": [{"table_name": "orphan"}],
+            "FROM pg_constraint con": [
+                {"fk_name": "order_widget_fk", "table_name": "order_item", "first_column": "widget_id"}
+            ],
+            "FROM pg_index ix1": [{"index_a": "a", "index_b": "b", "table_name": "widget"}],
+            "FROM pg_attribute att": [{"table_name": "widget", "column_name": "created"}],
+        }
+    )
+
+    report = await run_advisors(driver, "app")  # type: ignore[arg-type]
+
+    assert isinstance(report, AdvisorReport)
+    assert report.schema == "app"
+    assert set(report.rules_run) == {
+        RULE_MISSING_PRIMARY_KEY,
+        RULE_UNINDEXED_FOREIGN_KEY,
+        RULE_DUPLICATE_INDEXES,
+        RULE_NULLABLE_TIMESTAMP_WITHOUT_TZ,
+    }
+    rules_in_findings = {finding.rule for finding in report.findings}
+    assert rules_in_findings == set(report.rules_run)
+
+
+async def test_run_advisors_returns_an_empty_findings_list_for_a_clean_schema() -> None:
+    report = await run_advisors(FakeRoutingDriver({}), "app")  # type: ignore[arg-type]
+
+    assert report.schema == "app"
+    assert report.findings == []
+    assert len(report.rules_run) == 4
+
+
+async def test_run_advisors_tool_is_registered_and_callable() -> None:
+    server = create_server(_SETTINGS, database=FakeDatabase(FakeDriver()))  # type: ignore[arg-type]
+    async with create_connected_server_and_client_session(server) as client:
+        listed = {tool.name for tool in (await client.list_tools()).tools}
+        assert "run_advisors" in listed
+
+        result = await client.call_tool("run_advisors", {"schema": "public"})
+
+    assert result.isError is False
+    assert result.structuredContent is not None
+    assert result.structuredContent["schema"] == "public"
+    assert result.structuredContent["findings"] == []
+    assert len(result.structuredContent["rules_run"]) == 4


### PR DESCRIPTION
## Summary

First half of **Batch B** (`PLAN.md` §11). One new read-only tool —
`run_advisors` — that runs a set of codified catalog-driven lint rules
against a schema and returns a typed report of findings. Tool surface
54 → 55.

### Rules (first cut)

| Rule | Severity | What it catches |
| --- | --- | --- |
| `missing_primary_key` | warning | Base tables without a PRIMARY KEY constraint |
| `unindexed_foreign_key` | warning | FK constraints whose leading column lacks an index — slow joins + `DELETE CASCADE` storms. Uses `pg_constraint.conkey[1]` vs `pg_index.indkey[0]` for the leading-column heuristic |
| `duplicate_indexes` | warning | Two indexes on the same table with matching `indkey` AND same access method; deduplicated via `indexrelid` inequality |
| `nullable_timestamp_without_tz` | info | Nullable `timestamp` (not `timestamptz`) columns — most common source of TZ-coercion bugs |

Each finding carries a stable rule id, severity, qualified object
name, and human-readable message.

Rules are deliberately conservative: **"would a careful reviewer flag
this?"** rather than "is this provably wrong?". RLS gaps and unused
indexes are deferred (RLS has too much nuance; unused-index needs warm
`pg_stat_user_indexes` data).

## Test plan

- [ ] CI: ruff, mypy --strict, full unit + integration suites green
- [ ] CI matrix: PG 14 / 15 / 16 / 17 — the integration test seeds one
      violation per rule plus a clean control table, asserts every
      rule fires on the right object, and asserts the control table
      never appears in any finding
- [ ] 9 unit tests cover each rule in isolation (presence + emptiness),
      the aggregator (`rules_run` exhaustive, every rule contributes a
      finding), and the MCP tool wiring
- [ ] Coverage gate (90%) maintained; locally 500 pass / 9 skipped

## What's next after merge

**Phase 21 — audit trail with semantic diff** to close Batch B.
Touches `run_write` / `run_ddl` to emit a structured before/after diff
alongside the result; optional persistence to an `mcpg_audit` schema
behind a new opt-in setting. Then ADR-gated Batches D, E, F.

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Introduce a new read-only schema advisory tool and wire it into the MCP tool registry, along with progress and changelog updates.

New Features:
- Add a catalog-driven schema advisor module that runs multiple lint rules and returns a structured report of findings.
- Expose a new read-only MCP tool `run_advisors` that invokes the advisor module for a given schema.

Documentation:
- Update progress documentation to reflect completion of Phase 20, increased tool count, and describe the new advisor capabilities.

Tests:
- Add unit tests for each advisor rule, the aggregated report, and MCP tool wiring using fake drivers.
- Add an integration test that exercises all advisor rules against a live PostgreSQL schema seeded with representative violations.

Chores:
- Extend the changelog with details of the new `run_advisors` tool and its initial rule set.