### PR TITLE
feat: Phase 24a — export_query + export_table (Batch D first slice)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `export_query` tool — run a read-only SQL query and serialise the
+  rows to CSV or JSON. Reuses the safety checks of `run_select` and
+  truncates at the supplied row limit with a `truncated` flag in the
+  result so callers can paginate.
+- `export_table` tool — serialise every row in a `schema.table` (up
+  to the supplied limit) to CSV or JSON. Identifier names must match
+  the plain SQL allowlist; anything that needs delimited-identifier
+  quoting is rejected.
 - `list_audit_events` tool — read recent rows from `mcpg_audit.events`
   (newest first). Returns an empty list when `MCPG_AUDIT_PERSIST` has
   never been turned on (no audit table yet). Optional tool-name filter.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -6,21 +6,21 @@
 
 ## Current state
 
-- **Phase:** post-Phase-21 — ADR groundwork for Batches D / E / F
-  (Phases 0–18 + 20–23 + 28 complete; Batches A, B, C, G-first-cut
-  shipped)
+- **Phase:** 24a — In-process CSV/JSON export (Batch D first slice;
+  subprocess tools per ADR-0004 follow)
 - **Last updated:** 2026-05-24
 - **Branch:** `claude/postgresql-mcp-planning-8KssU`
-- **Tool count:** 56
+- **Tool count:** 58
 
 ## Next action
 
-> ADR-0004 (subprocess execution policy), ADR-0005 (LISTEN/NOTIFY
-> delivery model), and ADR-0006 (migration shadow strategy) accepted —
-> Batches D, E, F are no longer ADR-gated. Implementation order is the
-> user's call; recommend D first (subprocess gate also unblocks Phase
-> 27 if it later wants `pg_dump --schema-only`). Batch G follow-ons
-> (Drizzle / SQLAlchemy / sqlc exporters) remain available as filler.
+> Phase 24a done — `export_query` and `export_table` ship the
+> read-only half of Batch D in-process (no subprocess, no new attack
+> surface). Next slices: **Phase 24b** subprocess infrastructure +
+> `dump_database` / `restore_database` per ADR-0004; **Phase 24c**
+> imports (`import_csv` / `import_json`) once the COPY ... FROM STDIN
+> plumbing is in place; **Phase 24d** `copy_table_between_databases`
+> using the Phase 24b infrastructure.
 
 ## Phase 0 — Spike & foundation  ✅ COMPLETE
 
@@ -592,3 +592,21 @@
   `mcpg_migrations.staged` table alongside the existing
   `mcpg_audit.events`. Batches D, E, F are no longer ADR-gated;
   implementation order is open.
+- 2026-05-24 — PR #13 (ADRs) merged to `main`; branch re-synced.
+- 2026-05-24 — Phase 24a (Batch D first slice): new
+  `mcpg.data_movement` module exposes `export_query` (runs SQL
+  through the existing `run_select` safety checks, serialises rows
+  to CSV or JSON) and `export_table` (SELECT * FROM schema.table
+  with the identifier allowlist). Both are read-only, no subprocess,
+  no new attack surface — ADR-0004's subprocess gate isn't needed
+  yet. `truncated` flag in the result lets agents paginate without
+  silently losing rows. CSV writer quotes commas + stringifies
+  non-scalar values (datetime / UUID / Decimal) so the output is
+  always parseable; JSON serialiser passes `default=str` for the
+  same reason. 15 new unit tests cover the format helpers
+  (`_rows_to_csv` / `_rows_to_json`), every error path (unsupported
+  format, non-positive limit, non-SELECT SQL, invalid identifier),
+  the truncation flag, and the MCP tool wiring. 3 integration
+  tests build a real schema with a row containing a comma in its
+  text value and assert the CSV/JSON round-trip. Phase 24a complete
+  (58 MCP tools total). 541 tests, 100% coverage.

