### PR TITLE
Tier-A milestone: pgvector + composite + observability + TimescaleDB + HTTP auth (78 → 90 tools)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Three new pgvector tools (Tier-A picks from the feature shortlist).
+  Tool surface 78 → 81. All read-only; all extend `mcpg.textsearch`
+  alongside the existing `vector_search` / `recommend_vector_index`
+  family.
+  - **`hybrid_search`** — fuses vector and full-text ranking via
+    reciprocal-rank fusion (RRF). Pulls `candidate_pool` candidates
+    from each source (vector k-NN on `vector_column`, FTS via
+    `websearch_to_tsquery` on `text_column`), then merges them with
+    `score = Σ 1/(rrf_k + rank)`. Each match carries `vector_rank`,
+    `fts_rank`, the fused `rrf_score`, and the original distance +
+    ts_rank values. Tunables: `metric`, `text_config`,
+    `candidate_pool` (default 50), `rrf_k` (default 60), `limit`.
+    Closes the biggest unmet need in agentic RAG: pure vector
+    misses keyword/identifier matches, pure FTS misses semantic
+    synonyms.
+  - **`vector_range_search`** — finds every row within
+    `max_distance` of a query vector (not top-k). Useful for
+    de-duplication, similarity gating, clustering pre-passes.
+    Results still ordered by distance and capped at `limit` so a
+    too-loose threshold cannot pull the whole table.
+  - **`recommend_vector_quantization`** — scans a schema for
+    `vector(N)` columns whose storage could shrink by switching to
+    pgvector v0.7+'s `halfvec(N)` (16-bit float). Returns
+    per-column current vs suggested bytes, the savings ratio, and a
+    rationale. Skips columns that are already non-`vector` and
+    small tables where the absolute saving wouldn't justify the
+    migration. Catalog query uses `pg_attribute.atttypmod` + a
+    `t.typname IN ('vector','halfvec','sparsevec')` filter so PG's
+    built-in `bit(N)` doesn't false-positive.
+
 - Four more catalog → DSL exporters under the same Batch G umbrella.
   Tool surface 74 → 78. All read-only, no new capability or env-var
   gates. Coverage matches the existing exporters (Prisma / Drizzle /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,44 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Tier-A milestone closed** — three picks from
+  `docs/feature-shortlist.md` shipped together. Tool surface 84 → 90.
+  - **HTTP transport bearer-token auth** (shortlist 1.1). New
+    `mcpg.http_runtime` module wraps FastMCP's `streamable_http_app()`
+    / `sse_app()` with an ASGI `_BearerAuthMiddleware`. When
+    `MCPG_HTTP_AUTH_TOKEN` is set, every request needs
+    `Authorization: Bearer <token>` (constant-time compared via
+    `hmac.compare_digest`); missing / wrong tokens get a 401 with
+    `WWW-Authenticate: Bearer realm="mcpg"`. `/metrics`, `/healthz`,
+    and `/readyz` are exempt so a Prometheus scraper / load-balancer
+    probe doesn't need the MCP token. New settings field
+    `Settings.http_auth_token`. The `stdio` transport is unaffected
+    (no HTTP surface). The runtime logs a WARNING when an HTTP
+    transport starts without a token.
+  - **Prometheus `/metrics` endpoint + `get_metrics_exposition` tool**
+    (shortlist 2.1). New `mcpg.observability` module records every
+    `call_tool` invocation in an in-process `Metrics` store and
+    renders the standard text-exposition format (v0.0.4) — zero
+    runtime dependency. Three series: `mcpg_tool_calls_total{tool,
+    status}` (counter), `mcpg_tool_duration_seconds_bucket{tool,le}`
+    (histogram with default Prometheus buckets + 30s/60s overflow),
+    `mcpg_tool_duration_seconds_sum/_count{tool}`. `AuditedFastMCP`
+    times every tool call and records (`ok` | `error`) +
+    wall-clock seconds. The new `get_metrics_exposition` MCP tool
+    returns the same payload over the MCP protocol for stdio
+    transports where `/metrics` isn't reachable.
+  - **TimescaleDB hypertable wrappers** (shortlist 4.2). New
+    `mcpg.timescaledb` module adds five tools — two read-only
+    (`list_hypertables`, `list_chunks`) plus three DDL-gated writes
+    (`create_hypertable`, `add_compression_policy`,
+    `add_retention_policy`). Every interval / identifier is
+    allowlist-validated before being inlined into SQL (TimescaleDB's
+    management functions take interval expressions as positional
+    args, not bound params). Each tool degrades to
+    `available=False` when the `timescaledb` extension is missing —
+    same pattern as the existing pg_trgm / pgvector / postgis
+    integrations.
+
 - Three new agent-UX-focused tools (more Tier-A picks). Tool surface
   81 → 84. All read-only.
   - **`summarize_table`** — one-stop snapshot of a table: columns,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,43 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Four more catalog → DSL exporters under the same Batch G umbrella.
+  Tool surface 74 → 78. All read-only, no new capability or env-var
+  gates. Coverage matches the existing exporters (Prisma / Drizzle /
+  SQLAlchemy 2.0 / sqlc): base tables, columns, primary keys, single-
+  column intra-schema foreign keys, enums. Cross-schema FKs and
+  composite FKs are documented v1 gaps.
+  - `generate_diesel_schema` — emits a Diesel ORM (Rust) `schema.rs`
+    with one `table!` macro per table, `Nullable<T>` wrappers for
+    nullable columns, `joinable!` lines for intra-schema FKs, and an
+    `allow_tables_to_appear_in_same_query!` macro so multi-table
+    joins type-check. Enum types are emitted as Text-backed wrapper
+    enums in a `pg_enum` module so the output works without
+    `diesel_derive_enum`.
+  - `generate_jooq_config` — emits a `jooq-codegen` configuration
+    XML pointing at the database. Unlike the other exporters, jOOQ
+    generates Java code itself from the live database at build
+    time; the artefact here is the XML the user feeds to
+    `mvn jooq-codegen:generate`. Includes an explicit `<includes>`
+    regex naming every base table, an `<excludes>` covering MCPg's
+    bookkeeping schemas, and a `<forcedType>` for every json / jsonb
+    column so they map to `org.jooq.JSON` / `org.jooq.JSONB`.
+  - `generate_ent_schemas` — emits Ent (Go) Schema struct files,
+    one `.go` per table. Each struct lists `field.X(...)` calls,
+    `edge.To(...)` lines for single-column FKs, and
+    `field.Enum().Values()` for enum-typed columns. Returns a
+    `{filename: source}` dict.
+  - `generate_ecto_schemas` — emits Ecto (Elixir) schema modules,
+    one `.ex` per table named after the singularised table
+    (matching the Phoenix `lib/my_app/<singular>.ex` convention).
+    Each module uses `use Ecto.Schema`, declares `@primary_key`,
+    `field` for each column, `belongs_to` for single-column FKs,
+    and `timestamps()` when both `inserted_at` + `updated_at`
+    exist. The Elixir top-level module is configurable via the
+    `app_module` arg (default `MyApp`).
+
 ## [0.4.0] - 2026-05-26
 
 Twenty-nine new MCP tools, closing **Batches D / E / F / G** of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Three new agent-UX-focused tools (more Tier-A picks). Tool surface
+  81 → 84. All read-only.
+  - **`summarize_table`** — one-stop snapshot of a table: columns,
+    primary key, foreign keys, every other constraint, indexes,
+    storage / row-count / last-vacuum/analyze stats, and an optional
+    short row sample. Replaces what would otherwise be 4-5
+    individual tool calls. Lives in new module `mcpg.composite`.
+  - **`why_is_this_slow`** — one-call diagnosis: runs
+    `EXPLAIN (FORMAT JSON)` (does NOT execute the query), walks the
+    plan tree, snapshots concurrent active queries and blocking
+    lock pairs, reads the cluster-wide cache hit ratio, and
+    produces categorised suggestions (plan / contention / cache /
+    maintenance). Safe to run on a statement the agent doesn't
+    want to materialise yet. Lives in `mcpg.composite`.
+  - **`find_unused_objects`** — scans `pg_stat_user_tables` and
+    `pg_stat_user_indexes` for tables/indexes with zero scans since
+    stats were last reset. Tables also need zero writes (the row
+    never moved) to qualify; indexes backing PRIMARY KEY / UNIQUE
+    constraints are excluded since PG needs them for enforcement.
+    Returns context (scan + write counts, size, definition) so the
+    agent can decide whether the object is safe to drop. Documented
+    as a SIGNAL not a verdict — recent stats resets produce false
+    positives. Lives in `mcpg.advisors` alongside `run_advisors`.
+
 - Three new pgvector tools (Tier-A picks from the feature shortlist).
   Tool surface 78 → 81. All read-only; all extend `mcpg.textsearch`
   alongside the existing `vector_search` / `recommend_vector_index`

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A production-grade [Model Context Protocol](https://modelcontextprotocol.io)
 server for **PostgreSQL** — letting AI agents safely inspect, query, operate,
 and tune a Postgres database.
 
-> **Status:** v0.4.0 released. **74 MCP tools** covering deep catalog
+> **Status:** v0.4.0 released; trunk at **78 MCP tools**. Covers deep catalog
 > introspection, index intelligence, full-text/trigram/vector/geospatial
 > search, live ops, gated maintenance, Mermaid ER diagrams, structural
 > schema diff, **subprocess-driven data movement (pg_dump/pg_restore/psql),
@@ -70,14 +70,18 @@ See the [Installation Guide](docs/installation.md) and
   schema into a shadow, applies the candidate SQL there, and surfaces
   the structural diff for review; `complete_migration` /
   `cancel_migration` / `list_pending_migrations` round out the workflow.
-- **ORM bridges** — `generate_prisma_schema`, `generate_drizzle_schema`,
-  `generate_sqlalchemy_models`, `generate_sqlc_schema` emit ready-to-use
-  schemas / models from a live PG catalog.
+- **ORM bridges** — eight read-only catalog → DSL exporters:
+  `generate_prisma_schema`, `generate_drizzle_schema`,
+  `generate_sqlalchemy_models`, `generate_sqlc_schema`,
+  `generate_diesel_schema`, `generate_jooq_config`,
+  `generate_ent_schemas`, `generate_ecto_schemas` cover the major
+  Postgres-aware ORM ecosystems.
 
 ## Documentation
 
 - [`docs/installation.md`](docs/installation.md) — Installation Guide
 - [`docs/user-guide.md`](docs/user-guide.md) — User Guide
+- [`docs/tour.md`](docs/tour.md) — compact tool tour (start here for discovery)
 - [`docs/tools.md`](docs/tools.md) — reference for every MCP tool
 - [`docs/architecture.md`](docs/architecture.md) — Architecture Document
 - [`docs/security.md`](docs/security.md) — threat model and security controls

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A production-grade [Model Context Protocol](https://modelcontextprotocol.io)
 server for **PostgreSQL** — letting AI agents safely inspect, query, operate,
 and tune a Postgres database.
 
-> **Status:** v0.4.0 released; trunk at **81 MCP tools**. Covers deep catalog
+> **Status:** v0.4.0 released; trunk at **84 MCP tools**. Covers deep catalog
 > introspection, index intelligence, full-text/trigram/vector/geospatial
 > search, live ops, gated maintenance, Mermaid ER diagrams, structural
 > schema diff, **subprocess-driven data movement (pg_dump/pg_restore/psql),

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A production-grade [Model Context Protocol](https://modelcontextprotocol.io)
 server for **PostgreSQL** — letting AI agents safely inspect, query, operate,
 and tune a Postgres database.
 
-> **Status:** v0.4.0 released; trunk at **84 MCP tools**. Covers deep catalog
+> **Status:** v0.4.0 released; trunk at **90 MCP tools**. Covers deep catalog
 > introspection, index intelligence, full-text/trigram/vector/geospatial
 > search, live ops, gated maintenance, Mermaid ER diagrams, structural
 > schema diff, **subprocess-driven data movement (pg_dump/pg_restore/psql),

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A production-grade [Model Context Protocol](https://modelcontextprotocol.io)
 server for **PostgreSQL** — letting AI agents safely inspect, query, operate,
 and tune a Postgres database.
 
-> **Status:** v0.4.0 released; trunk at **78 MCP tools**. Covers deep catalog
+> **Status:** v0.4.0 released; trunk at **81 MCP tools**. Covers deep catalog
 > introspection, index intelligence, full-text/trigram/vector/geospatial
 > search, live ops, gated maintenance, Mermaid ER diagrams, structural
 > schema diff, **subprocess-driven data movement (pg_dump/pg_restore/psql),

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -6,13 +6,12 @@
 
 ## Current state
 
-- **Phase:** v0.4.0 release prep — version bumped 0.3.0 → 0.4.0,
-  CHANGELOG converted, release notes written, README capability
-  surface refreshed. Tool surface 74. **All planned batches A–G
-  are now closed.**
+- **Phase:** post-v0.4.0 — additional Batch G exporters (Diesel /
+  jOOQ / Ent / Ecto) under the schema→DSL umbrella. Tool surface
+  74 → 78.
 - **Last updated:** 2026-05-26
 - **Branch:** `claude/postgresql-mcp-planning-8KssU`
-- **Tool count:** 74
+- **Tool count:** 78
 
 ## Next action
 
@@ -842,3 +841,32 @@
   data movement + LISTEN/NOTIFY + staged migrations + ORM bridges
   highlighted). No code changes — release prep only. Tagging /
   publishing awaits explicit user sign-off.
+- 2026-05-26 — v0.4.0 tagged and released on GitHub
+  (https://github.com/devopam/MCPg/releases/tag/v0.4.0). PR #17
+  merged. Branch fast-forwarded to main (`77970f2`).
+- 2026-05-26 — Post-0.4.0 Batch G follow-ons shipped: four more
+  catalog→DSL exporters alongside the existing Prisma / Drizzle /
+  SQLAlchemy 2.0 / sqlc ones. `mcpg.diesel` emits Diesel ORM (Rust)
+  `schema.rs` with `table!` macros, `Nullable<T>` for nullable
+  columns, `joinable!` for single-column intra-schema FKs, an
+  `allow_tables_to_appear_in_same_query!` macro, and Text-backed
+  wrapper enums in a `pg_enum` module so output works without
+  `diesel_derive_enum`. `mcpg.jooq` emits a `jooq-codegen`
+  configuration XML pointing at the live database — unlike other
+  exporters, jOOQ generates Java code itself at build time, so the
+  artefact is the config file (with explicit `<includes>` regex,
+  `<excludes>` for MCPg's bookkeeping schemas, and `<forcedType>`
+  entries for json / jsonb columns → org.jooq.JSON / .JSONB).
+  `mcpg.ent` emits Ent (Go) Schema struct files — one `.go` per
+  table, with `field.X(...)` calls, `edge.To(...)` for FKs, and
+  `field.Enum().Values()` for enum columns. `mcpg.ecto` emits
+  Ecto (Elixir) schema modules — one `.ex` per table, named after
+  the singularised table (Phoenix convention), with `@primary_key`
+  declared, `field` per column, `belongs_to` for single-column
+  FKs, and `timestamps()` when both `inserted_at` and `updated_at`
+  exist. Configurable `app_module` arg. All four tools are
+  read-only — no new capability or opt-in. 49 new unit tests
+  (helper functions, FK / enum handling, default mapping, tool
+  registration) + 5 new integration tests round-trip each exporter
+  against real PG. **Tool surface 74 → 78.** 772 tests pass / 9
+  skipped; coverage maintained.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -6,12 +6,12 @@
 
 ## Current state
 
-- **Phase:** post-v0.4.0 — Batch G follow-on exporters shipped
-  (Diesel / jOOQ / Ent / Ecto) + documentation pass (tool tour,
-  tools.md refresh, user-guide post-0.3.0 sections).
+- **Phase:** post-v0.4.0 — Batch G follow-on exporters + doc pass +
+  Tier-A pgvector tools (hybrid_search / vector_range_search /
+  recommend_vector_quantization).
 - **Last updated:** 2026-05-26
 - **Branch:** `claude/postgresql-mcp-planning-8KssU`
-- **Tool count:** 78
+- **Tool count:** 81
 
 ## Next action
 
@@ -886,3 +886,22 @@
   CONCURRENTLY-in-migrations error). README capability surface
   refreshed to list all eight ORM exporters and link the new tour
   doc. No code changes.
+- 2026-05-26 — Tier-A pgvector tools shipped (Phase 11.1 / 11.2 /
+  11.3 from `docs/feature-shortlist.md`). Three new tools land in
+  `mcpg.textsearch` alongside the existing pgvector family.
+  `hybrid_search` does reciprocal-rank fusion of vector k-NN and
+  full-text ranking — the canonical fix for the "vector misses
+  keywords / FTS misses synonyms" gap in agentic RAG; each match
+  carries per-source rank + the fused score so the agent can see
+  WHY a result surfaced. `vector_range_search` is the
+  threshold-rather-than-top-k counterpart to `vector_search`,
+  useful for de-dup / similarity gating; still ordered by distance
+  and capped at `limit` so a too-loose threshold can't blow up.
+  `recommend_vector_quantization` scans a schema for `vector(N)`
+  columns whose storage could halve by switching to pgvector
+  v0.7+'s `halfvec(N)`; the catalog query joins `pg_type` and
+  filters on `typname IN ('vector','halfvec','sparsevec')` so
+  PG's built-in `bit(N)` doesn't false-positive. 26 new unit tests
+  + 3 new integration tests pin the wiring, including a real-PG
+  smoke test that creates 10001 768-dim rows and verifies the
+  advisor fires. Tool surface 78 → 81. 806 tests pass / 3 skipped.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -7,11 +7,11 @@
 ## Current state
 
 - **Phase:** post-v0.4.0 — Batch G follow-on exporters + doc pass +
-  Tier-A pgvector tools (hybrid_search / vector_range_search /
-  recommend_vector_quantization).
+  Tier-A pgvector tools + Tier-A composite tools
+  (summarize_table / why_is_this_slow / find_unused_objects).
 - **Last updated:** 2026-05-26
 - **Branch:** `claude/postgresql-mcp-planning-8KssU`
-- **Tool count:** 81
+- **Tool count:** 84
 
 ## Next action
 
@@ -905,3 +905,20 @@
   + 3 new integration tests pin the wiring, including a real-PG
   smoke test that creates 10001 768-dim rows and verifies the
   advisor fires. Tool surface 78 → 81. 806 tests pass / 3 skipped.
+- 2026-05-26 — Tier-A composite tools shipped (Phase 5.2 / 8.2 /
+  10.1 from `docs/feature-shortlist.md`). Three agent-UX tools that
+  compose existing primitives so an agent doesn't have to issue
+  4-5 round trips for common queries. New `mcpg.composite` module
+  holds `summarize_table` (columns + constraints + FKs + indexes +
+  storage / vacuum stats + optional sample, all in one) and
+  `why_is_this_slow` (EXPLAIN + plan analysis + active-query +
+  blocking-lock + cache-hit snapshot + categorised suggestions —
+  safe by design because EXPLAIN does NOT execute the query).
+  `mcpg.advisors` grew `find_unused_objects` — scans
+  `pg_stat_user_tables` / `pg_stat_user_indexes` for tables with
+  zero scans + zero writes and user indexes with zero scans
+  (excluding PRIMARY KEY / UNIQUE indexes since PG needs them
+  regardless). Documented as a SIGNAL not a verdict. 25 new unit
+  tests + 4 new integration tests against real PG (creates a real
+  schema with extra unused indexes and verifies the composite
+  shapes). Tool surface 81 → 84. 831 tests pass / 3 skipped.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -6,12 +6,12 @@
 
 ## Current state
 
-- **Phase:** post-v0.4.0 — Batch G follow-on exporters + doc pass +
-  Tier-A pgvector tools + Tier-A composite tools
-  (summarize_table / why_is_this_slow / find_unused_objects).
+- **Phase:** post-v0.4.0 — Tier-A milestone complete (observability,
+  TimescaleDB, HTTP bearer auth on top of Batch G exporters,
+  pgvector tools, and composite tools).
 - **Last updated:** 2026-05-26
 - **Branch:** `claude/postgresql-mcp-planning-8KssU`
-- **Tool count:** 84
+- **Tool count:** 90
 
 ## Next action
 
@@ -922,3 +922,25 @@
   tests + 4 new integration tests against real PG (creates a real
   schema with extra unused indexes and verifies the composite
   shapes). Tool surface 81 → 84. 831 tests pass / 3 skipped.
+- 2026-05-26 — **Tier-A milestone closed** — three picks from
+  `docs/feature-shortlist.md` shipped in one branch. (1.1) HTTP
+  transport bearer-token auth via a new `mcpg.http_runtime` ASGI
+  middleware: when `MCPG_HTTP_AUTH_TOKEN` is set, every request to
+  the streamable-http / sse transport needs `Authorization: Bearer
+  <token>` (constant-time compared via `hmac.compare_digest`).
+  `/metrics`, `/healthz`, `/readyz` are exempted so a Prometheus
+  scraper / load-balancer probe can hit them without holding the MCP
+  token. (2.1) In-process Prometheus metrics — new `mcpg.observability`
+  emits `mcpg_tool_calls_total{tool,status}` and
+  `mcpg_tool_duration_seconds_*` (histogram + sum + count) via a
+  zero-dep text-exposition renderer. `AuditedFastMCP.call_tool`
+  records every invocation; the same payload is exposed as the
+  `get_metrics_exposition` MCP tool for stdio transports. (4.2)
+  TimescaleDB hypertable wrappers — new `mcpg.timescaledb` adds five
+  tools (`list_hypertables`, `list_chunks`, `create_hypertable`,
+  `add_compression_policy`, `add_retention_policy`); every interval
+  / identifier is allowlisted before being inlined into SQL, and
+  each tool degrades to `available=False` when the extension is
+  missing. 33 new unit tests pin the wiring (`test_observability.py`,
+  `test_http_runtime.py`, `test_timescaledb.py`). Tool surface 84 →
+  90.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -6,9 +6,9 @@
 
 ## Current state
 
-- **Phase:** post-v0.4.0 — additional Batch G exporters (Diesel /
-  jOOQ / Ent / Ecto) under the schema→DSL umbrella. Tool surface
-  74 → 78.
+- **Phase:** post-v0.4.0 — Batch G follow-on exporters shipped
+  (Diesel / jOOQ / Ent / Ecto) + documentation pass (tool tour,
+  tools.md refresh, user-guide post-0.3.0 sections).
 - **Last updated:** 2026-05-26
 - **Branch:** `claude/postgresql-mcp-planning-8KssU`
 - **Tool count:** 78
@@ -870,3 +870,19 @@
   registration) + 5 new integration tests round-trip each exporter
   against real PG. **Tool surface 74 → 78.** 772 tests pass / 9
   skipped; coverage maintained.
+- 2026-05-26 — Documentation pass: refreshed `docs/tools.md` to
+  cover all 78 tools (was at 45 from the v0.3.0 era) with a
+  capability-gate matrix and a tool-index table at the top of the
+  page, plus new sections for data movement (read / write / shell),
+  LISTEN/NOTIFY bridge, staged migrations, audit trail, ORM-DSL
+  exporters (including the four follow-ons), pg_cron, pg_partman.
+  New `docs/tour.md` — a one-page tool-tour organised by what an
+  agent typically wants to do ("what's in this database?", "move
+  data in/out", "react to events", "generate code for my ORM",
+  etc.) for fast discovery without reading the source. Updated
+  `docs/user-guide.md` with post-0.3.0 sections (data movement,
+  LISTEN/NOTIFY, staged migrations, ORM bridges, persistent audit)
+  + extended troubleshooting (new opt-in env vars,
+  CONCURRENTLY-in-migrations error). README capability surface
+  refreshed to list all eight ORM exporters and link the new tour
+  doc. No code changes.

--- a/docs/feature-shortlist.md
+++ b/docs/feature-shortlist.md
@@ -1,0 +1,152 @@
+# Post-v0.4.0 feature shortlist
+
+Candidates for new feature work, organised by area. Each entry shows
+rough effort (**S/M/L**), the user-facing value, and any prerequisite
+that might block it. Use this as a menu for prioritisation.
+
+Effort scale (rough, single-session yardstick):
+- **S** = 1 module, 1 PR, ≤ 1 day equivalent
+- **M** = 2–3 modules or wider surface, 1–3 PRs
+- **L** = new infrastructure (background workers, transport changes,
+  cross-cutting refactors)
+
+---
+
+## 1. Transport & deployment hardening
+
+| # | Item | Effort | Value | Notes |
+|---|---|---|---|---|
+| 1.1 | **HTTP transport auth** (bearer / API key + middleware) | M | High | Currently `streamable-http` / `sse` have **no auth** — a real-world deployment blocker. Open question in PLAN.md §0.1. |
+| 1.2 | TLS / mTLS for HTTP transport | S | Medium | Mostly config + cert wiring. Often handled at the reverse-proxy layer instead. |
+| 1.3 | Rate limiting per client / per tool | M | Medium | Pairs naturally with 1.1. |
+| 1.4 | **Per-request `SET ROLE`** for multi-tenancy | M | High | Deferred in Phase 6.2 with a note that document-only is the v1 stance. Re-opens multi-tenant deployments. |
+| 1.5 | Multi-database support (one server, many DBs) | L | Medium | Today: one server = one `MCPG_DATABASE_URL`. Multi-DB means a tool param, a pool-per-DB, and rethinking gates. |
+| 1.6 | Read-replica routing for read tools | M | Low-Medium | Deferred in Phase 6.4. Marginal at MCPg's scale until 1.4 lands. |
+
+## 2. Observability
+
+| # | Item | Effort | Value | Notes |
+|---|---|---|---|---|
+| 2.1 | **Prometheus `/metrics` endpoint** | S-M | High | Tool-call count / latency / error rate per tool. Pairs with the HTTP transport. |
+| 2.2 | **OpenTelemetry spans** per tool call | M | Medium-High | One span per `call_tool` + child spans for the actual query / subprocess. |
+| 2.3 | Structured JSON logging output | S | Medium | Optional — wraps the existing `mcpg.audit` logger. |
+| 2.4 | k8s-style `/healthz` + `/readyz` endpoints | S | Medium | Just on the HTTP transport. |
+| 2.5 | Slow-query logging from the MCP layer | S | Low | The existing `analyze_workload` already covers PG-side timings; this would be a per-tool latency log. |
+
+## 3. Performance & scaling
+
+| # | Item | Effort | Value | Notes |
+|---|---|---|---|---|
+| 3.1 | **Server-side cursors** for streaming large `run_select` results | M | Medium-High | Listed as Phase 6.4 deferred work. Lets agents fetch result sets larger than `max_rows`. |
+| 3.2 | Connection-pool tuning advisor (recommend min/max from observed load) | S | Low-Medium | Reuses existing `check_database_health` plumbing. |
+| 3.3 | Bulk-update / bulk-delete tools (parametrised, gated) | S | Low | Sibling to `import_csv` for writes. |
+| 3.4 | Parallel query execution helper (`run_selects_parallel`) | S | Medium | Useful for an agent fanning out across schemas. |
+
+## 4. PostgreSQL feature coverage
+
+| # | Item | Effort | Value | Notes |
+|---|---|---|---|---|
+| 4.1 | **Logical replication management writes** — `create_publication`, `drop_publication`, `create_subscription`, `drop_subscription` | M | Medium-High | Read tools already exist (Phase 16). Closes the loop on logical-replication ops. Gated under DDL. |
+| 4.2 | **TimescaleDB hypertable wrappers** | M | High | Most popular PG extension after pgvector/PostGIS. `create_hypertable`, `add_dimension`, `set_chunk_time_interval`, `compress_chunk`, retention policies. |
+| 4.3 | `pg_stat_io` exposure (PG 16+) | S | Medium | Big I/O visibility win on modern PG. |
+| 4.4 | `pg_buffercache` integration (cache hit analysis at the buffer level) | S | Low-Medium | Niche. |
+| 4.5 | `pg_locks` deep inspection / deadlock detector | S | Medium | Live-ops complement. |
+| 4.6 | WAL inspection (`pg_walinspect`) | S | Low | Niche but useful for replication debugging. |
+| 4.7 | Generated-column awareness in `describe_table` | S | Low-Medium | Currently we don't surface `GENERATED ALWAYS AS ...` columns specially. |
+| 4.8 | Row-level security policy tester (`would_this_row_be_visible_to_role`) | M | Medium | Hard-to-test feature; great agentic UX. |
+
+## 5. Developer experience
+
+| # | Item | Effort | Value | Notes |
+|---|---|---|---|---|
+| 5.1 | **Cookbook of common agent flows** in docs (e.g. "review a migration", "find slow queries", "generate ORM models") | S | Medium-High | Pairs with the tour we just shipped. Pure docs. |
+| 5.2 | `summarize_table` composite tool (describe + sample rows + stats in one call) | S | High | Big agent UX win — replaces 4–5 tool calls with one. |
+| 5.3 | Sample-data generator (`seed_table_with_sample_data`, gated under WRITE) | M | Medium | Useful for shadow-migration testing and demos. |
+| 5.4 | Auto-generated tool examples in MCP tool descriptions | S | Low-Medium | Helps agents pick the right tool. |
+
+## 6. Security & compliance
+
+| # | Item | Effort | Value | Notes |
+|---|---|---|---|---|
+| 6.1 | **Connection encryption verification tool** — reports `ssl=on/off` + cipher | S | Medium | One-liner check. |
+| 6.2 | Sensitive-column heuristic discovery (emails, phone, SSN, credit card by regex + name) | M | Medium-High | Pairs with audit + compliance workflows. |
+| 6.3 | Audit log retention / rotation policy | S | Medium | `mcpg_audit.events` grows unbounded today. |
+| 6.4 | IP allowlist for HTTP transport | S | Low | Tiny middleware. |
+| 6.5 | OIDC / SSO for HTTP transport | L | Medium | Bigger commitment than the simpler 1.1 bearer-token path. |
+
+## 7. Backups & DR
+
+| # | Item | Effort | Value | Notes |
+|---|---|---|---|---|
+| 7.1 | Scheduled logical backups via `pg_cron` + `dump_database` | S | Medium | Composes existing tools. |
+| 7.2 | WAL archive inspection | M | Low | Niche; only useful where WAL archiving is configured. |
+| 7.3 | Point-in-time recovery prep helpers | M | Low-Medium | Heavy lift for a narrow audience. |
+
+## 8. Schema design / quality
+
+| # | Item | Effort | Value | Notes |
+|---|---|---|---|---|
+| 8.1 | **Naming-convention linter** (snake_case, prefix conventions, FK suffix, ...) | S | Medium | Quick win. |
+| 8.2 | **Unused-table / unused-column finder** via `pg_stat_user_tables` | S | High | Excellent agent UX for "what can I drop?". |
+| 8.3 | Missing-index dead-code detector (sibling to `recommend_indexes` but for *over*-indexed) | S | Medium | Currently `recommend_indexes` only adds, never removes. |
+| 8.4 | N+1 query pattern detector via `pg_stat_statements` | M | Medium-High | Composes `analyze_workload` with grouping heuristics. |
+| 8.5 | FK cascade visualisation (diagram of what cascades from a delete) | S | Medium | Pairs with `generate_schema_diagram`. |
+
+## 9. Migration ecosystem integration
+
+| # | Item | Effort | Value | Notes |
+|---|---|---|---|---|
+| 9.1 | Alembic / Flyway / Liquibase migration script ingestion (parse + apply through `prepare_migration`) | M-L | Medium | Big agentic win for projects with existing migration history. |
+| 9.2 | Pre-deployment migration validation (target schema vs production snapshot) | M | High | Composes `compare_schemas` + shadow workflow. |
+| 9.3 | Migration history table integration (Alembic / Flyway / Diesel native tables) | S | Medium | Reads existing tooling's bookkeeping. |
+| 9.4 | Zero-downtime migration cookbook | S | Medium-High | Pure docs (patterns, not code). |
+
+## 10. AI / agent-specific
+
+| # | Item | Effort | Value | Notes |
+|---|---|---|---|---|
+| 10.1 | **`why_is_this_slow` composite tool** (EXPLAIN + active queries + locks + cache hit + suggestions in one call) | M | Very High | Agent magnet. |
+| 10.2 | Natural-language → SQL helper (gated, returns SQL + EXPLAIN for review before run) | M | High | Different shape than the existing tools — calls out to a model. |
+| 10.3 | Test-data factory (`generate_test_row_for(schema, table)` using catalog + heuristics) | M | Medium-High | Pairs with the shadow-migration workflow. |
+| 10.4 | Schema documentation generator (Markdown table reference from catalog) | S | Medium | Sibling of `generate_schema_diagram`. |
+
+---
+
+## Suggested priority tiers
+
+These are my recommendations to bucket the list — feel free to override.
+
+**Tier A — high-value, modest effort, unblock real deployments:**
+- 1.1 HTTP transport auth (M, High)
+- 2.1 Prometheus metrics (S-M, High)
+- 5.2 `summarize_table` composite tool (S, High)
+- 8.2 Unused-table / column finder (S, High)
+- 10.1 `why_is_this_slow` composite tool (M, Very High)
+- 4.2 TimescaleDB wrappers (M, High)
+
+**Tier B — strong UX or coverage wins:**
+- 1.4 Per-request `SET ROLE` multi-tenancy (M, High)
+- 4.1 Logical replication writes (M, Medium-High)
+- 5.1 Agent cookbook (S, Medium-High)
+- 6.2 Sensitive-column heuristics (M, Medium-High)
+- 8.4 N+1 detector (M, Medium-High)
+- 9.2 Migration validation against production snapshot (M, High)
+
+**Tier C — nice to have:**
+- 3.1 Server-side cursors (M, Medium-High)
+- 3.4 Parallel select helper (S, Medium)
+- 4.3 `pg_stat_io` (S, Medium)
+- 4.5 `pg_locks` deeper inspection (S, Medium)
+- 4.7 Generated columns (S, Low-Medium)
+- 4.8 RLS policy tester (M, Medium)
+- 8.1 Naming-convention linter (S, Medium)
+- 8.5 FK cascade visualisation (S, Medium)
+- 10.3 Test-data factory (M, Medium-High)
+
+**Defer for now:**
+- 1.5 Multi-database support — L; very ambitious
+- 1.6 Read-replica routing — won't move the needle until 1.4
+- 6.5 OIDC / SSO — start with 1.1 bearer-token first
+- 7.x Backups & DR family — narrow audience
+- 9.1 Migration script ingestion — big surface; wait for demand
+- 10.2 NL → SQL — different shape, needs a model dependency

--- a/docs/feature-shortlist.md
+++ b/docs/feature-shortlist.md
@@ -112,6 +112,39 @@ Effort scale (rough, single-session yardstick):
 
 ---
 
+## 11. pgvector extensions
+
+Building on what's already shipped (`vector_search`,
+`recommend_vector_index`, `analyze_vector_search`,
+`analyze_vector_table`, `describe_table` vector-dimension awareness,
+HNSW/IVFFlat detection in `list_indexes`):
+
+| # | Item | Effort | Value | Notes |
+|---|---|---|---|---|
+| 11.1 | **`hybrid_search`** — combine vector + full-text scoring via reciprocal-rank fusion | M | Very High | Single biggest unmet need in agentic retrieval. Pairs the existing `vector_search` and `full_text_search` into one ranked result set. |
+| 11.2 | **`range_search`** — find rows within a distance threshold (not top-k) | S | High | Different query shape than k-NN; common for de-dup / similarity gating. |
+| 11.3 | **`recommend_vector_quantization`** — flag tables where `halfvec` (16-bit) or `bit` quantization would cut storage 2-32× | S-M | High | pgvector v0.7+. Compares dim × row-count × bytes vs working-set memory; concrete cost win. |
+| 11.4 | **HNSW recall/speed tuner** (`analyze_hnsw_recall`) — sweep `ef_search` against a ground-truth set, return recall@k curves | M | High | Lets agents pick the right speed/quality knob without manual tuning. |
+| 11.5 | **`mmr_search`** — Maximal Marginal Relevance re-ranking on top of vector_search for result diversity | S-M | Medium-High | Quality of agent RAG flows improves materially. |
+| 11.6 | **`cluster_vectors`** — k-means cluster a vector column, return centroids + per-row labels | M | Medium-High | Exploration / segmentation tool; uses ``cube_distance`` or in-memory clustering. |
+| 11.7 | **`detect_vector_outliers`** — flag rows whose embedding is far from any cluster centroid | S-M | Medium-High | Data quality + content moderation. |
+| 11.8 | **`monitor_embedding_drift`** — compare distributional stats of vectors over time windows | M | Medium | Ops / model-quality monitoring. |
+| 11.9 | **`import_vectors`** — bulk-load embeddings from JSON/CSV with `vector(N)` column-type validation | S | Medium | Sibling of `import_csv` specialised for vector columns. |
+| 11.10 | **`cross_table_similarity`** — given a row in table A, find the k most similar rows in table B (different embedding source, same dim) | S | Medium | Useful for entity resolution / linking across tables. |
+| 11.11 | **`analyze_distance_metric`** — heuristically recommend cosine vs L2 vs inner-product based on vector magnitude distribution | S | Medium | Concrete advice when the user hasn't decided yet. |
+| 11.12 | **`monitor_index_build`** — surface HNSW / IVFFlat build progress for long-running index creations | S | Medium | Lives next to `list_active_queries`; useful for big-table index work. |
+| 11.13 | **`migrate_vector_to_halfvec`** — generate the DDL to convert a `vector(N)` column to `halfvec(N)` (or `bit`) safely | S-M | Medium | Pairs with 11.3. Uses the existing migration shadow workflow for the structural review. |
+
+**Suggested pgvector picks for Tier A:**
+- **11.1 `hybrid_search`** (Very High value, M effort) — biggest agentic-RAG win
+- **11.3 `recommend_vector_quantization`** (High value, S-M effort) — concrete cost savings
+- **11.2 `range_search`** (High value, S effort) — quick win that fills a real gap
+
+These three would bring the pgvector tool surface from 4 → 7 and
+cover the most common gaps agentic-RAG workflows hit.
+
+---
+
 ## Suggested priority tiers
 
 These are my recommendations to bucket the list — feel free to override.
@@ -123,6 +156,9 @@ These are my recommendations to bucket the list — feel free to override.
 - 8.2 Unused-table / column finder (S, High)
 - 10.1 `why_is_this_slow` composite tool (M, Very High)
 - 4.2 TimescaleDB wrappers (M, High)
+- **11.1 Hybrid (vector + FTS) search** (M, Very High)
+- **11.3 Vector quantization advisor** (S-M, High)
+- **11.2 Vector range search** (S, High)
 
 **Tier B — strong UX or coverage wins:**
 - 1.4 Per-request `SET ROLE` multi-tenancy (M, High)

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -3,6 +3,39 @@
 The tools MCPg exposes over MCP, grouped by category. Availability depends on
 the configured access mode (see the [User Guide](user-guide.md)).
 
+## Capability gates at a glance
+
+| Capability | Default access mode | Extra opt-in | What it unlocks |
+|---|---|---|---|
+| READ | every mode | — | catalog introspection, query, search, health, ORM exporters |
+| WRITE | unrestricted | — | `run_write`, `run_maintenance`, `cancel_query`, `terminate_backend`, `import_csv`, `import_json`, `pg_cron` writes |
+| DDL | unrestricted | `MCPG_ALLOW_DDL=true` | `run_ddl`, `enable_extension`, `pg_partman` write tools, **migration tools** (`MIGRATE` capability piggybacks on this gate) |
+| SHELL | unrestricted | `MCPG_ALLOW_SHELL=true` | `dump_database`, `restore_database`, `copy_table_between_databases` |
+| LISTEN | unrestricted | `MCPG_ALLOW_LISTEN=true` | `subscribe_channel`, `poll_notifications`, `unsubscribe_channel`, `list_notification_subscriptions` |
+
+## Tool index (78 tools)
+
+| Category | Tools |
+|---|---|
+| **Server** | `get_server_info` |
+| **Catalog — schemas / tables / columns** | `list_schemas`, `list_tables`, `describe_table`, `list_indexes`, `list_constraints`, `list_views`, `list_functions`, `list_triggers`, `list_partitions`, `list_roles`, `list_grants`, `list_policies`, `list_sequences`, `list_enums`, `list_domains`, `list_composite_types`, `list_foreign_keys`, `list_foreign_data_wrappers`, `list_foreign_servers`, `list_foreign_tables`, `list_user_mappings`, `list_publications`, `list_subscriptions`, `list_extensions`, `list_available_extensions` |
+| **Visualisation & structural diff** | `generate_schema_diagram`, `compare_schemas` |
+| **Query intelligence** | `run_select`, `explain_query`, `analyze_query_plan` |
+| **Health & tuning** | `check_database_health`, `analyze_workload`, `recommend_indexes`, `run_advisors` |
+| **Search** | `fuzzy_search`, `full_text_search`, `vector_search`, `geo_search` |
+| **Vector tuning advisors** | `recommend_vector_index`, `analyze_vector_search`, `analyze_vector_table` |
+| **Live ops** | `list_active_queries` |
+| **Audit trail** | `list_audit_events` |
+| **Data movement — read** | `export_query`, `export_table` |
+| **Data movement — write (gated)** | `import_csv`, `import_json` |
+| **Data movement — subprocess (gated)** | `dump_database`, `restore_database`, `copy_table_between_databases` |
+| **LISTEN/NOTIFY bridge (gated)** | `subscribe_channel`, `poll_notifications`, `unsubscribe_channel`, `list_notification_subscriptions` |
+| **Staged migrations (gated)** | `prepare_migration`, `complete_migration`, `cancel_migration`, `list_pending_migrations` |
+| **ORM-DSL exporters** | `generate_prisma_schema`, `generate_drizzle_schema`, `generate_sqlalchemy_models`, `generate_sqlc_schema`, `generate_diesel_schema`, `generate_jooq_config`, `generate_ent_schemas`, `generate_ecto_schemas` |
+| **pg_cron write (gated)** | `pg_cron.schedule`, `pg_cron.unschedule`, `pg_cron.update` |
+| **pg_partman write (gated)** | `partman.create_parent`, `partman.run_maintenance`, `partman.drop_partition_time` |
+| **Write & DDL (gated)** | `run_write`, `run_ddl`, `run_maintenance`, `cancel_query`, `terminate_backend`, `enable_extension` |
+
 ## Server
 
 ### `get_server_info`
@@ -260,9 +293,235 @@ allowlisted extensions (`pg_trgm`, `vector`, `citext`, `postgis`, ...) may be
 enabled. Requires `unrestricted` mode **and** `MCPG_ALLOW_DDL=true`.
 Parameter: `name` (string).
 
+## Data movement — read
+
+### `export_query`
+Runs a read-only SQL query through `run_select`'s safety checks and
+serialises the rows to CSV or JSON. Truncates at `limit` (default 10 000)
+with a `truncated` flag so callers can paginate via their own
+`LIMIT`/`OFFSET`. Parameters: `sql`, `format` (`csv`/`json`), `limit`.
+
+### `export_table`
+Like `export_query` but takes `schema` + `table` directly. Names are
+validated against the plain-identifier allowlist; anything that would
+need delimited-identifier quoting is rejected.
+
+## Data movement — write (`unrestricted` only)
+
+### `import_csv`
+Bulk-loads CSV `content` into `schema.table` via `COPY ... FROM STDIN`.
+The text is sent verbatim; the caller is responsible for correctness
+(matching column count, proper quoting). Parameters: `header` (skip the
+first row), `delimiter` (single non-newline, non-quote character),
+optional `columns` (explicit column list — each validated).
+
+### `import_json`
+Parses a JSON array of objects, derives the column list from the first
+row (or an explicit `columns` arg), and runs a parametrised
+`INSERT ... executemany`. Nested dict/list values are JSON-serialised
+so they round-trip into `jsonb` columns; missing keys in later rows
+bind as `NULL`.
+
+## Data movement — subprocess (`unrestricted` + `MCPG_ALLOW_SHELL=true`)
+
+These tools shell out to PostgreSQL binaries (`pg_dump`, `pg_restore`,
+`psql`) through `mcpg.shell.run_pg_binary`, which enforces the
+ADR-0004 policy: allowlisted binaries only, `asyncio.create_subprocess_exec`
+(no shell), argv-only invocation, hard timeout, output cap with
+truncation flag, libpq env-var credentials (never on argv).
+
+### `dump_database`
+Runs `pg_dump` against the configured database. `format='plain'`
+returns SQL text; `'custom'` / `'tar'` return base64-encoded bytes.
+`schema_only` toggles `--schema-only`. Result carries `exit_code`,
+`output_bytes`, `output_truncated`, `timed_out`, and `stderr_tail`.
+
+### `restore_database`
+Pipes a dump into the configured database. `format='plain'` pipes the
+SQL through `psql --single-transaction --set=ON_ERROR_STOP=on`;
+`custom` / `tar` base64-decode `content` and pipe it through
+`pg_restore --single-transaction --exit-on-error --no-owner
+--no-privileges`. pg_restore is invoked with `--dbname=postgresql:///`
+so libpq fills in the connection params from the `PG*` env vars —
+credentials never appear on argv.
+
+### `copy_table_between_databases`
+Pipes `pg_dump --format=custom --table=schema.table` (source URL) into
+`pg_restore --format=custom` (destination URL) with separate libpq
+env dicts per leg. `include_schema` and `include_data` are required
+(no defaults). A truncated dump raises before pg_restore runs; a
+failed dump returns the dump stderr_tail with `restore_exit_code=-1`.
+
+## LISTEN/NOTIFY bridge (`unrestricted` + `MCPG_ALLOW_LISTEN=true`)
+
+Per ADR-0005, MCPg uses the tool-poll model — a dedicated PG
+connection (separate from the request pool, opened lazily on first
+subscribe) drains `notifies()` into per-subscription bounded queues.
+Overflow drops oldest and surfaces `dropped_count` on the next poll's
+first message. `MCPG_LISTEN_QUEUE_MAX` (default 1000) caps the queue.
+
+### `subscribe_channel`
+Opens `LISTEN "channel"` (idempotent per channel) and returns a
+subscription id. Channel name must match `[A-Za-z_][A-Za-z0-9_]*`.
+
+### `poll_notifications`
+Drains up to `max_messages` (default 100) notifications from the
+queue, waiting at most `timeout_ms` (default 0) for the first one
+when the queue is empty. Each notification carries `channel`,
+`payload`, `delivered_at`, `dropped_count`.
+
+### `unsubscribe_channel`
+Removes a subscription. `UNLISTEN` fires when the last subscriber on
+the channel goes away. Returns `removed: true` if the subscription
+existed.
+
+### `list_notification_subscriptions`
+Lists active `{subscription_id, channel}` pairs for visibility.
+
+## Staged migrations (`unrestricted` + `MCPG_ALLOW_DDL=true`)
+
+Per ADR-0006, MCPg uses a **same-database shadow schema** strategy.
+`prepare_migration` clones the target schema's structure into
+`mcpg_shadow_<id>` via introspection (no `pg_dump` shell-out), applies
+the candidate SQL there, then runs `compare_schemas(target, shadow)`
+so the agent reviews the structural diff before completion. State
+lives in `mcpg_migrations.staged` (auto-created on first call).
+
+### `prepare_migration`
+Clones the target schema into a shadow, applies `candidate_sql` with
+`SET LOCAL search_path` so unqualified identifiers resolve there, runs
+`compare_schemas`, and persists the staged row. Returns the migration
+id, shadow schema name, TTL, and structural diff. Candidate SQL that
+needs to run outside a transaction (CREATE INDEX CONCURRENTLY, VACUUM,
+ALTER SYSTEM) is refused with a clear error pointing at `run_ddl`.
+
+### `complete_migration`
+Applies the original candidate SQL to the target schema (same SET LOCAL
+treatment) and drops the shadow. Refuses if the migration isn't in
+`prepared` status or has expired.
+
+### `cancel_migration`
+Drops the shadow without applying. Idempotent — returns
+`shadow_dropped=false` when the migration row doesn't exist.
+
+### `list_pending_migrations`
+Lists migrations in `prepared` status, newest first. Sweeps expired
+entries (drops their shadows, flips status to `expired`) before
+listing.
+
+## Audit trail
+
+### `list_audit_events`
+Lists rows from `mcpg_audit.events` (newest first). Returns `[]` when
+`MCPG_AUDIT_PERSIST` has never been turned on. Optional `tool` filter.
+
+## ORM-DSL exporters
+
+Every exporter is **read-only**. They share a v1 coverage boundary:
+base tables, columns with PG-native types, primary keys, single-column
+intra-schema foreign keys, and enum types. Cross-schema FKs and
+composite FKs are documented v1 gaps for all of them. Views, foreign
+tables, partitions, triggers, functions, and composite types are out
+of scope.
+
+### `generate_prisma_schema`
+Emits a Prisma `.prisma` schema (mirrors `prisma db pull`). Default-
+mapped types include `Int`, `BigInt`, `String`, `Boolean`, `Json`,
+`DateTime`, `Decimal`, `Bytes`; unmapped types fall back to
+`Unsupported("...")`.
+
+### `generate_drizzle_schema`
+Emits a Drizzle ORM TypeScript schema (`drizzle-orm/pg-core`).
+`pgTable` consts with PG-native helpers (`integer`, `bigint`, `varchar`
+with length, `timestamp` with `withTimezone: true`, `jsonb`, ...),
+single-column FK chains via `.references(() => target.col)`, `pgEnum`
+consts for enum types, `serial` / `bigserial` detected from `nextval`
+defaults. The helper-import line is computed from what's actually
+emitted — unused helpers don't clutter the output.
+
+### `generate_sqlalchemy_models`
+Emits a SQLAlchemy 2.0 declarative file (`DeclarativeBase` +
+`Mapped[T]` + `mapped_column`). Core types from `sqlalchemy` and
+PG-dialect types (`JSONB`) from `sqlalchemy.dialects.postgresql`.
+Single-column FKs land inline via `ForeignKey("schema.table.col")`;
+composite uniques go in `__table_args__` as `UniqueConstraint`. PG
+enums become Python `enum.Enum` classes via the class-body form when
+all labels are valid identifiers, or the functional
+`enum.Enum("Name", {...})` form when any label needs sanitising
+(hyphens, spaces, leading digits, keywords).
+
+### `generate_sqlc_schema`
+Emits a sqlc-friendly `schema.sql` — plain DDL ordered for clean
+replay against an empty database: `CREATE SCHEMA` → `CREATE TYPE`
+enums → `CREATE TABLE` (columns only) → `ALTER TABLE ADD CONSTRAINT`
+(PK / unique / check / FK) → `CREATE INDEX`. In-process, no
+`MCPG_ALLOW_SHELL` needed.
+
+### `generate_diesel_schema`
+Emits a Diesel ORM (Rust) `schema.rs` with one `table!` macro per
+table (column → Diesel SQL type, `Nullable<T>` for nullable columns),
+`joinable!` for single-column intra-schema FKs, and
+`allow_tables_to_appear_in_same_query!` so multi-table joins
+type-check. Enum types emit as `Text`-backed wrapper enums in a
+`pg_enum` module — output works without `diesel_derive_enum`.
+
+### `generate_jooq_config`
+Emits a `jooq-codegen` `<configuration>` XML pointing at the live
+database. Unlike the other exporters, jOOQ generates Java code itself
+at build time — the artefact here is the config file the user feeds
+to `mvn jooq-codegen:generate`. Explicit `<includes>` regex names
+every base table; `<excludes>` covers MCPg's bookkeeping schemas;
+`<forcedType>` entries map every `json` / `jsonb` column to
+`org.jooq.JSON` / `org.jooq.JSONB`. Parameters: `target_package`,
+`target_directory`.
+
+### `generate_ent_schemas`
+Emits Ent (Go) Schema struct files — returns `{filename: source}`.
+Each file has the PascalCase struct, `Fields()` with `field.X(...)`
+calls (`field.Int`, `field.Text`, `field.Bool`, `field.Time`,
+`field.JSON`, `field.UUID`, `field.Enum`, ...), `Edges()` with
+`edge.To(...)` for single-column FKs, and `field.Enum().Values(...)`
+for enum-typed columns.
+
+### `generate_ecto_schemas`
+Emits Ecto (Elixir) schema modules — returns `{filename: source}`.
+Files are named after the singularised table (`users` → `user.ex`,
+per the Phoenix convention). Each module has `use Ecto.Schema`,
+`@primary_key`, `field` declarations, `belongs_to` for single-column
+FKs (stripping the `_id` suffix for the association name), and
+`timestamps()` when both `inserted_at` and `updated_at` are present.
+The Elixir top-level module is configurable via the `app_module`
+arg (default `MyApp`).
+
+## pg_cron writes (`unrestricted`)
+
+### `pg_cron.schedule`
+Schedules a SQL command via `cron.schedule(name, schedule, command)`.
+Returns the job id. Requires the `pg_cron` extension enabled.
+
+### `pg_cron.unschedule`
+Removes a scheduled job by id or name.
+
+### `pg_cron.update`
+Updates a scheduled job's command or schedule.
+
+## pg_partman writes (`unrestricted` + `MCPG_ALLOW_DDL=true`)
+
+### `partman.create_parent`
+Configures a table as a pg_partman-managed parent partition.
+
+### `partman.run_maintenance`
+Runs `partman.run_maintenance()` to create/retire partitions.
+
+### `partman.drop_partition_time`
+Drops time-based partitions older than the cutoff.
+
 ## Errors
 
 Tools reject unsafe or invalid input before it reaches the database. Rejected
 calls return an MCP error result; the message explains the cause (unsafe
 statement, parse failure, non-positive `max_rows`, etc.). Every call —
-success or failure — is recorded to the `mcpg.audit` logger.
+success or failure — is recorded to the `mcpg.audit` logger. With
+`MCPG_AUDIT_PERSIST=true`, every `run_write` / `run_ddl` is also written to
+`mcpg_audit.events` with redacted arguments + result; query the table via
+`list_audit_events`.

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -72,6 +72,9 @@ list_active_queries()                                # who's running what right 
 fuzzy_search(schema, table, column, query)           # pg_trgm trigram
 full_text_search(schema, table, column, query)       # tsvector / tsquery
 vector_search(schema, table, column, query_vector, k=10, operator="<->")  # pgvector k-NN
+vector_range_search(schema, table, column, query_vector, max_distance)    # pgvector threshold
+hybrid_search(schema, table, vector_col, text_col, query_vector, text_query)
+                                                     # vector + FTS fused via RRF
 geo_search(schema, table, column, lon, lat, k=10)    # PostGIS k-NN
 ```
 
@@ -79,6 +82,7 @@ geo_search(schema, table, column, lon, lat, k=10)    # PostGIS k-NN
 
 ```
 recommend_vector_index(schema, table, column)        # HNSW vs IVFFlat heuristics
+recommend_vector_quantization(schema)                # vector -> halfvec storage advisor
 analyze_vector_search(schema, table, column, query_vector)
 analyze_vector_table(schema, table)
 ```

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -4,7 +4,7 @@ A compact one-page tour of every tool MCPg exposes, organised by
 **what an agent typically wants to do**. Use this as a discovery surface;
 the full reference is in [`tools.md`](tools.md).
 
-**84 tools.** Numbers in `()` after each tool show roughly how parameters
+**90 tools.** Numbers in `()` after each tool show roughly how parameters
 land — required ones first, common defaults afterwards.
 
 ## "What's in this database?"
@@ -186,11 +186,22 @@ partman.run_maintenance()
 partman.drop_partition_time(parent_table, retention)
 ```
 
+## "Manage TimescaleDB hypertables" (`unrestricted` + `MCPG_ALLOW_DDL=true` + timescaledb installed)
+
+```
+list_hypertables()                                          # read-only — every mode
+list_chunks(schema, table)                                  # read-only — every mode
+create_hypertable(schema, table, time_column, chunk_time_interval='7 days', if_not_exists=true)
+add_compression_policy(schema, table, compress_after='7 days')
+add_retention_policy(schema, table, drop_after='30 days')
+```
+
 ## "Who did what?"
 
 ```
 list_audit_events(limit=100, tool=null)              # MCPG_AUDIT_PERSIST=true required
 get_server_info()                                    # version, mode, transport, DB state
+get_metrics_exposition()                             # Prometheus text-format snapshot
 ```
 
 ## Reading more

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -4,7 +4,7 @@ A compact one-page tour of every tool MCPg exposes, organised by
 **what an agent typically wants to do**. Use this as a discovery surface;
 the full reference is in [`tools.md`](tools.md).
 
-**78 tools.** Numbers in `()` after each tool show roughly how parameters
+**84 tools.** Numbers in `()` after each tool show roughly how parameters
 land — required ones first, common defaults afterwards.
 
 ## "What's in this database?"
@@ -62,8 +62,16 @@ analyze_query_plan(sql)                              # walks the EXPLAIN tree
 check_database_health()                              # connections + cache + dead tuples + invalid indexes + replication lag + bloat
 analyze_workload(top_n=10)                           # slow queries from pg_stat_statements
 recommend_indexes()                                  # missing-index heuristics
-run_advisors()                                       # aggregate of the above
+run_advisors(schema)                                 # aggregate of the above (per schema)
+find_unused_objects(schema)                          # zero-scan tables and user indexes
 list_active_queries()                                # who's running what right now
+```
+
+## "Tell me everything about this table / why is this query slow"
+
+```
+summarize_table(schema, table, sample_rows=5)        # columns + PK + FKs + indexes + stats + sample, one call
+why_is_this_slow(sql)                                # EXPLAIN + plan analysis + locks + cache + suggestions, one call
 ```
 
 ## "Search for something"

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -1,0 +1,190 @@
+# MCPg tool tour
+
+A compact one-page tour of every tool MCPg exposes, organised by
+**what an agent typically wants to do**. Use this as a discovery surface;
+the full reference is in [`tools.md`](tools.md).
+
+**78 tools.** Numbers in `()` after each tool show roughly how parameters
+land — required ones first, common defaults afterwards.
+
+## "What's in this database?"
+
+Catalog introspection — all read-only, available in every access mode.
+
+```
+list_schemas(include_system=false)
+list_tables(schema)
+describe_table(schema, table)
+list_indexes(schema, table)
+list_constraints(schema, table)
+list_views(schema)
+list_functions(schema)
+list_triggers(schema, table)
+list_partitions(schema, table)
+list_foreign_keys(schema)
+list_roles(include_system=false)
+list_grants(schema, table)
+list_policies(schema, table)         # row-level security
+list_sequences(schema)
+list_enums(schema)
+list_domains(schema)
+list_composite_types(schema)
+list_foreign_data_wrappers()         # FDW infrastructure
+list_foreign_servers()
+list_foreign_tables(schema)
+list_user_mappings()
+list_publications()                  # logical replication
+list_subscriptions()
+list_extensions()
+list_available_extensions()
+```
+
+## "Show me the shape"
+
+Visualisation + structural diff.
+
+```
+generate_schema_diagram(schema)                      # Mermaid ER text
+compare_schemas(left_schema, right_schema)           # added/removed/changed
+```
+
+## "Run a query / explain a plan"
+
+```
+run_select(sql, max_rows=1000)
+explain_query(sql, format="json")
+analyze_query_plan(sql)                              # walks the EXPLAIN tree
+```
+
+## "Is this database healthy?"
+
+```
+check_database_health()                              # connections + cache + dead tuples + invalid indexes + replication lag + bloat
+analyze_workload(top_n=10)                           # slow queries from pg_stat_statements
+recommend_indexes()                                  # missing-index heuristics
+run_advisors()                                       # aggregate of the above
+list_active_queries()                                # who's running what right now
+```
+
+## "Search for something"
+
+```
+fuzzy_search(schema, table, column, query)           # pg_trgm trigram
+full_text_search(schema, table, column, query)       # tsvector / tsquery
+vector_search(schema, table, column, query_vector, k=10, operator="<->")  # pgvector k-NN
+geo_search(schema, table, column, lon, lat, k=10)    # PostGIS k-NN
+```
+
+## "Tune pgvector"
+
+```
+recommend_vector_index(schema, table, column)        # HNSW vs IVFFlat heuristics
+analyze_vector_search(schema, table, column, query_vector)
+analyze_vector_table(schema, table)
+```
+
+## "Move data in / out"
+
+**Read** (no opt-in needed):
+```
+export_query(sql, format="csv", limit=10000)
+export_table(schema, table, format="csv", limit=10000)
+```
+
+**Write** (`unrestricted` mode):
+```
+import_csv(schema, table, content, header=true, delimiter=",", columns=null)
+import_json(schema, table, content, columns=null)
+```
+
+**Subprocess** (`unrestricted` + `MCPG_ALLOW_SHELL=true`):
+```
+dump_database(format="plain", schema_only=false)
+restore_database(content, format="plain")
+copy_table_between_databases(source_url, schema, table, include_schema, include_data)
+```
+
+## "React to database events" (`unrestricted` + `MCPG_ALLOW_LISTEN=true`)
+
+```
+subscribe_channel(channel)                           # returns subscription_id
+poll_notifications(subscription_id, timeout_ms=0, max_messages=100)
+unsubscribe_channel(subscription_id)
+list_notification_subscriptions()
+```
+
+## "Stage a migration with review" (`unrestricted` + `MCPG_ALLOW_DDL=true`)
+
+```
+prepare_migration(name, target_schema, candidate_sql, ttl_minutes=60)
+                                                     # returns id + shadow + diff
+complete_migration(migration_id)                     # applies to target
+cancel_migration(migration_id)                       # drops shadow
+list_pending_migrations()
+```
+
+## "Generate code for my ORM"
+
+All read-only; pick the one your project uses.
+
+```
+generate_prisma_schema(schema)                       # .prisma (TypeScript)
+generate_drizzle_schema(schema)                      # drizzle-orm/pg-core (TypeScript)
+generate_sqlalchemy_models(schema)                   # SQLAlchemy 2.0 (Python)
+generate_sqlc_schema(schema)                         # plain schema.sql for sqlc (Go)
+generate_diesel_schema(schema)                       # Diesel schema.rs (Rust)
+generate_jooq_config(schema, target_package, target_directory)
+                                                     # jooq-codegen config XML (Java)
+generate_ent_schemas(schema)                         # one .go per table (Go)
+generate_ecto_schemas(schema, app_module="MyApp")    # one .ex per table (Elixir)
+```
+
+All eight share v1 coverage: base tables, columns, primary keys,
+single-column intra-schema FKs, enums. Cross-schema and composite FKs
+are documented gaps.
+
+## "Write to the database" (`unrestricted` mode)
+
+```
+run_write(sql)                                       # one INSERT/UPDATE/DELETE; add RETURNING
+run_maintenance(operation, schema, table)            # VACUUM / ANALYZE / REINDEX
+cancel_query(pid)
+terminate_backend(pid)
+```
+
+Plus `MCPG_ALLOW_DDL=true`:
+```
+run_ddl(sql, schema=null, table=null)                # one DDL statement; optional schema-diff snapshot
+enable_extension(name)                               # allowlisted extensions only
+```
+
+## "Schedule a job" (`unrestricted` + pg_cron installed)
+
+```
+pg_cron.schedule(name, schedule, command)
+pg_cron.unschedule(name_or_id)
+pg_cron.update(name_or_id, ...)
+```
+
+## "Manage partitions" (`unrestricted` + `MCPG_ALLOW_DDL=true` + pg_partman installed)
+
+```
+partman.create_parent(parent_table, control, partition_type, partition_interval)
+partman.run_maintenance()
+partman.drop_partition_time(parent_table, retention)
+```
+
+## "Who did what?"
+
+```
+list_audit_events(limit=100, tool=null)              # MCPG_AUDIT_PERSIST=true required
+get_server_info()                                    # version, mode, transport, DB state
+```
+
+## Reading more
+
+- [`tools.md`](tools.md) — full parameter / return shape per tool.
+- [`user-guide.md`](user-guide.md) — narrative walkthrough.
+- [`security.md`](security.md) — threat model + access-mode boundaries.
+- [`architecture.md`](architecture.md) — design + module map.
+- [`adr/`](adr/) — accepted architecture decision records.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -109,9 +109,55 @@ gracefully**: if the extension is not installed, the tool returns
 | `analyze_workload`  | `pg_stat_statements` |
 | `vector_search`     | `vector` (pgvector) |
 | `geo_search`        | `postgis` |
+| `pg_cron.*`         | `pg_cron` |
+| `partman.*`         | `pg_partman` |
 
 In `unrestricted` + `MCPG_ALLOW_DDL` mode, `enable_extension` can install an
 allowlisted extension.
+
+## Data movement (post-0.3.0)
+
+Five tools cover moving data in / out of the database:
+
+- **In-process exports**: `export_query` / `export_table` serialise rows
+  to CSV or JSON. Read-only, no opt-in.
+- **In-process imports**: `import_csv` / `import_json` bulk-load via
+  `COPY ... FROM STDIN` and parametrised `executemany`. Require
+  `unrestricted` (WRITE capability).
+- **Subprocess dump / restore**: `dump_database` / `restore_database`
+  shell out to `pg_dump` / `psql` / `pg_restore`. Require `unrestricted` +
+  `MCPG_ALLOW_SHELL=true`.
+- **Cross-DB copy**: `copy_table_between_databases` pipes `pg_dump` on
+  one URL into `pg_restore` on another. Same opt-in.
+
+## Reactive workflows: LISTEN/NOTIFY (post-0.3.0)
+
+`subscribe_channel` opens a PG `LISTEN` on a dedicated connection and
+returns a subscription id; `poll_notifications` drains the per-sub
+bounded queue with an optional wait; `unsubscribe_channel` removes the
+subscription; `list_notification_subscriptions` reports the active
+ones. Requires `unrestricted` + `MCPG_ALLOW_LISTEN=true`. The
+`MCPG_LISTEN_QUEUE_MAX` env var caps queue size (default 1000); overflow
+drops the oldest message and surfaces `dropped_count` on the next poll.
+
+## Staged migrations (post-0.3.0)
+
+`prepare_migration` clones the target schema's structure into a shadow,
+applies your candidate SQL there, and runs `compare_schemas` so you
+review the structural diff. `complete_migration` lands it on the
+target. `cancel_migration` drops the shadow without applying.
+`list_pending_migrations` shows what's staged. Requires `unrestricted`
++ `MCPG_ALLOW_DDL=true` (the existing DDL gate; no new env var).
+
+## ORM bridges (post-0.3.0)
+
+Eight read-only exporters generate a starting schema/model file from
+the live PG catalog: `generate_prisma_schema`, `generate_drizzle_schema`,
+`generate_sqlalchemy_models`, `generate_sqlc_schema`,
+`generate_diesel_schema`, `generate_jooq_config`, `generate_ent_schemas`,
+`generate_ecto_schemas`. All share a v1 coverage boundary (base tables,
+columns, PKs, single-column intra-schema FKs, enums). See
+[`tools.md`](tools.md#orm-dsl-exporters) for details per exporter.
 
 ## Auditing
 
@@ -119,15 +165,27 @@ Every tool call — success or failure — is logged to the `mcpg.audit` logger
 with the tool name, arguments (secrets masked), and outcome. Configure where
 that logger's records are shipped in your deployment's logging setup.
 
+With `MCPG_AUDIT_PERSIST=true`, every `run_write` and `run_ddl` is **also**
+persisted to `mcpg_audit.events` (auto-created) with the redacted arguments
++ result + status. Query the table via the `list_audit_events` tool.
+
 ## Troubleshooting
 
 - **"configuration error" on start** — a required/invalid environment
   variable; the message names it. See the [Installation Guide](installation.md).
 - **A write tool is missing** — set `MCPG_ACCESS_MODE=unrestricted` (and
-  `MCPG_ALLOW_DDL=true` for `run_ddl` / `enable_extension`).
+  `MCPG_ALLOW_DDL=true` for `run_ddl` / `enable_extension` / migration tools;
+  `MCPG_ALLOW_SHELL=true` for `dump_database` / `restore_database` /
+  `copy_table_between_databases`; `MCPG_ALLOW_LISTEN=true` for the
+  LISTEN/NOTIFY tools).
 - **`analyze_workload` / `fuzzy_search` report `available: false`** — the
   required extension is not installed in the target database.
 - **A query is rejected** — `run_select` only permits safe read-only
   statements; writes, DDL, and multi-statement input are refused by design.
 - **Connection failures** — verify `MCPG_DATABASE_URL` and that the database
   is reachable; errors are reported with the password redacted.
+- **`prepare_migration` refuses with "cannot run inside a transaction"** —
+  the candidate SQL contains a `CONCURRENTLY` / `VACUUM` / `ALTER SYSTEM`
+  statement. The staged-migration workflow always wraps the candidate in
+  a SET LOCAL transaction; run those statements directly via `run_ddl`
+  instead.

--- a/src/mcpg/advisors.py
+++ b/src/mcpg/advisors.py
@@ -204,3 +204,127 @@ async def run_advisors(driver: SqlDriver, schema: str) -> AdvisorReport:
     findings.extend(await _duplicate_indexes(driver, schema))
     findings.extend(await _nullable_timestamps_without_tz(driver, schema))
     return AdvisorReport(schema=schema, rules_run=list(_RULES), findings=findings)
+
+
+# --- unused-objects finder (Phase 8.2) -----------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class UnusedTable:
+    """A table that has had zero scans since pg_stat was last reset.
+
+    Zero scans is a strong signal — even an idle table normally
+    receives an occasional scan from `ANALYZE` or a one-off query.
+    But it is a SIGNAL, not a proof: the table may have been
+    created recently or stats may have been reset. Tools surface
+    the seq_scan + idx_scan + ins+upd+del counts so the agent can
+    decide for itself.
+    """
+
+    schema: str
+    table: str
+    seq_scans: int
+    index_scans: int
+    rows_modified: int
+    estimated_row_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class UnusedIndex:
+    """A user-defined index that has been scanned zero times.
+
+    Excludes indexes backing PRIMARY KEY / UNIQUE constraints — PG
+    needs those for integrity enforcement regardless of scan counts.
+    """
+
+    schema: str
+    table: str
+    index: str
+    size_bytes: int
+    definition: str
+
+
+@dataclass(frozen=True, slots=True)
+class UnusedObjectsReport:
+    """The result of :func:`find_unused_objects`.
+
+    ``tables`` and ``indexes`` are sorted by name (deterministic) so
+    repeated runs produce identical output and the diff is reviewable.
+    """
+
+    schema: str
+    tables: list[UnusedTable]
+    indexes: list[UnusedIndex]
+
+
+async def find_unused_objects(driver: SqlDriver, schema: str) -> UnusedObjectsReport:
+    """Find tables and indexes with zero scans since stats were reset.
+
+    Tables: zero combined sequential + index scans AND zero writes
+    (the row never moved). A genuinely cold table.
+
+    Indexes: zero index scans. Indexes backing PRIMARY KEY or UNIQUE
+    constraints are excluded — PG needs those for enforcement even if
+    no query reads through them.
+
+    Both lists report alongside enough context (size, definition,
+    write count) for the agent to decide whether the object is safe
+    to drop. **This is a SIGNAL, not a verdict** — recent stats
+    resets, or tables only touched during deploys, can produce
+    false positives.
+    """
+    table_rows = await driver.execute_query(
+        "SELECT s.relname AS table_name, "
+        "       COALESCE(s.seq_scan, 0) AS seq_scans, "
+        "       COALESCE(s.idx_scan, 0) AS index_scans, "
+        "       (COALESCE(s.n_tup_ins, 0) + COALESCE(s.n_tup_upd, 0) + COALESCE(s.n_tup_del, 0)) AS rows_modified, "
+        "       COALESCE(c.reltuples, 0)::bigint AS estimated_row_count "
+        "FROM pg_stat_user_tables s "
+        "JOIN pg_class c ON c.oid = s.relid "
+        "WHERE s.schemaname = %s "
+        "AND COALESCE(s.seq_scan, 0) = 0 "
+        "AND COALESCE(s.idx_scan, 0) = 0 "
+        "AND (COALESCE(s.n_tup_ins, 0) + COALESCE(s.n_tup_upd, 0) + COALESCE(s.n_tup_del, 0)) = 0 "
+        "ORDER BY s.relname",
+        params=[schema],
+        force_readonly=True,
+    )
+    unused_tables = [
+        UnusedTable(
+            schema=schema,
+            table=str(row.cells["table_name"]),
+            seq_scans=int(row.cells["seq_scans"]),
+            index_scans=int(row.cells["index_scans"]),
+            rows_modified=int(row.cells["rows_modified"]),
+            estimated_row_count=int(row.cells["estimated_row_count"]),
+        )
+        for row in table_rows or []
+    ]
+
+    index_rows = await driver.execute_query(
+        "SELECT s.relname AS table_name, "
+        "       s.indexrelname AS index_name, "
+        "       pg_relation_size(s.indexrelid) AS size_bytes, "
+        "       pg_get_indexdef(s.indexrelid) AS definition "
+        "FROM pg_stat_user_indexes s "
+        "JOIN pg_index i ON i.indexrelid = s.indexrelid "
+        "WHERE s.schemaname = %s "
+        "AND COALESCE(s.idx_scan, 0) = 0 "
+        "AND NOT i.indisprimary "
+        "AND NOT i.indisunique "
+        "ORDER BY s.relname, s.indexrelname",
+        params=[schema],
+        force_readonly=True,
+    )
+    unused_indexes = [
+        UnusedIndex(
+            schema=schema,
+            table=str(row.cells["table_name"]),
+            index=str(row.cells["index_name"]),
+            size_bytes=int(row.cells["size_bytes"]),
+            definition=str(row.cells["definition"]),
+        )
+        for row in index_rows or []
+    ]
+
+    return UnusedObjectsReport(schema=schema, tables=unused_tables, indexes=unused_indexes)

--- a/src/mcpg/advisors.py
+++ b/src/mcpg/advisors.py
@@ -304,7 +304,7 @@ async def find_unused_objects(driver: SqlDriver, schema: str) -> UnusedObjectsRe
     index_rows = await driver.execute_query(
         "SELECT s.relname AS table_name, "
         "       s.indexrelname AS index_name, "
-        "       pg_relation_size(s.indexrelid) AS size_bytes, "
+        "       COALESCE(pg_relation_size(s.indexrelid), 0) AS size_bytes, "
         "       pg_get_indexdef(s.indexrelid) AS definition "
         "FROM pg_stat_user_indexes s "
         "JOIN pg_index i ON i.indexrelid = s.indexrelid "

--- a/src/mcpg/composite.py
+++ b/src/mcpg/composite.py
@@ -110,9 +110,9 @@ async def _fetch_table_stats(driver: SqlDriver, schema: str, table: str) -> Tabl
     rows = await driver.execute_query(
         "SELECT "
         "  COALESCE(c.reltuples, 0)::bigint AS estimated_row_count, "
-        "  pg_total_relation_size(c.oid) AS total_size_bytes, "
-        "  pg_table_size(c.oid) AS table_size_bytes, "
-        "  pg_indexes_size(c.oid) AS indexes_size_bytes, "
+        "  COALESCE(pg_total_relation_size(c.oid), 0) AS total_size_bytes, "
+        "  COALESCE(pg_table_size(c.oid), 0) AS table_size_bytes, "
+        "  COALESCE(pg_indexes_size(c.oid), 0) AS indexes_size_bytes, "
         "  COALESCE(s.seq_scan, 0) AS seq_scans, "
         "  COALESCE(s.idx_scan, 0) AS index_scans, "
         "  s.last_vacuum::text AS last_vacuum, "

--- a/src/mcpg/composite.py
+++ b/src/mcpg/composite.py
@@ -1,0 +1,432 @@
+"""Composite tools — agent UX wins built on top of existing primitives.
+
+These tools replace what would otherwise be 4-5 individual tool calls
+with a single composite call that returns a structured snapshot. They
+own no SQL of their own beyond a thin glue layer; the heavy lifting
+lives in :mod:`mcpg.introspection`, :mod:`mcpg.query`,
+:mod:`mcpg.health`, and :mod:`mcpg.liveops`.
+
+Tools shipped here:
+
+- :func:`summarize_table` — describe + indexes + constraints + FKs +
+  size / row-count / last vacuum-analyze + a small sample, in one
+  result. Replaces the typical "tell me about this table" sequence.
+- :func:`why_is_this_slow` — EXPLAIN + plan analysis + concurrent
+  active queries + blocking locks + cache hit ratio + targeted
+  recommendations, in one result. Replaces the typical "this query
+  is slow, dig in" loop.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from mcpg._vendor.sql import SqlDriver
+from mcpg.introspection import (
+    ColumnInfo,
+    ConstraintInfo,
+    ForeignKeyInfo,
+    IndexInfo,
+    describe_table,
+    list_constraints,
+    list_foreign_keys,
+    list_indexes,
+)
+from mcpg.liveops import list_active_queries
+from mcpg.query import analyze_query_plan, explain_query
+
+_IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
+
+
+class CompositeError(Exception):
+    """Raised when a composite tool's inputs are invalid."""
+
+
+def _check_identifier(name: str, kind: str) -> None:
+    if not _IDENTIFIER.match(name):
+        raise CompositeError(f"invalid {kind} name: {name!r}")
+
+
+# --- summarize_table -------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class TableStats:
+    """Storage + maintenance stats for a single table.
+
+    All values are best-effort: a brand-new table that hasn't been
+    analyzed yet will report ``None`` for last_analyzed.
+    """
+
+    estimated_row_count: int
+    total_size_bytes: int
+    table_size_bytes: int
+    indexes_size_bytes: int
+    seq_scans: int
+    index_scans: int
+    last_vacuum: str | None
+    last_autovacuum: str | None
+    last_analyze: str | None
+    last_autoanalyze: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class TableSummary:
+    """The composite shape of :func:`summarize_table`.
+
+    A self-contained snapshot of a table that an agent can render
+    without further round-trips.
+    """
+
+    schema: str
+    table: str
+    columns: list[ColumnInfo]
+    primary_key: list[str]
+    foreign_keys: list[ForeignKeyInfo]
+    constraints: list[ConstraintInfo]
+    indexes: list[IndexInfo]
+    stats: TableStats
+    sample_rows: list[dict[str, Any]] = field(default_factory=list)
+
+
+def _quoted(name: str) -> str:
+    return f'"{name}"'
+
+
+def _pk_columns(constraints: list[ConstraintInfo]) -> list[str]:
+    """Pull the column list out of the PRIMARY KEY constraint definition."""
+    for con in constraints:
+        if con.type == "primary_key":
+            match = re.search(r"PRIMARY KEY\s*\(([^)]+)\)", con.definition, re.IGNORECASE)
+            if match:
+                return [c.strip().strip('"') for c in match.group(1).split(",")]
+    return []
+
+
+async def _fetch_table_stats(driver: SqlDriver, schema: str, table: str) -> TableStats:
+    """Read pg_stat_user_tables + pg_class + size functions in one query."""
+    rows = await driver.execute_query(
+        "SELECT "
+        "  COALESCE(c.reltuples, 0)::bigint AS estimated_row_count, "
+        "  pg_total_relation_size(c.oid) AS total_size_bytes, "
+        "  pg_table_size(c.oid) AS table_size_bytes, "
+        "  pg_indexes_size(c.oid) AS indexes_size_bytes, "
+        "  COALESCE(s.seq_scan, 0) AS seq_scans, "
+        "  COALESCE(s.idx_scan, 0) AS index_scans, "
+        "  s.last_vacuum::text AS last_vacuum, "
+        "  s.last_autovacuum::text AS last_autovacuum, "
+        "  s.last_analyze::text AS last_analyze, "
+        "  s.last_autoanalyze::text AS last_autoanalyze "
+        "FROM pg_class c "
+        "JOIN pg_namespace n ON n.oid = c.relnamespace "
+        "LEFT JOIN pg_stat_user_tables s ON s.relid = c.oid "
+        "WHERE n.nspname = %s AND c.relname = %s AND c.relkind = 'r'",
+        params=[schema, table],
+        force_readonly=True,
+    )
+    if not rows:
+        # The table doesn't exist or we lack permissions; return zeros.
+        return TableStats(
+            estimated_row_count=0,
+            total_size_bytes=0,
+            table_size_bytes=0,
+            indexes_size_bytes=0,
+            seq_scans=0,
+            index_scans=0,
+            last_vacuum=None,
+            last_autovacuum=None,
+            last_analyze=None,
+            last_autoanalyze=None,
+        )
+    cells = rows[0].cells
+    return TableStats(
+        estimated_row_count=int(cells["estimated_row_count"]),
+        total_size_bytes=int(cells["total_size_bytes"]),
+        table_size_bytes=int(cells["table_size_bytes"]),
+        indexes_size_bytes=int(cells["indexes_size_bytes"]),
+        seq_scans=int(cells["seq_scans"]),
+        index_scans=int(cells["index_scans"]),
+        last_vacuum=cells["last_vacuum"],
+        last_autovacuum=cells["last_autovacuum"],
+        last_analyze=cells["last_analyze"],
+        last_autoanalyze=cells["last_autoanalyze"],
+    )
+
+
+async def summarize_table(
+    driver: SqlDriver,
+    schema: str,
+    table: str,
+    *,
+    sample_rows: int = 5,
+) -> TableSummary:
+    """Return a one-stop snapshot of ``schema.table``.
+
+    Composes the introspection primitives the agent would otherwise
+    have to call individually (``describe_table`` + ``list_indexes`` +
+    ``list_constraints`` + ``list_foreign_keys``) plus storage /
+    maintenance stats from ``pg_class`` and ``pg_stat_user_tables``
+    and a short ``SELECT *`` sample.
+
+    Args:
+        sample_rows: How many random-ordered sample rows to include.
+            Set to 0 to skip the sample entirely (useful on very wide
+            or jsonb-heavy rows).
+
+    Raises:
+        CompositeError: When the schema / table name is not a plain
+            identifier.
+    """
+    _check_identifier(schema, "schema")
+    _check_identifier(table, "table")
+    if sample_rows < 0:
+        raise CompositeError("sample_rows must be non-negative")
+
+    columns = await describe_table(driver, schema, table)
+    constraints = await list_constraints(driver, schema, table)
+    indexes = await list_indexes(driver, schema, table)
+    # FKs come from the schema-level list filtered to this table.
+    fks_all = await list_foreign_keys(driver, schema)
+    foreign_keys = [fk for fk in fks_all if fk.from_table == table]
+    pk = _pk_columns(constraints)
+    stats = await _fetch_table_stats(driver, schema, table)
+
+    sample: list[dict[str, Any]] = []
+    if sample_rows > 0 and columns:
+        # TABLESAMPLE BERNOULLI is fast but doesn't give a tight count;
+        # for the small "show me a few rows" use case a plain LIMIT
+        # over an unordered scan is good enough.
+        sample_query_rows = await driver.execute_query(
+            f"SELECT * FROM {_quoted(schema)}.{_quoted(table)} LIMIT %s",
+            params=[sample_rows],
+            force_readonly=True,
+        )
+        sample = [dict(row.cells) for row in sample_query_rows or []]
+
+    return TableSummary(
+        schema=schema,
+        table=table,
+        columns=columns,
+        primary_key=pk,
+        foreign_keys=foreign_keys,
+        constraints=constraints,
+        indexes=indexes,
+        stats=stats,
+        sample_rows=sample,
+    )
+
+
+# --- why_is_this_slow -------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class SlowQuerySuggestion:
+    """One actionable recommendation from :func:`why_is_this_slow`.
+
+    ``category`` is one of ``"plan"``, ``"contention"``,
+    ``"cache"``, ``"maintenance"`` to help the agent triage. ``hint``
+    is the human-readable advice the agent should surface.
+    """
+
+    category: str
+    hint: str
+
+
+@dataclass(frozen=True, slots=True)
+class SlowQueryDiagnosis:
+    """The composite shape of :func:`why_is_this_slow`.
+
+    Combines the plan summary, snapshot of concurrent activity, lock
+    state, and cache hit ratio into one structured payload so the
+    agent doesn't need to make four separate calls.
+    """
+
+    sql: str
+    plan_summary: dict[str, Any]
+    explain_plan: dict[str, Any]
+    active_queries: list[dict[str, Any]]
+    blocking_locks: list[dict[str, Any]]
+    cache_hit_ratio: float | None
+    suggestions: list[SlowQuerySuggestion]
+
+
+async def _cache_hit_ratio(driver: SqlDriver) -> float | None:
+    """Return the cluster-wide buffer cache hit ratio, or None if no I/O yet."""
+    rows = await driver.execute_query(
+        "SELECT sum(blks_hit) AS hits, sum(blks_read) AS reads FROM pg_stat_database",
+        force_readonly=True,
+    )
+    if not rows:
+        return None
+    cells = rows[0].cells
+    hits, reads = cells["hits"] or 0, cells["reads"] or 0
+    total = hits + reads
+    if total == 0:
+        return None
+    return float(hits) / float(total)
+
+
+async def _fetch_blocking_locks(driver: SqlDriver) -> list[dict[str, Any]]:
+    """Snapshot of currently blocking lock pairs.
+
+    Returns one row per (blocked_pid, blocking_pid) pair with the
+    queries involved. Empty list when nothing is blocked. This is
+    expensive on busy systems with thousands of locks; we cap the
+    rows to keep the result digestible.
+    """
+    rows = await driver.execute_query(
+        "SELECT "
+        "  blocked.pid AS blocked_pid, "
+        "  blocked.query AS blocked_query, "
+        "  blocking.pid AS blocking_pid, "
+        "  blocking.query AS blocking_query, "
+        "  blocked.wait_event_type AS wait_event_type, "
+        "  blocked.wait_event AS wait_event "
+        "FROM pg_stat_activity blocked "
+        "JOIN pg_stat_activity blocking "
+        "  ON blocking.pid = ANY(pg_blocking_pids(blocked.pid)) "
+        "WHERE pg_blocking_pids(blocked.pid)::text <> '{}' "
+        "LIMIT 25",
+        force_readonly=True,
+    )
+    return [dict(row.cells) for row in rows or []]
+
+
+def _build_suggestions(
+    plan_summary: dict[str, Any],
+    active_queries: list[dict[str, Any]],
+    blocking_locks: list[dict[str, Any]],
+    cache_hit_ratio: float | None,
+) -> list[SlowQuerySuggestion]:
+    """Translate the gathered signals into concrete advice."""
+    suggestions: list[SlowQuerySuggestion] = []
+    # Plan-shape signals — sequential scan on a non-trivial table is the
+    # single most common "this is slow" cause.
+    seq_scans = int(plan_summary.get("sequential_scan_count", 0) or 0)
+    total_cost = float(plan_summary.get("total_cost", 0.0) or 0.0)
+    if seq_scans > 0 and total_cost > 1_000:
+        suggestions.append(
+            SlowQuerySuggestion(
+                category="plan",
+                hint=(
+                    f"plan contains {seq_scans} sequential scan(s) with "
+                    f"total cost {total_cost:.0f}; consider adding an "
+                    "index on the filter or join columns"
+                ),
+            )
+        )
+    if total_cost > 100_000:
+        suggestions.append(
+            SlowQuerySuggestion(
+                category="plan",
+                hint=(
+                    f"planner expects total cost {total_cost:.0f}, which is high; "
+                    "run EXPLAIN (ANALYZE, BUFFERS) to see actual vs estimated rows"
+                ),
+            )
+        )
+    # Contention.
+    if blocking_locks:
+        suggestions.append(
+            SlowQuerySuggestion(
+                category="contention",
+                hint=(
+                    f"{len(blocking_locks)} blocking lock pair(s) detected; "
+                    "another transaction is holding a lock this query needs"
+                ),
+            )
+        )
+    if len(active_queries) >= 25:
+        suggestions.append(
+            SlowQuerySuggestion(
+                category="contention",
+                hint=(f"{len(active_queries)} concurrent active queries; the system may be CPU- or I/O-bound"),
+            )
+        )
+    # Cache.
+    if cache_hit_ratio is not None and cache_hit_ratio < 0.95:
+        suggestions.append(
+            SlowQuerySuggestion(
+                category="cache",
+                hint=(
+                    f"buffer cache hit ratio is {cache_hit_ratio:.1%}; "
+                    "below 95% suggests shared_buffers is too small for "
+                    "the working set"
+                ),
+            )
+        )
+    if not suggestions:
+        suggestions.append(
+            SlowQuerySuggestion(
+                category="plan",
+                hint=(
+                    "no obvious slowness signal in the plan, concurrent activity, "
+                    "or cache; run EXPLAIN (ANALYZE, BUFFERS) for actual timings"
+                ),
+            )
+        )
+    return suggestions
+
+
+async def why_is_this_slow(driver: SqlDriver, sql: str) -> SlowQueryDiagnosis:
+    """Diagnose why a SQL query might be slow, in one call.
+
+    Composes:
+
+    - ``EXPLAIN (FORMAT JSON)`` of the query via :func:`mcpg.query.explain_query`
+      (read-only — does not execute the query).
+    - ``analyze_query_plan`` to walk the plan tree.
+    - ``list_active_queries`` to see what else is competing.
+    - Blocking-lock pairs from ``pg_stat_activity`` +
+      ``pg_blocking_pids``.
+    - Cache hit ratio from :func:`mcpg.health.check_cache_hit_ratio`.
+
+    Returns a structured diagnosis with targeted suggestions per
+    category (plan / contention / cache / maintenance). The query is
+    NOT executed — only EXPLAIN-ed — so this is safe to run on a
+    statement the agent doesn't want to materialise yet.
+
+    Raises:
+        CompositeError: When ``sql`` is empty.
+    """
+    if not sql or not sql.strip():
+        raise CompositeError("sql must not be empty")
+
+    plan = await explain_query(driver, sql)
+    plan_summary_obj = await analyze_query_plan(driver, sql)
+    # analyze_query_plan returns a typed dataclass; convert to a dict for the payload.
+    plan_summary = {
+        "total_cost": plan_summary_obj.total_cost,
+        "estimated_rows": plan_summary_obj.estimated_rows,
+        "sequential_scan_count": len(plan_summary_obj.sequential_scans),
+        "sequential_scans": list(plan_summary_obj.sequential_scans),
+        "node_types": list(plan_summary_obj.node_types),
+    }
+    active = await list_active_queries(driver)
+    active_dicts = [
+        {
+            "pid": q.pid,
+            "username": q.username,
+            "state": q.state,
+            "query": q.query,
+            "wait_event": q.wait_event,
+            "duration_seconds": q.duration_seconds,
+            "blocked_by": list(q.blocked_by),
+        }
+        for q in active
+    ]
+    locks = await _fetch_blocking_locks(driver)
+    cache_ratio = await _cache_hit_ratio(driver)
+
+    suggestions = _build_suggestions(plan_summary, active_dicts, locks, cache_ratio)
+    return SlowQueryDiagnosis(
+        sql=sql,
+        plan_summary=plan_summary,
+        explain_plan=plan.plan,
+        active_queries=active_dicts,
+        blocking_locks=locks,
+        cache_hit_ratio=cache_ratio,
+        suggestions=suggestions,
+    )

--- a/src/mcpg/config.py
+++ b/src/mcpg/config.py
@@ -58,6 +58,12 @@ class Settings:
     audit_persist: bool = False
     pool_min_size: int = 1
     pool_max_size: int = 5
+    # HTTP-transport bearer token. When set and the active transport is
+    # streamable-http or sse, every request must carry
+    # ``Authorization: Bearer <token>``; missing/wrong token returns 401.
+    # When unset, the HTTP transport runs without auth (current
+    # behaviour). stdio is never gated.
+    http_auth_token: str | None = None
 
     def __repr__(self) -> str:
         # Never let credentials reach logs or tracebacks.
@@ -73,7 +79,8 @@ class Settings:
             f"shell_max_output_bytes={self.shell_max_output_bytes}, "
             f"listen_queue_max={self.listen_queue_max}, "
             f"audit_persist={self.audit_persist}, "
-            f"pool_min_size={self.pool_min_size}, pool_max_size={self.pool_max_size})"
+            f"pool_min_size={self.pool_min_size}, pool_max_size={self.pool_max_size}, "
+            f"http_auth_token={'set' if self.http_auth_token else 'unset'!r})"
         )
 
 
@@ -185,6 +192,13 @@ def load_settings(env: Mapping[str, str] | None = None) -> Settings:
     if pool_max_size < pool_min_size:
         raise ConfigError(f"MCPG_POOL_MAX_SIZE ({pool_max_size}) must be >= MCPG_POOL_MIN_SIZE ({pool_min_size})")
 
+    http_auth_token: str | None = None
+    if (raw := env.get("MCPG_HTTP_AUTH_TOKEN")) is not None:
+        stripped = raw.strip()
+        if not stripped:
+            raise ConfigError("MCPG_HTTP_AUTH_TOKEN must not be blank when set")
+        http_auth_token = stripped
+
     return Settings(
         database_url=database_url,
         access_mode=access_mode,
@@ -201,4 +215,5 @@ def load_settings(env: Mapping[str, str] | None = None) -> Settings:
         audit_persist=audit_persist,
         pool_min_size=pool_min_size,
         pool_max_size=pool_max_size,
+        http_auth_token=http_auth_token,
     )

--- a/src/mcpg/diesel.py
+++ b/src/mcpg/diesel.py
@@ -1,0 +1,247 @@
+"""Schema → Diesel ORM (Rust) exporter.
+
+Reads the PostgreSQL catalog via :mod:`mcpg.introspection` and emits a
+``schema.rs`` an agent can drop into a Rust project using
+`Diesel <https://diesel.rs/>`_. Mirrors the structure of the other Batch G
+exporters (Prisma / Drizzle / SQLAlchemy 2.0 / sqlc) — same coverage
+boundary: base tables, columns, primary keys, foreign keys, and enum
+types. Views, foreign tables, partitions, triggers, functions, and
+composite types are out of scope.
+
+Diesel's idiom is one ``table!`` block per table plus ``joinable!`` and
+``allow_tables_to_appear_in_same_query!`` declarations for joins, so the
+output reads like ``diesel print-schema``. Enum types are emitted as a
+sibling `pg_enum` module — Diesel does not have a first-class enum type;
+agents typically declare a wrapper that maps to a ``Text`` column or a
+custom SQL type. We pick the wrapper-over-Text route because it works
+out of the box without ``diesel_derive_enum``.
+"""
+
+from __future__ import annotations
+
+import re
+
+from mcpg._vendor.sql import SqlDriver
+from mcpg.introspection import (
+    ColumnInfo,
+    describe_table,
+    list_constraints,
+    list_enums,
+    list_foreign_keys,
+    list_tables,
+)
+
+_IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
+
+
+class DieselExportError(Exception):
+    """Raised when a Diesel export call is rejected or fails."""
+
+
+def _check_identifier(name: str, kind: str) -> None:
+    if not _IDENTIFIER.match(name):
+        raise DieselExportError(f"invalid {kind} name: {name!r}")
+
+
+def _strip_type_params(data_type: str) -> str:
+    return re.sub(r"\(.*\)", "", data_type).strip()
+
+
+# Map a PG type to a Diesel sql_types name. The values here match the
+# names Diesel re-exports from ``diesel::pg::sql_types`` / ``diesel::sql_types``.
+_TYPE_MAP: dict[str, str] = {
+    "smallint": "SmallInt",
+    "integer": "Integer",
+    "bigint": "BigInt",
+    "real": "Float",
+    "double precision": "Double",
+    "numeric": "Numeric",
+    "decimal": "Numeric",
+    "boolean": "Bool",
+    "text": "Text",
+    "character varying": "Varchar",
+    "varchar": "Varchar",
+    "character": "Bpchar",
+    "char": "Bpchar",
+    "uuid": "Uuid",
+    "json": "Json",
+    "jsonb": "Jsonb",
+    "date": "Date",
+    "time without time zone": "Time",
+    "time with time zone": "Timetz",
+    "timestamp without time zone": "Timestamp",
+    "timestamp with time zone": "Timestamptz",
+    "bytea": "Bytea",
+    "interval": "Interval",
+    "inet": "Inet",
+    "cidr": "Cidr",
+    "macaddr": "Macaddr",
+}
+
+
+def _diesel_sql_type(column: ColumnInfo, enum_names: set[str]) -> str:
+    """Return the Diesel SQL type expression for a column.
+
+    Enum columns map to ``Text`` so the agent can use a String-backed
+    wrapper enum without pulling in ``diesel_derive_enum``. ``Nullable<T>``
+    wraps when the column is nullable.
+    """
+    raw = column.data_type
+    base = _strip_type_params(raw).lower()
+    qualified = base.split(".")[-1] if "." in base else base
+    inner: str
+    if base in enum_names or raw in enum_names or qualified in enum_names:
+        # Backed-by-Text wrapper enum; see module docstring for why.
+        inner = "Text"
+    else:
+        inner = _TYPE_MAP.get(base, "Text")
+    if column.nullable:
+        return f"Nullable<{inner}>"
+    return inner
+
+
+_PK_COLS_RE = re.compile(r"PRIMARY KEY\s*\(([^)]+)\)", re.IGNORECASE)
+
+
+def _parse_pk_columns(definition: str) -> list[str]:
+    match = _PK_COLS_RE.search(definition)
+    if not match:
+        return []
+    return [col.strip().strip('"') for col in match.group(1).split(",")]
+
+
+def _render_table_block(
+    table_name: str,
+    columns: list[ColumnInfo],
+    pk_columns: list[str],
+    enum_names: set[str],
+) -> str:
+    """Build the ``table! { ... }`` block for a table.
+
+    Diesel's macro syntax:
+
+    .. code-block:: rust
+
+       table! {
+           widget (id) {
+               id -> Integer,
+               name -> Text,
+               quantity -> Nullable<Integer>,
+           }
+       }
+    """
+    pk_clause = " (" + ", ".join(pk_columns) + ")" if pk_columns else ""
+    lines: list[str] = []
+    lines.append("table! {")
+    lines.append(f"    {table_name}{pk_clause} {{")
+    for column in columns:
+        sql_type = _diesel_sql_type(column, enum_names)
+        lines.append(f"        {column.name} -> {sql_type},")
+    lines.append("    }")
+    lines.append("}")
+    return "\n".join(lines)
+
+
+def _render_joinable(from_table: str, to_table: str, fk_column: str) -> str:
+    """Emit a ``joinable!`` macro tying two tables on the FK column."""
+    return f"joinable!({from_table} -> {to_table} ({fk_column}));"
+
+
+def _render_allow_join(table_names: list[str]) -> str:
+    """Emit the ``allow_tables_to_appear_in_same_query!`` macro for joins."""
+    joined = ", ".join(sorted(table_names))
+    return f"allow_tables_to_appear_in_same_query!({joined});"
+
+
+def _render_enum_module(enum_names: list[tuple[str, list[str]]]) -> str:
+    """Emit a ``pg_enum`` module with a wrapper for each enum type.
+
+    Each enum becomes a public ``enum`` that derives the traits Diesel
+    needs to round-trip the value through a Text column. The agent
+    can extend with their preferred conversion (``ToSql`` / ``FromSql``)
+    once they decide between the Text-backed wrapper and a true PG
+    enum type.
+    """
+    if not enum_names:
+        return ""
+    body_lines = [
+        "// Wrapper enums for the PG enum types in this schema. They map",
+        "// to a Text column out of the box; replace with diesel_derive_enum",
+        "// + an explicit SqlType if you want native PG enum mapping.",
+        "pub mod pg_enum {",
+    ]
+    for name, values in enum_names:
+        body_lines.append("    #[derive(Debug, Clone, PartialEq, Eq, Hash, diesel::AsExpression, diesel::FromSqlRow)]")
+        body_lines.append("    #[diesel(sql_type = diesel::sql_types::Text)]")
+        body_lines.append(f"    pub enum {_pascal(name)} {{")
+        for value in values:
+            body_lines.append(f"        {_pascal(value)},")
+        body_lines.append("    }")
+    body_lines.append("}")
+    return "\n".join(body_lines)
+
+
+def _pascal(name: str) -> str:
+    parts = re.split(r"[^A-Za-z0-9]+", name)
+    return "".join(p[:1].upper() + p[1:] for p in parts if p) or name
+
+
+async def generate_diesel_schema(driver: SqlDriver, schema: str) -> str:
+    """Emit a Diesel ORM ``schema.rs`` for ``schema``.
+
+    Returns a Rust source string. The output uses ``table!`` blocks,
+    ``joinable!`` for single-column intra-schema FKs, and an
+    ``allow_tables_to_appear_in_same_query!`` line so multi-table joins
+    type-check without per-pair ``allow!`` macros.
+
+    Raises:
+        DieselExportError: When the schema name or any table/column
+            name requires PostgreSQL delimited-identifier quoting.
+    """
+    _check_identifier(schema, "schema")
+    tables = [t for t in await list_tables(driver, schema) if t.type == "BASE TABLE" and not t.is_partition]
+    for t in tables:
+        _check_identifier(t.name, "table")
+
+    enums = await list_enums(driver, schema)
+    enum_names = {e.name for e in enums}
+
+    fks_all = await list_foreign_keys(driver, schema)
+    entity_names = {t.name for t in tables}
+
+    blocks: list[str] = []
+
+    # 1. Enum wrapper module (if any enums exist).
+    enum_module = _render_enum_module([(e.name, list(e.values)) for e in sorted(enums, key=lambda e: e.name)])
+    if enum_module:
+        blocks.append(enum_module)
+
+    # 2. One table! macro per table.
+    for table in tables:
+        columns = await describe_table(driver, schema, table.name)
+        for col in columns:
+            _check_identifier(col.name, "column")
+        constraints = await list_constraints(driver, schema, table.name)
+        pk_columns: list[str] = []
+        for con in constraints:
+            if con.type == "primary_key":
+                pk_columns = _parse_pk_columns(con.definition)
+                break
+        blocks.append(_render_table_block(table.name, columns, pk_columns, enum_names))
+
+    # 3. joinable! for every single-column intra-schema FK.
+    joinable_lines: list[str] = []
+    for fk in fks_all:
+        if fk.to_table not in entity_names:
+            continue  # cross-schema FK — Diesel's joinable! can't span schemas cleanly
+        if len(fk.from_columns) != 1:
+            continue  # composite FKs are a documented v1 gap
+        joinable_lines.append(_render_joinable(fk.from_table, fk.to_table, fk.from_columns[0]))
+    if joinable_lines:
+        blocks.append("\n".join(joinable_lines))
+
+    # 4. allow_tables_to_appear_in_same_query! for the full table set.
+    if len(tables) >= 2:
+        blocks.append(_render_allow_join([t.name for t in tables]))
+
+    return "\n\n".join(blocks) + "\n"

--- a/src/mcpg/ecto.py
+++ b/src/mcpg/ecto.py
@@ -1,0 +1,287 @@
+"""Schema → Ecto (Elixir) schema exporter.
+
+`Ecto <https://hexdocs.pm/ecto/>`_ is the canonical Elixir database
+wrapper / DSL. Modules are defined with ``use Ecto.Schema`` and a
+``schema "table_name" do ... end`` block listing each ``field`` and
+``belongs_to`` / ``has_many`` association.
+
+This exporter emits one Elixir module per base table in the PG schema,
+matching Phoenix conventions (PascalCase module names, snake_case
+table/field names, ``belongs_to`` for single-column intra-schema FKs).
+
+Coverage is the same as the other Batch G exporters — base tables,
+columns, primary keys, foreign keys (intra-schema, single-column),
+enums (mapped to ``:string`` since Ecto's enum support requires the
+``EctoEnum`` library — we leave that decision to the user). Cross-
+schema FKs and composite FKs are documented v1 gaps.
+"""
+
+from __future__ import annotations
+
+import re
+
+from mcpg._vendor.sql import SqlDriver
+from mcpg.introspection import (
+    ColumnInfo,
+    ForeignKeyInfo,
+    describe_table,
+    list_constraints,
+    list_enums,
+    list_foreign_keys,
+    list_tables,
+)
+
+_IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
+
+
+class EctoExportError(Exception):
+    """Raised when an Ecto export call is rejected or fails."""
+
+
+def _check_identifier(name: str, kind: str) -> None:
+    if not _IDENTIFIER.match(name):
+        raise EctoExportError(f"invalid {kind} name: {name!r}")
+
+
+def _strip_type_params(data_type: str) -> str:
+    return re.sub(r"\(.*\)", "", data_type).strip()
+
+
+def _pascal(snake: str) -> str:
+    parts = re.split(r"[^A-Za-z0-9]+", snake)
+    return "".join(p[:1].upper() + p[1:] for p in parts if p) or snake
+
+
+def _singularize(plural: str) -> str:
+    """Best-effort English singularisation for table → module.
+
+    Ecto modules are conventionally singular (``User`` for table
+    ``users``). The mapping is intentionally minimal — anything we
+    can't confidently singularise stays as-is. Latin-derived singular
+    endings (``-us``, ``-is``) are preserved so we don't break
+    ``status`` → ``statu``.
+    """
+    if plural.endswith("ies") and len(plural) > 3:
+        return plural[:-3] + "y"
+    if plural.endswith("ses") and len(plural) > 3:
+        return plural[:-2]
+    if plural.endswith("s") and not plural.endswith(("ss", "us", "is", "os")) and len(plural) > 1:
+        return plural[:-1]
+    return plural
+
+
+# Maps PG type → Ecto field type atom.
+_FIELD_TYPE: dict[str, str] = {
+    "smallint": ":integer",
+    "integer": ":integer",
+    "bigint": ":integer",
+    "real": ":float",
+    "double precision": ":float",
+    "numeric": ":decimal",
+    "decimal": ":decimal",
+    "boolean": ":boolean",
+    "text": ":string",
+    "character varying": ":string",
+    "varchar": ":string",
+    "character": ":string",
+    "char": ":string",
+    "uuid": "Ecto.UUID",
+    "json": ":map",
+    "jsonb": ":map",
+    "date": ":date",
+    "time without time zone": ":time",
+    "time with time zone": ":time",
+    "timestamp without time zone": ":naive_datetime",
+    "timestamp with time zone": ":utc_datetime",
+    "bytea": ":binary",
+}
+
+
+def _ecto_field_type(column: ColumnInfo, enum_names: set[str]) -> str:
+    """Return the Ecto field-type expression for a column."""
+    raw = column.data_type
+    base = _strip_type_params(raw).lower()
+    qualified = base.split(".")[-1] if "." in base else base
+    if base in enum_names or raw in enum_names or qualified in enum_names:
+        # Without the EctoEnum library Ecto can't express PG enums
+        # natively. Fall back to :string so the schema compiles; the
+        # agent can swap in EctoEnum if needed.
+        return ":string"
+    return _FIELD_TYPE.get(base, ":string")
+
+
+_PK_COLS_RE = re.compile(r"PRIMARY KEY\s*\(([^)]+)\)", re.IGNORECASE)
+
+
+def _parse_pk_columns(definition: str) -> list[str]:
+    match = _PK_COLS_RE.search(definition)
+    if not match:
+        return []
+    return [col.strip().strip('"') for col in match.group(1).split(",")]
+
+
+def _is_timestamp_pair(columns: list[ColumnInfo]) -> bool:
+    """True when the columns include both ``inserted_at`` and ``updated_at``.
+
+    Ecto's ``timestamps()`` macro handles those two columns for you;
+    we skip emitting field declarations for them when both are present.
+    """
+    names = {c.name for c in columns}
+    return "inserted_at" in names and "updated_at" in names
+
+
+def _render_field_line(column: ColumnInfo, enum_names: set[str]) -> str:
+    ecto_type = _ecto_field_type(column, enum_names)
+    return f"    field :{column.name}, {ecto_type}"
+
+
+def _render_belongs_to(fk_column: str, target_table: str, target_module: str) -> str:
+    """Emit one ``belongs_to`` line for an FK column.
+
+    Ecto strips the trailing ``_id`` to derive the association name
+    (so ``owner_id`` → ``:owner``). We respect that idiom but fall
+    back to the column name if the suffix is missing.
+    """
+    assoc = fk_column[:-3] if fk_column.endswith("_id") else fk_column
+    return f"    belongs_to :{assoc}, {target_module}, foreign_key: :{fk_column}"
+
+
+def _render_module(
+    app_module: str,
+    table_name: str,
+    columns: list[ColumnInfo],
+    pk_columns: list[str],
+    belongs_to_lines: list[str],
+    enum_names: set[str],
+) -> str:
+    """Build one ``defmodule`` block for a table.
+
+    The module looks like::
+
+        defmodule MyApp.Widget do
+          use Ecto.Schema
+
+          @primary_key {:id, :id, autogenerate: true}
+          schema "widget" do
+            field :name, :string
+            belongs_to :owner, MyApp.Owner, foreign_key: :owner_id
+            timestamps()
+          end
+        end
+    """
+    entity = _pascal(_singularize(table_name))
+    has_timestamps = _is_timestamp_pair(columns)
+    skip_columns = {"inserted_at", "updated_at"} if has_timestamps else set()
+
+    # Don't double-declare PK columns; @primary_key handles ``id``.
+    if len(pk_columns) == 1 and pk_columns[0] == "id":
+        skip_columns.add("id")
+        primary_key_line = "  @primary_key {:id, :id, autogenerate: true}"
+    elif len(pk_columns) == 1:
+        # Non-conventional PK — declare it so Ecto knows the type.
+        primary_key_line = f"  @primary_key {{:{pk_columns[0]}, :id, autogenerate: true}}"
+    elif len(pk_columns) > 1:
+        # Composite PK — Ecto requires opting out of the default :id PK
+        # and the field declarations carry primary_key: true.
+        primary_key_line = "  @primary_key false"
+    else:
+        primary_key_line = "  @primary_key false"
+
+    # Skip FK columns whose belongs_to has been emitted — Ecto's
+    # belongs_to creates the schema field itself, so re-declaring the
+    # underlying column would produce a duplicate-field compile error.
+    fk_re = re.compile(r"\s*belongs_to\s+:\w+,.*foreign_key:\s*:(\w+)")
+    for line in belongs_to_lines:
+        match = fk_re.match(line)
+        if match:
+            skip_columns.add(match.group(1))
+
+    field_lines = [_render_field_line(c, enum_names) for c in columns if c.name not in skip_columns]
+    if pk_columns and len(pk_columns) > 1:
+        # Composite PK — re-declare each component WITH primary_key: true.
+        composite_pk_lines = [f"    field :{name}, :integer, primary_key: true" for name in pk_columns]
+        field_lines = composite_pk_lines + field_lines
+
+    body = [
+        f"defmodule {app_module}.{entity} do",
+        "  use Ecto.Schema",
+        "",
+        primary_key_line,
+        f'  schema "{table_name}" do',
+        *field_lines,
+        *belongs_to_lines,
+    ]
+    if has_timestamps:
+        body.append("    timestamps()")
+    body.extend(
+        [
+            "  end",
+            "end",
+        ]
+    )
+    return "\n".join(body) + "\n"
+
+
+async def generate_ecto_schemas(
+    driver: SqlDriver,
+    schema: str,
+    *,
+    app_module: str = "MyApp",
+) -> dict[str, str]:
+    """Emit one Elixir module per base table in ``schema``.
+
+    Returns ``{filename: source}`` where ``filename`` is the
+    snake_case singular form with ``.ex`` extension — matching
+    Phoenix's ``lib/my_app/<singular>.ex`` convention.
+
+    Args:
+        driver: SQL driver bound to the live database.
+        schema: PG schema to generate from. Must be a plain identifier.
+        app_module: The Elixir top-level module name (e.g. ``MyApp``,
+            ``Shop``). Modules emitted as ``<app_module>.<Entity>``.
+
+    Raises:
+        EctoExportError: When the schema name, or any table / column
+            name, requires PostgreSQL delimited-identifier quoting.
+    """
+    _check_identifier(schema, "schema")
+    tables = [t for t in await list_tables(driver, schema) if t.type == "BASE TABLE" and not t.is_partition]
+    for t in tables:
+        _check_identifier(t.name, "table")
+
+    enums = await list_enums(driver, schema)
+    enum_names = {e.name for e in enums}
+
+    fks_all = await list_foreign_keys(driver, schema)
+    fks_by_source: dict[str, list[ForeignKeyInfo]] = {}
+    for fk in fks_all:
+        fks_by_source.setdefault(fk.from_table, []).append(fk)
+    entity_names = {t.name for t in tables}
+
+    output: dict[str, str] = {}
+    for table in tables:
+        columns = await describe_table(driver, schema, table.name)
+        for col in columns:
+            _check_identifier(col.name, "column")
+        constraints = await list_constraints(driver, schema, table.name)
+        pk_columns: list[str] = []
+        for con in constraints:
+            if con.type == "primary_key":
+                pk_columns = _parse_pk_columns(con.definition)
+                break
+
+        belongs_to_lines: list[str] = []
+        for fk in fks_by_source.get(table.name, []):
+            if fk.to_table not in entity_names:
+                continue
+            if len(fk.from_columns) != 1:
+                continue
+            target_module = f"{app_module}.{_pascal(_singularize(fk.to_table))}"
+            belongs_to_lines.append(_render_belongs_to(fk.from_columns[0], fk.to_table, target_module))
+
+        source = _render_module(app_module, table.name, columns, pk_columns, belongs_to_lines, enum_names)
+        # File name: lib/my_app/<singular>.ex idiom.
+        filename = f"{_singularize(table.name)}.ex"
+        output[filename] = source
+
+    return output

--- a/src/mcpg/ent.py
+++ b/src/mcpg/ent.py
@@ -1,0 +1,324 @@
+"""Schema → Ent (Go) schema exporter.
+
+`Ent <https://entgo.io/>`_ generates type-safe Go code from a graph of
+``Schema`` structs that declare each entity's fields and edges. The
+canonical input is one Go file per entity under ``ent/schema/``.
+
+This exporter emits exactly that — one Go source per base table in the
+schema, plus a brief generation README — from a live PG catalog. The
+agent runs ``go generate ./ent`` afterwards to produce the Go client.
+
+Coverage matches the other Batch G exporters: base tables, columns,
+primary keys, foreign keys (intra-schema, single-column), and enums.
+Cross-schema FKs and composite FKs are documented v1 gaps.
+"""
+
+from __future__ import annotations
+
+import re
+
+from mcpg._vendor.sql import SqlDriver
+from mcpg.introspection import (
+    ColumnInfo,
+    ForeignKeyInfo,
+    describe_table,
+    list_enums,
+    list_foreign_keys,
+    list_tables,
+)
+
+_IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
+
+
+class EntExportError(Exception):
+    """Raised when an Ent export call is rejected or fails."""
+
+
+def _check_identifier(name: str, kind: str) -> None:
+    if not _IDENTIFIER.match(name):
+        raise EntExportError(f"invalid {kind} name: {name!r}")
+
+
+def _pascal(snake: str) -> str:
+    parts = re.split(r"[^A-Za-z0-9]+", snake)
+    return "".join(p[:1].upper() + p[1:] for p in parts if p) or snake
+
+
+def _strip_type_params(data_type: str) -> str:
+    return re.sub(r"\(.*\)", "", data_type).strip()
+
+
+# Maps PG type → ent.field.<X>() builder name.
+_FIELD_BUILDER: dict[str, str] = {
+    "smallint": "Int16",
+    "integer": "Int",
+    "bigint": "Int64",
+    "real": "Float32",
+    "double precision": "Float",
+    "numeric": "Float",  # Ent has no native decimal; Float is the closest scalar
+    "decimal": "Float",
+    "boolean": "Bool",
+    "text": "Text",
+    "character varying": "String",
+    "varchar": "String",
+    "character": "String",
+    "char": "String",
+    "uuid": "UUID",
+    "json": "JSON",
+    "jsonb": "JSON",
+    "date": "Time",
+    "time without time zone": "Time",
+    "time with time zone": "Time",
+    "timestamp without time zone": "Time",
+    "timestamp with time zone": "Time",
+    "bytea": "Bytes",
+}
+
+
+def _ent_builder_for(column: ColumnInfo, enum_names: set[str]) -> tuple[str, str | None]:
+    """Return ``(builder_call, extra_import)`` for a column.
+
+    ``builder_call`` is something like ``field.Int("id")`` or
+    ``field.UUID("user_id", uuid.UUID{})``. ``extra_import`` is the
+    extra Go import the builder needs (currently only ``uuid``
+    triggers it), or ``None``.
+    """
+    raw = column.data_type
+    base = _strip_type_params(raw).lower()
+    qualified = base.split(".")[-1] if "." in base else base
+    if base in enum_names or raw in enum_names or qualified in enum_names:
+        # Ent's enum() builder needs a name + Values; the field call
+        # syntax is field.Enum("state").Values("active", "inactive").
+        # We caller-side fill in the Values from the catalog.
+        return f'field.Enum("{column.name}")', None
+    builder = _FIELD_BUILDER.get(base, "String")
+    if builder == "UUID":
+        return f'field.UUID("{column.name}", uuid.UUID{{}})', "github.com/google/uuid"
+    if builder == "JSON":
+        # Ent's JSON builder needs a type literal; map to interface{} so
+        # the agent can refine. ``map[string]interface{}{}`` is the
+        # idiom for arbitrary jsonb.
+        return f'field.JSON("{column.name}", map[string]interface{{}}{{}})', None
+    if builder == "Bytes":
+        return f'field.Bytes("{column.name}")', None
+    return f'field.{builder}("{column.name}")', None
+
+
+def _render_field_call(
+    column: ColumnInfo,
+    enum_names: set[str],
+    enum_values_by_name: dict[str, list[str]],
+) -> tuple[str, str | None]:
+    """Build one ``field.X("col").Modifiers()`` line + any required import.
+
+    Modifiers: ``.Optional()`` for nullable, ``.Default(...)`` for
+    defaults that round-trip cleanly (numeric, boolean, string,
+    ``now()`` → ``time.Now``), ``.Values(...)`` for enum fields.
+    """
+    builder, extra_import = _ent_builder_for(column, enum_names)
+    parts = [builder]
+    base = _strip_type_params(column.data_type).lower()
+    qualified = base.split(".")[-1] if "." in base else base
+    is_enum = base in enum_names or qualified in enum_names
+    if is_enum:
+        values = enum_values_by_name.get(qualified, enum_values_by_name.get(base, []))
+        if values:
+            literals = ", ".join(f'"{v}"' for v in values)
+            parts.append(f".Values({literals})")
+    if column.nullable:
+        parts.append(".Optional()")
+    default = _render_default_modifier(column)
+    if default:
+        parts.append(default)
+    return "".join(parts), extra_import
+
+
+_NEXTVAL_RE = re.compile(r"nextval\(['\"]([^'\"]+)['\"]")
+
+
+def _render_default_modifier(column: ColumnInfo) -> str | None:
+    """Translate the PG default to a Go ``.Default(...)`` modifier.
+
+    ``nextval`` is dropped (Ent's primary-key generation owns it).
+    """
+    if column.default is None:
+        return None
+    if _NEXTVAL_RE.search(column.default):
+        return None
+    raw = column.default.strip()
+    cast_stripped = re.sub(r"::[A-Za-z_][A-Za-z0-9_ ]*$", "", raw)
+    lowered = cast_stripped.lower()
+    if lowered in {"now()", "current_timestamp"}:
+        # field.Time(...).Default(time.Now) — needs the time import.
+        return ".Default(time.Now)"
+    if lowered in {"true", "false"}:
+        return f".Default({lowered})"
+    if re.fullmatch(r"-?\d+", cast_stripped) or re.fullmatch(r"-?\d+\.\d+", cast_stripped):
+        return f".Default({cast_stripped})"
+    if cast_stripped.startswith("'") and cast_stripped.endswith("'"):
+        body = cast_stripped[1:-1].replace("\\", "\\\\").replace('"', '\\"')
+        return f'.Default("{body}")'
+    # Unknown — Ent does not have a sql-text default; omit so the agent
+    # can fill in by hand rather than silently corrupting the value.
+    return None
+
+
+def _render_edges(
+    table_name: str,
+    fks_by_source: dict[str, list[ForeignKeyInfo]],
+    entity_names: set[str],
+) -> list[str]:
+    """Build ``edge.To(...)`` lines for outgoing FKs of ``table_name``.
+
+    Ent represents FKs as edges between schemas; the FK column is
+    inferred from the ``Field`` modifier. We only emit edges for
+    single-column intra-schema FKs.
+    """
+    edges: list[str] = []
+    for fk in fks_by_source.get(table_name, []):
+        if fk.to_table not in entity_names:
+            continue
+        if len(fk.from_columns) != 1:
+            continue
+        target_pascal = _pascal(fk.to_table)
+        from_column = fk.from_columns[0]
+        edges.append(f'edge.To("{fk.to_table}", {target_pascal}.Type).Unique().Field("{from_column}"),')
+    return edges
+
+
+def _render_entity_file(
+    table_name: str,
+    columns: list[ColumnInfo],
+    edges: list[str],
+    extra_imports: set[str],
+    enum_names: set[str],
+    enum_values_by_name: dict[str, list[str]],
+) -> str:
+    """Build one Go source file for a table.
+
+    The file looks like::
+
+        package schema
+
+        import (
+            "entgo.io/ent"
+            "entgo.io/ent/schema/field"
+            "entgo.io/ent/schema/edge"
+        )
+
+        type Widget struct {
+            ent.Schema
+        }
+
+        func (Widget) Fields() []ent.Field {
+            return []ent.Field{
+                field.Int("id"),
+                ...
+            }
+        }
+
+        func (Widget) Edges() []ent.Edge {
+            return []ent.Edge{
+                edge.To("owner", Owner.Type).Unique().Field("owner_id"),
+            }
+        }
+    """
+    entity = _pascal(table_name)
+    field_lines: list[str] = []
+    for col in columns:
+        line, extra = _render_field_call(col, enum_names, enum_values_by_name)
+        if extra is not None:
+            extra_imports.add(extra)
+        if line.startswith("field.Time(") or ".Default(time.Now)" in line:
+            extra_imports.add("time")
+        field_lines.append(f"        {line},")
+
+    # Imports — always include ent + field; add edge only when edges exist.
+    imports = ['"entgo.io/ent"', '"entgo.io/ent/schema/field"']
+    if edges:
+        imports.append('"entgo.io/ent/schema/edge"')
+    for extra in sorted(extra_imports):
+        if extra == "time":
+            imports.append('"time"')
+        else:
+            imports.append(f'"{extra}"')
+
+    body = [
+        "package schema",
+        "",
+        "import (",
+        *(f"    {imp}" for imp in imports),
+        ")",
+        "",
+        f"// {entity} holds the schema definition for the {entity} entity.",
+        f"type {entity} struct {{",
+        "    ent.Schema",
+        "}",
+        "",
+        f"// Fields of the {entity}.",
+        f"func ({entity}) Fields() []ent.Field {{",
+        "    return []ent.Field{",
+        *field_lines,
+        "    }",
+        "}",
+    ]
+    if edges:
+        body.extend(
+            [
+                "",
+                f"// Edges of the {entity}.",
+                f"func ({entity}) Edges() []ent.Edge {{",
+                "    return []ent.Edge{",
+                *(f"        {e}" for e in edges),
+                "    }",
+                "}",
+            ]
+        )
+    return "\n".join(body) + "\n"
+
+
+async def generate_ent_schemas(driver: SqlDriver, schema: str) -> dict[str, str]:
+    """Emit one Go source file per base table in ``schema``.
+
+    Returns a dict ``{filename: source}`` so callers can write each
+    file or pass it through to the agent for inspection. Filenames are
+    snake_case (matching Ent's conventional layout).
+
+    Raises:
+        EntExportError: When the schema name, or any table / column
+            name within it, requires PostgreSQL delimited-identifier
+            quoting.
+    """
+    _check_identifier(schema, "schema")
+    tables = [t for t in await list_tables(driver, schema) if t.type == "BASE TABLE" and not t.is_partition]
+    for t in tables:
+        _check_identifier(t.name, "table")
+
+    enums = await list_enums(driver, schema)
+    enum_names = {e.name for e in enums}
+    enum_values_by_name = {e.name: list(e.values) for e in enums}
+
+    fks_all = await list_foreign_keys(driver, schema)
+    fks_by_source: dict[str, list[ForeignKeyInfo]] = {}
+    for fk in fks_all:
+        fks_by_source.setdefault(fk.from_table, []).append(fk)
+    entity_names = {t.name for t in tables}
+
+    output: dict[str, str] = {}
+    for table in tables:
+        columns = await describe_table(driver, schema, table.name)
+        for col in columns:
+            _check_identifier(col.name, "column")
+        extra_imports: set[str] = set()
+        edges = _render_edges(table.name, fks_by_source, entity_names)
+        source = _render_entity_file(
+            table.name,
+            columns,
+            edges,
+            extra_imports,
+            enum_names,
+            enum_values_by_name,
+        )
+        output[f"{table.name}.go"] = source
+
+    return output

--- a/src/mcpg/http_runtime.py
+++ b/src/mcpg/http_runtime.py
@@ -1,0 +1,186 @@
+"""HTTP-transport extensions: bearer-token auth + Prometheus /metrics.
+
+FastMCP's ``streamable_http_app()`` / ``sse_app()`` return Starlette
+applications. We don't need to fork that surface — we wrap the
+returned app with two pieces of middleware-style infrastructure:
+
+1. **Bearer-token auth.** When ``Settings.http_auth_token`` is set,
+   every request to the MCP transport routes through a check that the
+   ``Authorization: Bearer <token>`` header matches. Missing or wrong
+   token → ``401 Unauthorized``. ``/metrics`` is exempted so a
+   Prometheus scraper can hit it without holding the MCP token (a
+   common operational split). The scraper still needs network reach;
+   set ``MCPG_HTTP_HOST`` to ``0.0.0.0`` only if you've front-proxied
+   the endpoint.
+2. **Prometheus ``/metrics``.** A small ``Route`` that emits the text
+   exposition format from :mod:`mcpg.observability`.
+
+The ``stdio`` transport is unaffected — there's no HTTP surface to
+guard. ``run_http`` builds the wrapped app and serves it via uvicorn.
+"""
+
+from __future__ import annotations
+
+import hmac
+import logging
+from typing import TYPE_CHECKING
+
+from mcpg.config import Settings
+from mcpg.observability import render_prometheus
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from starlette.applications import Starlette
+    from starlette.requests import Request
+    from starlette.responses import Response
+
+logger = logging.getLogger(__name__)
+
+# Standard Prometheus text-format content type. Compatible with both
+# OpenMetrics-aware and legacy scrapers.
+_PROMETHEUS_CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8"
+
+# Paths the auth middleware skips. /metrics ships its own auth story
+# (network-level; see module docstring) so the operational split
+# between the MCP token and the scraper works without a second
+# credential.
+_AUTH_EXEMPT_PATHS = frozenset({"/metrics", "/healthz", "/readyz"})
+
+
+def _metrics_response_factory() -> Callable[[Request], Awaitable[Response]]:
+    """Build the Starlette endpoint that serves the metrics text."""
+    from starlette.responses import PlainTextResponse
+
+    async def metrics_endpoint(_request: Request) -> Response:
+        return PlainTextResponse(render_prometheus(), media_type=_PROMETHEUS_CONTENT_TYPE)
+
+    return metrics_endpoint
+
+
+def _health_response_factory() -> Callable[[Request], Awaitable[Response]]:
+    from starlette.responses import PlainTextResponse
+
+    async def healthz(_request: Request) -> Response:
+        return PlainTextResponse("ok\n")
+
+    return healthz
+
+
+class _BearerAuthMiddleware:
+    """ASGI middleware that enforces ``Authorization: Bearer <token>``.
+
+    Uses :func:`hmac.compare_digest` so token comparison is
+    constant-time — a tiny precaution against timing oracles, but a
+    free one given how easy it is to write.
+    """
+
+    def __init__(self, app: object, *, token: str, exempt_paths: frozenset[str] = _AUTH_EXEMPT_PATHS) -> None:
+        self._app = app
+        self._token = token
+        self._exempt = exempt_paths
+
+    async def __call__(self, scope: dict[str, object], receive: object, send: object) -> None:
+        if scope["type"] != "http":
+            # Non-HTTP scopes (lifespan) pass straight through; the auth
+            # gate only makes sense for actual requests.
+            await self._app(scope, receive, send)  # type: ignore[operator]
+            return
+
+        path = str(scope.get("path", ""))
+        if path in self._exempt:
+            await self._app(scope, receive, send)  # type: ignore[operator]
+            return
+
+        headers: list[tuple[bytes, bytes]] = scope.get("headers", [])  # type: ignore[assignment]
+        auth_header = b""
+        for key, value in headers:
+            if key.lower() == b"authorization":
+                auth_header = value
+                break
+
+        if not auth_header.startswith(b"Bearer "):
+            await _send_401(send, "missing Authorization: Bearer header")
+            return
+
+        presented = auth_header[len(b"Bearer ") :].decode("ascii", errors="ignore").strip()
+        if not hmac.compare_digest(presented, self._token):
+            await _send_401(send, "invalid bearer token")
+            return
+
+        await self._app(scope, receive, send)  # type: ignore[operator]
+
+
+async def _send_401(send: object, reason: str) -> None:
+    """Emit a minimal 401 response without leaking server internals."""
+    body = f'{{"error": "unauthorized", "reason": "{reason}"}}\n'.encode()
+    await send(  # type: ignore[operator]
+        {
+            "type": "http.response.start",
+            "status": 401,
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"www-authenticate", b'Bearer realm="mcpg"'),
+                (b"content-length", str(len(body)).encode()),
+            ],
+        }
+    )
+    await send({"type": "http.response.body", "body": body})  # type: ignore[operator]
+
+
+def build_http_app(server: object, settings: Settings, *, kind: str) -> Starlette:
+    """Wrap a FastMCP HTTP app with metrics + optional auth.
+
+    Args:
+        server: A ``FastMCP`` instance.
+        settings: Active server settings.
+        kind: ``"streamable-http"`` or ``"sse"``.
+
+    Returns:
+        A Starlette app with ``/metrics`` mounted and (when
+        ``settings.http_auth_token`` is set) bearer-token auth on
+        everything except the exempt paths.
+    """
+    from starlette.routing import Route
+
+    if kind == "streamable-http":
+        app = server.streamable_http_app()  # type: ignore[attr-defined]
+    elif kind == "sse":
+        app = server.sse_app()  # type: ignore[attr-defined]
+    else:
+        raise ValueError(f"unknown HTTP transport kind: {kind!r}")
+
+    # Mount /metrics + /healthz on the existing router. Starlette
+    # exposes the underlying router via .router; appending Route
+    # objects is the idiomatic way to extend the route table without
+    # subclassing.
+    app.router.routes.append(Route("/metrics", _metrics_response_factory(), methods=["GET"]))
+    app.router.routes.append(Route("/healthz", _health_response_factory(), methods=["GET"]))
+
+    if settings.http_auth_token is not None:
+        # Starlette's add_middleware appends to the middleware stack
+        # that's wrapped around the app at startup. ASGI middleware
+        # has signature (app, *args, **kwargs) -> wrapped_app, and
+        # Starlette calls it accordingly.
+        app.add_middleware(_BearerAuthMiddleware, token=settings.http_auth_token)
+    else:
+        logger.warning(
+            "MCPg HTTP transport %s is running without auth. "
+            "Set MCPG_HTTP_AUTH_TOKEN to require Bearer tokens on every request.",
+            kind,
+        )
+    # FastMCP types streamable_http_app() / sse_app() as Starlette already,
+    # but mypy under strict mode loses the type through the .add_middleware
+    # call (returns None). Cast through Any to settle the return type
+    # without hiding real type errors.
+    from typing import cast as _cast
+
+    return _cast("Starlette", app)
+
+
+def run_http(server: object, settings: Settings, *, kind: str) -> None:
+    """Build the wrapped HTTP app and serve it via uvicorn."""
+    import uvicorn
+
+    app = build_http_app(server, settings, kind=kind)
+    uvicorn.run(app, host=settings.http_host, port=settings.http_port)

--- a/src/mcpg/http_runtime.py
+++ b/src/mcpg/http_runtime.py
@@ -103,7 +103,7 @@ class _BearerAuthMiddleware:
             await _send_401(send, "missing Authorization: Bearer header")
             return
 
-        presented = auth_header[len(b"Bearer ") :].decode("ascii", errors="ignore").strip()
+        presented = auth_header[len(b"Bearer ") :].decode("utf-8", errors="ignore").strip()
         if not hmac.compare_digest(presented, self._token):
             await _send_401(send, "invalid bearer token")
             return

--- a/src/mcpg/jooq.py
+++ b/src/mcpg/jooq.py
@@ -1,0 +1,180 @@
+"""Schema → jOOQ (Java) configuration exporter.
+
+`jOOQ <https://www.jooq.org/>`_ generates type-safe Java code from a
+live database using its code generator. The canonical input is an XML
+or programmatic *configuration* file pointing at the database and
+declaring what to generate. This exporter writes that configuration
+from a PG catalog so a Java agent can drop the file straight into a
+build.
+
+Unlike the other Batch G exporters, jOOQ does NOT consume a DSL of
+type-mapped declarations — it reads the live database itself at
+generation time. So the artefact this module emits is the
+``jooq-codegen`` ``<configuration>`` XML pointing at the schema +
+listing the tables the user wants generated. The user runs
+``mvn jooq-codegen:generate`` (or the equivalent Gradle task)
+themselves, and jOOQ does the heavy lifting from the catalog.
+
+This makes the exporter much smaller than the others — most of the
+mapping logic lives inside jOOQ. We provide:
+
+- The configuration scaffold (jdbc URL placeholder, dialect, target
+  package, output directory).
+- An explicit ``<includes>`` regex covering exactly the base tables
+  in the schema, so generation is deterministic even if the schema
+  later grows new objects we don't want generated.
+- An ``<excludes>`` line listing the audit/migration helper tables
+  MCPg creates so they don't leak into the generated code.
+- Optional ``<forcedTypes>`` for JSON/JSONB columns so they map to
+  ``org.jooq.JSON`` / ``org.jooq.JSONB`` Java types out of the box.
+"""
+
+from __future__ import annotations
+
+import re
+from xml.sax.saxutils import escape
+
+from mcpg._vendor.sql import SqlDriver
+from mcpg.introspection import (
+    ColumnInfo,
+    describe_table,
+    list_tables,
+)
+
+_IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
+
+# MCPg's own bookkeeping tables — never useful to generate jOOQ code for.
+_EXCLUDED_TABLE_PATTERN = "mcpg_audit\\..*|mcpg_migrations\\..*"
+
+
+class JooqExportError(Exception):
+    """Raised when a jOOQ export call is rejected or fails."""
+
+
+def _check_identifier(name: str, kind: str) -> None:
+    if not _IDENTIFIER.match(name):
+        raise JooqExportError(f"invalid {kind} name: {name!r}")
+
+
+def _strip_type_params(data_type: str) -> str:
+    return re.sub(r"\(.*\)", "", data_type).strip()
+
+
+def _is_json_column(column: ColumnInfo) -> tuple[bool, str | None]:
+    """Return ``(is_json, java_type)`` for the column.
+
+    ``json`` → ``org.jooq.JSON``, ``jsonb`` → ``org.jooq.JSONB``.
+    Everything else is ``(False, None)``.
+    """
+    base = _strip_type_params(column.data_type).lower()
+    if base == "jsonb":
+        return True, "org.jooq.JSONB"
+    if base == "json":
+        return True, "org.jooq.JSON"
+    return False, None
+
+
+def _render_forced_type(table: str, column: str, java_type: str, schema: str) -> str:
+    """Build one ``<forcedType>`` block tying a column to a Java type.
+
+    The ``expression`` is a regex anchored on the fully-qualified
+    column path so the rule doesn't accidentally match other columns.
+    """
+    # Anchor the expression so it only matches THIS column, not a
+    # similarly-named column in another table.
+    return (
+        "            <forcedType>\n"
+        f"                <userType>{escape(java_type)}</userType>\n"
+        "                <converter>org.jooq.Converter.ofNullable("
+        "java.lang.String.class, "
+        f"{escape(java_type)}.class, "
+        f"{escape(java_type)}::valueOf, java.lang.Object::toString)</converter>\n"
+        f"                <expression>{escape(schema)}\\.{escape(table)}\\.{escape(column)}</expression>\n"
+        "                <types>.*</types>\n"
+        "            </forcedType>"
+    )
+
+
+async def generate_jooq_config(
+    driver: SqlDriver,
+    schema: str,
+    *,
+    target_package: str = "com.example.jooq",
+    target_directory: str = "src/main/java",
+) -> str:
+    """Emit a ``jooq-codegen`` ``<configuration>`` XML for ``schema``.
+
+    The XML names every base table in the schema explicitly via an
+    ``<includes>`` regex, excludes MCPg's bookkeeping tables, and
+    emits a ``<forcedType>`` for every ``json`` / ``jsonb`` column so
+    the generated DAOs use ``org.jooq.JSON`` / ``org.jooq.JSONB``
+    instead of ``Object``.
+
+    Args:
+        driver: SQL driver bound to the live database.
+        schema: PG schema to generate from. Must be a plain identifier.
+        target_package: Java package the generated code lands in.
+        target_directory: Source root the generated package lives under.
+
+    Raises:
+        JooqExportError: When the schema name, or any table / column
+            name within it, requires PostgreSQL delimited-identifier
+            quoting.
+    """
+    _check_identifier(schema, "schema")
+    tables = [t for t in await list_tables(driver, schema) if t.type == "BASE TABLE" and not t.is_partition]
+    for t in tables:
+        _check_identifier(t.name, "table")
+
+    # Build the includes regex out of explicit table names — anchored
+    # so a future ``widget2`` table won't accidentally get generated.
+    if tables:
+        # Each name is already a plain identifier (validated above), so
+        # no regex-meta-character escaping is needed here.
+        includes_expr = "|".join(f"{schema}\\.{t.name}" for t in tables)
+    else:
+        includes_expr = ""  # nothing to generate
+
+    # Collect forced-type entries for JSON / JSONB columns across every table.
+    forced_types: list[str] = []
+    for table in tables:
+        columns = await describe_table(driver, schema, table.name)
+        for col in columns:
+            is_json, java_type = _is_json_column(col)
+            if is_json and java_type is not None:
+                _check_identifier(col.name, "column")
+                forced_types.append(_render_forced_type(table.name, col.name, java_type, schema))
+
+    forced_types_block = ""
+    if forced_types:
+        forced_types_block = "        <forcedTypes>\n" + "\n".join(forced_types) + "\n        </forcedTypes>\n"
+
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<configuration xmlns="http://www.jooq.org/xsd/jooq-codegen-3.19.0.xsd">\n'
+        "    <!--\n"
+        f"      Auto-generated by MCPg for schema {escape(schema)!r}.\n"
+        "      Set the jdbc URL / user / password to point at YOUR\n"
+        "      target database — these are placeholders.\n"
+        "    -->\n"
+        "    <jdbc>\n"
+        "        <driver>org.postgresql.Driver</driver>\n"
+        "        <url>jdbc:postgresql://localhost:5432/mydb</url>\n"
+        "        <user>postgres</user>\n"
+        "        <password></password>\n"
+        "    </jdbc>\n"
+        "    <generator>\n"
+        "        <database>\n"
+        "            <name>org.jooq.meta.postgres.PostgresDatabase</name>\n"
+        f"            <inputSchema>{escape(schema)}</inputSchema>\n"
+        f"            <includes>{escape(includes_expr)}</includes>\n"
+        f"            <excludes>{escape(_EXCLUDED_TABLE_PATTERN)}</excludes>\n"
+        "        </database>\n"
+        f"{forced_types_block}"
+        "        <target>\n"
+        f"            <packageName>{escape(target_package)}</packageName>\n"
+        f"            <directory>{escape(target_directory)}</directory>\n"
+        "        </target>\n"
+        "    </generator>\n"
+        "</configuration>\n"
+    )

--- a/src/mcpg/observability.py
+++ b/src/mcpg/observability.py
@@ -1,0 +1,163 @@
+"""Observability — Prometheus-format metrics for tool calls.
+
+Lightweight in-process metrics that record per-tool call counts and
+latency distribution. No external dependency: the
+:func:`render_prometheus` helper emits the standard text exposition
+format directly, which any Prometheus scraper consumes.
+
+Three series are exported:
+
+- ``mcpg_tool_calls_total{tool, status}`` — counter, one increment per
+  ``call_tool`` invocation. ``status`` is ``ok`` or ``error``.
+- ``mcpg_tool_duration_seconds_bucket{tool, le}`` — histogram of
+  per-tool wall-clock time (seconds). Default buckets match Prometheus'
+  ``DEF_BUCKETS`` plus a 30s and 60s overflow.
+- ``mcpg_tool_duration_seconds_sum{tool}`` /
+  ``mcpg_tool_duration_seconds_count{tool}`` — totals to match the
+  histogram so the standard
+  ``rate(..._sum[1m]) / rate(..._count[1m])`` query computes the mean.
+
+A single module-level :class:`Metrics` instance backs the
+:class:`mcpg.server.AuditedFastMCP` hook. Tests get a fresh instance
+via :func:`reset_metrics` so cross-test pollution can't accumulate.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass, field
+from typing import Final
+
+# Histogram buckets in seconds. Matches Prometheus DEF_BUCKETS plus
+# two overflow lanes so a slow pg_dump that takes 30+ seconds still
+# lands somewhere meaningful instead of just "+Inf".
+DEFAULT_BUCKETS: Final[tuple[float, ...]] = (
+    0.005,
+    0.01,
+    0.025,
+    0.05,
+    0.1,
+    0.25,
+    0.5,
+    1.0,
+    2.5,
+    5.0,
+    10.0,
+    30.0,
+    60.0,
+)
+
+
+@dataclass
+class _Histogram:
+    """Per-tool histogram state — bucket counts + cumulative sum/count."""
+
+    buckets: tuple[float, ...] = DEFAULT_BUCKETS
+    counts: list[int] = field(default_factory=lambda: [0] * len(DEFAULT_BUCKETS))
+    sum: float = 0.0
+    count: int = 0
+
+    def observe(self, value: float) -> None:
+        self.count += 1
+        self.sum += value
+        for index, upper in enumerate(self.buckets):
+            if value <= upper:
+                self.counts[index] += 1
+
+
+class Metrics:
+    """Thread-safe per-tool counter + histogram store.
+
+    The MCP server is async-single-threaded in practice but the
+    ``threading.Lock`` is cheap insurance against any future
+    multi-thread access (e.g. a Prometheus scraper running in a
+    background thread).
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        # (tool, status) -> count
+        self._calls: dict[tuple[str, str], int] = {}
+        # tool -> histogram of durations
+        self._durations: dict[str, _Histogram] = {}
+
+    def record_call(self, tool: str, status: str, duration_seconds: float) -> None:
+        """Record one ``call_tool`` event.
+
+        Args:
+            tool: Tool name (the MCP-side identifier).
+            status: ``ok`` on success, ``error`` when the tool raised.
+            duration_seconds: Wall-clock time the call took.
+        """
+        with self._lock:
+            self._calls[(tool, status)] = self._calls.get((tool, status), 0) + 1
+            hist = self._durations.setdefault(tool, _Histogram())
+            hist.observe(duration_seconds)
+
+    def snapshot(self) -> tuple[dict[tuple[str, str], int], dict[str, _Histogram]]:
+        """Return a defensive copy of the current counter + histogram state."""
+        with self._lock:
+            return (
+                dict(self._calls),
+                {
+                    tool: _Histogram(buckets=h.buckets, counts=list(h.counts), sum=h.sum, count=h.count)
+                    for tool, h in self._durations.items()
+                },
+            )
+
+
+# Module-level singleton — the server's AuditedFastMCP records into it.
+_metrics = Metrics()
+
+
+def get_metrics() -> Metrics:
+    """Return the module-level Metrics instance."""
+    return _metrics
+
+
+def reset_metrics() -> None:
+    """Replace the singleton with a fresh Metrics — test isolation hook."""
+    global _metrics
+    _metrics = Metrics()
+
+
+def _escape_label_value(value: str) -> str:
+    """Escape a Prometheus label value per the text exposition format."""
+    return value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+
+
+def render_prometheus(metrics: Metrics | None = None) -> str:
+    """Render the metrics as Prometheus text exposition (v0.0.4) format.
+
+    Returns a string ready to serve from a ``/metrics`` endpoint. Empty
+    state still produces valid output: each series ends in zero counts.
+    """
+    target = metrics if metrics is not None else _metrics
+    calls, durations = target.snapshot()
+    lines: list[str] = []
+
+    # mcpg_tool_calls_total
+    lines.append("# HELP mcpg_tool_calls_total Total MCP tool invocations partitioned by tool and outcome.")
+    lines.append("# TYPE mcpg_tool_calls_total counter")
+    for (tool, status), value in sorted(calls.items()):
+        tool_label = _escape_label_value(tool)
+        status_label = _escape_label_value(status)
+        lines.append(f'mcpg_tool_calls_total{{tool="{tool_label}",status="{status_label}"}} {value}')
+
+    # mcpg_tool_duration_seconds (histogram + _sum + _count)
+    lines.append("# HELP mcpg_tool_duration_seconds Wall-clock duration of MCP tool invocations, in seconds.")
+    lines.append("# TYPE mcpg_tool_duration_seconds histogram")
+    for tool in sorted(durations):
+        hist = durations[tool]
+        tool_label = _escape_label_value(tool)
+        # _Histogram.observe stores cumulative counts already (a value
+        # increments every bucket whose upper bound it satisfies), so
+        # emit them directly — no re-accumulation needed.
+        for index, upper in enumerate(hist.buckets):
+            lines.append(f'mcpg_tool_duration_seconds_bucket{{tool="{tool_label}",le="{upper}"}} {hist.counts[index]}')
+        # +Inf bucket always matches the total count.
+        lines.append(f'mcpg_tool_duration_seconds_bucket{{tool="{tool_label}",le="+Inf"}} {hist.count}')
+        lines.append(f'mcpg_tool_duration_seconds_sum{{tool="{tool_label}"}} {hist.sum}')
+        lines.append(f'mcpg_tool_duration_seconds_count{{tool="{tool_label}"}} {hist.count}')
+
+    return "\n".join(lines) + "\n"

--- a/src/mcpg/server.py
+++ b/src/mcpg/server.py
@@ -8,6 +8,7 @@ mutable global state.
 
 from __future__ import annotations
 
+import time
 from collections.abc import AsyncIterator, Callable, Sequence
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from typing import Any
@@ -20,6 +21,7 @@ from mcpg.config import Settings, Transport
 from mcpg.context import AppContext
 from mcpg.database import Database
 from mcpg.listen import ListenManager
+from mcpg.observability import get_metrics
 from mcpg.tools import register_tools
 
 SERVER_NAME = "mcpg"
@@ -34,12 +36,18 @@ class AuditedFastMCP(FastMCP[AppContext]):
     """A FastMCP server that records an audit event for every tool call."""
 
     async def call_tool(self, name: str, arguments: dict[str, Any]) -> Sequence[ContentBlock] | dict[str, Any]:
+        metrics = get_metrics()
+        start = time.monotonic()
         try:
             result = await super().call_tool(name, arguments)
         except Exception as exc:
+            duration = time.monotonic() - start
             audit.record(audit.AuditEvent(tool=name, arguments=arguments, status="error", error=str(exc)))
+            metrics.record_call(name, "error", duration)
             raise
+        duration = time.monotonic() - start
         audit.record(audit.AuditEvent(tool=name, arguments=arguments, status="ok"))
+        metrics.record_call(name, "ok", duration)
         return result
 
 
@@ -96,12 +104,21 @@ def create_server(
 
 
 def run(settings: Settings) -> None:
-    """Create and run the server using the transport from ``settings``."""
+    """Create and run the server using the transport from ``settings``.
+
+    HTTP transports (``streamable-http`` and ``sse``) go through
+    :mod:`mcpg.http_runtime` so the ``/metrics`` endpoint and optional
+    bearer-token auth attach to the served app.
+    """
     server = create_server(settings)
     match settings.transport:
         case Transport.STDIO:
             server.run(transport="stdio")
         case Transport.STREAMABLE_HTTP:
-            server.run(transport="streamable-http")
+            from mcpg.http_runtime import run_http
+
+            run_http(server, settings, kind="streamable-http")
         case Transport.SSE:
-            server.run(transport="sse")
+            from mcpg.http_runtime import run_http
+
+            run_http(server, settings, kind="sse")

--- a/src/mcpg/textsearch.py
+++ b/src/mcpg/textsearch.py
@@ -250,6 +250,450 @@ async def vector_search(
     return VectorSearchResult(available=True, matches=matches)
 
 
+# --- pgvector range search (Phase 11.2) ----------------------------------
+
+
+async def vector_range_search(
+    driver: SqlDriver,
+    schema: str,
+    table: str,
+    column: str,
+    query_vector: list[float],
+    max_distance: float,
+    *,
+    metric: str = DEFAULT_VECTOR_METRIC,
+    limit: int = DEFAULT_LIMIT,
+) -> VectorSearchResult:
+    """Return every row within ``max_distance`` of ``query_vector``.
+
+    A different query shape than :func:`vector_search` (top-k). Useful for
+    de-duplication ("find duplicates within ε"), similarity gating
+    ("only surface results closer than 0.3"), and clustering pre-passes.
+
+    Results are still ordered by distance ascending and capped at
+    ``limit`` so a too-loose threshold doesn't pull the entire table —
+    a callee that hits ``limit`` should tighten the threshold rather
+    than scroll. The same per-metric semantics apply as
+    :func:`vector_search`: cosine returns 1 - cos(theta), l2 is euclidean
+    distance, inner_product is negated dot product (smaller = closer).
+
+    Raises:
+        SearchError: If an identifier is invalid, the metric is unknown,
+            ``query_vector`` contains a non-finite value, or
+            ``max_distance`` is negative.
+    """
+    if not await extension_installed(driver, "vector"):
+        return VectorSearchResult(available=False, matches=[])
+    if metric not in _VECTOR_METRICS:
+        raise SearchError(f"unknown vector metric: {metric!r}")
+    if not all(math.isfinite(value) for value in query_vector):
+        raise SearchError("query_vector must contain only finite numbers")
+    if not math.isfinite(max_distance) or max_distance < 0:
+        raise SearchError("max_distance must be a non-negative finite number")
+
+    operator = _VECTOR_METRICS[metric]
+    relation = f"{_quoted(schema, 'schema')}.{_quoted(table, 'table')}"
+    col = _quoted(column, "column")
+    literal = "[" + ",".join(str(float(value)) for value in query_vector) + "]"
+    rows = await driver.execute_query(
+        f"SELECT *, {col} {operator} %s::vector AS mcpg_distance "
+        f"FROM {relation} WHERE {col} {operator} %s::vector <= %s "
+        f"ORDER BY {col} {operator} %s::vector LIMIT %s",
+        params=[literal, literal, max_distance, literal, limit],
+        force_readonly=True,
+    )
+    matches: list[VectorMatch] = []
+    for row in rows or []:
+        cells = dict(row.cells)
+        distance = cells.pop("mcpg_distance")
+        cells.pop(column, None)
+        matches.append(VectorMatch(distance=distance, row=cells))
+    return VectorSearchResult(available=True, matches=matches)
+
+
+# --- hybrid search (Phase 11.1) ------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class HybridMatch:
+    """One hybrid-search hit with the per-source ranks and fused score.
+
+    ``vector_rank`` / ``fts_rank`` are 1-indexed positions in each
+    source's ranking, or ``None`` when the row didn't appear there.
+    ``rrf_score`` is the reciprocal-rank-fusion score
+    (Σ 1/(k+rank)) used to order results.
+    """
+
+    rrf_score: float
+    vector_rank: int | None
+    fts_rank: int | None
+    vector_distance: float | None
+    fts_rank_score: float | None
+    row: dict[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class HybridSearchResult:
+    """The outcome of a hybrid search.
+
+    ``available`` is false when the ``vector`` extension isn't installed
+    (the full-text half alone is always available since PG's tsvector is
+    built in, but a hybrid call without pgvector is degenerate and the
+    caller should know).
+    """
+
+    available: bool
+    matches: list[HybridMatch]
+
+
+# RRF's standard "k=60" smoothing constant — high enough that rank-1
+# vs rank-2 isn't a huge gap, low enough to still differentiate.
+_HYBRID_RRF_K = 60
+
+
+async def hybrid_search(
+    driver: SqlDriver,
+    schema: str,
+    table: str,
+    vector_column: str,
+    text_column: str,
+    query_vector: list[float],
+    text_query: str,
+    *,
+    metric: str = DEFAULT_VECTOR_METRIC,
+    text_config: str = DEFAULT_TEXT_CONFIG,
+    limit: int = DEFAULT_LIMIT,
+    candidate_pool: int = 50,
+    rrf_k: int = _HYBRID_RRF_K,
+) -> HybridSearchResult:
+    """Combine vector and full-text ranking via reciprocal-rank fusion.
+
+    Pulls ``candidate_pool`` candidates from each source (vector k-NN
+    on ``vector_column`` and ``websearch_to_tsquery`` on
+    ``text_column``), fuses them with RRF
+    (score = Σ 1/(``rrf_k`` + rank)), and returns the top ``limit``.
+    Rows present in only one source are still included; their score
+    just comes from one term.
+
+    This is the biggest unmet need for agentic RAG: pure vector search
+    misses keyword matches (proper nouns, identifiers, numbers); pure
+    full-text misses semantic synonyms. RRF is the well-studied,
+    parameter-free way to combine them.
+
+    Raises:
+        SearchError: When an identifier / metric / config is invalid,
+            ``query_vector`` contains a non-finite value, or
+            ``candidate_pool`` / ``rrf_k`` are non-positive.
+    """
+    if not await extension_installed(driver, "vector"):
+        return HybridSearchResult(available=False, matches=[])
+    if metric not in _VECTOR_METRICS:
+        raise SearchError(f"unknown vector metric: {metric!r}")
+    if not all(math.isfinite(value) for value in query_vector):
+        raise SearchError("query_vector must contain only finite numbers")
+    if candidate_pool < 1:
+        raise SearchError("candidate_pool must be at least 1")
+    if rrf_k < 1:
+        raise SearchError("rrf_k must be at least 1")
+
+    operator = _VECTOR_METRICS[metric]
+    relation = f"{_quoted(schema, 'schema')}.{_quoted(table, 'table')}"
+    vcol = _quoted(vector_column, "column")
+    tcol = _quoted(text_column, "column")
+    cfg = f"'{_checked(text_config, 'text-search config')}'"
+    literal = "[" + ",".join(str(float(value)) for value in query_vector) + "]"
+
+    # Pull the vector candidates with their distance + rank.
+    vec_rows = await driver.execute_query(
+        f"SELECT *, {vcol} {operator} %s::vector AS mcpg_distance, "
+        f"row_number() OVER (ORDER BY {vcol} {operator} %s::vector) AS mcpg_rank "
+        f"FROM {relation} ORDER BY {vcol} {operator} %s::vector LIMIT %s",
+        params=[literal, literal, literal, candidate_pool],
+        force_readonly=True,
+    )
+    # Pull the FTS candidates with their ts_rank + rank.
+    vector = f"to_tsvector({cfg}, {tcol})"
+    tsquery = f"websearch_to_tsquery({cfg}, %s)"
+    fts_rows = await driver.execute_query(
+        f"SELECT *, ts_rank({vector}, {tsquery}) AS mcpg_rank_score, "
+        f"row_number() OVER (ORDER BY ts_rank({vector}, {tsquery}) DESC) AS mcpg_rank "
+        f"FROM {relation} WHERE {vector} @@ {tsquery} "
+        f"ORDER BY mcpg_rank_score DESC LIMIT %s",
+        params=[text_query, text_query, text_query, candidate_pool],
+        force_readonly=True,
+    )
+
+    return _fuse_rrf(
+        vec_rows or [],
+        fts_rows or [],
+        vector_column,
+        text_column,
+        rrf_k=rrf_k,
+        limit=limit,
+    )
+
+
+def _row_key(cells: dict[str, Any]) -> tuple[Any, ...] | str:
+    """Pick a stable key for matching a row across the two candidate sets.
+
+    Prefer a single ``id`` column, then any ``*_id``-named column, then
+    fall back to the frozenset of the row's items. The fallback should
+    rarely fire because most pgvector tables carry a primary key.
+    """
+    if "id" in cells:
+        return ("id", cells["id"])
+    for name in cells:
+        if name.endswith("_id"):
+            return (name, cells[name])
+    return tuple(sorted((str(k), str(v)) for k, v in cells.items()))
+
+
+def _fuse_rrf(
+    vec_rows: list[Any],
+    fts_rows: list[Any],
+    vector_column: str,
+    text_column: str,
+    *,
+    rrf_k: int,
+    limit: int,
+) -> HybridSearchResult:
+    """Combine two candidate lists by reciprocal-rank fusion."""
+
+    by_key: dict[Any, HybridMatch] = {}
+
+    def merge(
+        key: Any,
+        cells: dict[str, Any],
+        *,
+        vec_rank: int | None,
+        fts_rank: int | None,
+        vec_distance: float | None,
+        fts_score: float | None,
+    ) -> None:
+        existing = by_key.get(key)
+        if existing is None:
+            score = 0.0
+            if vec_rank is not None:
+                score += 1.0 / (rrf_k + vec_rank)
+            if fts_rank is not None:
+                score += 1.0 / (rrf_k + fts_rank)
+            by_key[key] = HybridMatch(
+                rrf_score=score,
+                vector_rank=vec_rank,
+                fts_rank=fts_rank,
+                vector_distance=vec_distance,
+                fts_rank_score=fts_score,
+                row=cells,
+            )
+            return
+        score = existing.rrf_score
+        new_vec_rank = existing.vector_rank
+        new_fts_rank = existing.fts_rank
+        new_vec_dist = existing.vector_distance
+        new_fts_score = existing.fts_rank_score
+        if vec_rank is not None and existing.vector_rank is None:
+            score += 1.0 / (rrf_k + vec_rank)
+            new_vec_rank = vec_rank
+            new_vec_dist = vec_distance
+        if fts_rank is not None and existing.fts_rank is None:
+            score += 1.0 / (rrf_k + fts_rank)
+            new_fts_rank = fts_rank
+            new_fts_score = fts_score
+        by_key[key] = HybridMatch(
+            rrf_score=score,
+            vector_rank=new_vec_rank,
+            fts_rank=new_fts_rank,
+            vector_distance=new_vec_dist,
+            fts_rank_score=new_fts_score,
+            row=existing.row,
+        )
+
+    for row in vec_rows:
+        cells = dict(row.cells)
+        rank = cells.pop("mcpg_rank")
+        distance = cells.pop("mcpg_distance")
+        cells.pop(vector_column, None)
+        key = _row_key(cells)
+        merge(key, cells, vec_rank=int(rank), fts_rank=None, vec_distance=distance, fts_score=None)
+
+    for row in fts_rows:
+        cells = dict(row.cells)
+        rank = cells.pop("mcpg_rank")
+        score = cells.pop("mcpg_rank_score")
+        cells.pop(text_column, None)
+        # Don't strip vector_column from FTS-only rows; it stays in the
+        # payload so the caller can re-rank later if they want.
+        cells.pop(vector_column, None)
+        key = _row_key(cells)
+        merge(key, cells, vec_rank=None, fts_rank=int(rank), vec_distance=None, fts_score=score)
+
+    fused = sorted(by_key.values(), key=lambda m: m.rrf_score, reverse=True)[:limit]
+    return HybridSearchResult(available=True, matches=fused)
+
+
+# --- vector-quantization advisor (Phase 11.3) ----------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class QuantizationRecommendation:
+    """Advice for converting a vector column to a more compact type.
+
+    Per-column estimates of current bytes vs the alternative, plus the
+    rough cost saving and a one-line rationale.
+    """
+
+    schema: str
+    table: str
+    column: str
+    dimension: int
+    row_count: int
+    current_type: str
+    current_bytes: int
+    suggested_type: str
+    suggested_bytes: int
+    savings_ratio: float
+    rationale: str
+
+
+# pgvector storage per element:
+#   vector(N)   → 4 bytes per element (float4)
+#   halfvec(N)  → 2 bytes per element (float16) — pgvector v0.7+
+#   bit(N)      → 1 bit per element (vector of 0/1)
+_TYPE_BYTES_PER_ELEMENT: dict[str, float] = {
+    "vector": 4.0,
+    "halfvec": 2.0,
+    "bit": 1.0 / 8,
+}
+# Tuple-overhead per row in bytes — header + length prefix for the
+# varlena. Doesn't change between types so we omit it from the savings
+# calc, but document the assumption.
+
+
+def _suggest_quantization(
+    *,
+    schema: str,
+    table: str,
+    column: str,
+    current_type: str,
+    dimension: int,
+    row_count: int,
+) -> QuantizationRecommendation | None:
+    """Decide whether to recommend a more compact vector type.
+
+    The thresholds are intentionally conservative — quantization trades
+    storage for a small recall hit, so we only flag the column when
+    the win is large enough to justify the migration cost. v1
+    heuristic:
+
+    - Already non-``vector`` (halfvec / bit) → no recommendation; the
+      user already picked something compact.
+    - Estimated table footprint < 100 MiB → low value; skip.
+    - Dimension ≥ 768 → recommend ``halfvec`` (2x saving with minimal
+      recall loss for high-dim embeddings).
+    - Dimension < 768 and row_count x dimension x 4B ≥ 500 MiB →
+      recommend ``halfvec`` too; the absolute saving justifies it.
+    - ``bit`` is suggested only when the user opts into a much higher
+      recall hit (we leave it as a documented advanced option and do
+      not auto-recommend in v1).
+    """
+    if current_type not in {"vector"}:
+        return None  # already quantized; nothing to do
+    current_bytes_per_row = dimension * _TYPE_BYTES_PER_ELEMENT["vector"]
+    current_bytes = int(current_bytes_per_row * row_count)
+    if current_bytes < 100 * 1024 * 1024 and not (dimension >= 768 and row_count >= 10_000):
+        return None
+    # Recommend halfvec.
+    suggested_bytes_per_row = dimension * _TYPE_BYTES_PER_ELEMENT["halfvec"]
+    suggested_bytes = int(suggested_bytes_per_row * row_count)
+    savings_ratio = 1 - suggested_bytes / current_bytes if current_bytes else 0.0
+    rationale = (
+        f"halfvec halves storage with negligible recall loss for d={dimension} "
+        f"embeddings; saves ~{savings_ratio * 100:.0f}% on this column. "
+        "Requires pgvector v0.7+."
+    )
+    return QuantizationRecommendation(
+        schema=schema,
+        table=table,
+        column=column,
+        dimension=dimension,
+        row_count=row_count,
+        current_type=current_type,
+        current_bytes=current_bytes,
+        suggested_type="halfvec",
+        suggested_bytes=suggested_bytes,
+        savings_ratio=savings_ratio,
+        rationale=rationale,
+    )
+
+
+async def recommend_vector_quantization(
+    driver: SqlDriver,
+    schema: str,
+) -> list[QuantizationRecommendation]:
+    """Scan ``schema`` for ``vector(N)`` columns whose storage could shrink.
+
+    Returns one recommendation per column where switching to a more
+    compact pgvector type (``halfvec`` in v1) would yield a meaningful
+    saving on the table's estimated footprint. Skips columns that are
+    already non-``vector`` and small tables where the absolute saving
+    doesn't justify the migration.
+
+    Requires ``vector`` (pgvector) installed; when absent, returns
+    an empty list. Schema name is validated; only plain identifiers
+    accepted.
+    """
+    _checked(schema, "schema")
+    if not await extension_installed(driver, "vector"):
+        return []
+
+    # Find every (table, column) whose type matches the pgvector family.
+    # Restrict the base type via the typname so we don't pick up PG's
+    # built-in ``bit(N)`` type (which is unrelated to pgvector). pgvector's
+    # types are ``vector`` / ``halfvec`` / ``sparsevec``. atttypmod carries
+    # the dimension directly — pgvector stores it un-adjusted (no -4
+    # varlena header subtraction).
+    rows = await driver.execute_query(
+        "SELECT c.table_name, c.column_name, "
+        "       t.typname AS base_type, "
+        "       a.atttypmod AS dimension "
+        "FROM information_schema.columns c "
+        "JOIN pg_catalog.pg_attribute a ON a.attname = c.column_name "
+        "JOIN pg_catalog.pg_class cls ON cls.oid = a.attrelid AND cls.relname = c.table_name "
+        "JOIN pg_catalog.pg_namespace n ON n.oid = cls.relnamespace AND n.nspname = c.table_schema "
+        "JOIN pg_catalog.pg_type t ON t.oid = a.atttypid "
+        "WHERE c.table_schema = %s "
+        "AND t.typname IN ('vector', 'halfvec', 'sparsevec') "
+        "AND a.atttypmod > 0 "
+        "ORDER BY c.table_name, c.column_name",
+        params=[schema],
+        force_readonly=True,
+    )
+    recommendations: list[QuantizationRecommendation] = []
+    for row in rows or []:
+        table = str(row.cells["table_name"])
+        column = str(row.cells["column_name"])
+        base_type = str(row.cells["base_type"])
+        dimension = int(row.cells["dimension"])
+        # Live row count for the table (no estimates — small price for
+        # accurate advice).
+        count_rows = await driver.execute_query(
+            f"SELECT count(*) AS n FROM {_quoted(schema, 'schema')}.{_quoted(table, 'table')}",
+            force_readonly=True,
+        )
+        row_count = int(count_rows[0].cells["n"]) if count_rows else 0
+        rec = _suggest_quantization(
+            schema=schema,
+            table=table,
+            column=column,
+            current_type=base_type,
+            dimension=dimension,
+            row_count=row_count,
+        )
+        if rec is not None:
+            recommendations.append(rec)
+    return recommendations
+
+
 async def geo_search(
     driver: SqlDriver,
     schema: str,

--- a/src/mcpg/textsearch.py
+++ b/src/mcpg/textsearch.py
@@ -508,11 +508,15 @@ def _fuse_rrf(
             row=existing.row,
         )
 
+    # Strip BOTH the vector and text columns from the per-row key on
+    # every branch — the _row_key fallback (sorted cell tuple) only
+    # merges the two halves if their key inputs are identical.
     for row in vec_rows:
         cells = dict(row.cells)
         rank = cells.pop("mcpg_rank")
         distance = cells.pop("mcpg_distance")
         cells.pop(vector_column, None)
+        cells.pop(text_column, None)
         key = _row_key(cells)
         merge(key, cells, vec_rank=int(rank), fts_rank=None, vec_distance=distance, fts_score=None)
 
@@ -521,8 +525,6 @@ def _fuse_rrf(
         rank = cells.pop("mcpg_rank")
         score = cells.pop("mcpg_rank_score")
         cells.pop(text_column, None)
-        # Don't strip vector_column from FTS-only rows; it stays in the
-        # payload so the caller can re-rank later if they want.
         cells.pop(vector_column, None)
         key = _row_key(cells)
         merge(key, cells, vec_rank=None, fts_rank=int(rank), vec_distance=None, fts_score=score)

--- a/src/mcpg/timescaledb.py
+++ b/src/mcpg/timescaledb.py
@@ -198,8 +198,11 @@ async def create_hypertable(
             available=False, function="create_hypertable", details="timescaledb extension is not installed"
         )
     inex = "TRUE" if if_not_exists else "FALSE"
+    # Double-quote inside the string literal so a mixed-case relation
+    # name reaches regclass with its case preserved — unquoted identifiers
+    # passed to functions that cast to regclass are folded to lowercase.
     sql = (
-        f"SELECT create_hypertable('{schema}.{table}', '{time_column}', "
+        f"SELECT create_hypertable('\"{schema}\".\"{table}\"', '{time_column}', "
         f"chunk_time_interval => INTERVAL '{chunk_time_interval}', "
         f"if_not_exists => {inex}) AS result"
     )
@@ -231,7 +234,7 @@ async def add_compression_policy(
         )
     await driver.execute_query(f'ALTER TABLE "{schema}"."{table}" SET (timescaledb.compress = TRUE)')
     rows = await driver.execute_query(
-        f"SELECT add_compression_policy('{schema}.{table}', INTERVAL '{compress_after}') AS job_id"
+        f"SELECT add_compression_policy('\"{schema}\".\"{table}\"', INTERVAL '{compress_after}') AS job_id"
     )
     detail = f"job_id={rows[0].cells['job_id']}" if rows else "policy added"
     return TimescaleWriteResult(available=True, function="add_compression_policy", details=detail)
@@ -253,7 +256,7 @@ async def add_retention_policy(
             available=False, function="add_retention_policy", details="timescaledb extension is not installed"
         )
     rows = await driver.execute_query(
-        f"SELECT add_retention_policy('{schema}.{table}', INTERVAL '{drop_after}') AS job_id"
+        f"SELECT add_retention_policy('\"{schema}\".\"{table}\"', INTERVAL '{drop_after}') AS job_id"
     )
     detail = f"job_id={rows[0].cells['job_id']}" if rows else "policy added"
     return TimescaleWriteResult(available=True, function="add_retention_policy", details=detail)

--- a/src/mcpg/timescaledb.py
+++ b/src/mcpg/timescaledb.py
@@ -1,0 +1,266 @@
+"""TimescaleDB hypertable + compression + retention helpers.
+
+Thin wrappers around the most-used TimescaleDB management functions:
+``create_hypertable``, ``add_dimension``, ``set_chunk_time_interval``,
+the compression/retention/continuous-aggregate policies, and the
+read tools that introspect what already exists. Every tool degrades
+gracefully when the ``timescaledb`` extension is not installed —
+returning ``available=False`` rather than raising — so an MCPg
+deployment that doesn't have Timescale on the target database still
+reports the tools as callable.
+
+Write tools are gated under ``Capability.DDL`` + ``MCPG_ALLOW_DDL``;
+the underlying TimescaleDB functions issue DDL.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from mcpg._vendor.sql import SqlDriver
+from mcpg.extensions import extension_installed
+
+_IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
+# A whitelist of intervals we'll inline into SQL. Validated against this
+# pattern then passed as a SQL literal (TimescaleDB takes interval
+# expressions as positional args, not bound params).
+_INTERVAL = re.compile(
+    r"\A\d+\s+(microseconds?|milliseconds?|seconds?|minutes?|hours?|days?|weeks?|months?|years?)\Z", re.IGNORECASE
+)
+
+
+class TimescaleError(Exception):
+    """Raised when a TimescaleDB tool call is rejected or fails."""
+
+
+def _check_identifier(name: str, kind: str) -> None:
+    if not _IDENTIFIER.match(name):
+        raise TimescaleError(f"invalid {kind} name: {name!r}")
+
+
+def _check_interval(value: str) -> None:
+    if not _INTERVAL.match(value.strip()):
+        raise TimescaleError(f"invalid interval {value!r}; expected e.g. '7 days', '1 hour', '30 minutes'")
+
+
+def _quoted(name: str) -> str:
+    return f'"{name}"'
+
+
+@dataclass(frozen=True, slots=True)
+class HypertableInfo:
+    """Summary of one TimescaleDB hypertable."""
+
+    schema: str
+    name: str
+    num_dimensions: int
+    num_chunks: int
+    compression_enabled: bool
+    total_size_bytes: int
+
+
+@dataclass(frozen=True, slots=True)
+class HypertableListResult:
+    """The result of :func:`list_hypertables`.
+
+    ``available`` is ``False`` when the ``timescaledb`` extension is
+    not installed on the target database.
+    """
+
+    available: bool
+    hypertables: list[HypertableInfo]
+
+
+@dataclass(frozen=True, slots=True)
+class ChunkInfo:
+    """One chunk under a hypertable."""
+
+    hypertable_schema: str
+    hypertable_name: str
+    chunk_schema: str
+    chunk_name: str
+    range_start: str | None
+    range_end: str | None
+    is_compressed: bool
+
+
+@dataclass(frozen=True, slots=True)
+class ChunkListResult:
+    """The result of :func:`list_chunks`."""
+
+    available: bool
+    chunks: list[ChunkInfo]
+
+
+@dataclass(frozen=True, slots=True)
+class TimescaleWriteResult:
+    """The outcome of a TimescaleDB write tool call."""
+
+    available: bool
+    function: str
+    details: str
+
+
+async def list_hypertables(driver: SqlDriver) -> HypertableListResult:
+    """List every hypertable visible to the current role.
+
+    Reads from ``timescaledb_information.hypertables`` (Timescale's
+    public catalog view); pre-2.x columns are not supported.
+    """
+    if not await extension_installed(driver, "timescaledb"):
+        return HypertableListResult(available=False, hypertables=[])
+    rows = await driver.execute_query(
+        "SELECT hypertable_schema, hypertable_name, num_dimensions, "
+        "       num_chunks, compression_enabled, "
+        "       COALESCE("
+        "         hypertable_size(format('%I.%I', hypertable_schema, hypertable_name)::regclass), "
+        "         0"
+        "       ) AS total_size_bytes "
+        "FROM timescaledb_information.hypertables "
+        "ORDER BY hypertable_schema, hypertable_name",
+        force_readonly=True,
+    )
+    hypertables = [
+        HypertableInfo(
+            schema=str(row.cells["hypertable_schema"]),
+            name=str(row.cells["hypertable_name"]),
+            num_dimensions=int(row.cells["num_dimensions"]),
+            num_chunks=int(row.cells["num_chunks"]),
+            compression_enabled=bool(row.cells["compression_enabled"]),
+            total_size_bytes=int(row.cells["total_size_bytes"]),
+        )
+        for row in rows or []
+    ]
+    return HypertableListResult(available=True, hypertables=hypertables)
+
+
+async def list_chunks(driver: SqlDriver, schema: str, table: str) -> ChunkListResult:
+    """List the chunks of ``schema.table``.
+
+    Empty list when the table is not a hypertable; the caller can
+    cross-check with :func:`list_hypertables` first.
+    """
+    _check_identifier(schema, "schema")
+    _check_identifier(table, "table")
+    if not await extension_installed(driver, "timescaledb"):
+        return ChunkListResult(available=False, chunks=[])
+    rows = await driver.execute_query(
+        "SELECT hypertable_schema, hypertable_name, chunk_schema, chunk_name, "
+        "       range_start::text AS range_start, range_end::text AS range_end, "
+        "       is_compressed "
+        "FROM timescaledb_information.chunks "
+        "WHERE hypertable_schema = %s AND hypertable_name = %s "
+        "ORDER BY range_start NULLS LAST",
+        params=[schema, table],
+        force_readonly=True,
+    )
+    chunks = [
+        ChunkInfo(
+            hypertable_schema=str(row.cells["hypertable_schema"]),
+            hypertable_name=str(row.cells["hypertable_name"]),
+            chunk_schema=str(row.cells["chunk_schema"]),
+            chunk_name=str(row.cells["chunk_name"]),
+            range_start=str(row.cells["range_start"]) if row.cells["range_start"] is not None else None,
+            range_end=str(row.cells["range_end"]) if row.cells["range_end"] is not None else None,
+            is_compressed=bool(row.cells["is_compressed"]),
+        )
+        for row in rows or []
+    ]
+    return ChunkListResult(available=True, chunks=chunks)
+
+
+async def create_hypertable(
+    driver: SqlDriver,
+    schema: str,
+    table: str,
+    time_column: str,
+    *,
+    chunk_time_interval: str = "7 days",
+    if_not_exists: bool = True,
+) -> TimescaleWriteResult:
+    """Convert an existing table into a hypertable on ``time_column``.
+
+    Args:
+        chunk_time_interval: TimescaleDB interval expression (e.g.
+            ``'7 days'``, ``'1 hour'``). Validated against an allowlist
+            pattern before being inlined into SQL.
+        if_not_exists: When ``True``, calling on a table that's
+            already a hypertable is a no-op rather than an error.
+    """
+    _check_identifier(schema, "schema")
+    _check_identifier(table, "table")
+    _check_identifier(time_column, "time_column")
+    _check_interval(chunk_time_interval)
+    if not await extension_installed(driver, "timescaledb"):
+        return TimescaleWriteResult(
+            available=False, function="create_hypertable", details="timescaledb extension is not installed"
+        )
+    inex = "TRUE" if if_not_exists else "FALSE"
+    sql = (
+        f"SELECT create_hypertable('{schema}.{table}', '{time_column}', "
+        f"chunk_time_interval => INTERVAL '{chunk_time_interval}', "
+        f"if_not_exists => {inex}) AS result"
+    )
+    rows = await driver.execute_query(sql)
+    detail = str(rows[0].cells["result"]) if rows else "OK"
+    return TimescaleWriteResult(available=True, function="create_hypertable", details=detail)
+
+
+async def add_compression_policy(
+    driver: SqlDriver,
+    schema: str,
+    table: str,
+    *,
+    compress_after: str = "7 days",
+) -> TimescaleWriteResult:
+    """Enable compression on ``schema.table`` and schedule the policy.
+
+    Two calls under one tool: ``ALTER TABLE ... SET (timescaledb.compress)``
+    and ``add_compression_policy``. Idempotent on the ALTER (TimescaleDB
+    no-ops when compression is already enabled) and on the policy
+    (TimescaleDB raises a friendly error which we surface).
+    """
+    _check_identifier(schema, "schema")
+    _check_identifier(table, "table")
+    _check_interval(compress_after)
+    if not await extension_installed(driver, "timescaledb"):
+        return TimescaleWriteResult(
+            available=False, function="add_compression_policy", details="timescaledb extension is not installed"
+        )
+    await driver.execute_query(f'ALTER TABLE "{schema}"."{table}" SET (timescaledb.compress = TRUE)')
+    rows = await driver.execute_query(
+        f"SELECT add_compression_policy('{schema}.{table}', INTERVAL '{compress_after}') AS job_id"
+    )
+    detail = f"job_id={rows[0].cells['job_id']}" if rows else "policy added"
+    return TimescaleWriteResult(available=True, function="add_compression_policy", details=detail)
+
+
+async def add_retention_policy(
+    driver: SqlDriver,
+    schema: str,
+    table: str,
+    *,
+    drop_after: str = "30 days",
+) -> TimescaleWriteResult:
+    """Schedule a retention policy that drops chunks older than ``drop_after``."""
+    _check_identifier(schema, "schema")
+    _check_identifier(table, "table")
+    _check_interval(drop_after)
+    if not await extension_installed(driver, "timescaledb"):
+        return TimescaleWriteResult(
+            available=False, function="add_retention_policy", details="timescaledb extension is not installed"
+        )
+    rows = await driver.execute_query(
+        f"SELECT add_retention_policy('{schema}.{table}', INTERVAL '{drop_after}') AS job_id"
+    )
+    detail = f"job_id={rows[0].cells['job_id']}" if rows else "policy added"
+    return TimescaleWriteResult(available=True, function="add_retention_policy", details=detail)
+
+
+def _quoted_unused(_: Any) -> None:
+    # Placeholder so an editor's "unused import" warning on _quoted
+    # doesn't fire in modules that only validate identifiers but never
+    # build qualified relations directly.
+    pass

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -17,6 +17,7 @@ from mcpg import (
     __version__,
     advisors,
     audit_trail,
+    composite,
     cron,
     data_movement,
     diagrams,
@@ -507,6 +508,55 @@ def _register_advisors(server: FastMCP[AppContext]) -> None:
     async def run_advisors(ctx: _Ctx, schema: str) -> dict[str, Any]:
         report = await advisors.run_advisors(_driver(ctx), schema)
         return asdict(report)
+
+    @server.tool(
+        name="find_unused_objects",
+        description=(
+            "Find tables and indexes with zero scans since pg_stat was last "
+            "reset — a strong signal of dead code, but NOT a verdict. Tables "
+            "report seq+idx scan counts, write counts, and estimated row "
+            "count; indexes report size and definition. Excludes PRIMARY KEY "
+            "and UNIQUE indexes (PG needs those regardless of scans). Run "
+            "this after the database has been hot for a meaningful period — "
+            "fresh stats produce false positives."
+        ),
+    )
+    async def find_unused_objects(ctx: _Ctx, schema: str) -> dict[str, Any]:
+        report = await advisors.find_unused_objects(_driver(ctx), schema)
+        return asdict(report)
+
+
+def _register_composite(server: FastMCP[AppContext]) -> None:
+    @server.tool(
+        name="summarize_table",
+        description=(
+            "Return a one-stop snapshot of a table: columns, primary key, "
+            "foreign keys, every other constraint, indexes, storage + "
+            "row-count + last-vacuum/analyze stats, and (optionally) a "
+            "short sample of rows. Replaces what would otherwise be 4-5 "
+            "individual tool calls. Set sample_rows=0 on wide / jsonb-"
+            "heavy tables where the sample isn't useful."
+        ),
+    )
+    async def summarize_table(ctx: _Ctx, schema: str, table: str, sample_rows: int = 5) -> dict[str, Any]:
+        result = await composite.summarize_table(_driver(ctx), schema, table, sample_rows=sample_rows)
+        return asdict(result)
+
+    @server.tool(
+        name="why_is_this_slow",
+        description=(
+            "Diagnose why a SQL query might be slow, in one call. Runs "
+            "EXPLAIN (FORMAT JSON) — does NOT execute the query — walks the "
+            "plan tree, snapshots concurrent active queries + blocking "
+            "lock pairs, reads the cluster-wide cache hit ratio, and "
+            "produces categorised suggestions (plan / contention / cache / "
+            "maintenance). Read-only; safe to run on a statement the agent "
+            "doesn't want to materialise yet."
+        ),
+    )
+    async def why_is_this_slow(ctx: _Ctx, sql: str) -> dict[str, Any]:
+        result = await composite.why_is_this_slow(_driver(ctx), sql)
+        return asdict(result)
 
 
 def _register_data_movement(server: FastMCP[AppContext]) -> None:
@@ -1306,6 +1356,7 @@ def register_tools(server: FastMCP[AppContext], settings: Settings) -> None:
         _register_vector_tuning(server)
         _register_prisma(server)
         _register_advisors(server)
+        _register_composite(server)
         _register_data_movement(server)
         _register_audit_trail(server)
         _register_query(server)

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -20,11 +20,15 @@ from mcpg import (
     cron,
     data_movement,
     diagrams,
+    diesel,
     drizzle,
+    ecto,
+    ent,
     extensions,
     health,
     indexing,
     introspection,
+    jooq,
     liveops,
     maintenance,
     migrations,
@@ -386,6 +390,78 @@ def _register_prisma(server: FastMCP[AppContext]) -> None:
     )
     async def generate_drizzle_schema(ctx: _Ctx, schema: str) -> str:
         return await drizzle.generate_drizzle_schema(_driver(ctx), schema)
+
+    @server.tool(
+        name="generate_diesel_schema",
+        description=(
+            "Read a PostgreSQL schema and emit a Diesel ORM (Rust) schema.rs. "
+            "One `table!` macro per table with column SQL types, `Nullable<T>` "
+            "for nullable columns, plus `joinable!` declarations for single-"
+            "column intra-schema FKs and an `allow_tables_to_appear_in_same_query!` "
+            "macro so multi-table joins type-check. Enum types are emitted as "
+            "Text-backed wrapper enums in a `pg_enum` module so the output "
+            "works without `diesel_derive_enum`. Composite FKs are a "
+            "documented v1 gap."
+        ),
+    )
+    async def generate_diesel_schema(ctx: _Ctx, schema: str) -> str:
+        return await diesel.generate_diesel_schema(_driver(ctx), schema)
+
+    @server.tool(
+        name="generate_jooq_config",
+        description=(
+            "Read a PostgreSQL schema and emit a jooq-codegen configuration XML "
+            "pointing at it. Unlike the other exporters, jOOQ generates Java "
+            "code itself from a live database — the artefact here is the "
+            "configuration file the user feeds to mvn jooq-codegen:generate "
+            "(or the Gradle task). The XML lists every base table explicitly "
+            "via an <includes> regex, excludes MCPg's bookkeeping tables, and "
+            "emits a <forcedType> for every json / jsonb column so they map "
+            "to org.jooq.JSON / org.jooq.JSONB out of the box. Default Java "
+            "package is com.example.jooq; override via the target_package arg."
+        ),
+    )
+    async def generate_jooq_config(
+        ctx: _Ctx,
+        schema: str,
+        target_package: str = "com.example.jooq",
+        target_directory: str = "src/main/java",
+    ) -> str:
+        return await jooq.generate_jooq_config(
+            _driver(ctx),
+            schema,
+            target_package=target_package,
+            target_directory=target_directory,
+        )
+
+    @server.tool(
+        name="generate_ent_schemas",
+        description=(
+            "Read a PostgreSQL schema and emit Ent (Go) Schema struct files — "
+            "one .go file per table. Each file exports a struct that lists "
+            "field.X(...) calls for every column, edge.To(...) for single-"
+            "column intra-schema FKs, and field.Enum().Values() for enum-typed "
+            "columns. Composite FKs are a documented v1 gap. Returns a JSON "
+            "object {filename: source} so the agent can write each file."
+        ),
+    )
+    async def generate_ent_schemas(ctx: _Ctx, schema: str) -> dict[str, str]:
+        return await ent.generate_ent_schemas(_driver(ctx), schema)
+
+    @server.tool(
+        name="generate_ecto_schemas",
+        description=(
+            "Read a PostgreSQL schema and emit Ecto (Elixir) schema modules — "
+            "one .ex file per table, named after the singularised table. Each "
+            "module uses Ecto.Schema with field declarations, belongs_to for "
+            "single-column intra-schema FKs, and timestamps() when both "
+            "inserted_at and updated_at exist. The Elixir top-level module is "
+            "configurable via app_module (default MyApp). Returns a JSON "
+            "object {filename: source} so the agent can write each file."
+        ),
+    )
+    async def generate_ecto_schemas(ctx: _Ctx, schema: str, app_module: str = "MyApp") -> dict[str, str]:
+        return await ecto.generate_ecto_schemas(_driver(ctx), schema, app_module=app_module)
 
     @server.tool(
         name="generate_sqlalchemy_models",

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -978,6 +978,97 @@ def _register_health(server: FastMCP[AppContext]) -> None:
         return asdict(result)
 
     @server.tool(
+        name="vector_range_search",
+        description=(
+            "Return every row within `max_distance` of a query vector (a "
+            "threshold-based query rather than top-k). Useful for de-dup, "
+            "similarity gating, and clustering pre-passes. Still ordered by "
+            "distance and capped at `limit` to avoid pulling huge result "
+            "sets. Reports available=false if the pgvector extension is "
+            "not installed."
+        ),
+    )
+    async def vector_range_search(
+        ctx: _Ctx,
+        schema: str,
+        table: str,
+        column: str,
+        query_vector: list[float],
+        max_distance: float,
+        metric: str = textsearch.DEFAULT_VECTOR_METRIC,
+        limit: int = textsearch.DEFAULT_LIMIT,
+    ) -> dict[str, Any]:
+        result = await textsearch.vector_range_search(
+            _driver(ctx),
+            schema,
+            table,
+            column,
+            query_vector,
+            max_distance,
+            metric=metric,
+            limit=limit,
+        )
+        return asdict(result)
+
+    @server.tool(
+        name="hybrid_search",
+        description=(
+            "Combine vector and full-text ranking via reciprocal-rank fusion "
+            "(RRF) — pulls candidates from each source, then fuses them so "
+            "rows ranked highly in EITHER source surface. Closes the gap "
+            "between pure vector (misses keyword/identifier matches) and "
+            "pure full-text (misses semantic synonyms). Parameters: "
+            "vector_column, text_column, query_vector, text_query, plus "
+            "metric / text_config / limit / candidate_pool / rrf_k tunables. "
+            "Each match carries vector_rank, fts_rank, the fused rrf_score, "
+            "and (when present) the original distance + ts_rank values."
+        ),
+    )
+    async def hybrid_search(
+        ctx: _Ctx,
+        schema: str,
+        table: str,
+        vector_column: str,
+        text_column: str,
+        query_vector: list[float],
+        text_query: str,
+        metric: str = textsearch.DEFAULT_VECTOR_METRIC,
+        text_config: str = textsearch.DEFAULT_TEXT_CONFIG,
+        limit: int = textsearch.DEFAULT_LIMIT,
+        candidate_pool: int = 50,
+    ) -> dict[str, Any]:
+        result = await textsearch.hybrid_search(
+            _driver(ctx),
+            schema,
+            table,
+            vector_column,
+            text_column,
+            query_vector,
+            text_query,
+            metric=metric,
+            text_config=text_config,
+            limit=limit,
+            candidate_pool=candidate_pool,
+        )
+        return asdict(result)
+
+    @server.tool(
+        name="recommend_vector_quantization",
+        description=(
+            "Scan a schema for `vector(N)` columns whose storage could be "
+            "halved by switching to pgvector v0.7+'s `halfvec(N)` type "
+            "(16-bit float). Returns one recommendation per qualifying "
+            "column with current vs suggested bytes, the savings ratio, "
+            "and a one-line rationale. Skips columns that are already "
+            "non-`vector` and small tables where the absolute saving "
+            "wouldn't justify the migration."
+        ),
+    )
+    async def recommend_vector_quantization(ctx: _Ctx, schema: str) -> list[dict[str, Any]]:
+        recommendations = await textsearch.recommend_vector_quantization(_driver(ctx), schema)
+        return [asdict(rec) for rec in recommendations]
+
+    @server.tool(
         name="geo_search",
         description=(
             "Find the rows nearest to a lon/lat point by PostGIS distance. "

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -40,6 +40,7 @@ from mcpg import (
     sqlalchemy_export,
     sqlc,
     textsearch,
+    timescaledb,
     vector_tuning,
     workload,
     write,
@@ -85,6 +86,23 @@ def _register_server_info(server: FastMCP[AppContext]) -> None:
     )
     async def get_server_info(ctx: _Ctx) -> dict[str, Any]:
         return asdict(build_server_info(ctx.request_context.lifespan_context))
+
+    @server.tool(
+        name="get_metrics_exposition",
+        description=(
+            "Return the in-process Prometheus-format metrics for this MCPg "
+            "server. Three series: mcpg_tool_calls_total (counter by tool / "
+            "status), mcpg_tool_duration_seconds (histogram by tool with "
+            "sum and count). Useful when the HTTP transport's /metrics "
+            "endpoint is unreachable (e.g. running over stdio) or to fetch "
+            "via the MCP protocol itself."
+        ),
+    )
+    async def get_metrics_exposition(ctx: _Ctx) -> str:
+        del ctx  # context unused; tool reads from process-wide singleton
+        from mcpg.observability import render_prometheus
+
+        return render_prometheus()
 
 
 def _register_introspection(server: FastMCP[AppContext]) -> None:
@@ -734,6 +752,90 @@ def _register_migrations(server: FastMCP[AppContext]) -> None:
         ]
 
 
+def _register_timescaledb_reads(server: FastMCP[AppContext]) -> None:
+    @server.tool(
+        name="list_hypertables",
+        description=(
+            "List every TimescaleDB hypertable visible to the current "
+            "role, with chunk count, compression flag, and total size. "
+            "Reports available=false when the timescaledb extension is "
+            "not installed."
+        ),
+    )
+    async def list_hypertables(ctx: _Ctx) -> dict[str, Any]:
+        result = await timescaledb.list_hypertables(_driver(ctx))
+        return asdict(result)
+
+    @server.tool(
+        name="list_chunks",
+        description=(
+            "List the chunks of a TimescaleDB hypertable with each chunk's "
+            "range_start / range_end and whether it has been compressed. "
+            "Empty list when the table is not a hypertable."
+        ),
+    )
+    async def list_chunks(ctx: _Ctx, schema: str, table: str) -> dict[str, Any]:
+        result = await timescaledb.list_chunks(_driver(ctx), schema, table)
+        return asdict(result)
+
+
+def _register_timescaledb_writes(server: FastMCP[AppContext]) -> None:
+    @server.tool(
+        name="create_hypertable",
+        description=(
+            "Convert an existing table into a TimescaleDB hypertable on "
+            "`time_column`. Validates schema / table / column names against "
+            "the plain-identifier allowlist and the chunk interval against "
+            "a TimescaleDB-style pattern (e.g. '7 days', '1 hour'). "
+            "Requires unrestricted mode + MCPG_ALLOW_DDL."
+        ),
+    )
+    async def create_hypertable(
+        ctx: _Ctx,
+        schema: str,
+        table: str,
+        time_column: str,
+        chunk_time_interval: str = "7 days",
+        if_not_exists: bool = True,
+    ) -> dict[str, Any]:
+        result = await timescaledb.create_hypertable(
+            _driver(ctx),
+            schema,
+            table,
+            time_column,
+            chunk_time_interval=chunk_time_interval,
+            if_not_exists=if_not_exists,
+        )
+        return asdict(result)
+
+    @server.tool(
+        name="add_compression_policy",
+        description=(
+            "Enable TimescaleDB column-store compression on a hypertable and "
+            "schedule a policy that compresses chunks older than "
+            "`compress_after` (e.g. '7 days'). Requires unrestricted mode "
+            "+ MCPG_ALLOW_DDL."
+        ),
+    )
+    async def add_compression_policy(
+        ctx: _Ctx, schema: str, table: str, compress_after: str = "7 days"
+    ) -> dict[str, Any]:
+        result = await timescaledb.add_compression_policy(_driver(ctx), schema, table, compress_after=compress_after)
+        return asdict(result)
+
+    @server.tool(
+        name="add_retention_policy",
+        description=(
+            "Schedule a TimescaleDB retention policy that drops hypertable "
+            "chunks older than `drop_after` (e.g. '30 days'). Requires "
+            "unrestricted mode + MCPG_ALLOW_DDL."
+        ),
+    )
+    async def add_retention_policy(ctx: _Ctx, schema: str, table: str, drop_after: str = "30 days") -> dict[str, Any]:
+        result = await timescaledb.add_retention_policy(_driver(ctx), schema, table, drop_after=drop_after)
+        return asdict(result)
+
+
 def _register_listen(server: FastMCP[AppContext]) -> None:
     @server.tool(
         name="subscribe_channel",
@@ -1362,6 +1464,7 @@ def register_tools(server: FastMCP[AppContext], settings: Settings) -> None:
         _register_query(server)
         _register_health(server)
         _register_liveops(server)
+        _register_timescaledb_reads(server)
     if is_permitted(settings.access_mode, Capability.WRITE):
         _register_write(server)
         _register_maintenance(server)
@@ -1371,6 +1474,7 @@ def register_tools(server: FastMCP[AppContext], settings: Settings) -> None:
     if is_permitted(settings.access_mode, Capability.DDL) and settings.allow_ddl:
         _register_ddl(server)
         _register_partman(server)
+        _register_timescaledb_writes(server)
     if is_permitted(settings.access_mode, Capability.MIGRATE) and settings.allow_ddl:
         _register_migrations(server)
     if is_permitted(settings.access_mode, Capability.SHELL) and settings.allow_shell:

--- a/tests/integration/test_composite_integration.py
+++ b/tests/integration/test_composite_integration.py
@@ -1,0 +1,102 @@
+"""Integration tests for the composite tools against real PG."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+
+from mcpg.advisors import find_unused_objects
+from mcpg.composite import summarize_table, why_is_this_slow
+from mcpg.database import Database
+
+_SCHEMA = "mcpg_composite_it"
+
+
+@pytest.fixture
+async def populated_schema(connected_database: Database) -> AsyncIterator[str]:
+    driver = connected_database.driver()
+    await driver.execute_query(f"DROP SCHEMA IF EXISTS {_SCHEMA} CASCADE")
+    await driver.execute_query(f"CREATE SCHEMA {_SCHEMA}")
+    await driver.execute_query(
+        f"CREATE TABLE {_SCHEMA}.widget ("
+        "id serial PRIMARY KEY, "
+        "name text NOT NULL UNIQUE, "
+        "qty integer NOT NULL DEFAULT 0, "
+        "metadata jsonb)"
+    )
+    await driver.execute_query(f"CREATE INDEX widget_qty_idx ON {_SCHEMA}.widget(qty)")
+    await driver.execute_query(f"CREATE INDEX widget_unused_idx ON {_SCHEMA}.widget(name, qty)")
+    await driver.execute_query(
+        f"INSERT INTO {_SCHEMA}.widget (name, qty) VALUES ('alpha', 1), ('beta', 2), ('gamma', 3)"
+    )
+    # Force stats to refresh so the size functions return realistic values.
+    await driver.execute_query(f"ANALYZE {_SCHEMA}.widget")
+    try:
+        yield _SCHEMA
+    finally:
+        await driver.execute_query(f"DROP SCHEMA IF EXISTS {_SCHEMA} CASCADE")
+
+
+async def test_summarize_table_returns_columns_indexes_constraints_stats_and_sample(
+    connected_database: Database, populated_schema: str
+) -> None:
+    driver = connected_database.driver()
+    result = await summarize_table(driver, populated_schema, "widget", sample_rows=2)
+
+    assert result.schema == populated_schema
+    assert result.table == "widget"
+    column_names = {c.name for c in result.columns}
+    assert {"id", "name", "qty", "metadata"} <= column_names
+    assert result.primary_key == ["id"]
+    # Indexes include the PK, the UNIQUE one, and the two we created.
+    index_names = {idx.name for idx in result.indexes}
+    assert "widget_qty_idx" in index_names and "widget_unused_idx" in index_names
+    # Stats present and reasonable.
+    assert result.stats.estimated_row_count >= 0
+    assert result.stats.total_size_bytes >= 0
+    # Sample respects the limit.
+    assert 0 < len(result.sample_rows) <= 2
+
+
+async def test_summarize_table_skips_sample_when_sample_rows_is_zero(
+    connected_database: Database, populated_schema: str
+) -> None:
+    driver = connected_database.driver()
+    result = await summarize_table(driver, populated_schema, "widget", sample_rows=0)
+
+    assert result.sample_rows == []
+
+
+async def test_find_unused_objects_detects_unused_index_on_real_table(
+    connected_database: Database, populated_schema: str
+) -> None:
+    driver = connected_database.driver()
+    report = await find_unused_objects(driver, populated_schema)
+
+    # The widget_unused_idx was never scanned (we only inserted; didn't
+    # query). It may or may not be flagged depending on whether the
+    # other indexes were touched by the INSERT path — what we can
+    # reliably assert is that the report shape is correct.
+    assert report.schema == populated_schema
+    # Every index in the report is from this schema.
+    assert all(idx.schema == populated_schema for idx in report.indexes)
+    # Every reported index has a non-empty definition.
+    assert all(idx.definition.startswith("CREATE") for idx in report.indexes)
+
+
+async def test_why_is_this_slow_returns_full_diagnosis_for_a_real_query(
+    connected_database: Database, populated_schema: str
+) -> None:
+    driver = connected_database.driver()
+    diagnosis = await why_is_this_slow(driver, f"SELECT * FROM {populated_schema}.widget WHERE name = 'alpha'")
+
+    # The plan summary is populated.
+    assert "total_cost" in diagnosis.plan_summary
+    assert diagnosis.plan_summary["total_cost"] >= 0
+    # The full EXPLAIN payload is included.
+    assert diagnosis.explain_plan is not None
+    # Suggestions never empty — fallback message is always emitted.
+    assert len(diagnosis.suggestions) >= 1
+    # Cache hit ratio is a float (or None on a fresh cluster).
+    assert diagnosis.cache_hit_ratio is None or 0.0 <= diagnosis.cache_hit_ratio <= 1.0

--- a/tests/integration/test_diesel_integration.py
+++ b/tests/integration/test_diesel_integration.py
@@ -1,0 +1,81 @@
+"""Integration tests for the Diesel ORM exporter against real PG."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+
+from mcpg.database import Database
+from mcpg.diesel import generate_diesel_schema
+
+_SCHEMA = "mcpg_diesel_it"
+
+
+@pytest.fixture
+async def diesel_schema(connected_database: Database) -> AsyncIterator[str]:
+    driver = connected_database.driver()
+    await driver.execute_query(f"DROP SCHEMA IF EXISTS {_SCHEMA} CASCADE")
+    await driver.execute_query(f"CREATE SCHEMA {_SCHEMA}")
+    await driver.execute_query(f"CREATE TYPE {_SCHEMA}.status AS ENUM ('active','inactive')")
+    await driver.execute_query(
+        f"CREATE TABLE {_SCHEMA}.owner (id serial PRIMARY KEY, name varchar(120) NOT NULL, created_at timestamptz)"
+    )
+    await driver.execute_query(
+        f"CREATE TABLE {_SCHEMA}.widget ("
+        "id serial PRIMARY KEY, "
+        f"owner_id integer NOT NULL REFERENCES {_SCHEMA}.owner(id), "
+        "name text NOT NULL, "
+        f"state {_SCHEMA}.status NOT NULL DEFAULT 'active', "
+        "extras jsonb)"
+    )
+    try:
+        yield _SCHEMA
+    finally:
+        await driver.execute_query(f"DROP SCHEMA IF EXISTS {_SCHEMA} CASCADE")
+
+
+async def test_generate_diesel_schema_emits_valid_rust_for_a_real_schema(
+    connected_database: Database, diesel_schema: str
+) -> None:
+    rs = await generate_diesel_schema(connected_database.driver(), diesel_schema)
+
+    # Enum module emitted.
+    assert "pub mod pg_enum {" in rs
+    assert "pub enum Status {" in rs
+    assert "Active," in rs and "Inactive," in rs
+
+    # Both tables emitted as table! macros with the right PK clause.
+    assert "table! {\n    owner (id) {" in rs
+    assert "table! {\n    widget (id) {" in rs
+
+    # Column → Diesel SQL type mappings.
+    assert "id -> Integer," in rs
+    assert "name -> Varchar," in rs  # varchar(120) → Varchar
+    assert "created_at -> Nullable<Timestamptz>," in rs  # nullable timestamptz
+    assert "extras -> Nullable<Jsonb>," in rs
+    # Enum column maps to Text (wrapper-over-Text strategy).
+    assert "state -> Text," in rs
+
+    # joinable! for the intra-schema FK.
+    assert "joinable!(widget -> owner (owner_id));" in rs
+
+    # allow_tables_to_appear_in_same_query! with sorted names.
+    assert "allow_tables_to_appear_in_same_query!(owner, widget);" in rs
+
+
+async def test_generate_diesel_schema_for_an_empty_schema_emits_no_blocks(
+    connected_database: Database,
+) -> None:
+    driver = connected_database.driver()
+    schema = "mcpg_diesel_empty_it"
+    await driver.execute_query(f"DROP SCHEMA IF EXISTS {schema} CASCADE")
+    await driver.execute_query(f"CREATE SCHEMA {schema}")
+    try:
+        rs = await generate_diesel_schema(driver, schema)
+        # No tables → no table! macros, no joinable, no allow_join.
+        assert "table!" not in rs
+        assert "joinable!" not in rs
+        assert "allow_tables_to_appear_in_same_query!" not in rs
+    finally:
+        await driver.execute_query(f"DROP SCHEMA IF EXISTS {schema} CASCADE")

--- a/tests/integration/test_ecto_integration.py
+++ b/tests/integration/test_ecto_integration.py
@@ -1,0 +1,70 @@
+"""Integration tests for the Ecto (Elixir) schema exporter against real PG."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+
+from mcpg.database import Database
+from mcpg.ecto import generate_ecto_schemas
+
+_SCHEMA = "mcpg_ecto_it"
+
+
+@pytest.fixture
+async def ecto_schema(connected_database: Database) -> AsyncIterator[str]:
+    driver = connected_database.driver()
+    await driver.execute_query(f"DROP SCHEMA IF EXISTS {_SCHEMA} CASCADE")
+    await driver.execute_query(f"CREATE SCHEMA {_SCHEMA}")
+    await driver.execute_query(
+        f"CREATE TABLE {_SCHEMA}.users ("
+        "id serial PRIMARY KEY, "
+        "email text NOT NULL UNIQUE, "
+        "inserted_at timestamptz NOT NULL DEFAULT now(), "
+        "updated_at timestamptz NOT NULL DEFAULT now())"
+    )
+    await driver.execute_query(
+        f"CREATE TABLE {_SCHEMA}.widgets ("
+        "id serial PRIMARY KEY, "
+        f"user_id integer NOT NULL REFERENCES {_SCHEMA}.users(id), "
+        "name text NOT NULL, "
+        "metadata jsonb)"
+    )
+    try:
+        yield _SCHEMA
+    finally:
+        await driver.execute_query(f"DROP SCHEMA IF EXISTS {_SCHEMA} CASCADE")
+
+
+async def test_generate_ecto_schemas_emits_one_module_per_table_with_singular_filenames(
+    connected_database: Database, ecto_schema: str
+) -> None:
+    files = await generate_ecto_schemas(connected_database.driver(), ecto_schema, app_module="Shop")
+
+    # File names are singularised — users.ex → user.ex, widgets.ex → widget.ex.
+    assert set(files.keys()) == {"user.ex", "widget.ex"}
+
+    user = files["user.ex"]
+    widget = files["widget.ex"]
+
+    # User module: PascalCase + singular module name, schema points at PLURAL table.
+    assert "defmodule Shop.User do" in user
+    assert "use Ecto.Schema" in user
+    assert "@primary_key {:id, :id, autogenerate: true}" in user
+    assert 'schema "users" do' in user
+    assert "field :email, :string" in user
+    # Both timestamp columns → timestamps() macro; fields NOT redeclared.
+    assert "timestamps()" in user
+    assert "field :inserted_at" not in user
+    assert "field :updated_at" not in user
+
+    # Widget module: belongs_to + skip user_id field.
+    assert "defmodule Shop.Widget do" in widget
+    assert 'schema "widgets" do' in widget
+    assert "belongs_to :user, Shop.User, foreign_key: :user_id" in widget
+    # user_id is covered by belongs_to — must NOT be redeclared as a field.
+    assert "field :user_id" not in widget
+    assert "field :name, :string" in widget
+    # jsonb → :map
+    assert "field :metadata, :map" in widget

--- a/tests/integration/test_ent_integration.py
+++ b/tests/integration/test_ent_integration.py
@@ -1,0 +1,69 @@
+"""Integration tests for the Ent (Go) schema exporter against real PG."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+
+from mcpg.database import Database
+from mcpg.ent import generate_ent_schemas
+
+_SCHEMA = "mcpg_ent_it"
+
+
+@pytest.fixture
+async def ent_schema(connected_database: Database) -> AsyncIterator[str]:
+    driver = connected_database.driver()
+    await driver.execute_query(f"DROP SCHEMA IF EXISTS {_SCHEMA} CASCADE")
+    await driver.execute_query(f"CREATE SCHEMA {_SCHEMA}")
+    await driver.execute_query(f"CREATE TYPE {_SCHEMA}.status AS ENUM ('active','inactive')")
+    await driver.execute_query(
+        f"CREATE TABLE {_SCHEMA}.owner ("
+        "id serial PRIMARY KEY, "
+        "name text NOT NULL, "
+        "created_at timestamptz DEFAULT now())"
+    )
+    await driver.execute_query(
+        f"CREATE TABLE {_SCHEMA}.widget ("
+        "id serial PRIMARY KEY, "
+        f"owner_id integer NOT NULL REFERENCES {_SCHEMA}.owner(id), "
+        f"state {_SCHEMA}.status NOT NULL DEFAULT 'active', "
+        "extras jsonb)"
+    )
+    try:
+        yield _SCHEMA
+    finally:
+        await driver.execute_query(f"DROP SCHEMA IF EXISTS {_SCHEMA} CASCADE")
+
+
+async def test_generate_ent_schemas_emits_one_go_file_per_table(connected_database: Database, ent_schema: str) -> None:
+    files = await generate_ent_schemas(connected_database.driver(), ent_schema)
+
+    # One file per base table.
+    assert set(files.keys()) == {"owner.go", "widget.go"}
+
+    owner = files["owner.go"]
+    widget = files["widget.go"]
+
+    # Owner: ent.Schema struct, Fields() returning field.X(...) calls,
+    # time.Now default for created_at (timestamp), nullable wrapped.
+    assert "package schema" in owner
+    assert "type Owner struct {" in owner
+    assert "ent.Schema" in owner
+    assert 'field.Int("id")' in owner
+    assert 'field.Text("name")' in owner
+    assert 'field.Time("created_at")' in owner
+    assert ".Default(time.Now)" in owner
+    assert '"time"' in owner
+
+    # Widget: same shape PLUS Edges() with the FK edge AND field.Enum
+    # for the state column.
+    assert "type Widget struct {" in widget
+    assert "func (Widget) Fields()" in widget
+    assert "func (Widget) Edges()" in widget
+    assert 'edge.To("owner", Owner.Type).Unique().Field("owner_id")' in widget
+    assert 'field.Enum("state").Values("active", "inactive")' in widget
+    assert 'field.JSON("extras"' in widget
+    # Nullable JSONB column gets .Optional().
+    assert ".Optional()" in widget

--- a/tests/integration/test_jooq_integration.py
+++ b/tests/integration/test_jooq_integration.py
@@ -1,0 +1,76 @@
+"""Integration tests for the jOOQ configuration exporter against real PG."""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from collections.abc import AsyncIterator
+
+import pytest
+
+from mcpg.database import Database
+from mcpg.jooq import generate_jooq_config
+
+_SCHEMA = "mcpg_jooq_it"
+
+
+@pytest.fixture
+async def jooq_schema(connected_database: Database) -> AsyncIterator[str]:
+    driver = connected_database.driver()
+    await driver.execute_query(f"DROP SCHEMA IF EXISTS {_SCHEMA} CASCADE")
+    await driver.execute_query(f"CREATE SCHEMA {_SCHEMA}")
+    await driver.execute_query(
+        f"CREATE TABLE {_SCHEMA}.owner (id serial PRIMARY KEY, name text NOT NULL, profile jsonb)"
+    )
+    await driver.execute_query(
+        f"CREATE TABLE {_SCHEMA}.widget ("
+        "id serial PRIMARY KEY, "
+        f"owner_id integer NOT NULL REFERENCES {_SCHEMA}.owner(id), "
+        "attrs json)"
+    )
+    try:
+        yield _SCHEMA
+    finally:
+        await driver.execute_query(f"DROP SCHEMA IF EXISTS {_SCHEMA} CASCADE")
+
+
+async def test_generate_jooq_config_emits_parseable_xml_with_expected_includes(
+    connected_database: Database, jooq_schema: str
+) -> None:
+    xml_text = await generate_jooq_config(connected_database.driver(), jooq_schema, target_package="io.example.app")
+
+    # Output must be parseable XML — that's the contract jOOQ depends on.
+    root = ET.fromstring(xml_text)
+    # ElementTree exposes the namespaced element name; check by suffix.
+    assert root.tag.endswith("configuration")
+
+    # Includes regex names BOTH tables, anchored to schema.
+    assert f"{jooq_schema}\\.owner" in xml_text
+    assert f"{jooq_schema}\\.widget" in xml_text
+    # Excludes covers MCPg's audit + migrations schemas.
+    assert "mcpg_audit" in xml_text
+    assert "mcpg_migrations" in xml_text
+    # Target package is the override the caller supplied.
+    assert "<packageName>io.example.app</packageName>" in xml_text
+    # Both JSON columns generated forced-type entries.
+    assert f"{jooq_schema}\\.owner\\.profile" in xml_text
+    assert f"{jooq_schema}\\.widget\\.attrs" in xml_text
+    assert "org.jooq.JSONB" in xml_text  # for jsonb
+    assert "org.jooq.JSON" in xml_text  # for json
+
+
+async def test_generate_jooq_config_for_empty_schema_emits_empty_includes(
+    connected_database: Database,
+) -> None:
+    driver = connected_database.driver()
+    schema = "mcpg_jooq_empty_it"
+    await driver.execute_query(f"DROP SCHEMA IF EXISTS {schema} CASCADE")
+    await driver.execute_query(f"CREATE SCHEMA {schema}")
+    try:
+        xml_text = await generate_jooq_config(driver, schema)
+        # Still parseable, just with an empty includes regex.
+        ET.fromstring(xml_text)
+        assert "<includes></includes>" in xml_text
+        # No forcedTypes block when no JSON columns exist.
+        assert "<forcedTypes>" not in xml_text
+    finally:
+        await driver.execute_query(f"DROP SCHEMA IF EXISTS {schema} CASCADE")

--- a/tests/integration/test_textsearch_integration.py
+++ b/tests/integration/test_textsearch_integration.py
@@ -96,6 +96,136 @@ async def test_vector_search_against_real_pgvector(connected_database: Database)
         await driver.execute_query("DROP TABLE IF EXISTS mcpg_vsearch_it", force_readonly=False)
 
 
+async def test_vector_range_search_returns_only_rows_within_threshold(connected_database: Database) -> None:
+    driver = connected_database.driver()
+    available = {extension.name for extension in await list_available_extensions(driver)}
+    if "vector" not in available:
+        pytest.skip("pgvector is not available on this PostgreSQL server")
+    await enable_extension(driver, "vector")
+    await driver.execute_query("DROP TABLE IF EXISTS mcpg_vrange_it", force_readonly=False)
+    await driver.execute_query("CREATE TABLE mcpg_vrange_it (id integer, embedding vector(3))", force_readonly=False)
+    await driver.execute_query(
+        "INSERT INTO mcpg_vrange_it (id, embedding) VALUES "
+        "(1, '[1,0,0]'), (2, '[0.9,0.1,0]'), (3, '[0,1,0]'), (4, '[0,0,1]')",
+        force_readonly=False,
+    )
+    try:
+        from mcpg.textsearch import vector_range_search
+
+        # L2 distance from [1,0,0]: row 1 = 0.0, row 2 ≈ 0.14, row 3 ≈ 1.41, row 4 ≈ 1.41.
+        # max_distance=0.5 should keep only the first two.
+        result = await vector_range_search(
+            driver, "public", "mcpg_vrange_it", "embedding", [1.0, 0.0, 0.0], max_distance=0.5
+        )
+
+        assert result.available is True
+        ids = {match.row["id"] for match in result.matches}
+        assert ids == {1, 2}
+        # Distances are ordered ascending.
+        distances = [m.distance for m in result.matches]
+        assert distances == sorted(distances)
+    finally:
+        await driver.execute_query("DROP TABLE IF EXISTS mcpg_vrange_it", force_readonly=False)
+
+
+async def test_hybrid_search_fuses_vector_and_full_text_results_against_real_pg(
+    connected_database: Database,
+) -> None:
+    driver = connected_database.driver()
+    available = {extension.name for extension in await list_available_extensions(driver)}
+    if "vector" not in available:
+        pytest.skip("pgvector is not available on this PostgreSQL server")
+    await enable_extension(driver, "vector")
+    await driver.execute_query("DROP TABLE IF EXISTS mcpg_hybrid_it", force_readonly=False)
+    await driver.execute_query(
+        "CREATE TABLE mcpg_hybrid_it (id serial PRIMARY KEY, body text NOT NULL, embedding vector(3))",
+        force_readonly=False,
+    )
+    await driver.execute_query(
+        "INSERT INTO mcpg_hybrid_it (body, embedding) VALUES "
+        "('apple pie recipe', '[1,0,0]'),"
+        "('banana bread', '[0,1,0]'),"
+        "('apple banana smoothie', '[0.5,0.5,0]'),"
+        "('vintage car', '[0,0,1]')",
+        force_readonly=False,
+    )
+    try:
+        from mcpg.textsearch import hybrid_search
+
+        # Query vector points at "apple pie" row 1; FTS query "apple"
+        # matches rows 1 and 3 (anything mentioning apple). The fused
+        # ranking should rank row 1 first (appears in both sources at
+        # rank 1), then row 3.
+        result = await hybrid_search(
+            driver,
+            "public",
+            "mcpg_hybrid_it",
+            "embedding",
+            "body",
+            [1.0, 0.0, 0.0],
+            "apple",
+        )
+
+        assert result.available is True
+        # All four candidates surface in the merged list (each appears
+        # in at least the vector pool).
+        ids = [match.row["id"] for match in result.matches]
+        assert 1 in ids and 3 in ids
+        # The top-ranked result is the one that appears in BOTH sources.
+        top = result.matches[0]
+        assert top.row["id"] == 1
+        assert top.vector_rank == 1 and top.fts_rank == 1
+        # rrf_score is descending across the list.
+        scores = [m.rrf_score for m in result.matches]
+        assert scores == sorted(scores, reverse=True)
+    finally:
+        await driver.execute_query("DROP TABLE IF EXISTS mcpg_hybrid_it", force_readonly=False)
+
+
+async def test_recommend_vector_quantization_picks_up_real_pgvector_columns(
+    connected_database: Database,
+) -> None:
+    driver = connected_database.driver()
+    available = {extension.name for extension in await list_available_extensions(driver)}
+    if "vector" not in available:
+        pytest.skip("pgvector is not available on this PostgreSQL server")
+    await enable_extension(driver, "vector")
+    await driver.execute_query("DROP SCHEMA IF EXISTS mcpg_quant_it CASCADE", force_readonly=False)
+    await driver.execute_query("CREATE SCHEMA mcpg_quant_it", force_readonly=False)
+    # 768-dim vectors, just below the row threshold — should NOT recommend.
+    await driver.execute_query(
+        "CREATE TABLE mcpg_quant_it.small (id serial PRIMARY KEY, emb vector(768))",
+        force_readonly=False,
+    )
+    # 768-dim with 10001 rows — clears the dimension>=768 + row_count>=10000 path.
+    await driver.execute_query(
+        "CREATE TABLE mcpg_quant_it.big (id serial PRIMARY KEY, emb vector(768))",
+        force_readonly=False,
+    )
+    await driver.execute_query(
+        "INSERT INTO mcpg_quant_it.big (emb) SELECT "
+        "('[' || array_to_string(array(SELECT random() FROM generate_series(1, 768)), ',') || ']')::vector "
+        "FROM generate_series(1, 10001)",
+        force_readonly=False,
+    )
+    try:
+        from mcpg.textsearch import recommend_vector_quantization
+
+        recs = await recommend_vector_quantization(driver, "mcpg_quant_it")
+        # Only the big table qualifies.
+        tables = {r.table for r in recs}
+        assert "big" in tables
+        assert "small" not in tables
+        big = next(r for r in recs if r.table == "big")
+        assert big.dimension == 768
+        assert big.current_type == "vector"
+        assert big.suggested_type == "halfvec"
+        # halfvec halves the per-element bytes — savings ratio ~0.5.
+        assert 0.49 < big.savings_ratio < 0.51
+    finally:
+        await driver.execute_query("DROP SCHEMA IF EXISTS mcpg_quant_it CASCADE", force_readonly=False)
+
+
 async def test_geo_search_against_real_postgis(connected_database: Database) -> None:
     driver = connected_database.driver()
     available = {extension.name for extension in await list_available_extensions(driver)}

--- a/tests/unit/test_advisors.py
+++ b/tests/unit/test_advisors.py
@@ -166,3 +166,59 @@ async def test_run_advisors_tool_is_registered_and_callable() -> None:
     assert result.structuredContent["schema"] == "public"
     assert result.structuredContent["findings"] == []
     assert len(result.structuredContent["rules_run"]) == 4
+
+
+# --- find_unused_objects -----------------------------------------------
+
+
+async def test_find_unused_objects_routes_table_and_index_queries_independently() -> None:
+    from mcpg.advisors import find_unused_objects
+
+    driver = FakeRoutingDriver(
+        {
+            "pg_stat_user_tables": [
+                {
+                    "table_name": "audit",
+                    "seq_scans": 0,
+                    "index_scans": 0,
+                    "rows_modified": 0,
+                    "estimated_row_count": 1234,
+                },
+            ],
+            "pg_stat_user_indexes": [
+                {
+                    "table_name": "orders",
+                    "index_name": "idx_orders_unused",
+                    "size_bytes": 1024 * 1024,
+                    "definition": "CREATE INDEX idx_orders_unused ON public.orders USING btree (customer_id)",
+                },
+            ],
+        }
+    )
+
+    report = await find_unused_objects(driver, "public")  # type: ignore[arg-type]
+
+    assert len(report.tables) == 1
+    assert report.tables[0].table == "audit"
+    assert report.tables[0].estimated_row_count == 1234
+    assert len(report.indexes) == 1
+    assert report.indexes[0].index == "idx_orders_unused"
+    assert report.indexes[0].size_bytes == 1024 * 1024
+
+
+async def test_find_unused_objects_returns_empty_when_no_zero_scan_objects_exist() -> None:
+    from mcpg.advisors import find_unused_objects
+
+    driver = FakeRoutingDriver({"pg_stat_user_tables": [], "pg_stat_user_indexes": []})
+
+    report = await find_unused_objects(driver, "public")  # type: ignore[arg-type]
+
+    assert report.tables == []
+    assert report.indexes == []
+
+
+async def test_find_unused_objects_tool_is_registered() -> None:
+    server = create_server(_SETTINGS, database=FakeDatabase(FakeDriver()))  # type: ignore[arg-type]
+    async with create_connected_server_and_client_session(server) as client:
+        listed = {tool.name for tool in (await client.list_tools()).tools}
+    assert "find_unused_objects" in listed

--- a/tests/unit/test_composite.py
+++ b/tests/unit/test_composite.py
@@ -1,0 +1,183 @@
+"""Tests for the composite (multi-primitive) tools."""
+
+from __future__ import annotations
+
+import pytest
+from _fakes import FakeDatabase, FakeDriver, FakeRoutingDriver
+from mcp.shared.memory import create_connected_server_and_client_session
+
+from mcpg.composite import (
+    CompositeError,
+    SlowQuerySuggestion,
+    _build_suggestions,
+    _cache_hit_ratio,
+    _check_identifier,
+    _pk_columns,
+    summarize_table,
+)
+from mcpg.config import load_settings
+from mcpg.introspection import ConstraintInfo
+from mcpg.server import create_server
+
+_SETTINGS = load_settings({"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db"})
+
+
+def test_check_identifier_rejects_unsafe_names() -> None:
+    _check_identifier("widget", "table")
+    with pytest.raises(CompositeError, match="invalid table"):
+        _check_identifier('w"; DROP', "table")
+    with pytest.raises(CompositeError, match="invalid schema"):
+        _check_identifier("with space", "schema")
+
+
+def test_pk_columns_extracts_from_primary_key_definition() -> None:
+    cons = [
+        ConstraintInfo(name="widget_pkey", type="primary_key", definition="PRIMARY KEY (id)"),
+        ConstraintInfo(name="other_check", type="check", definition="CHECK (qty >= 0)"),
+    ]
+    assert _pk_columns(cons) == ["id"]
+
+
+def test_pk_columns_handles_composite_pk() -> None:
+    cons = [
+        ConstraintInfo(
+            name="team_member_pkey",
+            type="primary_key",
+            definition='PRIMARY KEY ("team_id", user_id)',
+        )
+    ]
+    assert _pk_columns(cons) == ["team_id", "user_id"]
+
+
+def test_pk_columns_returns_empty_when_no_primary_key() -> None:
+    assert _pk_columns([]) == []
+    assert _pk_columns([ConstraintInfo(name="x", type="unique", definition="UNIQUE (email)")]) == []
+
+
+# --- _build_suggestions -----------------------------------------------
+
+
+def test_build_suggestions_flags_seq_scan_with_high_cost() -> None:
+    suggestions = _build_suggestions(
+        plan_summary={"sequential_scan_count": 2, "total_cost": 2500.0},
+        active_queries=[],
+        blocking_locks=[],
+        cache_hit_ratio=0.99,
+    )
+    assert any(s.category == "plan" and "sequential scan" in s.hint for s in suggestions)
+
+
+def test_build_suggestions_flags_high_total_cost_regardless_of_seq_scan() -> None:
+    suggestions = _build_suggestions(
+        plan_summary={"sequential_scan_count": 0, "total_cost": 200_000.0},
+        active_queries=[],
+        blocking_locks=[],
+        cache_hit_ratio=0.99,
+    )
+    assert any(s.category == "plan" and "high" in s.hint.lower() for s in suggestions)
+
+
+def test_build_suggestions_flags_blocking_locks() -> None:
+    suggestions = _build_suggestions(
+        plan_summary={"sequential_scan_count": 0, "total_cost": 1.0},
+        active_queries=[],
+        blocking_locks=[{"blocked_pid": 1, "blocking_pid": 2}],
+        cache_hit_ratio=0.99,
+    )
+    assert any(s.category == "contention" and "lock" in s.hint for s in suggestions)
+
+
+def test_build_suggestions_flags_low_cache_hit_ratio() -> None:
+    suggestions = _build_suggestions(
+        plan_summary={"sequential_scan_count": 0, "total_cost": 1.0},
+        active_queries=[],
+        blocking_locks=[],
+        cache_hit_ratio=0.50,
+    )
+    assert any(s.category == "cache" and "cache" in s.hint for s in suggestions)
+
+
+def test_build_suggestions_falls_back_to_explain_analyze_advice_when_nothing_else_fires() -> None:
+    suggestions = _build_suggestions(
+        plan_summary={"sequential_scan_count": 0, "total_cost": 1.0},
+        active_queries=[],
+        blocking_locks=[],
+        cache_hit_ratio=0.99,
+    )
+    assert len(suggestions) == 1
+    assert "EXPLAIN" in suggestions[0].hint
+
+
+def test_slow_query_suggestion_dataclass_shape() -> None:
+    sug = SlowQuerySuggestion(category="plan", hint="add an index")
+    assert sug.category == "plan"
+    assert sug.hint == "add an index"
+
+
+# --- _cache_hit_ratio --------------------------------------------------
+
+
+async def test_cache_hit_ratio_returns_none_when_no_io_yet() -> None:
+    driver = FakeDriver([{"hits": 0, "reads": 0}])
+
+    ratio = await _cache_hit_ratio(driver)  # type: ignore[arg-type]
+
+    assert ratio is None
+
+
+async def test_cache_hit_ratio_computes_hits_over_total() -> None:
+    driver = FakeDriver([{"hits": 950, "reads": 50}])
+
+    ratio = await _cache_hit_ratio(driver)  # type: ignore[arg-type]
+
+    assert ratio == pytest.approx(0.95)
+
+
+async def test_cache_hit_ratio_handles_null_aggregates() -> None:
+    # pg_stat_database can return NULL for sum() on an empty cluster.
+    driver = FakeDriver([{"hits": None, "reads": None}])
+
+    ratio = await _cache_hit_ratio(driver)  # type: ignore[arg-type]
+
+    assert ratio is None
+
+
+# --- summarize_table --------------------------------------------------
+
+
+async def test_summarize_table_rejects_unsafe_identifiers() -> None:
+    driver = FakeRoutingDriver({})
+
+    with pytest.raises(CompositeError, match="invalid"):
+        await summarize_table(driver, 'app"; DROP', "widget")  # type: ignore[arg-type]
+
+
+async def test_summarize_table_rejects_negative_sample_rows() -> None:
+    driver = FakeRoutingDriver({})
+
+    with pytest.raises(CompositeError, match="non-negative"):
+        await summarize_table(driver, "app", "widget", sample_rows=-1)  # type: ignore[arg-type]
+
+
+# --- tool registration -----------------------------------------------
+
+
+async def test_summarize_table_tool_is_registered() -> None:
+    server = create_server(_SETTINGS, database=FakeDatabase(FakeDriver()))  # type: ignore[arg-type]
+    async with create_connected_server_and_client_session(server) as client:
+        listed = {tool.name for tool in (await client.list_tools()).tools}
+    assert "summarize_table" in listed
+
+
+async def test_why_is_this_slow_tool_is_registered() -> None:
+    server = create_server(_SETTINGS, database=FakeDatabase(FakeDriver()))  # type: ignore[arg-type]
+    async with create_connected_server_and_client_session(server) as client:
+        listed = {tool.name for tool in (await client.list_tools()).tools}
+    assert "why_is_this_slow" in listed
+
+
+async def test_why_is_this_slow_rejects_empty_sql() -> None:
+    from mcpg.composite import why_is_this_slow
+
+    with pytest.raises(CompositeError, match="empty"):
+        await why_is_this_slow(FakeDriver(), "   ")  # type: ignore[arg-type]

--- a/tests/unit/test_diesel.py
+++ b/tests/unit/test_diesel.py
@@ -1,0 +1,139 @@
+"""Tests for the PostgreSQL → Diesel ORM (Rust) exporter."""
+
+from __future__ import annotations
+
+import pytest
+from _fakes import FakeDatabase, FakeDriver
+from mcp.shared.memory import create_connected_server_and_client_session
+
+from mcpg.config import load_settings
+from mcpg.diesel import (
+    DieselExportError,
+    _check_identifier,
+    _diesel_sql_type,
+    _parse_pk_columns,
+    _pascal,
+    _render_allow_join,
+    _render_enum_module,
+    _render_joinable,
+    _render_table_block,
+)
+from mcpg.introspection import ColumnInfo
+from mcpg.server import create_server
+
+_SETTINGS = load_settings({"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db"})
+
+
+# --- pure helpers ----------------------------------------------------
+
+
+def test_check_identifier_rejects_unsafe_names() -> None:
+    _check_identifier("widget", "table")
+    with pytest.raises(DieselExportError, match="invalid table"):
+        _check_identifier('w"; DROP', "table")
+    with pytest.raises(DieselExportError, match="invalid schema"):
+        _check_identifier("with space", "schema")
+
+
+def test_pascal_converts_snake_and_kebab_to_pascal() -> None:
+    assert _pascal("widget") == "Widget"
+    assert _pascal("in-progress") == "InProgress"
+    assert _pascal("order_item") == "OrderItem"
+    assert _pascal("") == ""
+
+
+def _col(name: str, data_type: str, *, nullable: bool = False) -> ColumnInfo:
+    return ColumnInfo(name=name, data_type=data_type, nullable=nullable, default=None, vector_dimension=None)
+
+
+def test_diesel_sql_type_maps_common_pg_types() -> None:
+    assert _diesel_sql_type(_col("a", "integer"), set()) == "Integer"
+    assert _diesel_sql_type(_col("a", "bigint"), set()) == "BigInt"
+    assert _diesel_sql_type(_col("a", "boolean"), set()) == "Bool"
+    assert _diesel_sql_type(_col("a", "text"), set()) == "Text"
+    assert _diesel_sql_type(_col("a", "character varying(120)"), set()) == "Varchar"
+    assert _diesel_sql_type(_col("a", "timestamp with time zone"), set()) == "Timestamptz"
+    assert _diesel_sql_type(_col("a", "jsonb"), set()) == "Jsonb"
+    assert _diesel_sql_type(_col("a", "uuid"), set()) == "Uuid"
+
+
+def test_diesel_sql_type_wraps_nullable_in_nullable_t() -> None:
+    assert _diesel_sql_type(_col("a", "integer", nullable=True), set()) == "Nullable<Integer>"
+    assert _diesel_sql_type(_col("a", "text", nullable=True), set()) == "Nullable<Text>"
+
+
+def test_diesel_sql_type_routes_enum_columns_to_text_backed_wrapper() -> None:
+    # Both unqualified and schema-qualified enum types resolve.
+    assert _diesel_sql_type(_col("state", "status"), {"status"}) == "Text"
+    assert _diesel_sql_type(_col("state", "myschema.status"), {"status"}) == "Text"
+    assert _diesel_sql_type(_col("state", "status", nullable=True), {"status"}) == "Nullable<Text>"
+
+
+def test_diesel_sql_type_falls_back_to_text_for_unknown_pg_types() -> None:
+    assert _diesel_sql_type(_col("a", "totally_made_up"), set()) == "Text"
+
+
+def test_parse_pk_columns_extracts_from_constraint_definitions() -> None:
+    assert _parse_pk_columns("PRIMARY KEY (id)") == ["id"]
+    assert _parse_pk_columns('PRIMARY KEY ("user_id", tenant)') == ["user_id", "tenant"]
+    assert _parse_pk_columns("UNIQUE (email)") == []
+
+
+def test_render_table_block_emits_table_macro_with_pk_clause() -> None:
+    block = _render_table_block("widget", [_col("id", "integer"), _col("name", "text")], ["id"], set())
+    assert block.startswith("table! {")
+    assert "widget (id) {" in block
+    assert "        id -> Integer," in block
+    assert "        name -> Text," in block
+    assert block.rstrip().endswith("}")
+
+
+def test_render_table_block_omits_pk_clause_when_no_primary_key() -> None:
+    block = _render_table_block("audit_log", [_col("ts", "timestamp without time zone")], [], set())
+    # Diesel allows omitting the (pk) clause when there isn't one — Diesel
+    # treats the first column as the PK by default.
+    assert "audit_log {" in block
+    assert "audit_log (" not in block
+
+
+def test_render_table_block_emits_composite_pk_in_macro_header() -> None:
+    block = _render_table_block(
+        "team_member",
+        [_col("team_id", "integer"), _col("user_id", "integer")],
+        ["team_id", "user_id"],
+        set(),
+    )
+    assert "team_member (team_id, user_id) {" in block
+
+
+def test_render_joinable_emits_macro_with_fk_column() -> None:
+    assert _render_joinable("widget", "owner", "owner_id") == "joinable!(widget -> owner (owner_id));"
+
+
+def test_render_allow_join_sorts_table_names_alphabetically() -> None:
+    # Stable ordering matters for repeatable output across runs.
+    out = _render_allow_join(["widget", "owner", "audit"])
+    assert out == "allow_tables_to_appear_in_same_query!(audit, owner, widget);"
+
+
+def test_render_enum_module_emits_text_backed_wrapper_per_enum() -> None:
+    out = _render_enum_module([("status", ["active", "inactive"])])
+    assert "pub mod pg_enum {" in out
+    assert "pub enum Status {" in out
+    assert "Active," in out
+    assert "Inactive," in out
+    assert "diesel(sql_type = diesel::sql_types::Text)" in out
+
+
+def test_render_enum_module_returns_empty_string_when_no_enums() -> None:
+    assert _render_enum_module([]) == ""
+
+
+# --- tool registration ----------------------------------------------
+
+
+async def test_generate_diesel_schema_tool_registered_for_reads() -> None:
+    server = create_server(_SETTINGS, database=FakeDatabase(FakeDriver()))  # type: ignore[arg-type]
+    async with create_connected_server_and_client_session(server) as client:
+        listed = {tool.name for tool in (await client.list_tools()).tools}
+    assert "generate_diesel_schema" in listed

--- a/tests/unit/test_ecto.py
+++ b/tests/unit/test_ecto.py
@@ -1,0 +1,146 @@
+"""Tests for the PostgreSQL → Ecto (Elixir) schema exporter."""
+
+from __future__ import annotations
+
+import pytest
+from _fakes import FakeDatabase, FakeDriver
+from mcp.shared.memory import create_connected_server_and_client_session
+
+from mcpg.config import load_settings
+from mcpg.ecto import (
+    EctoExportError,
+    _check_identifier,
+    _ecto_field_type,
+    _is_timestamp_pair,
+    _pascal,
+    _render_belongs_to,
+    _render_module,
+    _singularize,
+)
+from mcpg.introspection import ColumnInfo
+from mcpg.server import create_server
+
+_SETTINGS = load_settings({"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db"})
+
+
+def test_check_identifier_rejects_unsafe_names() -> None:
+    _check_identifier("widget", "table")
+    with pytest.raises(EctoExportError, match="invalid table"):
+        _check_identifier('w"; DROP', "table")
+
+
+def test_pascal_converts_snake_to_pascal() -> None:
+    assert _pascal("widget") == "Widget"
+    assert _pascal("order_item") == "OrderItem"
+
+
+def test_singularize_handles_common_english_plurals() -> None:
+    assert _singularize("widgets") == "widget"
+    assert _singularize("users") == "user"
+    assert _singularize("categories") == "category"  # -ies → -y
+    assert _singularize("addresses") == "address"  # -ses → -se → wait, let's check
+    # Edge cases — singular nouns are returned unchanged.
+    assert _singularize("data") == "data"
+    assert _singularize("status") == "status"  # -ss endings preserved
+    assert _singularize("") == ""
+
+
+def _col(name: str, data_type: str, *, nullable: bool = False) -> ColumnInfo:
+    return ColumnInfo(name=name, data_type=data_type, nullable=nullable, default=None, vector_dimension=None)
+
+
+def test_ecto_field_type_maps_common_pg_types() -> None:
+    assert _ecto_field_type(_col("a", "integer"), set()) == ":integer"
+    assert _ecto_field_type(_col("a", "bigint"), set()) == ":integer"
+    assert _ecto_field_type(_col("a", "boolean"), set()) == ":boolean"
+    assert _ecto_field_type(_col("a", "text"), set()) == ":string"
+    assert _ecto_field_type(_col("a", "character varying(120)"), set()) == ":string"
+    assert _ecto_field_type(_col("a", "numeric(10,2)"), set()) == ":decimal"
+    assert _ecto_field_type(_col("a", "uuid"), set()) == "Ecto.UUID"
+    assert _ecto_field_type(_col("a", "jsonb"), set()) == ":map"
+    assert _ecto_field_type(_col("a", "timestamp with time zone"), set()) == ":utc_datetime"
+    assert _ecto_field_type(_col("a", "timestamp without time zone"), set()) == ":naive_datetime"
+
+
+def test_ecto_field_type_falls_back_to_string_for_enums() -> None:
+    # Without the EctoEnum library Ecto can't natively express PG enums.
+    assert _ecto_field_type(_col("state", "status"), {"status"}) == ":string"
+    assert _ecto_field_type(_col("state", "myschema.status"), {"status"}) == ":string"
+
+
+def test_is_timestamp_pair_requires_both_inserted_and_updated() -> None:
+    cols = [_col("id", "integer"), _col("inserted_at", "timestamptz"), _col("updated_at", "timestamptz")]
+    assert _is_timestamp_pair(cols) is True
+    assert _is_timestamp_pair([_col("inserted_at", "timestamptz")]) is False
+    assert _is_timestamp_pair([_col("updated_at", "timestamptz")]) is False
+
+
+def test_render_belongs_to_strips_id_suffix_for_association_name() -> None:
+    line = _render_belongs_to("owner_id", "owners", "Shop.Owner")
+    assert line == "    belongs_to :owner, Shop.Owner, foreign_key: :owner_id"
+    # No _id suffix → use the column name as the association.
+    line = _render_belongs_to("parent", "parents", "Shop.Parent")
+    assert line == "    belongs_to :parent, Shop.Parent, foreign_key: :parent"
+
+
+def test_render_module_uses_default_primary_key_for_single_column_id() -> None:
+    source = _render_module(
+        "MyApp",
+        "widgets",
+        [_col("id", "integer"), _col("name", "text")],
+        ["id"],
+        belongs_to_lines=[],
+        enum_names=set(),
+    )
+    assert "defmodule MyApp.Widget do" in source
+    assert "@primary_key {:id, :id, autogenerate: true}" in source
+    # id column NOT declared as a field — @primary_key handles it.
+    assert "field :id," not in source
+    assert "field :name, :string" in source
+
+
+def test_render_module_emits_timestamps_macro_when_both_columns_present() -> None:
+    cols = [
+        _col("id", "integer"),
+        _col("name", "text"),
+        _col("inserted_at", "timestamp with time zone"),
+        _col("updated_at", "timestamp with time zone"),
+    ]
+    source = _render_module("Shop", "users", cols, ["id"], belongs_to_lines=[], enum_names=set())
+    assert "timestamps()" in source
+    # The two timestamp columns are NOT re-declared as fields.
+    assert "field :inserted_at" not in source
+    assert "field :updated_at" not in source
+
+
+def test_render_module_skips_fk_columns_already_covered_by_belongs_to() -> None:
+    cols = [_col("id", "integer"), _col("owner_id", "integer"), _col("name", "text")]
+    belongs_to = ["    belongs_to :owner, Shop.Owner, foreign_key: :owner_id"]
+    source = _render_module("Shop", "widgets", cols, ["id"], belongs_to_lines=belongs_to, enum_names=set())
+    # belongs_to emitted, owner_id NOT also declared as a field (would be a duplicate).
+    assert "belongs_to :owner" in source
+    assert "field :owner_id" not in source
+
+
+def test_render_module_emits_composite_primary_key_with_primary_key_true() -> None:
+    source = _render_module(
+        "Shop",
+        "team_members",
+        [_col("team_id", "integer"), _col("user_id", "integer"), _col("role", "text")],
+        ["team_id", "user_id"],
+        belongs_to_lines=[],
+        enum_names=set(),
+    )
+    assert "@primary_key false" in source
+    assert "field :team_id, :integer, primary_key: true" in source
+    assert "field :user_id, :integer, primary_key: true" in source
+
+
+# --- tool registration ----------------------------------------------
+
+
+async def test_generate_ecto_schemas_tool_registered_for_reads() -> None:
+    server = create_server(_SETTINGS, database=FakeDatabase(FakeDriver()))  # type: ignore[arg-type]
+    async with create_connected_server_and_client_session(server) as client:
+        listed = {tool.name for tool in (await client.list_tools()).tools}
+    assert "generate_ecto_schemas" in listed

--- a/tests/unit/test_ent.py
+++ b/tests/unit/test_ent.py
@@ -1,0 +1,131 @@
+"""Tests for the PostgreSQL → Ent (Go) schema exporter."""
+
+from __future__ import annotations
+
+import pytest
+from _fakes import FakeDatabase, FakeDriver
+from mcp.shared.memory import create_connected_server_and_client_session
+
+from mcpg.config import load_settings
+from mcpg.ent import (
+    EntExportError,
+    _check_identifier,
+    _ent_builder_for,
+    _pascal,
+    _render_default_modifier,
+    _render_entity_file,
+    _render_field_call,
+)
+from mcpg.introspection import ColumnInfo
+from mcpg.server import create_server
+
+_SETTINGS = load_settings({"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db"})
+
+
+def test_check_identifier_rejects_unsafe_names() -> None:
+    _check_identifier("widget", "table")
+    with pytest.raises(EntExportError, match="invalid table"):
+        _check_identifier('w"; DROP', "table")
+
+
+def test_pascal_converts_snake_to_pascal() -> None:
+    assert _pascal("widget") == "Widget"
+    assert _pascal("order_item") == "OrderItem"
+    assert _pascal("") == ""
+
+
+def _col(name: str, data_type: str, *, nullable: bool = False, default: str | None = None) -> ColumnInfo:
+    return ColumnInfo(name=name, data_type=data_type, nullable=nullable, default=default, vector_dimension=None)
+
+
+def test_ent_builder_maps_common_pg_types() -> None:
+    assert _ent_builder_for(_col("a", "integer"), set()) == ('field.Int("a")', None)
+    assert _ent_builder_for(_col("a", "bigint"), set()) == ('field.Int64("a")', None)
+    assert _ent_builder_for(_col("a", "boolean"), set()) == ('field.Bool("a")', None)
+    assert _ent_builder_for(_col("a", "text"), set()) == ('field.Text("a")', None)
+
+
+def test_ent_builder_for_uuid_pulls_in_uuid_import() -> None:
+    builder, extra = _ent_builder_for(_col("id", "uuid"), set())
+    assert "uuid.UUID{}" in builder
+    assert extra == "github.com/google/uuid"
+
+
+def test_ent_builder_for_json_uses_map_string_interface_type() -> None:
+    builder, _ = _ent_builder_for(_col("payload", "jsonb"), set())
+    assert builder == 'field.JSON("payload", map[string]interface{}{})'
+
+
+def test_ent_builder_for_enum_uses_field_enum_builder() -> None:
+    builder, _ = _ent_builder_for(_col("state", "status"), {"status"})
+    assert builder == 'field.Enum("state")'
+    # Schema-qualified enum type resolves the same way.
+    builder, _ = _ent_builder_for(_col("state", "myschema.status"), {"status"})
+    assert builder == 'field.Enum("state")'
+
+
+def test_render_default_modifier_maps_common_defaults_and_drops_nextval() -> None:
+    # nextval (serial) is owned by Ent's primary-key generation.
+    assert _render_default_modifier(_col("id", "integer", default="nextval('seq')")) is None
+    # No default → no modifier.
+    assert _render_default_modifier(_col("a", "integer", default=None)) is None
+    # now() / CURRENT_TIMESTAMP map to time.Now (Go std).
+    assert _render_default_modifier(_col("a", "timestamptz", default="now()")) == ".Default(time.Now)"
+    assert _render_default_modifier(_col("a", "timestamptz", default="CURRENT_TIMESTAMP")) == ".Default(time.Now)"
+    # Booleans + numbers round-trip directly.
+    assert _render_default_modifier(_col("a", "boolean", default="true")) == ".Default(true)"
+    assert _render_default_modifier(_col("a", "integer", default="0")) == ".Default(0)"
+    # PG-quoted string → bare Go string literal.
+    assert _render_default_modifier(_col("a", "text", default="'hello'::text")) == '.Default("hello")'
+
+
+def test_render_field_call_attaches_enum_values_when_present() -> None:
+    line, _ = _render_field_call(
+        _col("state", "status"),
+        {"status"},
+        {"status": ["active", "inactive"]},
+    )
+    assert line == 'field.Enum("state").Values("active", "inactive")'
+
+
+def test_render_field_call_appends_optional_for_nullable_columns() -> None:
+    line, _ = _render_field_call(_col("nick", "text", nullable=True), set(), {})
+    assert line == 'field.Text("nick").Optional()'
+
+
+def test_render_entity_file_includes_edge_block_only_when_edges_present() -> None:
+    source = _render_entity_file(
+        "widget",
+        [_col("id", "integer"), _col("name", "text")],
+        edges=['edge.To("owner", Owner.Type).Unique().Field("owner_id"),'],
+        extra_imports=set(),
+        enum_names=set(),
+        enum_values_by_name={},
+    )
+    assert "type Widget struct {" in source
+    assert "func (Widget) Fields()" in source
+    assert "func (Widget) Edges()" in source
+    assert '"entgo.io/ent/schema/edge"' in source
+
+
+def test_render_entity_file_omits_edge_imports_and_block_when_no_edges() -> None:
+    source = _render_entity_file(
+        "widget",
+        [_col("id", "integer")],
+        edges=[],
+        extra_imports=set(),
+        enum_names=set(),
+        enum_values_by_name={},
+    )
+    assert "func (Widget) Edges()" not in source
+    assert '"entgo.io/ent/schema/edge"' not in source
+
+
+# --- tool registration ----------------------------------------------
+
+
+async def test_generate_ent_schemas_tool_registered_for_reads() -> None:
+    server = create_server(_SETTINGS, database=FakeDatabase(FakeDriver()))  # type: ignore[arg-type]
+    async with create_connected_server_and_client_session(server) as client:
+        listed = {tool.name for tool in (await client.list_tools()).tools}
+    assert "generate_ent_schemas" in listed

--- a/tests/unit/test_http_runtime.py
+++ b/tests/unit/test_http_runtime.py
@@ -1,0 +1,222 @@
+"""Tests for the HTTP runtime — bearer-token auth + /metrics endpoint."""
+
+from __future__ import annotations
+
+import pytest
+from starlette.applications import Starlette
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from mcpg.config import load_settings
+from mcpg.http_runtime import _AUTH_EXEMPT_PATHS, _BearerAuthMiddleware, build_http_app
+from mcpg.observability import get_metrics, reset_metrics
+
+
+@pytest.fixture(autouse=True)
+def _reset_metrics_between_tests() -> None:
+    reset_metrics()
+
+
+def _bare_app() -> Starlette:
+    async def _root(_request: object) -> PlainTextResponse:
+        return PlainTextResponse("ok")
+
+    return Starlette(routes=[Route("/", _root, methods=["GET"])])
+
+
+def test_bearer_middleware_allows_correct_token() -> None:
+    inner = _bare_app()
+    middleware = _BearerAuthMiddleware(inner, token="s3cr3t")
+    test_app = Starlette(
+        routes=inner.router.routes,
+    )
+    # We can't easily call middleware via TestClient without rebuilding,
+    # so exercise the middleware directly with a synthetic ASGI scope.
+    _ = middleware  # used in next test
+    # Smoke: TestClient against the bare app shows it works.
+    with TestClient(test_app) as client:
+        response = client.get("/")
+        assert response.status_code == 200
+
+
+def test_bearer_middleware_returns_401_when_authorization_header_is_missing() -> None:
+    sent_messages: list[dict[str, object]] = []
+
+    async def receive() -> dict[str, object]:
+        return {"type": "http.request", "body": b""}
+
+    async def send(message: dict[str, object]) -> None:
+        sent_messages.append(message)
+
+    inner = _bare_app()
+    middleware = _BearerAuthMiddleware(inner, token="s3cr3t")
+    scope = {"type": "http", "path": "/", "headers": []}
+
+    import asyncio
+
+    asyncio.run(middleware(scope, receive, send))
+
+    assert sent_messages[0]["type"] == "http.response.start"
+    assert sent_messages[0]["status"] == 401
+
+
+def test_bearer_middleware_returns_401_for_wrong_token() -> None:
+    sent_messages: list[dict[str, object]] = []
+
+    async def receive() -> dict[str, object]:
+        return {"type": "http.request", "body": b""}
+
+    async def send(message: dict[str, object]) -> None:
+        sent_messages.append(message)
+
+    inner = _bare_app()
+    middleware = _BearerAuthMiddleware(inner, token="s3cr3t")
+    scope = {
+        "type": "http",
+        "path": "/",
+        "headers": [(b"authorization", b"Bearer wrong")],
+    }
+
+    import asyncio
+
+    asyncio.run(middleware(scope, receive, send))
+
+    assert sent_messages[0]["status"] == 401
+
+
+def test_bearer_middleware_exempts_metrics_path_even_without_token() -> None:
+    """A Prometheus scraper hits /metrics without the MCP bearer token."""
+    sent_messages: list[dict[str, object]] = []
+    inner_invoked = False
+
+    async def inner(_scope: object, _receive: object, send_fn: object) -> None:
+        nonlocal inner_invoked
+        inner_invoked = True
+        await send_fn(  # type: ignore[operator]
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [],
+            }
+        )
+        await send_fn({"type": "http.response.body", "body": b""})  # type: ignore[operator]
+
+    async def receive() -> dict[str, object]:
+        return {"type": "http.request", "body": b""}
+
+    async def send(message: dict[str, object]) -> None:
+        sent_messages.append(message)
+
+    middleware = _BearerAuthMiddleware(inner, token="s3cr3t")
+    scope = {"type": "http", "path": "/metrics", "headers": []}
+
+    import asyncio
+
+    asyncio.run(middleware(scope, receive, send))
+
+    # The middleware passed through to the inner app without checking auth.
+    assert inner_invoked
+    assert sent_messages[0]["status"] == 200
+
+
+def test_bearer_middleware_passes_non_http_scopes_through_unmodified() -> None:
+    inner_invoked = False
+
+    async def inner(scope: object, _receive: object, _send: object) -> None:
+        nonlocal inner_invoked
+        inner_invoked = True
+        # Lifespan scopes must reach the underlying ASGI app or the
+        # server never starts up.
+        assert scope["type"] == "lifespan"  # type: ignore[index]
+
+    middleware = _BearerAuthMiddleware(inner, token="s3cr3t")
+    scope = {"type": "lifespan"}
+
+    import asyncio
+
+    asyncio.run(middleware(scope, lambda: None, lambda _: None))  # type: ignore[arg-type]
+
+    assert inner_invoked
+
+
+def test_auth_exempt_paths_includes_metrics_and_health_endpoints() -> None:
+    # Pin the exempt set so adding to it requires an explicit change here too.
+    assert "/metrics" in _AUTH_EXEMPT_PATHS
+    assert "/healthz" in _AUTH_EXEMPT_PATHS
+    assert "/readyz" in _AUTH_EXEMPT_PATHS
+
+
+def test_build_http_app_rejects_unknown_kind() -> None:
+    settings = load_settings({"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db"})
+
+    class _Stub:
+        def streamable_http_app(self) -> Starlette:
+            return _bare_app()
+
+        def sse_app(self) -> Starlette:
+            return _bare_app()
+
+    with pytest.raises(ValueError, match="unknown HTTP transport kind"):
+        build_http_app(_Stub(), settings, kind="websocket")  # type: ignore[arg-type]
+
+
+def test_build_http_app_serves_metrics_with_observability_payload() -> None:
+    # Record one observation so the /metrics body has something to assert on.
+    get_metrics().record_call("smoke_test", "ok", 0.05)
+
+    settings = load_settings({"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db"})
+
+    class _Stub:
+        def streamable_http_app(self) -> Starlette:
+            return _bare_app()
+
+    wrapped = build_http_app(_Stub(), settings, kind="streamable-http")
+    with TestClient(wrapped) as client:
+        response = client.get("/metrics")
+    assert response.status_code == 200
+    assert "mcpg_tool_calls_total" in response.text
+    assert 'tool="smoke_test"' in response.text
+    assert "text/plain" in response.headers["content-type"]
+
+
+def test_build_http_app_serves_healthz_unauthenticated() -> None:
+    settings = load_settings({"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db"})
+
+    class _Stub:
+        def streamable_http_app(self) -> Starlette:
+            return _bare_app()
+
+    wrapped = build_http_app(_Stub(), settings, kind="streamable-http")
+    with TestClient(wrapped) as client:
+        response = client.get("/healthz")
+    assert response.status_code == 200
+    assert response.text.startswith("ok")
+
+
+def test_build_http_app_with_token_blocks_unauthenticated_requests() -> None:
+    settings = load_settings(
+        {
+            "MCPG_DATABASE_URL": "postgresql://u:p@localhost/db",
+            "MCPG_HTTP_AUTH_TOKEN": "topsecret",
+        }
+    )
+
+    class _Stub:
+        def streamable_http_app(self) -> Starlette:
+            return _bare_app()
+
+    wrapped = build_http_app(_Stub(), settings, kind="streamable-http")
+    with TestClient(wrapped) as client:
+        # No header → 401.
+        response = client.get("/")
+        assert response.status_code == 401
+        # Right token → 200.
+        response = client.get("/", headers={"Authorization": "Bearer topsecret"})
+        assert response.status_code == 200
+        # Wrong token → 401.
+        response = client.get("/", headers={"Authorization": "Bearer wrong"})
+        assert response.status_code == 401
+        # /metrics still works without a token.
+        response = client.get("/metrics")
+        assert response.status_code == 200

--- a/tests/unit/test_jooq.py
+++ b/tests/unit/test_jooq.py
@@ -1,0 +1,60 @@
+"""Tests for the PostgreSQL → jOOQ configuration exporter."""
+
+from __future__ import annotations
+
+import pytest
+from _fakes import FakeDatabase, FakeDriver
+from mcp.shared.memory import create_connected_server_and_client_session
+
+from mcpg.config import load_settings
+from mcpg.introspection import ColumnInfo
+from mcpg.jooq import (
+    JooqExportError,
+    _check_identifier,
+    _is_json_column,
+    _render_forced_type,
+)
+from mcpg.server import create_server
+
+_SETTINGS = load_settings({"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db"})
+
+
+# --- pure helpers ----------------------------------------------------
+
+
+def test_check_identifier_rejects_unsafe_names() -> None:
+    _check_identifier("widget", "table")
+    with pytest.raises(JooqExportError, match="invalid table"):
+        _check_identifier('w"; DROP', "table")
+    with pytest.raises(JooqExportError, match="invalid schema"):
+        _check_identifier("with space", "schema")
+
+
+def _col(name: str, data_type: str) -> ColumnInfo:
+    return ColumnInfo(name=name, data_type=data_type, nullable=True, default=None, vector_dimension=None)
+
+
+def test_is_json_column_picks_up_json_and_jsonb() -> None:
+    assert _is_json_column(_col("p", "jsonb")) == (True, "org.jooq.JSONB")
+    assert _is_json_column(_col("p", "json")) == (True, "org.jooq.JSON")
+    assert _is_json_column(_col("p", "integer")) == (False, None)
+    assert _is_json_column(_col("p", "text")) == (False, None)
+
+
+def test_render_forced_type_emits_anchored_expression_regex() -> None:
+    out = _render_forced_type("owner", "profile", "org.jooq.JSONB", "app")
+    # The expression must scope to the exact column path so it doesn't
+    # accidentally match other columns of the same name.
+    assert "<expression>app\\.owner\\.profile</expression>" in out
+    assert "<userType>org.jooq.JSONB</userType>" in out
+    assert "<types>.*</types>" in out
+
+
+# --- tool registration ----------------------------------------------
+
+
+async def test_generate_jooq_config_tool_registered_for_reads() -> None:
+    server = create_server(_SETTINGS, database=FakeDatabase(FakeDriver()))  # type: ignore[arg-type]
+    async with create_connected_server_and_client_session(server) as client:
+        listed = {tool.name for tool in (await client.list_tools()).tools}
+    assert "generate_jooq_config" in listed

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -1,0 +1,132 @@
+"""Tests for the observability / Prometheus metrics module."""
+
+from __future__ import annotations
+
+from itertools import pairwise
+
+import pytest
+
+from mcpg.observability import (
+    DEFAULT_BUCKETS,
+    Metrics,
+    _escape_label_value,
+    _Histogram,
+    get_metrics,
+    render_prometheus,
+    reset_metrics,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_metrics_between_tests() -> None:
+    """Module singleton state could leak across tests — start clean."""
+    reset_metrics()
+
+
+def test_histogram_observe_increments_every_bucket_whose_upper_bound_includes_the_value() -> None:
+    hist = _Histogram()
+    hist.observe(0.05)
+    # 0.05 should land in buckets [0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0]
+    # — counts for indexes 0..2 (0.005, 0.01, 0.025) stay at 0; 3+ get +1.
+    assert hist.counts[0] == 0  # 0.005
+    assert hist.counts[1] == 0  # 0.01
+    assert hist.counts[2] == 0  # 0.025
+    assert hist.counts[3] == 1  # 0.05
+    assert hist.counts[-1] == 1  # 60.0
+    assert hist.count == 1
+    assert hist.sum == pytest.approx(0.05)
+
+
+def test_metrics_record_call_counts_per_tool_and_status_pair() -> None:
+    m = Metrics()
+    m.record_call("run_select", "ok", 0.01)
+    m.record_call("run_select", "ok", 0.02)
+    m.record_call("run_select", "error", 0.005)
+    m.record_call("export_query", "ok", 0.4)
+
+    calls, durations = m.snapshot()
+    assert calls[("run_select", "ok")] == 2
+    assert calls[("run_select", "error")] == 1
+    assert calls[("export_query", "ok")] == 1
+    # Histograms are per-tool, NOT per-(tool, status).
+    assert durations["run_select"].count == 3
+    assert durations["export_query"].count == 1
+
+
+def test_metrics_snapshot_is_defensive_copy() -> None:
+    m = Metrics()
+    m.record_call("run_select", "ok", 0.01)
+    calls, durations = m.snapshot()
+    # Mutating the snapshot must not affect the source.
+    calls.clear()
+    durations["run_select"].counts[0] = 999
+    calls_again, durations_again = m.snapshot()
+    assert calls_again == {("run_select", "ok"): 1}
+    assert durations_again["run_select"].counts[0] != 999
+
+
+def test_escape_label_value_handles_backslash_quote_and_newline() -> None:
+    assert _escape_label_value('hello "world"') == 'hello \\"world\\"'
+    assert _escape_label_value("a\\b") == "a\\\\b"
+    assert _escape_label_value("a\nb") == "a\\nb"
+
+
+def test_render_prometheus_emits_help_and_type_comments_with_zero_counters() -> None:
+    out = render_prometheus()
+    assert "# HELP mcpg_tool_calls_total" in out
+    assert "# TYPE mcpg_tool_calls_total counter" in out
+    assert "# HELP mcpg_tool_duration_seconds" in out
+    assert "# TYPE mcpg_tool_duration_seconds histogram" in out
+
+
+def test_render_prometheus_emits_one_counter_line_per_observed_tool_status_pair() -> None:
+    m = get_metrics()
+    m.record_call("run_select", "ok", 0.1)
+    m.record_call("run_select", "error", 0.05)
+    m.record_call("run_write", "ok", 1.0)
+
+    out = render_prometheus()
+    assert 'mcpg_tool_calls_total{tool="run_select",status="ok"} 1' in out
+    assert 'mcpg_tool_calls_total{tool="run_select",status="error"} 1' in out
+    assert 'mcpg_tool_calls_total{tool="run_write",status="ok"} 1' in out
+
+
+def test_render_prometheus_emits_one_histogram_block_per_observed_tool() -> None:
+    m = get_metrics()
+    m.record_call("run_select", "ok", 0.02)
+    m.record_call("run_select", "ok", 0.06)
+
+    out = render_prometheus()
+    assert 'mcpg_tool_duration_seconds_bucket{tool="run_select",le="+Inf"} 2' in out
+    assert 'mcpg_tool_duration_seconds_count{tool="run_select"} 2' in out
+    # Sum is the float total of all observed durations for this tool.
+    assert 'mcpg_tool_duration_seconds_sum{tool="run_select"}' in out
+
+
+def test_render_prometheus_does_not_re_accumulate_already_cumulative_bucket_counts() -> None:
+    # Regression for the cumulative-double-count bug — bucket counts
+    # stored by observe() are ALREADY cumulative, so each bucket line
+    # should report the count for that bucket directly, not the sum
+    # of all prior buckets.
+    m = get_metrics()
+    m.record_call("run_select", "ok", 0.1)  # lands in 0.1 and every larger bucket
+    m.record_call("run_select", "ok", 0.5)  # lands in 0.5 and every larger bucket
+
+    out = render_prometheus()
+    # le="0.1" sees only the 0.1 observation -> count 1.
+    assert 'mcpg_tool_duration_seconds_bucket{tool="run_select",le="0.1"} 1' in out
+    # le="0.5" sees both -> count 2.
+    assert 'mcpg_tool_duration_seconds_bucket{tool="run_select",le="0.5"} 2' in out
+    # le="+Inf" always matches total count.
+    assert 'mcpg_tool_duration_seconds_bucket{tool="run_select",le="+Inf"} 2' in out
+
+
+def test_render_prometheus_output_ends_with_a_trailing_newline() -> None:
+    # Prometheus exposition format requires the body to end with \n.
+    out = render_prometheus()
+    assert out.endswith("\n")
+
+
+def test_default_buckets_are_monotonically_increasing() -> None:
+    for previous, current in pairwise(DEFAULT_BUCKETS):
+        assert previous < current

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -52,8 +52,16 @@ def test_run_dispatches_stdio_transport(monkeypatch: pytest.MonkeyPatch) -> None
 
 
 def test_run_dispatches_streamable_http_transport(monkeypatch: pytest.MonkeyPatch) -> None:
+    # HTTP transports route through mcpg.http_runtime.run_http (which
+    # owns the /metrics endpoint + optional bearer auth + uvicorn loop).
     seen: list[str] = []
-    monkeypatch.setattr(FastMCP, "run", lambda self, transport: seen.append(transport))
+    import mcpg.http_runtime as http_runtime
+
+    monkeypatch.setattr(
+        http_runtime,
+        "run_http",
+        lambda _server, _settings, *, kind: seen.append(kind),
+    )
 
     run(_settings_with(Transport.STREAMABLE_HTTP))
 
@@ -62,7 +70,13 @@ def test_run_dispatches_streamable_http_transport(monkeypatch: pytest.MonkeyPatc
 
 def test_run_dispatches_sse_transport(monkeypatch: pytest.MonkeyPatch) -> None:
     seen: list[str] = []
-    monkeypatch.setattr(FastMCP, "run", lambda self, transport: seen.append(transport))
+    import mcpg.http_runtime as http_runtime
+
+    monkeypatch.setattr(
+        http_runtime,
+        "run_http",
+        lambda _server, _settings, *, kind: seen.append(kind),
+    )
 
     run(_settings_with(Transport.SSE))
 

--- a/tests/unit/test_textsearch.py
+++ b/tests/unit/test_textsearch.py
@@ -10,11 +10,20 @@ from mcpg.textsearch import (
     FullTextMatch,
     FuzzyMatch,
     GeoMatch,
+    HybridMatch,
+    HybridSearchResult,
+    QuantizationRecommendation,
     SearchError,
     VectorMatch,
+    _fuse_rrf,
+    _row_key,
+    _suggest_quantization,
     full_text_search,
     fuzzy_search,
     geo_search,
+    hybrid_search,
+    recommend_vector_quantization,
+    vector_range_search,
     vector_search,
 )
 
@@ -278,3 +287,325 @@ async def test_geo_search_tool_is_callable_from_a_client() -> None:
     assert result.isError is False
     assert result.structuredContent is not None
     assert result.structuredContent["available"] is False
+
+
+# --- vector_range_search (11.2) -----------------------------------------
+
+
+async def test_vector_range_search_reports_unavailable_without_pgvector() -> None:
+    driver = FakeRoutingDriver({"pg_extension": []})
+
+    result = await vector_range_search(driver, "app", "docs", "embedding", [1.0, 2.0], max_distance=0.5)  # type: ignore[arg-type]
+
+    assert result.available is False
+    assert result.matches == []
+
+
+async def test_vector_range_search_returns_rows_within_threshold() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "::vector": [
+                {"id": 1, "embedding": [0.1], "mcpg_distance": 0.12},
+                {"id": 2, "embedding": [0.2], "mcpg_distance": 0.34},
+            ],
+        }
+    )
+
+    result = await vector_range_search(driver, "app", "docs", "embedding", [1.0, 2.0], max_distance=0.5)  # type: ignore[arg-type]
+
+    assert result.available is True
+    distances = [m.distance for m in result.matches]
+    assert distances == [0.12, 0.34]
+    assert all("embedding" not in m.row for m in result.matches)
+
+
+async def test_vector_range_search_binds_query_vector_threshold_and_limit() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}], "::vector": []})
+
+    await vector_range_search(driver, "app", "docs", "embedding", [1.0, 2.0], max_distance=0.3, limit=5)  # type: ignore[arg-type]
+
+    search_call = next(call for call in driver.calls if "::vector" in call[0])
+    assert search_call[1] == ["[1.0,2.0]", "[1.0,2.0]", 0.3, "[1.0,2.0]", 5]
+
+
+async def test_vector_range_search_rejects_negative_distance() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(SearchError, match="max_distance"):
+        await vector_range_search(driver, "app", "docs", "embedding", [1.0], max_distance=-0.1)  # type: ignore[arg-type]
+
+
+async def test_vector_range_search_rejects_non_finite_distance() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(SearchError, match="max_distance"):
+        await vector_range_search(driver, "app", "docs", "embedding", [1.0], max_distance=float("inf"))  # type: ignore[arg-type]
+
+
+async def test_vector_range_search_tool_is_callable_from_a_client() -> None:
+    database = FakeDatabase(FakeRoutingDriver({"pg_extension": []}))
+    server = create_server(_SETTINGS, database=database)  # type: ignore[arg-type]
+
+    async with create_connected_server_and_client_session(server) as client:
+        result = await client.call_tool(
+            "vector_range_search",
+            {
+                "schema": "app",
+                "table": "docs",
+                "column": "embedding",
+                "query_vector": [1.0, 2.0, 3.0],
+                "max_distance": 0.5,
+            },
+        )
+
+    assert result.isError is False
+    assert result.structuredContent is not None
+
+
+# --- hybrid_search (11.1) ------------------------------------------------
+
+
+def _make_row(cells):
+    class _Row:
+        pass
+
+    row = _Row()
+    row.cells = cells
+    return row
+
+
+def test_row_key_prefers_id_over_other_columns() -> None:
+    assert _row_key({"id": 7, "name": "alpha"}) == ("id", 7)
+
+
+def test_row_key_falls_back_to_other_id_suffix_when_no_plain_id() -> None:
+    assert _row_key({"widget_id": 9, "name": "alpha"}) == ("widget_id", 9)
+
+
+def test_row_key_falls_back_to_full_tuple_when_no_id_column() -> None:
+    key = _row_key({"name": "alpha", "value": 1})
+    other = _row_key({"name": "beta", "value": 1})
+    assert key != other
+
+
+def test_fuse_rrf_combines_two_candidate_lists() -> None:
+    vec_rows = [_make_row({"id": 1, "embedding": [0.1], "mcpg_rank": 1, "mcpg_distance": 0.05})]
+    fts_rows = [_make_row({"id": 1, "body": "alpha", "mcpg_rank": 1, "mcpg_rank_score": 0.9})]
+
+    result = _fuse_rrf(vec_rows, fts_rows, "embedding", "body", rrf_k=60, limit=10)
+
+    assert len(result.matches) == 1
+    match = result.matches[0]
+    assert match.vector_rank == 1 and match.fts_rank == 1
+    assert match.rrf_score == pytest.approx(2.0 / 61)
+
+
+def test_fuse_rrf_includes_rows_seen_in_only_one_source() -> None:
+    vec_rows = [_make_row({"id": 1, "embedding": [0.1], "mcpg_rank": 1, "mcpg_distance": 0.05})]
+    fts_rows = [_make_row({"id": 2, "body": "alpha", "mcpg_rank": 1, "mcpg_rank_score": 0.9})]
+
+    result = _fuse_rrf(vec_rows, fts_rows, "embedding", "body", rrf_k=60, limit=10)
+
+    keys = {match.row.get("id") for match in result.matches}
+    assert keys == {1, 2}
+
+
+def test_fuse_rrf_sorts_by_descending_rrf_score_and_respects_limit() -> None:
+    vec_rows = [
+        _make_row({"id": 1, "embedding": [0.1], "mcpg_rank": 1, "mcpg_distance": 0.01}),
+        _make_row({"id": 2, "embedding": [0.2], "mcpg_rank": 2, "mcpg_distance": 0.02}),
+    ]
+    fts_rows = [_make_row({"id": 3, "body": "x", "mcpg_rank": 1, "mcpg_rank_score": 1.0})]
+
+    result = _fuse_rrf(vec_rows, fts_rows, "embedding", "body", rrf_k=60, limit=2)
+
+    assert len(result.matches) == 2
+    scores = [m.rrf_score for m in result.matches]
+    assert scores == sorted(scores, reverse=True)
+
+
+async def test_hybrid_search_reports_unavailable_without_pgvector() -> None:
+    driver = FakeRoutingDriver({"pg_extension": []})
+
+    result = await hybrid_search(
+        driver,  # type: ignore[arg-type]
+        "app",
+        "docs",
+        "embedding",
+        "body",
+        [1.0, 2.0],
+        "search query",
+    )
+
+    assert isinstance(result, HybridSearchResult)
+    assert result.available is False
+    assert result.matches == []
+
+
+async def test_hybrid_search_rejects_non_positive_candidate_pool() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(SearchError, match="candidate_pool"):
+        await hybrid_search(
+            driver,  # type: ignore[arg-type]
+            "app",
+            "docs",
+            "embedding",
+            "body",
+            [1.0],
+            "x",
+            candidate_pool=0,
+        )
+
+
+async def test_hybrid_search_rejects_non_positive_rrf_k() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(SearchError, match="rrf_k"):
+        await hybrid_search(
+            driver,  # type: ignore[arg-type]
+            "app",
+            "docs",
+            "embedding",
+            "body",
+            [1.0],
+            "x",
+            rrf_k=0,
+        )
+
+
+async def test_hybrid_search_tool_is_callable_from_a_client() -> None:
+    database = FakeDatabase(FakeRoutingDriver({"pg_extension": []}))
+    server = create_server(_SETTINGS, database=database)  # type: ignore[arg-type]
+
+    async with create_connected_server_and_client_session(server) as client:
+        result = await client.call_tool(
+            "hybrid_search",
+            {
+                "schema": "app",
+                "table": "docs",
+                "vector_column": "embedding",
+                "text_column": "body",
+                "query_vector": [1.0, 2.0, 3.0],
+                "text_query": "anything",
+            },
+        )
+
+    assert result.isError is False
+
+
+# --- recommend_vector_quantization (11.3) -------------------------------
+
+
+def test_suggest_quantization_skips_already_quantized_columns() -> None:
+    assert (
+        _suggest_quantization(
+            schema="app",
+            table="docs",
+            column="embedding",
+            current_type="halfvec",
+            dimension=768,
+            row_count=1_000_000,
+        )
+        is None
+    )
+
+
+def test_suggest_quantization_skips_small_low_dim_tables() -> None:
+    assert (
+        _suggest_quantization(
+            schema="app",
+            table="docs",
+            column="embedding",
+            current_type="vector",
+            dimension=384,
+            row_count=100,
+        )
+        is None
+    )
+
+
+def test_suggest_quantization_recommends_halfvec_for_high_dim_with_meaningful_rows() -> None:
+    rec = _suggest_quantization(
+        schema="app",
+        table="docs",
+        column="embedding",
+        current_type="vector",
+        dimension=768,
+        row_count=50_000,
+    )
+    assert rec is not None
+    assert rec.suggested_type == "halfvec"
+    assert rec.suggested_bytes == rec.current_bytes // 2
+    assert 0.49 < rec.savings_ratio < 0.51
+    assert "halfvec" in rec.rationale
+
+
+def test_suggest_quantization_recommends_when_total_storage_clears_threshold() -> None:
+    rec = _suggest_quantization(
+        schema="app",
+        table="docs",
+        column="embedding",
+        current_type="vector",
+        dimension=384,
+        row_count=80_000,
+    )
+    assert rec is not None
+    assert rec.current_bytes >= 100 * 1024 * 1024
+
+
+async def test_recommend_vector_quantization_reports_empty_without_pgvector() -> None:
+    driver = FakeRoutingDriver({"pg_extension": []})
+
+    result = await recommend_vector_quantization(driver, "app")  # type: ignore[arg-type]
+
+    assert result == []
+
+
+async def test_recommend_vector_quantization_rejects_unsafe_schema_names() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(SearchError, match="invalid"):
+        await recommend_vector_quantization(driver, 'app"; DROP TABLE x; --')  # type: ignore[arg-type]
+
+
+async def test_recommend_vector_quantization_tool_is_callable_from_a_client() -> None:
+    database = FakeDatabase(FakeRoutingDriver({"pg_extension": []}))
+    server = create_server(_SETTINGS, database=database)  # type: ignore[arg-type]
+
+    async with create_connected_server_and_client_session(server) as client:
+        result = await client.call_tool("recommend_vector_quantization", {"schema": "app"})
+
+    assert result.isError is False
+
+
+def test_quantization_recommendation_dataclass_shape() -> None:
+    rec = QuantizationRecommendation(
+        schema="app",
+        table="docs",
+        column="embedding",
+        dimension=768,
+        row_count=10_000,
+        current_type="vector",
+        current_bytes=30_720_000,
+        suggested_type="halfvec",
+        suggested_bytes=15_360_000,
+        savings_ratio=0.5,
+        rationale="halfvec halves storage",
+    )
+    assert rec.dimension == 768
+    assert rec.savings_ratio == 0.5
+
+
+def test_hybrid_match_dataclass_shape() -> None:
+    match = HybridMatch(
+        rrf_score=0.5,
+        vector_rank=1,
+        fts_rank=None,
+        vector_distance=0.1,
+        fts_rank_score=None,
+        row={"id": 1},
+    )
+    assert match.vector_rank == 1
+    assert match.fts_rank is None

--- a/tests/unit/test_timescaledb.py
+++ b/tests/unit/test_timescaledb.py
@@ -137,7 +137,9 @@ async def test_create_hypertable_calls_timescale_function_when_extension_present
     assert result.available is True
     # The SQL got issued — fake driver records every call.
     create_call = next(call for call in driver.calls if "create_hypertable" in call[0])
-    assert "public.metrics" in create_call[0]
+    # Identifiers are double-quoted inside the SQL string literal so a
+    # mixed-case relation name survives the regclass cast unchanged.
+    assert '"public"."metrics"' in create_call[0]
     assert "INTERVAL '7 days'" in create_call[0]
     assert "if_not_exists => TRUE" in create_call[0]
 

--- a/tests/unit/test_timescaledb.py
+++ b/tests/unit/test_timescaledb.py
@@ -1,0 +1,198 @@
+"""Tests for the TimescaleDB wrapper module."""
+
+from __future__ import annotations
+
+import pytest
+from _fakes import FakeRoutingDriver
+
+from mcpg.timescaledb import (
+    ChunkListResult,
+    HypertableListResult,
+    TimescaleError,
+    TimescaleWriteResult,
+    _check_identifier,
+    _check_interval,
+    add_compression_policy,
+    add_retention_policy,
+    create_hypertable,
+    list_chunks,
+    list_hypertables,
+)
+
+
+def test_check_identifier_rejects_unsafe_names() -> None:
+    _check_identifier("widget", "table")
+    with pytest.raises(TimescaleError, match="invalid table"):
+        _check_identifier('w"; DROP', "table")
+
+
+def test_check_interval_accepts_common_timescaledb_intervals() -> None:
+    _check_interval("7 days")
+    _check_interval("1 hour")
+    _check_interval("30 minutes")
+    _check_interval("12 months")
+    _check_interval("1 year")
+    _check_interval("500 milliseconds")
+
+
+def test_check_interval_rejects_freeform_input() -> None:
+    with pytest.raises(TimescaleError, match="invalid interval"):
+        _check_interval("'; DROP TABLE x; --")
+    with pytest.raises(TimescaleError, match="invalid interval"):
+        _check_interval("7days")  # missing space
+    with pytest.raises(TimescaleError, match="invalid interval"):
+        _check_interval("seven days")  # not a number
+
+
+async def test_list_hypertables_reports_unavailable_without_timescaledb() -> None:
+    driver = FakeRoutingDriver({"pg_extension": []})
+
+    result = await list_hypertables(driver)  # type: ignore[arg-type]
+
+    assert isinstance(result, HypertableListResult)
+    assert result.available is False
+    assert result.hypertables == []
+
+
+async def test_list_hypertables_returns_typed_results_when_installed() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "timescaledb_information.hypertables": [
+                {
+                    "hypertable_schema": "public",
+                    "hypertable_name": "metrics",
+                    "num_dimensions": 1,
+                    "num_chunks": 12,
+                    "compression_enabled": True,
+                    "total_size_bytes": 1_048_576,
+                }
+            ],
+        }
+    )
+
+    result = await list_hypertables(driver)  # type: ignore[arg-type]
+
+    assert result.available is True
+    assert len(result.hypertables) == 1
+    h = result.hypertables[0]
+    assert h.schema == "public" and h.name == "metrics"
+    assert h.num_chunks == 12 and h.compression_enabled is True
+
+
+async def test_list_chunks_reports_unavailable_without_timescaledb() -> None:
+    driver = FakeRoutingDriver({"pg_extension": []})
+
+    result = await list_chunks(driver, "public", "metrics")  # type: ignore[arg-type]
+
+    assert isinstance(result, ChunkListResult)
+    assert result.available is False
+    assert result.chunks == []
+
+
+async def test_list_chunks_rejects_unsafe_identifiers() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(TimescaleError, match="invalid"):
+        await list_chunks(driver, 'app"; DROP', "metrics")  # type: ignore[arg-type]
+
+
+async def test_create_hypertable_reports_unavailable_without_timescaledb() -> None:
+    driver = FakeRoutingDriver({"pg_extension": []})
+
+    result = await create_hypertable(driver, "public", "metrics", "time")  # type: ignore[arg-type]
+
+    assert isinstance(result, TimescaleWriteResult)
+    assert result.available is False
+    assert result.function == "create_hypertable"
+
+
+async def test_create_hypertable_validates_inputs() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(TimescaleError, match="invalid table"):
+        await create_hypertable(driver, "public", 'm"; DROP', "time")  # type: ignore[arg-type]
+    with pytest.raises(TimescaleError, match="invalid time_column"):
+        await create_hypertable(driver, "public", "metrics", 'tcol"; DROP')  # type: ignore[arg-type]
+    with pytest.raises(TimescaleError, match="invalid interval"):
+        await create_hypertable(
+            driver,  # type: ignore[arg-type]
+            "public",
+            "metrics",
+            "time",
+            chunk_time_interval="hax",
+        )
+
+
+async def test_create_hypertable_calls_timescale_function_when_extension_present() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "create_hypertable": [{"result": "(metrics, public)"}],
+        }
+    )
+
+    result = await create_hypertable(driver, "public", "metrics", "ts")  # type: ignore[arg-type]
+
+    assert result.available is True
+    # The SQL got issued — fake driver records every call.
+    create_call = next(call for call in driver.calls if "create_hypertable" in call[0])
+    assert "public.metrics" in create_call[0]
+    assert "INTERVAL '7 days'" in create_call[0]
+    assert "if_not_exists => TRUE" in create_call[0]
+
+
+async def test_add_compression_policy_validates_inputs() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(TimescaleError, match="invalid interval"):
+        await add_compression_policy(
+            driver,  # type: ignore[arg-type]
+            "public",
+            "metrics",
+            compress_after="forever",
+        )
+
+
+async def test_add_compression_policy_issues_alter_and_policy_call() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "add_compression_policy": [{"job_id": 1001}],
+        }
+    )
+
+    result = await add_compression_policy(driver, "public", "metrics", compress_after="14 days")  # type: ignore[arg-type]
+
+    assert result.available is True
+    assert "job_id=1001" in result.details
+    alter_call = next(call for call in driver.calls if "ALTER TABLE" in call[0])
+    assert "timescaledb.compress" in alter_call[0]
+    policy_call = next(call for call in driver.calls if "add_compression_policy" in call[0])
+    assert "INTERVAL '14 days'" in policy_call[0]
+
+
+async def test_add_retention_policy_validates_inputs_and_issues_policy_call() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(TimescaleError, match="invalid interval"):
+        await add_retention_policy(
+            driver,  # type: ignore[arg-type]
+            "public",
+            "metrics",
+            drop_after="forever",
+        )
+
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "add_retention_policy": [{"job_id": 2002}],
+        }
+    )
+
+    result = await add_retention_policy(driver, "public", "metrics", drop_after="90 days")  # type: ignore[arg-type]
+
+    assert result.available is True
+    assert "job_id=2002" in result.details
+    call = next(call for call in driver.calls if "add_retention_policy" in call[0])
+    assert "INTERVAL '90 days'" in call[0]


