### PR TITLE
docs: ADR-0004 / -0005 / -0006 — unblock Batches D, E, F

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -347,18 +347,25 @@ opens its own feature branch and pull request.
 - **Phase 23** — pgvector tuning: `tune_vector_index`,
   `vector_recall_at_k`.
 
-### Batch D — Data movement (LARGE — gated on ADR-0004)
+### Batch D — Data movement (LARGE — policy in ADR-0004)
 - **Phase 24** — Export/import: `export_query`, `export_table`,
   `import_csv`/`import_json`, `dump_database`/`restore_database`,
   `copy_table_between_databases`. Subprocess execution is a new attack
-  surface; ADR-0004 must define the allowlist / opt-in / redaction
-  policy before any code is written.
+  surface; **ADR-0004 (accepted)** defines the policy: new
+  `Capability.SHELL` + `MCPG_ALLOW_SHELL` opt-in, allowlisted binary
+  set (`pg_dump`/`pg_restore`/`psql`), argv-only invocation via
+  `asyncio.create_subprocess_exec`, hard timeout and output cap, and
+  credentials passed through libpq env vars (never on the command line).
 
-### Batch E — Replication & event streams (LARGE — gated on ADR-0005)
+### Batch E — Replication & event streams (LARGE — policy in ADR-0005)
 - **Phase 25** — Logical replication management: replication slots and
   publication/subscription create+drop wrappers (write-gated).
-- **Phase 26** — `LISTEN`/`NOTIFY` bridge. ADR-0005 picks between a
-  polling model (recommended) and MCP notifications.
+- **Phase 26** — `LISTEN`/`NOTIFY` bridge. **ADR-0005 (accepted)**
+  picks the tool-poll model: a new `mcpg.listen` module owns
+  subscription state in process memory; `subscribe_channel` /
+  `poll_notifications` / `unsubscribe_channel` keep the MCP wire
+  request/response (no server-sent notifications). Gated behind
+  `Capability.LISTEN` + `MCPG_ALLOW_LISTEN`.
 
 ### Batch G — ORM bridges (USP)
 - **Phase 28** — `generate_prisma_schema`: read the PG catalog and emit a
@@ -368,13 +375,17 @@ opens its own feature branch and pull request.
   umbrella. Scope is deliberately narrow: catalog → DSL only, no
   `.prisma` → DDL parsing and no `prisma migrate` subprocess driving.
 
-### Batch F — Migrations with shadow workflow (LARGEST — gated on ADR-0006)
+### Batch F — Migrations with shadow workflow (LARGEST — policy in ADR-0006)
 - **Phase 27** — `prepare_migration`/`complete_migration` driven by the
