### PR TITLE
feat: Phase 24c — restore_database + fix shell stdin ordering deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `restore_database` tool — restore a dump into the connected database
+  via the ADR-0004 subprocess gate. `format='plain'` pipes SQL text
+  through `psql --single-transaction --set=ON_ERROR_STOP=on` so a
+  syntax error rolls back the whole restore; `format='custom'`/`'tar'`
+  base64-decode the payload and pipe the binary archive into
+  `pg_restore --single-transaction --exit-on-error`. Credentials reach
+  the binary via libpq env vars; the dump bytes flow through stdin and
+  are never interpolated into argv. Gated on unrestricted mode +
+  `MCPG_ALLOW_SHELL`.
+
+### Fixed
+
+- `mcpg.shell.run_pg_binary` now writes the optional `stdin` payload
+  concurrently with the stdout/stderr drain. The previous "write
+  stdin after wait()" ordering would have deadlocked any subprocess
+  that consumes stdin (`pg_restore`, `psql -f -`); no shipped tool
+  used stdin yet, but the bug blocked `restore_database` from working.
+
 - `dump_database` tool — wraps `pg_dump` to capture the connected
   database's schema (and optionally data) as a plain-SQL string or
   base64-encoded binary archive. Implements the ADR-0004 subprocess

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -6,24 +6,23 @@
 
 ## Current state
 
-- **Phase:** 24b — Subprocess infrastructure + `dump_database`
-  (ADR-0004 shell gate live)
+- **Phase:** 24c — `restore_database` (full dump/restore round-trip
+  via the shell gate)
 - **Last updated:** 2026-05-25
 - **Branch:** `claude/postgresql-mcp-planning-8KssU`
-- **Tool count:** 59
+- **Tool count:** 60
 
 ## Next action
 
-> Phase 24b shipped — new `mcpg.shell` module enforces the ADR-0004
-> subprocess policy (allowlisted binaries, argv-only invocation, hard
-> timeout, output cap, libpq env-var credentials), `Capability.SHELL`
-> + `MCPG_ALLOW_SHELL` opt-in gate is live, and `dump_database` is
-> the first consumer. Next slices: **Phase 24c** `restore_database`
-> (uses the same gate with `stdin` piping); **Phase 24d**
+> Phase 24c shipped — `restore_database` completes the dump/restore
+> symmetry, and the integration test now exercises a real end-to-end
+> `pg_dump` → drop schema → `psql` restore against every PG version
+> in the matrix. Also fixed a latent `stdin` ordering bug in
+> `mcpg.shell` that would have deadlocked any subprocess consuming
+> stdin (no tool relied on it yet). Next slices: **Phase 24d**
 > `copy_table_between_databases`; **Phase 24e** `import_csv` /
 > `import_json` once `COPY ... FROM STDIN` plumbing lands. Batch G
-> follow-ons (Drizzle / SQLAlchemy / sqlc) and Batches E and F also
-> remain open.
+> follow-ons and Batches E and F also remain open.
 
 ## Phase 0 — Spike & foundation  ✅ COMPLETE
 
@@ -637,3 +636,27 @@
   cover allowlist / env filtering / redaction / truncation / timeout
   / URL parsing / format selection / tool-wiring gate. Phase 24b
   complete (59 MCP tools total). 568 tests, 100% coverage.
+- 2026-05-25 — PR #15 review fix: PG 17/18 CI failed because the
+  ubuntu-latest runner ships an older pg_dump that refuses to dump
+  from a newer server. Workflow now installs the matching
+  postgresql-client-N from the pgdg apt repo before each test job,
+  so pg_dump always matches the matrix server version. PG 14-18
+  all green after the fix; PR #15 merged.
+- 2026-05-25 — Phase 24c (restore half of Batch D dump/restore
+  symmetry): new `restore_database` tool pipes a dump back into the
+  connected database — `format='plain'` through psql with
+  `--single-transaction --set=ON_ERROR_STOP=on`, `custom`/`tar`
+  through `pg_restore --single-transaction --exit-on-error`.
+  Base64-decodes binary payloads; rejects malformed base64 with
+  ShellError. Audit trail integration is identical to dump_database.
+  Fixed a latent `mcpg.shell` bug: `stdin` was written AFTER
+  `process.wait()` returned, which would deadlock any consumer of
+  stdin (no shipped tool exercised stdin yet so it didn't bite, but
+  it blocked restore_database from working). Now writes stdin
+  concurrently with the stdout/stderr drain. 7 new unit tests cover
+  plain → psql wiring, custom → pg_restore wiring + base64 decoding,
+  unsupported format / invalid base64 / missing-database rejection,
+  and the shell-gate tool-wiring matrix. 1 new integration test runs
+  a real dump → drop schema → restore round-trip against every PG
+  version in the CI matrix. Phase 24c complete (60 MCP tools total).
+  576 tests, 100% coverage.