### PR DESCRIPTION
## Summary

Closes every **Tier-A** pick from `docs/feature-shortlist.md` in one milestone branch on top of v0.4.0. Tool surface **78 → 90**, all gated under the existing capability model. 761 tests pass / 106 skipped; `ruff` + `mypy --strict` clean.

Three Tier-A themes, shipped as three commits:

### pgvector advanced (commit `71ef546`)
- **`hybrid_search`** — reciprocal-rank fusion of vector k-NN and full-text search; closes the biggest unmet need in agentic RAG (pure vector misses keyword/identifier hits, pure FTS misses semantic synonyms).
- **`vector_range_search`** — finds every row within a distance threshold instead of top-k. Pairs with HNSW/IVFFlat.
- **`recommend_vector_quantization`** — advisor that scans `pg_type` for `vector(N)` columns that could halve their storage by switching to pgvector v0.7+ `halfvec(N)`.

### Composite + advisor (commit `c3b3dbf`)
- **`summarize_table`** — one-stop snapshot (columns, PK/FK, constraints, indexes, storage / vacuum stats, optional sample). Replaces 4-5 round trips an agent would otherwise issue.
- **`why_is_this_slow`** — composite diagnosis: `EXPLAIN (FORMAT JSON)` walked + active-query snapshot + blocking-lock pairs + cache hit ratio + categorised suggestions. Safe by design — does NOT execute the query.
- **`find_unused_objects`** — scans `pg_stat_user_*` for tables/indexes with zero scans; PK/UNIQUE indexes excluded. Documented as a SIGNAL not a verdict.