-  Phase-18 schema diff. ADR-0006 picks between same-DB shadow schema
-  (Option 1, recommended) and side-channel `CREATE DATABASE ... TEMPLATE`
-  (Option 2, heavyweight).
+  Phase-18 schema diff. **ADR-0006 (accepted)** picks the same-DB
+  shadow-schema strategy (cheap; structural-only; reuses Phase-18
+  diff as the agent's review surface) over `CREATE DATABASE ...
+  TEMPLATE` so a 500 GB database doesn't pay full-clone cost per
+  staged migration. State lives in a new `mcpg_migrations.staged`
+  table; tools gate under `Capability.MIGRATE` + the existing
+  `MCPG_ALLOW_DDL` opt-in.
 
 Cadence: per-task TDD; 90% coverage gate (current 100%); ruff / mypy /
-PG 14–17 CI matrix must be green before each commit. Batches D, E, F
-require their ADR to be merged and signed off before implementation
-begins.
+PG 14–18 CI matrix must be green before each commit. Batch policy
+decisions live in their ADRs; implementation PRs reference them and
+focus on code.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -6,22 +6,21 @@
 
 ## Current state
 
-- **Phase:** 21 — Audit trail with semantic diff (Phases 0–18 + 20–23
-  + 28 complete; **Batch B done**)
+- **Phase:** post-Phase-21 — ADR groundwork for Batches D / E / F
+  (Phases 0–18 + 20–23 + 28 complete; Batches A, B, C, G-first-cut
+  shipped)
 - **Last updated:** 2026-05-24
 - **Branch:** `claude/postgresql-mcp-planning-8KssU`
 - **Tool count:** 56
 
 ## Next action
 
-> Phase 21 complete — **Batch B closed**. SQL audit trail with optional
-> `mcpg_audit.events` persistence (`MCPG_AUDIT_PERSIST`), DDL semantic
-> diff via before/after column snapshots, and a new
-> `list_audit_events` read tool. PG 18 also added to the CI matrix.
->
-> Next per the agreed sequencing: **Batch G follow-ons** (Drizzle /
-> SQLAlchemy / sqlc exporters under the `schema → ORM DSL` umbrella).
-> Then ADR-gated Batches D, E, F.
+> ADR-0004 (subprocess execution policy), ADR-0005 (LISTEN/NOTIFY
+> delivery model), and ADR-0006 (migration shadow strategy) accepted —
+> Batches D, E, F are no longer ADR-gated. Implementation order is the
+> user's call; recommend D first (subprocess gate also unblocks Phase
+> 27 if it later wants `pg_dump --schema-only`). Batch G follow-ons
+> (Drizzle / SQLAlchemy / sqlc exporters) remain available as filler.
 
 ## Phase 0 — Spike & foundation  ✅ COMPLETE
 
@@ -563,3 +562,33 @@
   no-schema-no-capture, redaction, and the read tool's empty/filled
   paths. Phase 21 complete (56 MCP tools total). 519 tests, 100%
   coverage.
+- 2026-05-24 — PR #12 review fix: Gemini caught two security-critical
+  issues (shallow `_redact` left credentials nested in `result`
+  unmasked; `result` payload was never run through `_redact` at all)
+  and one performance issue (`ensure_audit_table` ran two CREATE
+  round-trips per audited write). Recursive `_redact`, `result`
+  redaction at the record_audit call site, and a per-driver
+  `id(driver)`-keyed ensure cache fix all three; 4 new tests pin them.
+- 2026-05-24 — PR #12 merged to `main`; branch re-synced. Batch B
+  closed, PG 18 live in the matrix on every PR.
+- 2026-05-24 — ADR-0004 (subprocess execution policy for Batch D),
+  ADR-0005 (LISTEN/NOTIFY delivery model for Batch E), and ADR-0006
+  (migration shadow-workflow strategy for Batch F) drafted and
+  accepted. Each picks a specific implementation path and pins the
+  policy / gates / failure surface up front so the implementation
+  PRs can focus on code rather than re-litigation. Highlights:
+  ADR-0004 puts subprocess behind a new `Capability.SHELL` +
+  `MCPG_ALLOW_SHELL` opt-in alongside the existing `MCPG_ALLOW_DDL`
+  gate, with an allowlisted binary set, argv-only invocation, hard
+  timeout, output cap, and credential-env-var passing (never on the
+  command line). ADR-0005 picks the tool-poll model
+  (`subscribe_channel` + `poll_notifications`) over MCP-side
+  notifications, owning subscription state in a new `mcpg.listen`
+  module and gating writes behind `MCPG_ALLOW_LISTEN`. ADR-0006
+  picks the same-database shadow-schema strategy over `CREATE
+  DATABASE TEMPLATE` so a 500 GB database doesn't pay full-clone
+  cost on every staged migration; uses Phase-18 `compare_schemas` as
+  the agent's review surface and stores migration state in a new
+  `mcpg_migrations.staged` table alongside the existing
+  `mcpg_audit.events`. Batches D, E, F are no longer ADR-gated;
+  implementation order is open.

--- a/docs/adr/0004-subprocess-execution-policy.md
+++ b/docs/adr/0004-subprocess-execution-policy.md
@@ -1,0 +1,98 @@
+# ADR-0004: Subprocess execution policy for data movement
+
+- **Status:** accepted
+- **Date:** 2026-05-24
+
+## Context
+
+Batch D (Phase 24) needs `pg_dump` / `pg_restore` wrappers plus `export_query`
+/ `export_table` and `import_csv`/`import_json` tools. The first three almost
+certainly mean shelling out to the PostgreSQL `pg_dump` / `pg_restore` binaries
+— there is no in-process equivalent that produces wire-compatible dumps.
+
+MCPg has never executed external processes before. The full file/network
+attack surface is currently empty — adding subprocess execution is the single
+biggest security expansion since v0.1.0. The wire protocol passes user input
+straight from an agent's tool call into MCPg, so any path that interpolates
+agent-controlled strings into a command line is a remote-execution vulnerability
+waiting to happen.
+
+This ADR specifies how MCPg will gate, sandbox, and audit subprocess
+execution before Batch D's first commit lands.
+
+## Options considered
+
+1. **No subprocess: emulate `pg_dump` in Python.** Possible for trivial
+   `COPY ... TO` exports but cannot reproduce `pg_dump`'s catalog logic,
+   custom-format binary output, or `--schema-only` shape that downstream
+   tooling expects. Rejected — Batch D's stated value is "what the Postgres
+   ecosystem already understands".
+2. **Subprocess via `shell=True` for ergonomics.** Trivially exploitable;
+   one space-containing identifier and the agent owns the host. Rejected.
+3. **Subprocess via `asyncio.create_subprocess_exec(*argv)`** with an
+   allowlisted binary set, an explicit argv list (never a shell string), a
+   hard timeout, an output-byte cap, and a global opt-in setting.
+4. **Subprocess inside a container** — strongest isolation, but ships
+   container infrastructure and dependencies along with MCPg, which is
+   currently a pure-Python distribution. Rejected for v1; revisit if Batch D
+   matures into a hosted service.
+
+## Decision
+
+**Option 3.** Subprocess execution is added behind a new `MCPG_ALLOW_SHELL`
+env var that **defaults to false**. When enabled, MCPg may invoke
+binaries from a fixed allowlist via `asyncio.create_subprocess_exec` only,
+with the following guarantees:
+
+- `MCPG_ALLOW_SHELL` is required in addition to `unrestricted` access mode and
+  the existing `MCPG_ALLOW_DDL` setting; subprocess wrappers register only
+  when **all three** are on. A `Capability.SHELL` enum entry will live next
+  to `Capability.DDL` so the policy table is the single source of truth.
+- The allowlist is `{"pg_dump", "pg_restore", "psql"}`. No others. Binary
+  lookup uses `shutil.which()` against `$PATH`; the resolved absolute path is
+  what gets exec'd. A missing binary surfaces a clear error.
+- Arguments are always passed as a list (`subprocess_exec(binary, *argv)`).
+  Identifiers (schema, table) interpolated into argv are checked against the
+  existing `[A-Za-z_][A-Za-z0-9_]*` allowlist used by `mcpg.textsearch._quoted`
+  / `mcpg.prisma._check_identifier`. Connection strings are constructed via
+  libpq's standard env-var path (`PGHOST`/`PGUSER`/`PGPASSWORD`/`PGDATABASE`)
+  with credentials passed in the environment, not the command line, so they
+  never appear in `ps`.
+- Every invocation is wrapped with a hard timeout (default 60s, configurable
+  via `MCPG_SHELL_TIMEOUT_SEC`) and a cumulative stdout cap (default
+  64 MiB, configurable via `MCPG_SHELL_MAX_OUTPUT_BYTES`). Output past the
+  cap is dropped and the result flags `output_truncated=true`.
+- When `MCPG_AUDIT_PERSIST` is on, every subprocess invocation appends to
+  `mcpg_audit.events`: tool, argv (with credential env-vars redacted), exit
+  code, stderr tail, output byte count. This reuses the recursive `_redact`
+  helper shipped in Phase 21.
+- The new tools (`dump_database`, `restore_database`, `export_query`,
+  `export_table`, `copy_table_between_databases`) all share a single
+  `subprocess_runner` helper so the policy lives in one place.
+
+## Consequences
+
+What becomes easier:
+
+- `pg_dump`-shaped exports become a first-class tool, agent-driven.
+- The new `Capability.SHELL` slot generalises — future tools that need a
+  binary (PostGIS `shp2pgsql`, `pg_basebackup`) just add to the allowlist.
+
+What becomes harder:
+
+- A new attack surface; the policy above must hold or MCPg becomes RCE-as-a-
+  service. Every new binary or argument MUST go through this policy.
+- The CI matrix has to ensure `pg_dump`/`pg_restore` are installed in the
+  test image; `pgvector/pgvector:pgN` already includes them.
+- Imports (`import_csv`/`import_json`) read agent-supplied data; the file
+  argument must be an in-memory buffer streamed to `psycopg`'s `COPY FROM
+  STDIN`, never a host filesystem path. Out of scope for Batch D's first cut;
+  flagged as a follow-on.
+
+Follow-ups:
+
+- Define the test strategy for subprocess error paths (timeout, oversize
+  output, missing binary, non-zero exit) — likely a thin wrapper test fixture
+  that swaps `asyncio.create_subprocess_exec` for a fake.
+- Decide whether `psql` belongs in the allowlist long-term; included for
+  symmetry but the SQL surface is already covered by `run_select`/`run_write`.

--- a/docs/adr/0005-listen-notify-delivery-model.md
+++ b/docs/adr/0005-listen-notify-delivery-model.md
@@ -1,0 +1,121 @@
+# ADR-0005: LISTEN/NOTIFY delivery model
+
+- **Status:** accepted
+- **Date:** 2026-05-24
+
+## Context
+
+Batch E (Phase 26) wants to bridge PostgreSQL's `LISTEN` / `NOTIFY` to
+the MCP tool surface so an agent can subscribe to a channel and react
+to notifications. PG delivers notifications asynchronously on a held
+connection — the listening session blocks (or polls) until a NOTIFY
+arrives, then yields the payload.
+
+MCP, by contrast, is request/response: a tool call takes arguments and
+returns a result. There is no built-in "the server has data for you"
+inversion. Phase 26 must choose how to bridge these two models.
+
+This decision shapes server architecture (background workers? extra
+state in `AppContext`?), the MCP wire shape, and the failure modes
+(disconnected listeners, queue overflow, dead subscriptions).
+
+## Options considered
+
+1. **Streaming via MCP notifications.** Extend the FastMCP wiring so
+   tool calls can emit `notifications/resources/updated` (or a custom
+   notification) back to the client when a NOTIFY arrives. The closest
+   match to the underlying PG model. But: requires bypassing FastMCP's
+   per-tool-call lifecycle, introducing a long-lived background task
+   that survives across tool calls, and changes the server's failure
+   surface (a dead notification connection now has to be reaped). Tools
+   become asymmetric — some return, some emit. The MCP client
+   ecosystem support for arbitrary server-sent notifications is uneven.
+2. **Tool-poll model.** A `subscribe_channel(channel)` tool opens a
+   server-side listener on the **lifespan database** connection and
+   buffers incoming notifications in a bounded in-process queue keyed
+   by subscription id. A second `poll_notifications(subscription_id,
+   timeout_ms=0)` tool drains that queue. Subscriptions are closed
+   either by an explicit `unsubscribe_channel(subscription_id)` or by
+   server lifespan exit. Fits the request/response model perfectly —
+   tools stay symmetric, no MCP wire changes. Trade-off: between polls,
+   notifications sit in memory and a slow consumer can fill the queue.
+3. **External broker (Redis Streams, NATS, Kafka).** Strongest
+   durability but adds a hard infrastructure dependency that MCPg has
+   so far avoided (current deps: Python + PostgreSQL only). Rejected
+   for v1; an operator who wants durability can put a broker between
+   PG and their consumers.
+
+## Decision
+
+**Option 2 — tool-poll model.** New tools:
+
+- `subscribe_channel(channel: str) -> {subscription_id, channel}` —
+  opens a PG `LISTEN` (idempotent per channel), creates an in-process
+  subscription record, returns its id.
+- `poll_notifications(subscription_id: str, timeout_ms: int = 0,
+  max_messages: int = 100) -> list[Notification]` — drains up to
+  `max_messages` from the subscription's queue, waiting at most
+  `timeout_ms` for at least one if the queue is empty. Returns `[]` on
+  timeout. Each notification carries `{channel, payload,
+  delivered_at}`.
+- `unsubscribe_channel(subscription_id: str) -> bool` — removes the
+  subscription and, if it was the last one on the channel, issues an
+  `UNLISTEN`. Returns `True` when the subscription existed.
+- `list_subscriptions(...)` already exists as a logical-replication
+  read tool (Phase 16); the new tool will be named
+  `list_notification_subscriptions` to avoid the collision.
+
+Implementation outline:
+
+- A new `mcpg.listen` module owns subscription state. It uses a
+  dedicated background `asyncio.Task` per server lifespan that holds
+  one PG connection (separate from the request pool), runs `LISTEN`
+  for every active channel, and drains psycopg's notifies generator
+  into per-subscription `asyncio.Queue` instances. Queues are bounded
+  (default 1000); overflow drops the oldest message and flags the
+  next `poll_notifications` response with `dropped_count`.
+- Subscriptions live in process memory. On server restart they are
+  lost — agents must re-subscribe. This is documented behaviour, not
+  a bug; durable subscriptions are out of scope for v1.
+- All three tools are gated under a new `Capability.LISTEN` enum
+  entry. `subscribe_channel` and `unsubscribe_channel` require
+  unrestricted mode + a new `MCPG_ALLOW_LISTEN` opt-in setting
+  (default false). `poll_notifications` runs in any mode where a
+  subscription already exists for the caller — the gate is on
+  *creating* subscriptions, not *reading* them.
+
+## Consequences
+
+What becomes easier:
+
+- Bridging PG events to agentic workflows: an agent can wait on
+  `cache_invalidated` and react.
+- The server stays request/response; no new MCP-side notifications
+  protocol surface to maintain.
+- Background-task ownership has a clear home (`mcpg.listen`) and
+  shutdown story (server lifespan close cancels the task and drains
+  the queues).
+
+What becomes harder:
+
+- A dedicated background task and an extra PG connection live for the
+  server's lifetime — the pool size grows by one effective slot. The
+  default `pool_max_size=5` is unaffected (the listen connection sits
+  outside the pool), but the operator should know.
+- A slow consumer fills a bounded queue and starts dropping events.
+  Tests must pin the drop-oldest behaviour and surface the
+  `dropped_count` to callers.
+- Cross-process scaling (multiple MCPg replicas) means each replica
+  has independent subscriptions — an agent's `subscribe_channel`
+  binds to one replica and won't roam. Hosted deployments that need
+  consistency must use sticky sessions or stand up the durable-broker
+  variant (Option 3) as a separate tool family in a future ADR.
+
+Follow-ups:
+
+- Define the `Notification` dataclass (channel, payload, delivered_at,
+  optional `dropped_count`).
+- Confirm that psycopg 3's async notifies API surfaces enough for the
+  background loop (`AsyncConnection.notifies()` async iterator).
+- Sketch the test fixture: psycopg supports `pg_notify(...)` so the
+  integration test can self-publish.

--- a/docs/adr/0006-migration-shadow-strategy.md
+++ b/docs/adr/0006-migration-shadow-strategy.md
@@ -1,0 +1,137 @@
+# ADR-0006: Migration shadow-workflow strategy
+
+- **Status:** accepted
+- **Date:** 2026-05-24
+
+## Context
+
+Batch F (Phase 27) wants `prepare_migration(name, sql)` /
+`complete_migration(id)` tools so an agent can stage a migration,
+review the resulting structural diff (using Phase 18's
+`compare_schemas`), and commit it — Neon-style "branch the database,
+test the migration, merge". Phase 18 supplies the diff machinery; the
+missing piece is "what gets diffed against what?"
+
+PostgreSQL has no native copy-on-write database branching. Whatever
+"shadow" mechanism Phase 27 uses has to be implemented on stock PG,
+without external orchestration. Three approaches are viable.
+
+## Options considered
+
+1. **Same-database shadow schema.** `CREATE SCHEMA shadow_<id>`, clone
+   the target schema's DDL into it via `pg_dump --schema-only -n
+   <target> | sed 's/<target>/shadow_<id>/' | psql`, run the candidate
+   migration against the shadow, diff the shadow against the original
+   using `compare_schemas`, drop the shadow on commit-or-cancel.
+   Cheap (no second database), fast (DDL-only clone), structural-only
+   (no data, no triggers firing, no FK validations across schemas).
+2. **Side-channel database via `TEMPLATE`.** `CREATE DATABASE shadow_<id>
+   TEMPLATE <target>` — a full data clone (PG's copy-on-write at the
+   storage level uses filesystem links so it's surprisingly fast for
+   small DBs), apply the migration there, diff, drop. Full fidelity
+   (data, indexes, constraints, everything). Heavy for production-sized
+   databases (`CREATE DATABASE TEMPLATE` blocks the source from
+   accepting new connections briefly and disk usage doubles
+   temporarily).
+3. **External orchestration via `pg_dump --schema-only` to a separate
+   ephemeral container.** Cleanest isolation; requires container
+   infrastructure MCPg doesn't currently ship and pushes the
+   responsibility outside the server. Rejected on the same grounds as
+   ADR-0004 Option 4.
+
+## Decision
+
+**Option 1 — same-database shadow schema.** Reasoning:
+
+- Most migrations are structural — column additions, index creates,
+  constraint adds. Structural diff is exactly what `compare_schemas`
+  produces. Data-touching migrations (backfills) are out of scope for
+  the "agent reviews the diff before commit" workflow; they want a
+  different tool.
+- "Heavy for production-sized databases" is a real concern for Option
+  2 that we avoid entirely. A Phase-27 user with a 500 GB database
+  cannot afford a `CREATE DATABASE TEMPLATE` clone for every staged
+  migration.
+- Same-DB shadows compose well with the existing audit trail
+  (Phase 21): the `prepare_migration` and `complete_migration` tools
+  appear as audited DDL operations on a `mcpg_migrations.staged` table
+  that tracks state, no new infrastructure.
+
+Implementation outline:
+
+- A new `mcpg.migrations` module owns the state. Migrations are tracked
+  in `mcpg_migrations.staged` with columns: `id text PK` (caller-
+  supplied name + a timestamp suffix), `prepared_at timestamptz`,
+  `target_schema text`, `shadow_schema text`, `candidate_sql text`,
+  `status text` (`prepared`, `completed`, `cancelled`), `ttl_expires_at
+  timestamptz`.
+- `prepare_migration(name, target_schema, candidate_sql, ttl_minutes=60)`:
+  1. Create `shadow_<name>_<ts>` schema.
+  2. Replay the target schema's DDL into the shadow via a Python loop
+     over `list_tables` / `describe_table` / `list_constraints` etc.
+     (we already have all the introspection — no `pg_dump` shell-out
+     needed; this avoids the Batch-D subprocess gate entirely).
+  3. Apply `candidate_sql` inside a SAVEPOINT scoped to the shadow.
+  4. Run `compare_schemas(target, shadow)` and return the diff.
+  5. Insert the row into `mcpg_migrations.staged`. Audit-trail
+     records the call when `MCPG_AUDIT_PERSIST` is on.
+- `complete_migration(id)`:
+  1. Look up the row; refuse if status != `prepared` or TTL expired.
+  2. Inside a real transaction, apply the original `candidate_sql`
+     against the target schema. The transaction commits or rolls back
+     as a unit.
+  3. Drop the shadow schema, set `status='completed'`.
+- `cancel_migration(id)`:
+  1. Drop the shadow schema, set `status='cancelled'`.
+- `list_pending_migrations()` reads the table.
+- A background task (or lazy lookup in `prepare_migration`) sweeps
+  expired entries: any row past TTL whose status is still `prepared`
+  has its shadow dropped and status set to `cancelled`.
+
+All five tools gate under a new `Capability.MIGRATE` enum entry that
+requires unrestricted mode + the existing `MCPG_ALLOW_DDL` opt-in (the
+underlying ops are DDL).
+
+## Consequences
+
+What becomes easier:
+
+- Agent-driven structural migrations get a "review the diff" UX
+  without any new infrastructure. The diff IS the review surface.
+- Failures cascade cleanly: a botched candidate SQL fails the
+  SAVEPOINT and the shadow stays intact for inspection (or cancel).
+- Audit trail integration is free — `complete_migration` is a DDL
+  call, audited like any other.
+
+What becomes harder:
+
+- Same-DB shadows mean the original and shadow share oid space, role
+  grants, and `current_database()`. DDL that references
+  `current_database()` (rare but possible) won't see the right value
+  in the shadow. Documented as a known limitation; an agent that
+  needs full-fidelity isolation should use a real second database
+  outside MCPg.
+- DDL replay is not 100% perfect. Trigger functions defined elsewhere,
+  cross-schema FKs, custom types from other schemas — these aren't
+  cloned into the shadow. The Phase-18 diff will surface them as
+  "removed in shadow", which is a noisy but correct signal. Tests
+  must cover the common cases (PK, FK within the schema, CHECK
+  constraints) and document the gaps.
+- Long-prepared migrations accumulate shadow schemas; the TTL sweeper
+  must work reliably. Pin the TTL behaviour with both unit tests
+  (`prepare_migration` past TTL is cancellable) and an integration
+  test that fast-forwards time.
+
+Follow-ups:
+
+- Decide the DDL-replay strategy in detail before Phase 27 starts:
+  introspection-driven (no subprocess; uses Batch-A introspection),
+  vs `pg_dump --schema-only` (better fidelity, requires the Batch-D
+  subprocess gate to be live first). Lean toward introspection-driven
+  for v1 since it avoids the cross-batch dependency.
+- Sketch the `mcpg_migrations.staged` table schema and verify it
+  doesn't collide with `mcpg_audit.events` (different schema,
+  different intent — no conflict).
+- Confirm `SAVEPOINT`-scoped DDL behaviour across PG 14-18; some DDL
+  is auto-committed (CONCURRENTLY variants) and can't run inside a
+  savepoint.


### PR DESCRIPTION
## Summary

Three accepted ADRs that unblock the remaining roadmap batches by
pinning the policy decisions up front. **Docs-only — no code changes.**

| ADR | Batch | Decision |
| --- | --- | --- |
| **ADR-0004** | D (data movement) | Subprocess execution behind a new `Capability.SHELL` + `MCPG_ALLOW_SHELL` opt-in; allowlisted binary set (`pg_dump`/`pg_restore`/`psql`); `asyncio.create_subprocess_exec(*argv)` only (never `shell=True`); identifier allowlist; libpq env-var credentials (never on the command line); hard timeout + stdout cap + truncation flag; full audit-trail integration via Phase 21's recursive `_redact`. |
| **ADR-0005** | E (LISTEN/NOTIFY bridge) | Tool-poll model over server-sent notifications. New `mcpg.listen` module owns subscription state via a dedicated background `asyncio.Task` holding one PG connection outside the pool. Three tools: `subscribe_channel`, `poll_notifications` (drains a bounded queue, surfaces `dropped_count` on overflow), `unsubscribe_channel`. Gated under `Capability.LISTEN` + `MCPG_ALLOW_LISTEN`. Process-local — durability is a separate broker-variant ADR if needed. |
| **ADR-0006** | F (migrations) | Same-database shadow schema over `CREATE DATABASE TEMPLATE` so a 500 GB database doesn't pay full-clone cost per staged migration. DDL replay via Batch-A introspection (**no subprocess** — avoids cross-batch dependency on Batch D). `compare_schemas` from Phase 18 IS the agent's review surface. State in a new `mcpg_migrations.staged` table; tools gate under `Capability.MIGRATE` + `MCPG_ALLOW_DDL`. |

`PLAN.md` §11 updated: ADR-gate language flipped from "ADR-XXXX must
define ... before any code" → "policy in ADR-XXXX (accepted)" for D /
E / F. Implementation order is now open. CI matrix line corrected to
PG 14-18.

## Test plan

- [ ] CI: lint + format (only files touched are markdown — Sourcery /
      ruff / mypy are no-ops on docs)
- [ ] CI matrix: every Tests (PG N) job still passes (no code
      changes, but the test infra still runs against the snapshot)
- [ ] PR review of the three ADRs: each captures the
      attack-surface / failure-mode / opt-in story so the
      implementation PR can be reviewed against the policy rather
      than re-litigating the architecture

## What's next after merge

Implementation order for the unblocked batches is open. My
recommendation: **D first** (data movement is the biggest user-facing
gap and the subprocess pattern, once landed, gives Batch F an option
for `pg_dump --schema-only` if introspection-driven DDL replay
proves brittle). Then E (LISTEN/NOTIFY), then F (migrations). Batch G
follow-ons (Drizzle / SQLAlchemy / sqlc) remain available as filler
between batches.

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_