--- a/src/mcpg/data_movement.py
+++ b/src/mcpg/data_movement.py
@@ -270,3 +270,96 @@ async def dump_database(
         binary=result.binary,
         argv=result.argv,
     )
+
+
+@dataclass(frozen=True, slots=True)
+class RestoreResult:
+    """The outcome of a ``pg_restore`` or ``psql`` invocation."""
+
+    exit_code: int
+    output_bytes: int
+    output_truncated: bool
+    timed_out: bool
+    stderr_tail: str
+    binary: str
+    argv: list[str]
+
+
+_PG_RESTORE_FORMATS = frozenset({"plain", "custom", "tar"})
+
+
+async def restore_database(
+    database_url: str,
+    content: str,
+    *,
+    timeout_sec: int,
+    max_output_bytes: int,
+    format: str = "plain",
+) -> RestoreResult:
+    """Restore a dump into the database in ``database_url``.
+
+    ``format='plain'`` pipes ``content`` (SQL text) into ``psql``;
+    ``custom`` and ``tar`` base64-decode ``content`` and pipe the bytes
+    into ``pg_restore``. ``--single-transaction`` + ``ON_ERROR_STOP``
+    are set for psql so a syntax error rolls the whole restore back
+    rather than half-applying. Credentials reach the binary via libpq
+    env vars (PGPASSWORD), never on the command line.
+
+    Raises:
+        ShellError: pg_restore/psql not on the allowlist or PATH, the
+            URL is unparseable, the format is unsupported, or the
+            subprocess fails to spawn.
+    """
+    if format not in _PG_RESTORE_FORMATS:
+        raise ShellError(f"unsupported restore format {format!r}; expected one of {sorted(_PG_RESTORE_FORMATS)}")
+    env = _libpq_env_from_url(database_url)
+    if "PGDATABASE" not in env:
+        raise ShellError("database_url must specify a database name")
+
+    if format == "plain":
+        binary = "psql"
+        argv = [
+            "--quiet",
+            "--single-transaction",
+            "--set=ON_ERROR_STOP=on",
+            "--file=-",  # read from stdin
+        ]
+        stdin = content.encode("utf-8")
+    else:
+        import base64
+
+        binary = "pg_restore"
+        argv = [
+            "--no-owner",
+            "--no-privileges",
+            "--single-transaction",
+            "--exit-on-error",
+            f"--format={format}",
+        ]
+        try:
+            stdin = base64.b64decode(content, validate=True)
+        except (ValueError, TypeError) as exc:
+            raise ShellError(f"content is not valid base64 for {format!r} format: {exc}") from exc
+
+    result = await run_pg_binary(
+        binary,
+        *argv,
+        env=env,
+        timeout_sec=timeout_sec,
+        max_output_bytes=max_output_bytes,
+        stdin=stdin,
+    )
+
+    stderr_tail = result.stderr.decode("utf-8", errors="replace")
+    if len(stderr_tail) > 4096:
+        stderr_tail = stderr_tail[-4096:]
+
+    return RestoreResult(
+        exit_code=result.exit_code,
+        output_bytes=result.output_bytes,
+        output_truncated=result.output_truncated,
+        timed_out=result.timed_out,
+        stderr_tail=stderr_tail,
+        binary=result.binary,
+        argv=result.argv,
+    )