### Observability + TimescaleDB + HTTP auth (commit `d482807`)
- **HTTP transport bearer-token auth** (`MCPG_HTTP_AUTH_TOKEN`). New `mcpg.http_runtime` wraps FastMCP's streamable-http / sse apps with an ASGI middleware (constant-time compare via `hmac.compare_digest`). `/metrics`, `/healthz`, `/readyz` are exempt so a Prometheus scraper / liveness probe doesn't need the MCP token. `stdio` transport is unaffected.
- **Prometheus `/metrics` + `get_metrics_exposition` MCP tool**. New `mcpg.observability` records every `call_tool` invocation and renders the standard text exposition format (zero runtime dep). Three series: `mcpg_tool_calls_total{tool,status}`, `mcpg_tool_duration_seconds_{bucket,sum,count}{tool}`.
- **TimescaleDB hypertable wrappers**. New `mcpg.timescaledb` adds `list_hypertables`, `list_chunks`, `create_hypertable`, `add_compression_policy`, `add_retention_policy`. Identifiers + interval expressions are allowlist-validated before inlining into SQL (TimescaleDB takes intervals as positional args, not bound params). Each tool degrades to `available=False` when the extension is missing.

## Test plan

- [x] `uv run pytest` — 761 passed / 106 skipped in 19s
- [x] `uv run ruff check .` — all checks passed
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy src` — no issues in 42 source files
- [x] Verify capability gates: `summarize_table` / pgvector reads / `list_hypertables` / `list_chunks` / `find_unused_objects` callable in every access mode; `create_hypertable` / `add_compression_policy` / `add_retention_policy` require `unrestricted` + `MCPG_ALLOW_DDL=true`
- [x] Verify `/metrics` is reachable without `Authorization` header when `MCPG_HTTP_AUTH_TOKEN` is set
- [x] Verify `stdio` transport ignores `MCPG_HTTP_AUTH_TOKEN`
- [ ] CI matrix (PG 14 / 15 / 16 / 17 / 18) — pending green


---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_