--- a/src/mcpg/data_movement.py
+++ b/src/mcpg/data_movement.py
@@ -58,6 +58,31 @@ def _check_identifier(name: str, kind: str) -> None:
         raise ExportError(f"invalid {kind} name: {name!r}")
 
 
+def _csv_cell(value: Any) -> Any:
+    """Coerce a row cell to a CSV-safe value.
+
+    - ``None`` becomes the empty string, the standard CSV NULL marker;
+      passing ``None`` straight to ``DictWriter`` would emit the literal
+      ``"None"``.
+    - ``dict`` / ``list`` (the shape psycopg hands back for ``jsonb`` /
+      ``json`` columns) are re-serialised as JSON so the cell holds a
+      valid JSON string a downstream consumer can parse. Plain ``str()``
+      would produce Python repr — single quotes, ``True`` instead of
+      ``true`` — which no JSON reader will accept.
+    - Plain scalars (``str``, ``int``, ``float``, ``bool``) pass through.
+    - Everything else (datetime, UUID, Decimal, custom types) is
+      ``str()``'d so the CSV is always readable, with round-tripping
+      left to the consumer.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, default=str)
+    return str(value)
+
+
 def _rows_to_csv(rows: list[dict[str, Any]]) -> str:
     """Serialise dict rows to CSV with a header row taken from the first row."""
     if not rows:
@@ -66,15 +91,7 @@ def _rows_to_csv(rows: list[dict[str, Any]]) -> str:
     writer = csv.DictWriter(buffer, fieldnames=list(rows[0].keys()))
     writer.writeheader()
     for row in rows:
-        # Coerce any non-trivial values (datetimes, UUIDs, JSON dicts)
-        # to strings so the CSV is round-trippable. Plain scalars pass
-        # through unchanged so they survive in a SQL-typed reader.
-        writer.writerow(
-            {
-                key: value if isinstance(value, (str, int, float, bool)) or value is None else str(value)
-                for key, value in row.items()
-            }
-        )
+        writer.writerow({key: _csv_cell(value) for key, value in row.items()})
     return buffer.getvalue()
 
 

--- a/src/mcpg/data_movement.py
+++ b/src/mcpg/data_movement.py
@@ -1,0 +1,132 @@
+"""Data-movement tools — in-process export to CSV and JSON.
+
+This module covers the read-only half of Batch D (Phase 24): two tools
+that serialise SQL query results or full tables to a string an agent
+can inspect or write to a file.
+
+The subprocess-driven half (``dump_database``, ``restore_database``,
+``copy_table_between_databases``) follows ADR-0004 and lives in a
+separate PR. Imports (``import_csv`` / ``import_json``) need
+``COPY ... FROM STDIN`` plumbing that the vendored driver doesn't
+expose yet; they're tracked as Phase 24c.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from mcpg._vendor.sql import SqlDriver
+from mcpg.query import QueryError, run_select
+
+# Same identifier allowlist as mcpg.textsearch / mcpg.prisma / mcpg.vector_tuning —
+# refuse names that need delimited-identifier quoting, accept plain ones.
+_IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
+
+EXPORT_FORMATS = frozenset({"csv", "json"})
+
+# Default ceiling for an export call. Agents wanting more can paginate
+# their own LIMIT/OFFSET via ``export_query``.
+DEFAULT_EXPORT_LIMIT = 10_000
+
+
+class ExportError(Exception):
+    """Raised when an export call is rejected or fails."""
+
+
+@dataclass(frozen=True, slots=True)
+class ExportResult:
+    """The outcome of an export call.
+
+    ``content`` holds the serialised rows. ``truncated`` is ``True`` when
+    the underlying query produced more rows than the requested ``limit``;
+    the caller should re-export with a higher limit or paginate.
+    """
+
+    format: str
+    content: str
+    row_count: int
+    truncated: bool
+
+
+def _check_identifier(name: str, kind: str) -> None:
+    if not _IDENTIFIER.match(name):
+        raise ExportError(f"invalid {kind} name: {name!r}")
+
+
+def _rows_to_csv(rows: list[dict[str, Any]]) -> str:
+    """Serialise dict rows to CSV with a header row taken from the first row."""
+    if not rows:
+        return ""
+    buffer = io.StringIO()
+    writer = csv.DictWriter(buffer, fieldnames=list(rows[0].keys()))
+    writer.writeheader()
+    for row in rows:
+        # Coerce any non-trivial values (datetimes, UUIDs, JSON dicts)
+        # to strings so the CSV is round-trippable. Plain scalars pass
+        # through unchanged so they survive in a SQL-typed reader.
+        writer.writerow(
+            {
+                key: value if isinstance(value, (str, int, float, bool)) or value is None else str(value)
+                for key, value in row.items()
+            }
+        )
+    return buffer.getvalue()
+
+
+def _rows_to_json(rows: list[dict[str, Any]]) -> str:
+    """Serialise dict rows to a JSON array, with non-JSON values stringified."""
+    # ``default=str`` covers datetime, UUID, Decimal, and any custom type
+    # the catalog hands us back — anything that isn't JSON-native becomes
+    # its ``str()`` form. Round-tripping is the consumer's responsibility.
+    return json.dumps(rows, default=str)
+
+
+async def export_query(
+    driver: SqlDriver,
+    sql: str,
+    *,
+    format: str = "csv",
+    limit: int = DEFAULT_EXPORT_LIMIT,
+) -> ExportResult:
+    """Run a read-only SQL query and serialise its rows.
+
+    Reuses :func:`mcpg.query.run_select`, so the same SQL safety checks
+    apply: the statement must parse as read-only via the vendored
+    ``SafeSqlDriver`` allowlist. ``limit`` caps the row count; a query
+    producing more rows yields ``truncated=True``.
+    """
+    if format not in EXPORT_FORMATS:
+        raise ExportError(f"unsupported export format {format!r}; expected one of {sorted(EXPORT_FORMATS)}")
+    if limit < 1:
+        raise ExportError("limit must be at least 1")
+    try:
+        result = await run_select(driver, sql, max_rows=limit)
+    except QueryError as exc:
+        raise ExportError(str(exc)) from exc
+
+    content = _rows_to_csv(result.rows) if format == "csv" else _rows_to_json(result.rows)
+    return ExportResult(format=format, content=content, row_count=result.row_count, truncated=result.truncated)
+
+
+async def export_table(
+    driver: SqlDriver,
+    schema: str,
+    table: str,
+    *,
+    format: str = "csv",
+    limit: int = DEFAULT_EXPORT_LIMIT,
+) -> ExportResult:
+    """Serialise every row in ``schema.table`` (up to ``limit``).
+
+    Schema and table names must match the plain identifier pattern —
+    anything that requires delimited-identifier quoting is rejected.
+    """
+    _check_identifier(schema, "schema")
+    _check_identifier(table, "table")
+    sql = f'SELECT * FROM "{schema}"."{table}"'
+    return await export_query(driver, sql, format=format, limit=limit)

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -18,6 +18,7 @@ from mcpg import (
     advisors,
     audit_trail,
     cron,
+    data_movement,
     diagrams,
     extensions,
     health,
@@ -382,6 +383,39 @@ def _register_advisors(server: FastMCP[AppContext]) -> None:
     async def run_advisors(ctx: _Ctx, schema: str) -> dict[str, Any]:
         report = await advisors.run_advisors(_driver(ctx), schema)
         return asdict(report)
+
+
+def _register_data_movement(server: FastMCP[AppContext]) -> None:
+    @server.tool(
+        name="export_query",
+        description=(
+            "Run a read-only SQL query and serialise its rows to CSV or JSON. "
+            "Reuses the SQL-safety checks of run_select. Truncates at `limit` "
+            "rows and flags it in the result so callers can paginate."
+        ),
+    )
+    async def export_query(
+        ctx: _Ctx, sql: str, format: str = "csv", limit: int = data_movement.DEFAULT_EXPORT_LIMIT
+    ) -> dict[str, Any]:
+        result = await data_movement.export_query(_driver(ctx), sql, format=format, limit=limit)
+        return asdict(result)
+
+    @server.tool(
+        name="export_table",
+        description=(
+            "Serialise every row in schema.table (up to `limit`) to CSV or JSON. "
+            "Schema and table names must be plain identifiers."
+        ),
+    )
+    async def export_table(
+        ctx: _Ctx,
+        schema: str,
+        table: str,
+        format: str = "csv",
+        limit: int = data_movement.DEFAULT_EXPORT_LIMIT,
+    ) -> dict[str, Any]:
+        result = await data_movement.export_table(_driver(ctx), schema, table, format=format, limit=limit)
+        return asdict(result)
 
 
 def _register_audit_trail(server: FastMCP[AppContext]) -> None:
@@ -773,6 +807,7 @@ def register_tools(server: FastMCP[AppContext], settings: Settings) -> None:
         _register_vector_tuning(server)
         _register_prisma(server)
         _register_advisors(server)
+        _register_data_movement(server)
         _register_audit_trail(server)
         _register_query(server)
         _register_health(server)

--- a/tests/integration/test_data_movement_integration.py
+++ b/tests/integration/test_data_movement_integration.py
@@ -1,0 +1,74 @@
+"""Integration tests for in-process CSV/JSON export against real PG."""
+
+import json
+from collections.abc import AsyncIterator
+
+import pytest
+
+from mcpg.data_movement import export_query, export_table
+from mcpg.database import Database
+
+_SCHEMA = "mcpg_data_movement_it"
+
+
+@pytest.fixture
+async def export_schema(connected_database: Database) -> AsyncIterator[str]:
+    driver = connected_database.driver()
+    await driver.execute_query(f"DROP SCHEMA IF EXISTS {_SCHEMA} CASCADE")
+    await driver.execute_query(f"CREATE SCHEMA {_SCHEMA}")
+    await driver.execute_query(
+        f"CREATE TABLE {_SCHEMA}.widget (id integer PRIMARY KEY, name text NOT NULL, created_at timestamptz)"
+    )
+    await driver.execute_query(
+        f"INSERT INTO {_SCHEMA}.widget (id, name, created_at) "
+        "VALUES (1, 'alpha', '2026-05-24T12:00:00Z'), "
+        "       (2, 'beta',  '2026-05-24T12:01:00Z'), "
+        "       (3, 'gamma, with comma', '2026-05-24T12:02:00Z')"
+    )
+    try:
+        yield _SCHEMA
+    finally:
+        await driver.execute_query(f"DROP SCHEMA IF EXISTS {_SCHEMA} CASCADE")
+
+
+async def test_export_query_returns_csv_for_a_real_query(connected_database: Database, export_schema: str) -> None:
+    result = await export_query(
+        connected_database.driver(),
+        f"SELECT id, name FROM {export_schema}.widget ORDER BY id",
+        format="csv",
+    )
+
+    lines = result.content.splitlines()
+    assert lines[0] == "id,name"
+    assert result.row_count == 3
+    assert result.truncated is False
+    # The "gamma, with comma" row must be quoted so the CSV is parseable.
+    assert '"gamma, with comma"' in result.content
+
+
+async def test_export_table_returns_json_with_timestamps_stringified(
+    connected_database: Database, export_schema: str
+) -> None:
+    result = await export_table(connected_database.driver(), export_schema, "widget", format="json")
+
+    rows = json.loads(result.content)
+    assert {row["name"] for row in rows} == {"alpha", "beta", "gamma, with comma"}
+    # The default=str pass means datetime values appear as ISO-ish strings,
+    # not objects.
+    assert all(isinstance(row["created_at"], str) for row in rows)
+
+
+async def test_export_query_truncates_at_limit_against_a_large_real_result(
+    connected_database: Database, export_schema: str
+) -> None:
+    result = await export_query(
+        connected_database.driver(),
+        f"SELECT id FROM {export_schema}.widget ORDER BY id",
+        format="csv",
+        limit=2,
+    )
+
+    assert result.row_count == 2
+    assert result.truncated is True
+    # The header + 2 data rows == 3 lines.
+    assert len(result.content.splitlines()) == 3

--- a/tests/unit/test_data_movement.py
+++ b/tests/unit/test_data_movement.py
@@ -1,0 +1,155 @@
+"""Tests for the in-process data-movement export tools."""
+
+import json
+
+import pytest
+from _fakes import FakeDatabase, FakeDriver
+from mcp.shared.memory import create_connected_server_and_client_session
+
+from mcpg.config import load_settings
+from mcpg.data_movement import (
+    DEFAULT_EXPORT_LIMIT,
+    EXPORT_FORMATS,
+    ExportError,
+    ExportResult,
+    _rows_to_csv,
+    _rows_to_json,
+    export_query,
+    export_table,
+)
+from mcpg.server import create_server
+
+_SETTINGS = load_settings({"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db"})
+
+
+# --- _rows_to_csv / _rows_to_json -----------------------------------------
+
+
+def test_rows_to_csv_emits_header_and_quotes_strings_with_commas() -> None:
+    out = _rows_to_csv([{"id": 1, "name": "a, b"}, {"id": 2, "name": "c"}])
+    assert out.splitlines()[0] == "id,name"
+    assert '"a, b"' in out
+
+
+def test_rows_to_csv_returns_empty_string_for_no_rows() -> None:
+    assert _rows_to_csv([]) == ""
+
+
+def test_rows_to_csv_stringifies_non_scalar_cell_values() -> None:
+    # datetime / UUID / decimal arrive verbatim — anything not a plain
+    # scalar gets str()'d so the CSV is always readable.
+    from datetime import datetime
+
+    out = _rows_to_csv([{"created": datetime(2026, 5, 24, 12, 0, 0)}])
+    assert "2026-05-24" in out
+
+
+def test_rows_to_json_serialises_with_default_str_for_non_native_types() -> None:
+    from datetime import datetime
+
+    out = _rows_to_json([{"id": 1, "created": datetime(2026, 5, 24)}])
+    parsed = json.loads(out)
+    assert parsed[0]["id"] == 1
+    assert "2026-05-24" in parsed[0]["created"]
+
+
+# --- export_query ---------------------------------------------------------
+
+
+async def test_export_query_emits_csv_with_header_and_rows() -> None:
+    driver = FakeDriver([{"id": 1, "name": "a"}, {"id": 2, "name": "b"}])
+
+    result = await export_query(driver, "SELECT id, name FROM widget", format="csv")  # type: ignore[arg-type]
+
+    assert isinstance(result, ExportResult)
+    assert result.format == "csv"
+    assert result.row_count == 2
+    assert result.truncated is False
+    lines = result.content.splitlines()
+    assert lines[0] == "id,name"
+    assert lines[1].startswith("1,")
+    assert lines[2].startswith("2,")
+
+
+async def test_export_query_emits_json_array_of_objects() -> None:
+    driver = FakeDriver([{"id": 1, "name": "a"}])
+
+    result = await export_query(driver, "SELECT id, name FROM widget", format="json")  # type: ignore[arg-type]
+
+    parsed = json.loads(result.content)
+    assert parsed == [{"id": 1, "name": "a"}]
+
+
+async def test_export_query_flags_truncation_when_query_yields_more_than_limit() -> None:
+    driver = FakeDriver([{"id": i} for i in range(5)])
+
+    result = await export_query(driver, "SELECT id FROM widget", format="csv", limit=2)  # type: ignore[arg-type]
+
+    assert result.truncated is True
+    assert result.row_count == 2
+
+
+async def test_export_query_rejects_unsupported_format() -> None:
+    with pytest.raises(ExportError, match="unsupported export format"):
+        await export_query(FakeDriver(), "SELECT 1", format="xml")  # type: ignore[arg-type]
+
+
+async def test_export_query_rejects_non_positive_limit() -> None:
+    with pytest.raises(ExportError, match="must be at least 1"):
+        await export_query(FakeDriver(), "SELECT 1", limit=0)  # type: ignore[arg-type]
+
+
+async def test_export_query_wraps_query_errors() -> None:
+    # SafeSqlDriver inside run_select rejects non-SELECT — surfaces as
+    # ExportError so the agent sees a single failure mode.
+    with pytest.raises(ExportError):
+        await export_query(FakeDriver(), "DELETE FROM widget")  # type: ignore[arg-type]
+
+
+# --- export_table ---------------------------------------------------------
+
+
+async def test_export_table_builds_a_safe_select_against_quoted_identifiers() -> None:
+    driver = FakeDriver([{"id": 1}])
+
+    await export_table(driver, "app", "widget", format="csv")  # type: ignore[arg-type]
+
+    # The vendored SafeSqlDriver wraps the raw driver — the call we
+    # care about is whatever SQL it eventually issued. Inspect the
+    # FakeDriver's call log for the schema-qualified SELECT shape.
+    sqls = [call[0] for call in driver.calls]
+    assert any('"app"."widget"' in sql or "app.widget" in sql for sql in sqls)
+
+
+async def test_export_table_rejects_invalid_identifier_characters() -> None:
+    with pytest.raises(ExportError, match="invalid schema name"):
+        await export_table(FakeDriver(), 'app"; DROP TABLE x; --', "widget")  # type: ignore[arg-type]
+    with pytest.raises(ExportError, match="invalid table name"):
+        await export_table(FakeDriver(), "app", "widget; DROP")  # type: ignore[arg-type]
+
+
+# --- module exports + tool wiring -----------------------------------------
+
+
+def test_export_formats_set_is_complete() -> None:
+    assert EXPORT_FORMATS == {"csv", "json"}
+
+
+def test_default_export_limit_is_a_sensible_ceiling() -> None:
+    # Documented in the docstring; tests pin the constant so accidental
+    # bumps surface in PR review.
+    assert DEFAULT_EXPORT_LIMIT == 10_000
+
+
+async def test_export_tools_are_registered_and_callable_in_read_mode() -> None:
+    server = create_server(_SETTINGS, database=FakeDatabase(FakeDriver([{"id": 1}])))  # type: ignore[arg-type]
+    async with create_connected_server_and_client_session(server) as client:
+        listed = {tool.name for tool in (await client.list_tools()).tools}
+        assert {"export_query", "export_table"} <= listed
+
+        result = await client.call_tool("export_query", {"sql": "SELECT id FROM widget"})
+    assert result.isError is False
+    payload = result.structuredContent
+    assert payload is not None
+    assert payload["format"] == "csv"
+    assert payload["row_count"] == 1

--- a/tests/unit/test_data_movement.py
+++ b/tests/unit/test_data_movement.py
@@ -1,5 +1,7 @@
 """Tests for the in-process data-movement export tools."""
 
+import csv
+import io
 import json
 
 import pytest
@@ -42,6 +44,42 @@ def test_rows_to_csv_stringifies_non_scalar_cell_values() -> None:
 
     out = _rows_to_csv([{"created": datetime(2026, 5, 24, 12, 0, 0)}])
     assert "2026-05-24" in out
+
+
+def test_rows_to_csv_emits_empty_string_for_none_not_the_literal_none() -> None:
+    # CSV NULL convention is an empty field. Passing None to DictWriter
+    # would otherwise write the literal "None" — bad for downstream
+    # consumers that try to load the file with a typed reader.
+    out = _rows_to_csv([{"id": 1, "name": None}])
+    lines = out.splitlines()
+    # Header + one data row.
+    assert lines[0] == "id,name"
+    # Row is ``1,`` — the trailing field is empty, not the string "None".
+    assert lines[1] == "1,"
+    assert "None" not in out
+
+
+def test_rows_to_csv_serialises_dicts_and_lists_as_json_strings() -> None:
+    # psycopg returns jsonb columns as Python dicts/lists. Calling str()
+    # on them would produce Python repr (single quotes, ``True`` not
+    # ``true``); json.dumps gives a valid JSON cell a JSON reader can
+    # parse on the round-trip.
+    out = _rows_to_csv([{"id": 1, "config": {"a": 1, "b": True}, "tags": [1, 2, 3]}])
+
+    # Round-trip through DictReader so the CSV quoting is interpreted
+    # correctly (don't hand-roll comma splitting on a field that
+    # itself contains commas).
+    parsed_rows = list(csv.DictReader(io.StringIO(out)))
+    assert len(parsed_rows) == 1
+    row = parsed_rows[0]
+    assert row["id"] == "1"
+    # The jsonb-shaped cells round-trip cleanly through json.loads —
+    # they are valid JSON strings, not Python repr.
+    assert json.loads(row["config"]) == {"a": 1, "b": True}
+    assert json.loads(row["tags"]) == [1, 2, 3]
+    # No Python repr leaked into the raw CSV text.
+    assert " True" not in out  # JSON form is lowercase ``true``
+    assert "'a'" not in out
 
 
 def test_rows_to_json_serialises_with_default_str_for_non_native_types() -> None:


### PR DESCRIPTION
## Summary

**Batch D first slice — Phase 24a.** Two new read-only tools that ship
CSV/JSON export in-process. Tool surface 56 → 58. No subprocess, no
new attack surface — ADR-0004's `MCPG_ALLOW_SHELL` gate is not engaged
yet; that comes in Phase 24b.

### `export_query(sql, format='csv'|'json', limit=10000)`

- Runs SQL through `run_select`, so the existing `SafeSqlDriver`
  allowlist applies — non-SELECT statements are rejected.
- CSV: `DictWriter` with header row; commas inside string values are
  quoted; non-scalar cell values (datetime / UUID / Decimal) are
  `str()`'d so the CSV is always parseable.
- JSON: array of objects with `default=str` for non-JSON-native types.
- Truncates at `limit` and surfaces `truncated=True` so callers can
  paginate via their own `LIMIT`/`OFFSET`.

### `export_table(schema, table, format, limit)`

- Builds `SELECT * FROM "schema"."table"` after running both names
  through the standard `[A-Za-z_][A-Za-z0-9_]*` identifier allowlist
  (same as `mcpg.textsearch` / `mcpg.prisma` / `mcpg.vector_tuning`).
- Anything that needs delimited-identifier quoting is rejected up
  front with `ExportError`.

## Test plan

- [ ] CI: ruff, mypy --strict, full unit + integration suites green
- [ ] CI matrix: PG **14 / 15 / 16 / 17 / 18** — integration tests
      seed a real schema with a row whose text contains a comma and
      assert CSV/JSON round-trip + truncation
- [ ] 15 unit tests cover format helpers, every error path
      (unsupported format, non-positive limit, non-SELECT SQL,
      invalid identifier), truncation, and MCP tool wiring
- [ ] Coverage gate maintained; locally **541 pass / 9 skipped**

## What's next after merge

- **Phase 24b** — Subprocess infrastructure per ADR-0004 +
  `dump_database` / `restore_database` (new `Capability.SHELL` +
  `MCPG_ALLOW_SHELL`).
- **Phase 24c** — Imports (`import_csv` / `import_json`) once the
  vendored driver exposes `COPY ... FROM STDIN`.
- **Phase 24d** — `copy_table_between_databases` using Phase 24b's
  subprocess runner.

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_