--- a/src/mcpg/shell.py
+++ b/src/mcpg/shell.py
@@ -172,6 +172,9 @@ async def run_pg_binary(
     truncated = False
     output_bytes_seen = 0
     stdout_chunks: list[bytes] = []
+    # Initialise so an unexpected exception path doesn't leave this
+    # name unbound when we build the SubprocessResult.
+    stderr_bytes: bytes = b""
 
     async def _read_capped() -> None:
         nonlocal output_bytes_seen, truncated
@@ -195,16 +198,27 @@ async def run_pg_binary(
                     truncated = True
 
     async def _write_stdin() -> None:
+        # The child may exit early on a SQL error (psql) or invalid
+        # archive (pg_restore) while we're still writing. That closes
+        # the pipe and raises BrokenPipeError / ConnectionResetError
+        # here — if those propagate through asyncio.gather, we never
+        # return the real exit code or stderr, and the agent loses
+        # the diagnostic. Swallow them and let process.wait() +
+        # stderr_task surface the actual failure cause.
         if stdin is None or process.stdin is None:
             return
         try:
             process.stdin.write(stdin)
             await process.stdin.drain()
-        finally:
+        except (BrokenPipeError, ConnectionResetError):
+            pass
+        try:
             process.stdin.close()
             # Wait for the OS-level close to land so the child sees EOF
             # before we wait() on it.
             await process.stdin.wait_closed()
+        except (BrokenPipeError, ConnectionResetError):
+            pass
 
     try:
         async with asyncio.timeout(timeout_sec):

--- a/src/mcpg/shell.py
+++ b/src/mcpg/shell.py
@@ -194,10 +194,26 @@ async def run_pg_binary(
                         stdout_chunks.append(chunk[:keep])
                     truncated = True
 
+    async def _write_stdin() -> None:
+        if stdin is None or process.stdin is None:
+            return
+        try:
+            process.stdin.write(stdin)
+            await process.stdin.drain()
+        finally:
+            process.stdin.close()
+            # Wait for the OS-level close to land so the child sees EOF
+            # before we wait() on it.
+            await process.stdin.wait_closed()
+
     try:
         async with asyncio.timeout(timeout_sec):
             stderr_task = asyncio.create_task(process.stderr.read())  # type: ignore[union-attr]
-            await asyncio.gather(_read_capped(), stderr_task, process.wait())
+            # stdin is written concurrently with stdout/stderr draining
+            # — pg_restore (and any consumer) only starts producing
+            # stdout/stderr after it begins reading stdin, so the
+            # earlier "write stdin after wait" ordering would deadlock.
+            await asyncio.gather(_write_stdin(), _read_capped(), stderr_task, process.wait())
             stderr_bytes = stderr_task.result()
     except TimeoutError:
         timed_out = True
@@ -212,16 +228,6 @@ async def run_pg_binary(
             stderr_bytes = await process.stderr.read() if process.stderr else b""
         except Exception:
             stderr_bytes = b""
-
-    # ``stdin`` is written then closed before reading begins for
-    # simplicity (small payloads only — large restores stream their
-    # archive via temp file, which is a Phase 24c concern).
-    if stdin is not None and process.stdin is not None:
-        try:
-            process.stdin.write(stdin)
-            await process.stdin.drain()
-        finally:
-            process.stdin.close()
 
     stdout_bytes = b"".join(stdout_chunks)
     return SubprocessResult(

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -442,6 +442,28 @@ def _register_data_movement_shell(server: FastMCP[AppContext]) -> None:
         )
         return asdict(result)
 
+    @server.tool(
+        name="restore_database",
+        description=(
+            "Restore a dump into the connected database. `format='plain'` pipes "
+            "the SQL text in `content` through psql with --single-transaction + "
+            "ON_ERROR_STOP; `custom`/`tar` base64-decode `content` and pipe the "
+            "bytes through pg_restore. Credentials pass through libpq env vars, "
+            "never on the command line. Performs subprocess execution — requires "
+            "unrestricted mode + MCPG_ALLOW_SHELL."
+        ),
+    )
+    async def restore_database(ctx: _Ctx, content: str, format: str = "plain") -> dict[str, Any]:
+        app = ctx.request_context.lifespan_context
+        result = await data_movement.restore_database(
+            app.settings.database_url,
+            content,
+            timeout_sec=app.settings.shell_timeout_sec,
+            max_output_bytes=app.settings.shell_max_output_bytes,
+            format=format,
+        )
+        return asdict(result)
+
 
 def _register_audit_trail(server: FastMCP[AppContext]) -> None:
     @server.tool(

--- a/tests/integration/test_data_movement_integration.py
+++ b/tests/integration/test_data_movement_integration.py
@@ -6,7 +6,7 @@ from collections.abc import AsyncIterator
 
 import pytest
 
-from mcpg.data_movement import dump_database, export_query, export_table
+from mcpg.data_movement import dump_database, export_query, export_table, restore_database
 from mcpg.database import Database
 
 _SCHEMA = "mcpg_data_movement_it"
@@ -102,3 +102,44 @@ async def test_dump_database_runs_real_pg_dump_against_a_live_schema(
     assert "PostgreSQL database dump" in result.content
     # The widget table we seeded earlier should appear in the schema dump.
     assert "widget" in result.content
+
+
+async def test_dump_then_restore_round_trip_against_real_pg(connected_database: Database, export_schema: str) -> None:
+    if shutil.which("pg_dump") is None or shutil.which("psql") is None:
+        pytest.skip("pg_dump / psql not on PATH on this runner")
+
+    settings = connected_database._settings
+    # Dump the seeded test schema (--schema-only is enough; data isn't
+    # the point of the round-trip).
+    dump = await dump_database(
+        settings.database_url,
+        timeout_sec=settings.shell_timeout_sec,
+        max_output_bytes=settings.shell_max_output_bytes,
+        format="plain",
+        schema_only=True,
+    )
+    assert dump.exit_code == 0
+    assert "widget" in dump.content
+
+    # Drop the schema, then restore from the dump.
+    driver = connected_database.driver()
+    await driver.execute_query(f"DROP SCHEMA IF EXISTS {export_schema} CASCADE")
+
+    restored = await restore_database(
+        settings.database_url,
+        dump.content,
+        timeout_sec=settings.shell_timeout_sec,
+        max_output_bytes=settings.shell_max_output_bytes,
+        format="plain",
+    )
+    assert restored.exit_code == 0
+    assert restored.timed_out is False
+
+    # The widget table should be back; the data was dropped with the
+    # schema but the structure has been re-created.
+    rows = await driver.execute_query(
+        f"SELECT count(*) AS n FROM {export_schema}.widget",
+        force_readonly=True,
+    )
+    assert rows is not None
+    assert rows[0].cells["n"] == 0

--- a/tests/unit/test_data_movement.py
+++ b/tests/unit/test_data_movement.py
@@ -20,6 +20,7 @@ from mcpg.data_movement import (
     dump_database,
     export_query,
     export_table,
+    restore_database,
 )
 from mcpg.server import create_server
 from mcpg.shell import ShellError, SubprocessResult
@@ -348,3 +349,135 @@ async def test_dump_database_tool_registered_in_unrestricted_with_allow_shell() 
     async with create_connected_server_and_client_session(server) as client:
         listed = {tool.name for tool in (await client.list_tools()).tools}
     assert "dump_database" in listed
+
+
+# --- restore_database -----------------------------------------------------
+
+
+async def test_restore_database_plain_format_uses_psql_and_pipes_sql_to_stdin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_run(binary: str, *argv: str, **kwargs: object) -> SubprocessResult:
+        captured["binary"] = binary
+        captured["argv"] = list(argv)
+        captured["stdin"] = kwargs.get("stdin")
+        captured["env"] = kwargs.get("env")
+        return SubprocessResult(
+            binary=binary,
+            argv=list(argv),
+            exit_code=0,
+            stdout=b"",
+            stderr=b"",
+            output_bytes=0,
+            output_truncated=False,
+            timed_out=False,
+            env_redacted={},
+        )
+
+    monkeypatch.setattr("mcpg.data_movement.run_pg_binary", fake_run)
+
+    sql = "CREATE TABLE w (id integer);"
+    result = await restore_database(
+        "postgresql://u:p@h/db",
+        sql,
+        timeout_sec=10,
+        max_output_bytes=1024,
+    )
+
+    assert captured["binary"] == "psql"
+    # Single-transaction and ON_ERROR_STOP keep partial-restore footguns away.
+    assert "--single-transaction" in captured["argv"]  # type: ignore[operator]
+    assert "--set=ON_ERROR_STOP=on" in captured["argv"]  # type: ignore[operator]
+    assert "--file=-" in captured["argv"]  # type: ignore[operator]
+    # The SQL must be piped through stdin, not interpolated into argv.
+    assert captured["stdin"] == sql.encode("utf-8")
+    assert result.exit_code == 0
+
+
+async def test_restore_database_custom_format_base64_decodes_content_and_invokes_pg_restore(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import base64
+
+    captured: dict[str, object] = {}
+
+    async def fake_run(binary: str, *argv: str, **kwargs: object) -> SubprocessResult:
+        captured["binary"] = binary
+        captured["argv"] = list(argv)
+        captured["stdin"] = kwargs.get("stdin")
+        return SubprocessResult(
+            binary=binary,
+            argv=list(argv),
+            exit_code=0,
+            stdout=b"",
+            stderr=b"",
+            output_bytes=0,
+            output_truncated=False,
+            timed_out=False,
+            env_redacted={},
+        )
+
+    monkeypatch.setattr("mcpg.data_movement.run_pg_binary", fake_run)
+
+    raw = b"\x00\x01PGDMP\xff binary archive"
+    encoded = base64.b64encode(raw).decode("ascii")
+    await restore_database(
+        "postgresql://u@h/db",
+        encoded,
+        timeout_sec=10,
+        max_output_bytes=1024,
+        format="custom",
+    )
+
+    assert captured["binary"] == "pg_restore"
+    assert "--format=custom" in captured["argv"]  # type: ignore[operator]
+    # The base64-decoded raw bytes must be piped through stdin verbatim.
+    assert captured["stdin"] == raw
+
+
+async def test_restore_database_rejects_unsupported_format() -> None:
+    with pytest.raises(ShellError, match="unsupported restore format"):
+        await restore_database(
+            "postgresql://u@h/db",
+            "noop",
+            timeout_sec=10,
+            max_output_bytes=1024,
+            format="bogus",
+        )
+
+
+async def test_restore_database_rejects_invalid_base64_for_binary_formats() -> None:
+    with pytest.raises(ShellError, match="not valid base64"):
+        await restore_database(
+            "postgresql://u@h/db",
+            "!!!not-base64!!!",
+            timeout_sec=10,
+            max_output_bytes=1024,
+            format="custom",
+        )
+
+
+async def test_restore_database_requires_a_database_name_in_the_url() -> None:
+    with pytest.raises(ShellError, match="must specify a database"):
+        await restore_database(
+            "postgresql://user@host:5432/",
+            "noop",
+            timeout_sec=10,
+            max_output_bytes=1024,
+        )
+
+
+async def test_restore_database_tool_hidden_without_allow_shell() -> None:
+    server = create_server(_UNRESTRICTED_NO_SHELL, database=FakeDatabase(FakeDriver()))  # type: ignore[arg-type]
+    async with create_connected_server_and_client_session(server) as client:
+        listed = {tool.name for tool in (await client.list_tools()).tools}
+    assert "restore_database" not in listed
+
+
+async def test_restore_database_tool_registered_with_allow_shell() -> None:
+    server = create_server(_UNRESTRICTED_SHELL, database=FakeDatabase(FakeDriver()))  # type: ignore[arg-type]
+    async with create_connected_server_and_client_session(server) as client:
+        listed = {tool.name for tool in (await client.list_tools()).tools}
+    assert "restore_database" in listed

--- a/tests/unit/test_shell.py
+++ b/tests/unit/test_shell.py
@@ -206,3 +206,46 @@ async def test_run_pg_binary_flags_timeout_and_kills_the_process(
     # timeout_sec=0 triggers asyncio.timeout(0) which fires immediately.
     assert result.timed_out is True
     assert process._killed is True
+
+
+class _BrokenStdin:
+    """A stdin pipe stand-in whose write/drain/close raise BrokenPipeError."""
+
+    def write(self, _data: bytes) -> None:
+        raise BrokenPipeError("child closed stdin early")
+
+    async def drain(self) -> None:
+        raise BrokenPipeError("child closed stdin early")
+
+    def close(self) -> None:
+        raise BrokenPipeError("child closed stdin early")
+
+    async def wait_closed(self) -> None:
+        raise BrokenPipeError("child closed stdin early")
+
+
+async def test_run_pg_binary_surfaces_exit_code_when_child_closes_stdin_early(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Simulates `psql` exiting on a SQL error before the parent finishes
+    # writing the dump. The previous implementation would propagate
+    # BrokenPipeError through asyncio.gather and lose the exit code +
+    # stderr. After the fix, the broken pipe is swallowed and the real
+    # exit code and stderr surface in the result.
+    process = _FakeProcess(stdout=[], stderr=b"ERROR: syntax", returncode=3)
+    process.stdin = _BrokenStdin()  # type: ignore[assignment]
+    _patch_exec(monkeypatch, process)
+
+    result = await run_pg_binary(
+        "psql",
+        "--file=-",
+        timeout_sec=10,
+        max_output_bytes=1024,
+        stdin=b"BAD SQL HERE;",
+    )
+
+    # No exception bubbled up — the agent gets the real diagnostic
+    # instead of an opaque BrokenPipeError.
+    assert result.exit_code == 3
+    assert result.stderr == b"ERROR: syntax"
+    assert result.timed_out is False


### PR DESCRIPTION
## Summary

**Phase 24c — completes the dump/restore symmetry.** One new tool +
fixes a latent stdin-ordering bug in `mcpg.shell` before any shipped
tool got bitten by it. Tool surface 59 → 60.

### `restore_database`

- **`format='plain'`** pipes the SQL text in `content` through
  `psql --single-transaction --set=ON_ERROR_STOP=on` — a syntax
  error rolls the whole restore back rather than half-applying.
- **`format='custom'`** / **`'tar'`** base64-decode `content` and
  pipe the bytes through `pg_restore --single-transaction
  --exit-on-error`. Invalid base64 surfaces as a clean `ShellError`
  instead of trying to call `pg_restore` with garbage.
- Credentials reach the binary via the libpq `PG*` env vars (the
  same `_libpq_env_from_url` helper `dump_database` uses); the dump
  bytes flow through stdin, never argv.
- Gated under unrestricted mode + `MCPG_ALLOW_SHELL` (same gate as
  `dump_database`).

### `mcpg.shell` fix — stdin write ordering

`run_pg_binary` previously wrote the optional `stdin` payload **after**
awaiting `process.wait()`. That ordering would deadlock: the child
waits for stdin, the parent waits for the child to exit. No shipped
tool used the `stdin` parameter yet, so the bug hadn't surfaced — but
it blocked `restore_database` from working at all.

Fix: write `stdin` concurrently with the stdout/stderr drain via
`asyncio.gather`. The helper closes the pipe and awaits the OS-level
close before the `wait()` lands.

## Test plan

- [ ] CI: ruff, mypy --strict, full unit + integration suites green
- [ ] CI matrix: PG **14 / 15 / 16 / 17 / 18** — integration test
      runs a real `pg_dump` → `DROP SCHEMA` → `psql` restore
      round-trip and asserts the restored schema is queryable again
- [ ] 7 new unit tests cover the wiring (plain → psql, custom →
      pg_restore, base64 decoding), every error path (unsupported
      format, invalid base64, missing DB in URL), and the
      `MCPG_ALLOW_SHELL` gate matrix
- [ ] Existing 13 shell unit tests still pass (the stdin reorder is
      backwards-compatible — none of them exercise stdin)
- [ ] Coverage gate maintained; locally **576 pass / 9 skipped**

## What's next after merge

- **Phase 24d** — `copy_table_between_databases` (pipe pg_dump on
  one URL into pg_restore on another).
- **Phase 24e** — `import_csv` / `import_json` (in-process via
  COPY ... FROM STDIN; the `stdin` plumbing is now ready).
- Plus Batch G follow-ons (Drizzle / SQLAlchemy / sqlc) and
  Batches E and F still in play.

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_