### PR TITLE
Add NL→SQL translation tool with multi-provider LLM support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ dependencies = [
     "psycopg-pool>=3.3.0",
     "pglast==7.11",
     "typing-extensions>=4.12",
+    # httpx ships transitively via mcp; declare it explicitly so the
+    # NL→SQL providers in mcpg.nl2sql have a guaranteed surface.
+    "httpx>=0.27",
 ]
 
 [project.scripts]

--- a/src/mcpg/config.py
+++ b/src/mcpg/config.py
@@ -77,6 +77,16 @@ class Settings:
     # are validated against ``[A-Za-z_][A-Za-z0-9_]*`` regardless.
     default_role: str | None = None
     allowed_roles: tuple[str, ...] = ()
+    # NL→SQL helper. ``nl2sql_provider`` is one of "anthropic", "openai",
+    # "gemini"; unset means the tool reports unavailable. ``nl2sql_api_key``
+    # falls back to ANTHROPIC_API_KEY / OPENAI_API_KEY / GEMINI_API_KEY /
+    # GOOGLE_API_KEY when not set explicitly. ``nl2sql_base_url`` lets the
+    # OpenAI path target a self-hosted endpoint (Ollama, vLLM, OpenRouter).
+    nl2sql_provider: str | None = None
+    nl2sql_api_key: str | None = None
+    nl2sql_model: str | None = None
+    nl2sql_base_url: str | None = None
+    nl2sql_max_tokens: int = 2048
 
     def __repr__(self) -> str:
         # Never let credentials reach logs or tracebacks.
@@ -95,7 +105,12 @@ class Settings:
             f"pool_min_size={self.pool_min_size}, pool_max_size={self.pool_max_size}, "
             f"http_auth_token={'set' if self.http_auth_token else 'unset'!r}, "
             f"default_role={self.default_role!r}, "
-            f"allowed_roles={self.allowed_roles!r})"
+            f"allowed_roles={self.allowed_roles!r}, "
+            f"nl2sql_provider={self.nl2sql_provider!r}, "
+            f"nl2sql_api_key={'set' if self.nl2sql_api_key else 'unset'!r}, "
+            f"nl2sql_model={self.nl2sql_model!r}, "
+            f"nl2sql_base_url={self.nl2sql_base_url!r}, "
+            f"nl2sql_max_tokens={self.nl2sql_max_tokens})"
         )
 
 
@@ -238,6 +253,58 @@ def load_settings(env: Mapping[str, str] | None = None) -> Settings:
                 f"MCPG_DEFAULT_ROLE ({default_role!r}) is not in MCPG_ALLOWED_ROLES ({list(allowed_roles)!r})"
             )
 
+    nl2sql_provider: str | None = None
+    if (raw := env.get("MCPG_NL2SQL_PROVIDER")) is not None:
+        candidate = raw.strip().lower()
+        if not candidate:
+            raise ConfigError("MCPG_NL2SQL_PROVIDER must not be blank when set")
+        if candidate not in {"anthropic", "openai", "gemini"}:
+            raise ConfigError(f"MCPG_NL2SQL_PROVIDER must be one of: anthropic, openai, gemini (got {raw!r})")
+        nl2sql_provider = candidate
+
+    # API key falls back to the vendor's conventional env var so users
+    # don't have to duplicate it. Order matters when multiple are set;
+    # the explicit MCPG_NL2SQL_API_KEY always wins.
+    nl2sql_api_key: str | None = None
+    if (raw := env.get("MCPG_NL2SQL_API_KEY")) is not None:
+        stripped = raw.strip()
+        if not stripped:
+            raise ConfigError("MCPG_NL2SQL_API_KEY must not be blank when set")
+        nl2sql_api_key = stripped
+    elif nl2sql_provider == "anthropic":
+        nl2sql_api_key = (env.get("ANTHROPIC_API_KEY") or "").strip() or None
+    elif nl2sql_provider == "openai":
+        nl2sql_api_key = (env.get("OPENAI_API_KEY") or "").strip() or None
+    elif nl2sql_provider == "gemini":
+        # Either GEMINI_API_KEY or the more common GOOGLE_API_KEY.
+        nl2sql_api_key = (env.get("GEMINI_API_KEY") or "").strip() or (env.get("GOOGLE_API_KEY") or "").strip() or None
+
+    if nl2sql_provider is not None and nl2sql_api_key is None:
+        raise ConfigError(
+            f"MCPG_NL2SQL_PROVIDER={nl2sql_provider!r} but no API key found; "
+            "set MCPG_NL2SQL_API_KEY (or the vendor's conventional env var)"
+        )
+
+    nl2sql_model: str | None = None
+    if (raw := env.get("MCPG_NL2SQL_MODEL")) is not None:
+        stripped = raw.strip()
+        if not stripped:
+            raise ConfigError("MCPG_NL2SQL_MODEL must not be blank when set")
+        nl2sql_model = stripped
+
+    nl2sql_base_url: str | None = None
+    if (raw := env.get("MCPG_NL2SQL_BASE_URL")) is not None:
+        stripped = raw.strip()
+        if not stripped:
+            raise ConfigError("MCPG_NL2SQL_BASE_URL must not be blank when set")
+        nl2sql_base_url = stripped
+
+    nl2sql_max_tokens = 2048
+    if (raw := env.get("MCPG_NL2SQL_MAX_TOKENS")) is not None:
+        nl2sql_max_tokens = _parse_positive_int("MCPG_NL2SQL_MAX_TOKENS", raw)
+        if nl2sql_max_tokens > 16_384:
+            raise ConfigError(f"MCPG_NL2SQL_MAX_TOKENS ({nl2sql_max_tokens}) exceeds the hard cap of 16384")
+
     return Settings(
         database_url=database_url,
         access_mode=access_mode,
@@ -257,4 +324,9 @@ def load_settings(env: Mapping[str, str] | None = None) -> Settings:
         http_auth_token=http_auth_token,
         default_role=default_role,
         allowed_roles=allowed_roles,
+        nl2sql_provider=nl2sql_provider,
+        nl2sql_api_key=nl2sql_api_key,
+        nl2sql_model=nl2sql_model,
+        nl2sql_base_url=nl2sql_base_url,
+        nl2sql_max_tokens=nl2sql_max_tokens,
     )

--- a/src/mcpg/nl2sql.py
+++ b/src/mcpg/nl2sql.py
@@ -383,6 +383,11 @@ def _parse_response(raw: str) -> tuple[str, str]:
         parsed = json.loads(stripped)
     except json.JSONDecodeError:
         return ("", raw.strip())
+    # json.loads succeeds for non-dict shapes (lists, raw strings,
+    # numbers); .get on those crashes. Treat anything non-dict as a
+    # parse failure so the raw text reaches the agent unchanged.
+    if not isinstance(parsed, dict):
+        return ("", raw.strip())
     sql = str(parsed.get("sql", "")).strip()
     explanation = str(parsed.get("explanation", "")).strip()
     return (sql, explanation)
@@ -434,11 +439,16 @@ async def translate_nl_to_sql(
         columns_per_table=columns_per_table,
         table_filter=table_filter,
     )
-    user_prompt = _USER_PROMPT_TEMPLATE.format(
-        schema=schema,
-        max_tables=max_tables_in_brief,
-        schema_brief=schema_brief,
-        question=question.strip(),
+    # ``.replace`` (not ``.format``) so curly braces in the user's
+    # question (e.g. asking about a jsonb literal like ``{"k":1}``)
+    # don't get interpreted as format placeholders and crash with
+    # KeyError. The placeholders below are fixed strings; no need
+    # for str.format's escape semantics.
+    user_prompt = (
+        _USER_PROMPT_TEMPLATE.replace("{schema}", schema)
+        .replace("{max_tables}", str(max_tables_in_brief))
+        .replace("{schema_brief}", schema_brief)
+        .replace("{question}", question.strip())
     )
 
     try:

--- a/src/mcpg/nl2sql.py
+++ b/src/mcpg/nl2sql.py
@@ -1,0 +1,496 @@
+"""Natural-language → SQL helper.
+
+``translate_nl_to_sql`` gathers schema context, asks a configurable
+LLM to translate the question into a read-only SQL query, and
+optionally runs it through the existing safety + execution stack.
+
+Provider plumbing is intentionally thin: three concrete classes
+(:class:`AnthropicProvider`, :class:`OpenAIProvider`,
+:class:`GeminiProvider`) talk to each vendor's HTTPS API directly via
+``httpx``. No SDK dependency, no hidden state. The provider is picked
+at startup via ``MCPG_NL2SQL_PROVIDER``; the API key is read from
+``MCPG_NL2SQL_API_KEY`` (or the vendor's conventional environment
+variable as a fallback).
+
+Safety:
+
+* The generated SQL is passed through ``SafeSqlDriver``'s allowlist
+  before execution — writes / DDL / multi-statement input are
+  rejected regardless of what the model produced.
+* Execution is opt-in (``execute=False`` by default); the agent gets
+  the SQL to review before running.
+* The LLM is instructed to return JSON with two fields (``sql``,
+  ``explanation``). When the response fails to parse, the raw text
+  is surfaced as ``explanation`` and ``sql`` is empty — agents see
+  the failure instead of silently running garbage.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+import httpx
+
+from mcpg._vendor.sql import SqlDriver
+from mcpg.introspection import describe_table, list_foreign_keys, list_tables
+from mcpg.query import DEFAULT_MAX_ROWS, QueryError, run_select
+
+logger = logging.getLogger(__name__)
+
+# Default models per provider — chosen for low cost / high availability
+# at writing time. Override via ``MCPG_NL2SQL_MODEL``.
+DEFAULT_MODELS: dict[str, str] = {
+    "anthropic": "claude-sonnet-4-6",
+    "openai": "gpt-4o-mini",
+    "gemini": "gemini-2.0-flash",
+}
+
+# Conservative budget — NL→SQL responses are usually a few hundred
+# tokens of JSON. Override via ``MCPG_NL2SQL_MAX_TOKENS``.
+DEFAULT_MAX_TOKENS = 2048
+
+# Hard upper bound — refuse calls above this even if the env asked
+# for more, so a misconfiguration can't surprise-bill the operator.
+HARD_MAX_TOKENS = 16_384
+
+# Default request timeout. Most NL→SQL completions finish in under
+# 30s; pad for slow networks / slower models.
+DEFAULT_TIMEOUT_SECONDS = 60.0
+
+_SUPPORTED_PROVIDERS = frozenset({"anthropic", "openai", "gemini"})
+
+# Schema-brief sizing — bounded so the prompt doesn't explode on large
+# schemas. The agent can always paginate by passing a specific
+# ``table_filter`` to focus on a subset.
+DEFAULT_MAX_TABLES_IN_BRIEF = 30
+DEFAULT_COLUMNS_PER_TABLE = 60
+
+
+class NL2SQLError(Exception):
+    """Raised when NL→SQL translation is rejected or fails."""
+
+
+@dataclass(frozen=True, slots=True)
+class TranslationResult:
+    """Result of :func:`translate_nl_to_sql`.
+
+    ``sql`` is the generated query; empty when parsing failed.
+    ``explanation`` is the model's natural-language rationale. When
+    ``execute=True`` and the SQL passed the safety check, ``rows`` /
+    ``columns`` / ``row_count`` are populated and ``executed`` is
+    ``True``. On safety / execution failure, ``error`` carries the
+    reason and the rest is empty.
+    """
+
+    sql: str
+    explanation: str
+    model: str
+    provider: str
+    executed: bool
+    rows: list[dict[str, Any]]
+    columns: list[str]
+    row_count: int
+    error: str | None
+
+
+@runtime_checkable
+class LLMProvider(Protocol):
+    """Common interface for the NL→SQL chat completion call.
+
+    Each provider's :meth:`complete` returns the raw text from the
+    LLM. The caller does JSON parsing — that way provider-specific
+    JSON-mode quirks don't leak into this module.
+    """
+
+    name: str
+
+    async def complete(
+        self,
+        *,
+        system_prompt: str,
+        user_prompt: str,
+        model: str,
+        max_tokens: int,
+        timeout: float,
+    ) -> str:
+        """Send the prompt; return the completion text. Raises on transport error."""
+        ...
+
+
+class AnthropicProvider:
+    """Anthropic Messages API caller — `POST /v1/messages`."""
+
+    name = "anthropic"
+
+    def __init__(self, api_key: str, *, base_url: str = "https://api.anthropic.com") -> None:
+        self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
+
+    async def complete(
+        self,
+        *,
+        system_prompt: str,
+        user_prompt: str,
+        model: str,
+        max_tokens: int,
+        timeout: float,
+    ) -> str:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.post(
+                f"{self._base_url}/v1/messages",
+                headers={
+                    "x-api-key": self._api_key,
+                    "anthropic-version": "2023-06-01",
+                    "content-type": "application/json",
+                },
+                json={
+                    "model": model,
+                    "max_tokens": max_tokens,
+                    "system": system_prompt,
+                    "messages": [{"role": "user", "content": user_prompt}],
+                },
+            )
+        response.raise_for_status()
+        body = response.json()
+        # content is a list of blocks; for plain text we want the first
+        # text block. JSON-mode isn't strictly supported, so we ask for
+        # JSON in the prompt and trust the model to comply.
+        for block in body.get("content", []):
+            if block.get("type") == "text":
+                return str(block.get("text", ""))
+        return ""
+
+
+class OpenAIProvider:
+    """OpenAI / OpenAI-compatible chat completions caller.
+
+    Works against ``api.openai.com`` by default; override
+    ``base_url`` for self-hosted gateways (Ollama, vLLM, LM Studio,
+    OpenRouter, Azure proxies).
+    """
+
+    name = "openai"
+
+    def __init__(self, api_key: str, *, base_url: str = "https://api.openai.com/v1") -> None:
+        self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
+
+    async def complete(
+        self,
+        *,
+        system_prompt: str,
+        user_prompt: str,
+        model: str,
+        max_tokens: int,
+        timeout: float,
+    ) -> str:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.post(
+                f"{self._base_url}/chat/completions",
+                headers={
+                    "authorization": f"Bearer {self._api_key}",
+                    "content-type": "application/json",
+                },
+                json={
+                    "model": model,
+                    "max_tokens": max_tokens,
+                    "messages": [
+                        {"role": "system", "content": system_prompt},
+                        {"role": "user", "content": user_prompt},
+                    ],
+                    "response_format": {"type": "json_object"},
+                },
+            )
+        response.raise_for_status()
+        body = response.json()
+        choices = body.get("choices", [])
+        if not choices:
+            return ""
+        return str(choices[0].get("message", {}).get("content", ""))
+
+
+class GeminiProvider:
+    """Google Gemini generateContent caller."""
+
+    name = "gemini"
+
+    def __init__(self, api_key: str, *, base_url: str = "https://generativelanguage.googleapis.com") -> None:
+        self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
+
+    async def complete(
+        self,
+        *,
+        system_prompt: str,
+        user_prompt: str,
+        model: str,
+        max_tokens: int,
+        timeout: float,
+    ) -> str:
+        # Gemini accepts the API key as a query string or `x-goog-api-key`
+        # header — we use the header to avoid logging-route leakage.
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.post(
+                f"{self._base_url}/v1beta/models/{model}:generateContent",
+                headers={
+                    "x-goog-api-key": self._api_key,
+                    "content-type": "application/json",
+                },
+                json={
+                    "systemInstruction": {"parts": [{"text": system_prompt}]},
+                    "contents": [{"role": "user", "parts": [{"text": user_prompt}]}],
+                    "generationConfig": {
+                        "maxOutputTokens": max_tokens,
+                        "responseMimeType": "application/json",
+                    },
+                },
+            )
+        response.raise_for_status()
+        body = response.json()
+        candidates = body.get("candidates", [])
+        if not candidates:
+            return ""
+        parts = candidates[0].get("content", {}).get("parts", [])
+        return "".join(str(p.get("text", "")) for p in parts)
+
+
+def is_valid_provider(name: str) -> bool:
+    """Return ``True`` for any name :func:`build_provider` will accept."""
+    return name in _SUPPORTED_PROVIDERS
+
+
+def build_provider(
+    name: str,
+    api_key: str,
+    *,
+    base_url: str | None = None,
+) -> LLMProvider:
+    """Construct the provider matching ``name``.
+
+    Raises:
+        NL2SQLError: When ``name`` is not in :data:`_SUPPORTED_PROVIDERS`.
+    """
+    if name == "anthropic":
+        return AnthropicProvider(api_key=api_key, **({"base_url": base_url} if base_url else {}))
+    if name == "openai":
+        return OpenAIProvider(api_key=api_key, **({"base_url": base_url} if base_url else {}))
+    if name == "gemini":
+        return GeminiProvider(api_key=api_key, **({"base_url": base_url} if base_url else {}))
+    raise NL2SQLError(f"unknown NL→SQL provider {name!r}; supported: {sorted(_SUPPORTED_PROVIDERS)}")
+
+
+_SYSTEM_PROMPT = """You are a PostgreSQL expert helping an automation agent.
+
+Your job: translate the user's natural-language question into ONE read-only PostgreSQL query.
+
+Hard rules:
+- The query MUST be a single SELECT (or WITH ... SELECT).
+  No INSERT / UPDATE / DELETE / DDL / DCL / multi-statement input.
+- Always qualify table names with their schema.
+- Prefer explicit column lists over SELECT *.
+- Add a LIMIT when the result could be large.
+- Inline literals directly into the SQL so it runs as-is — do NOT
+  emit $1 / $2 / %s placeholders.
+
+Respond with strict JSON only:
+{"sql": "SELECT ... FROM schema.table ...", "explanation": "what the query does in one or two sentences"}
+
+If the question cannot be answered with the given schema, return:
+{"sql": "", "explanation": "why this can't be answered"}"""
+
+
+_USER_PROMPT_TEMPLATE = """Schema name: {schema}
+
+Tables (truncated to {max_tables}):
+{schema_brief}
+
+User question:
+{question}
+
+Return JSON with `sql` and `explanation`. Inline literals — do NOT use $1 / $2 placeholders."""
+
+
+async def _build_schema_brief(
+    driver: SqlDriver,
+    schema: str,
+    *,
+    max_tables: int,
+    columns_per_table: int,
+    table_filter: tuple[str, ...] | None,
+) -> str:
+    """Produce a compact text description of ``schema`` for the prompt.
+
+    Lists tables with their columns (type + nullability) and the FKs
+    between them. Bounded so the prompt stays small on big schemas.
+    """
+    tables = await list_tables(driver, schema)
+    filter_set = set(table_filter) if table_filter else None
+    relevant = [t for t in tables if filter_set is None or t.name in filter_set]
+    if not relevant:
+        return f"(no tables match filter in schema {schema!r})"
+    bounded = relevant[:max_tables]
+
+    lines: list[str] = []
+    for table in bounded:
+        lines.append(f"- {schema}.{table.name} ({table.type.lower()}):")
+        columns = await describe_table(driver, schema, table.name)
+        for col in columns[:columns_per_table]:
+            nullable = "" if not col.nullable else " NULL"
+            default = f" DEFAULT {col.default}" if col.default else ""
+            lines.append(f"    * {col.name}: {col.data_type}{nullable}{default}")
+        if len(columns) > columns_per_table:
+            lines.append(f"    * ... +{len(columns) - columns_per_table} more columns")
+
+    if filter_set is None and len(relevant) > max_tables:
+        lines.append(f"... +{len(relevant) - max_tables} more tables not shown")
+
+    foreign_keys = await list_foreign_keys(driver, schema)
+    if foreign_keys:
+        lines.append("")
+        lines.append("Foreign keys:")
+        bounded_names = {t.name for t in bounded}
+        for fk in foreign_keys:
+            if fk.from_table not in bounded_names:
+                continue
+            lines.append(
+                f"- {schema}.{fk.from_table}({','.join(fk.from_columns)}) "
+                f"-> {fk.to_schema}.{fk.to_table}({','.join(fk.to_columns)})"
+            )
+
+    return "\n".join(lines)
+
+
+# Strip Markdown code fences the model might emit around the JSON
+# despite being told to return JSON only. Greedy enough to handle both
+# ```json and ```sql variants and trim either side.
+_CODE_FENCE = re.compile(r"^\s*```(?:json|sql)?\s*|\s*```\s*$", re.IGNORECASE | re.MULTILINE)
+
+
+def _parse_response(raw: str) -> tuple[str, str]:
+    """Return ``(sql, explanation)`` parsed from a provider's text reply.
+
+    Tolerates a leading / trailing code fence and falls back to
+    treating the whole response as ``explanation`` (with empty SQL)
+    when the JSON shape isn't recognised — so the agent always sees
+    *something*.
+    """
+    stripped = _CODE_FENCE.sub("", raw).strip()
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError:
+        return ("", raw.strip())
+    sql = str(parsed.get("sql", "")).strip()
+    explanation = str(parsed.get("explanation", "")).strip()
+    return (sql, explanation)
+
+
+async def translate_nl_to_sql(
+    driver: SqlDriver,
+    *,
+    provider: LLMProvider,
+    model: str,
+    question: str,
+    schema: str,
+    execute: bool = False,
+    table_filter: tuple[str, ...] | None = None,
+    max_tokens: int = DEFAULT_MAX_TOKENS,
+    max_rows: int = DEFAULT_MAX_ROWS,
+    max_tables_in_brief: int = DEFAULT_MAX_TABLES_IN_BRIEF,
+    columns_per_table: int = DEFAULT_COLUMNS_PER_TABLE,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> TranslationResult:
+    """Translate ``question`` into a SQL query against ``schema``.
+
+    Args:
+        provider: A constructed :class:`LLMProvider` instance.
+        model: Vendor-specific model id (e.g. ``claude-sonnet-4-6``).
+        execute: When ``True``, the generated SQL is validated by
+            ``SafeSqlDriver`` and run via :func:`mcpg.query.run_select`.
+            Writes / DDL / multi-statement input are rejected.
+        table_filter: Optional restrict-list of table names; the
+            schema brief omits everything else. Useful when the user's
+            question is clearly about a known subset.
+        max_tokens / max_rows / max_tables_in_brief / columns_per_table:
+            Bounds on the prompt and the executed result. The hard
+            cap on ``max_tokens`` is :data:`HARD_MAX_TOKENS`.
+
+    Raises:
+        NL2SQLError: When inputs fail validation or the model returns
+            something fundamentally unusable.
+    """
+    if not question.strip():
+        raise NL2SQLError("question must not be empty")
+    if max_tokens < 1 or max_tokens > HARD_MAX_TOKENS:
+        raise NL2SQLError(f"max_tokens must be between 1 and {HARD_MAX_TOKENS}")
+
+    schema_brief = await _build_schema_brief(
+        driver,
+        schema,
+        max_tables=max_tables_in_brief,
+        columns_per_table=columns_per_table,
+        table_filter=table_filter,
+    )
+    user_prompt = _USER_PROMPT_TEMPLATE.format(
+        schema=schema,
+        max_tables=max_tables_in_brief,
+        schema_brief=schema_brief,
+        question=question.strip(),
+    )
+
+    try:
+        raw = await provider.complete(
+            system_prompt=_SYSTEM_PROMPT,
+            user_prompt=user_prompt,
+            model=model,
+            max_tokens=max_tokens,
+            timeout=timeout,
+        )
+    except httpx.HTTPError as exc:
+        raise NL2SQLError(f"NL→SQL provider request failed: {exc}") from exc
+
+    sql, explanation = _parse_response(raw)
+
+    if not execute or not sql:
+        return TranslationResult(
+            sql=sql,
+            explanation=explanation,
+            model=model,
+            provider=provider.name,
+            executed=False,
+            rows=[],
+            columns=[],
+            row_count=0,
+            error=None if sql else "model returned no SQL",
+        )
+
+    # Execution path: route through the same safety stack as run_select.
+    try:
+        result = await run_select(driver, sql, max_rows=max_rows)
+    except QueryError as exc:
+        return TranslationResult(
+            sql=sql,
+            explanation=explanation,
+            model=model,
+            provider=provider.name,
+            executed=False,
+            rows=[],
+            columns=[],
+            row_count=0,
+            error=str(exc),
+        )
+
+    return TranslationResult(
+        sql=sql,
+        explanation=explanation,
+        model=model,
+        provider=provider.name,
+        executed=True,
+        rows=result.rows,
+        columns=result.columns,
+        row_count=result.row_count,
+        error=None,
+    )

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -37,6 +37,7 @@ from mcpg import (
     maintenance,
     migrations,
     naming,
+    nl2sql,
     partman,
     prisma,
     query,
@@ -1296,6 +1297,59 @@ def _register_query(server: FastMCP[AppContext]) -> None:
     )
     async def analyze_query_plan(ctx: _Ctx, sql: str) -> dict[str, Any]:
         result = await query.analyze_query_plan(_driver(ctx), sql)
+        return asdict(result)
+
+    @server.tool(
+        name="translate_nl_to_sql",
+        description=(
+            "Translate a natural-language question into a read-only "
+            "PostgreSQL query against `schema`. The configured LLM "
+            "provider (anthropic / openai / gemini, set via "
+            "MCPG_NL2SQL_PROVIDER) sees a compact brief of the schema "
+            "(tables, columns, foreign keys) and is instructed to "
+            "return JSON with `sql` and `explanation`. When "
+            "execute=true, the generated SQL goes through the SAME "
+            "safety allowlist as run_select before running — writes / "
+            "DDL / multi-statement input are rejected even if the "
+            "model produced them. Returns the SQL, model rationale, "
+            "and (when executed) rows / columns / row_count. "
+            "table_filter narrows the brief to a known subset when "
+            "the question is clearly scoped. When the server isn't "
+            "configured with a provider + API key, returns an error "
+            "rather than guessing."
+        ),
+    )
+    async def translate_nl_to_sql(
+        ctx: _Ctx,
+        question: str,
+        schema: str,
+        execute: bool = False,
+        table_filter: list[str] | None = None,
+        max_rows: int = query.DEFAULT_MAX_ROWS,
+    ) -> dict[str, Any]:
+        settings = ctx.request_context.lifespan_context.settings
+        if settings.nl2sql_provider is None or settings.nl2sql_api_key is None:
+            raise nl2sql.NL2SQLError(
+                "translate_nl_to_sql is not configured; set MCPG_NL2SQL_PROVIDER "
+                "and MCPG_NL2SQL_API_KEY (or the vendor's conventional env var)"
+            )
+        provider = nl2sql.build_provider(
+            settings.nl2sql_provider,
+            settings.nl2sql_api_key,
+            base_url=settings.nl2sql_base_url,
+        )
+        model = settings.nl2sql_model or nl2sql.DEFAULT_MODELS[settings.nl2sql_provider]
+        result = await nl2sql.translate_nl_to_sql(
+            _driver(ctx),
+            provider=provider,
+            model=model,
+            question=question,
+            schema=schema,
+            execute=execute,
+            table_filter=tuple(table_filter) if table_filter else None,
+            max_tokens=settings.nl2sql_max_tokens,
+            max_rows=max_rows,
+        )
         return asdict(result)
 
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -186,3 +186,116 @@ def test_default_role_must_appear_in_allowed_roles_when_both_set() -> None:
                 "MCPG_ALLOWED_ROLES": "tenant_a,tenant_b",
             }
         )
+
+
+# --- NL→SQL provider config (Phase 10.2) ---------------------------------
+
+
+def test_nl2sql_defaults_to_unset_and_zero_overhead() -> None:
+    settings = load_settings({"MCPG_DATABASE_URL": _DB_URL})
+    assert settings.nl2sql_provider is None
+    assert settings.nl2sql_api_key is None
+    assert settings.nl2sql_model is None
+    assert settings.nl2sql_max_tokens == 2048
+
+
+def test_nl2sql_provider_rejects_unknown_vendor() -> None:
+    with pytest.raises(ConfigError, match="MCPG_NL2SQL_PROVIDER"):
+        load_settings(
+            {
+                "MCPG_DATABASE_URL": _DB_URL,
+                "MCPG_NL2SQL_PROVIDER": "perplexity",
+                "MCPG_NL2SQL_API_KEY": "k",
+            }
+        )
+
+
+def test_nl2sql_provider_requires_an_api_key_somewhere() -> None:
+    with pytest.raises(ConfigError, match="no API key found"):
+        load_settings(
+            {
+                "MCPG_DATABASE_URL": _DB_URL,
+                "MCPG_NL2SQL_PROVIDER": "anthropic",
+            }
+        )
+
+
+def test_nl2sql_explicit_api_key_wins_over_vendor_fallback() -> None:
+    settings = load_settings(
+        {
+            "MCPG_DATABASE_URL": _DB_URL,
+            "MCPG_NL2SQL_PROVIDER": "anthropic",
+            "MCPG_NL2SQL_API_KEY": "explicit-key",
+            "ANTHROPIC_API_KEY": "vendor-fallback",
+        }
+    )
+    assert settings.nl2sql_api_key == "explicit-key"
+
+
+def test_nl2sql_falls_back_to_anthropic_api_key_env() -> None:
+    settings = load_settings(
+        {
+            "MCPG_DATABASE_URL": _DB_URL,
+            "MCPG_NL2SQL_PROVIDER": "anthropic",
+            "ANTHROPIC_API_KEY": "fallback",
+        }
+    )
+    assert settings.nl2sql_api_key == "fallback"
+
+
+def test_nl2sql_falls_back_to_openai_api_key_env() -> None:
+    settings = load_settings(
+        {
+            "MCPG_DATABASE_URL": _DB_URL,
+            "MCPG_NL2SQL_PROVIDER": "openai",
+            "OPENAI_API_KEY": "fallback",
+        }
+    )
+    assert settings.nl2sql_api_key == "fallback"
+
+
+def test_nl2sql_falls_back_to_gemini_or_google_api_key_env() -> None:
+    settings = load_settings(
+        {
+            "MCPG_DATABASE_URL": _DB_URL,
+            "MCPG_NL2SQL_PROVIDER": "gemini",
+            "GOOGLE_API_KEY": "google-fallback",
+        }
+    )
+    assert settings.nl2sql_api_key == "google-fallback"
+
+    settings = load_settings(
+        {
+            "MCPG_DATABASE_URL": _DB_URL,
+            "MCPG_NL2SQL_PROVIDER": "gemini",
+            "GEMINI_API_KEY": "gemini-fallback",
+            # GOOGLE_API_KEY also set — GEMINI wins because it's checked first.
+            "GOOGLE_API_KEY": "google-fallback",
+        }
+    )
+    assert settings.nl2sql_api_key == "gemini-fallback"
+
+
+def test_nl2sql_rejects_max_tokens_above_hard_cap() -> None:
+    with pytest.raises(ConfigError, match="hard cap"):
+        load_settings(
+            {
+                "MCPG_DATABASE_URL": _DB_URL,
+                "MCPG_NL2SQL_PROVIDER": "anthropic",
+                "MCPG_NL2SQL_API_KEY": "k",
+                "MCPG_NL2SQL_MAX_TOKENS": "100000",
+            }
+        )
+
+
+def test_nl2sql_api_key_never_appears_in_repr() -> None:
+    settings = load_settings(
+        {
+            "MCPG_DATABASE_URL": _DB_URL,
+            "MCPG_NL2SQL_PROVIDER": "anthropic",
+            "MCPG_NL2SQL_API_KEY": "sk-not-a-real-key-secret",
+        }
+    )
+    rendered = repr(settings)
+    assert "sk-not-a-real-key-secret" not in rendered
+    assert "nl2sql_api_key='set'" in rendered

--- a/tests/unit/test_nl2sql.py
+++ b/tests/unit/test_nl2sql.py
@@ -261,3 +261,38 @@ def test_llm_provider_protocol_is_satisfied_by_the_concrete_classes() -> None:
         assert isinstance(provider, LLMProvider)  # type: ignore[arg-type]
         assert hasattr(provider, "complete")
         assert provider.name in DEFAULT_MODELS
+
+
+def test_parse_response_returns_empty_when_json_is_not_an_object() -> None:
+    """Regression: a JSON list / scalar must not crash ``.get`` access.
+
+    Some models return ``"sorry"`` (a quoted string) or a JSON array
+    when they don't understand the schema. ``json.loads`` succeeds on
+    both; the result must fall through to the raw-text branch.
+    """
+    sql, explanation = _parse_response('"sorry, I cannot answer"')
+    assert sql == ""
+    assert "sorry" in explanation
+
+    sql, explanation = _parse_response("[1, 2, 3]")
+    assert sql == ""
+    assert "[1, 2, 3]" in explanation
+
+
+async def test_translate_nl_to_sql_handles_curly_braces_in_the_question() -> None:
+    """Regression: a question containing ``{`` / ``}`` (e.g. asking about a
+    jsonb literal) must NOT crash the prompt builder."""
+    provider = _StubProvider(response='{"sql": "SELECT 1", "explanation": "ok"}')
+
+    result = await translate_nl_to_sql(
+        FakeRoutingDriver(_routes_for_simple_schema()),  # type: ignore[arg-type]
+        provider=provider,  # type: ignore[arg-type]
+        model="m",
+        question="find rows where data = '{\"k\": 1}' and {empty: braces}",
+        schema="public",
+    )
+
+    # No crash, and the question reached the model verbatim.
+    assert result.sql == "SELECT 1"
+    assert '{"k": 1}' in provider.captured_user
+    assert "{empty: braces}" in provider.captured_user

--- a/tests/unit/test_nl2sql.py
+++ b/tests/unit/test_nl2sql.py
@@ -1,0 +1,263 @@
+"""Tests for the NL→SQL helper (Phase 10.2)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+from _fakes import FakeRoutingDriver
+
+from mcpg.nl2sql import (
+    DEFAULT_MODELS,
+    HARD_MAX_TOKENS,
+    AnthropicProvider,
+    GeminiProvider,
+    LLMProvider,
+    NL2SQLError,
+    OpenAIProvider,
+    _parse_response,
+    build_provider,
+    is_valid_provider,
+    translate_nl_to_sql,
+)
+
+
+@dataclass
+class _StubProvider:
+    """LLMProvider double — returns whatever ``response`` was given.
+
+    Captures the prompts so tests can assert on the schema brief.
+    """
+
+    name: str = "stub"
+    response: str = ""
+    captured_system: str = ""
+    captured_user: str = ""
+    captured_model: str = ""
+    captured_max_tokens: int = 0
+
+    async def complete(
+        self,
+        *,
+        system_prompt: str,
+        user_prompt: str,
+        model: str,
+        max_tokens: int,
+        timeout: float,
+    ) -> str:
+        _ = timeout
+        self.captured_system = system_prompt
+        self.captured_user = user_prompt
+        self.captured_model = model
+        self.captured_max_tokens = max_tokens
+        return self.response
+
+
+def _routes_for_simple_schema() -> dict[str, list[dict[str, object]]]:
+    """SQL→rows routes that build a tiny one-table schema brief."""
+    return {
+        # list_tables — substring unique to its query (relispartition
+        # only appears in this one).
+        "c.relispartition": [{"name": "widget", "relkind": "r", "is_partition": False}],
+        # describe_table — substring unique to its column listing query.
+        "format_type(a.atttypid, a.atttypmod)": [
+            {
+                "column_name": "id",
+                "data_type": "integer",
+                "nullable": False,
+                "column_default": None,
+                "type_name": "int4",
+                "type_mod": -1,
+            },
+            {
+                "column_name": "name",
+                "data_type": "text",
+                "nullable": True,
+                "column_default": None,
+                "type_name": "text",
+                "type_mod": -1,
+            },
+        ],
+        # list_foreign_keys — empty for the simple schema.
+        "WHERE con.contype = 'f'": [],
+    }
+
+
+def test_is_valid_provider_recognises_the_three_built_ins() -> None:
+    assert is_valid_provider("anthropic")
+    assert is_valid_provider("openai")
+    assert is_valid_provider("gemini")
+    assert not is_valid_provider("perplexity")
+
+
+def test_build_provider_returns_the_right_concrete_class() -> None:
+    assert isinstance(build_provider("anthropic", "key"), AnthropicProvider)
+    assert isinstance(build_provider("openai", "key"), OpenAIProvider)
+    assert isinstance(build_provider("gemini", "key"), GeminiProvider)
+
+
+def test_build_provider_rejects_unknown_name() -> None:
+    with pytest.raises(NL2SQLError, match="unknown"):
+        build_provider("bogus", "key")
+
+
+def test_default_models_table_covers_every_supported_provider() -> None:
+    assert set(DEFAULT_MODELS) == {"anthropic", "openai", "gemini"}
+
+
+def test_parse_response_extracts_sql_and_explanation_from_clean_json() -> None:
+    raw = '{"sql": "SELECT 1", "explanation": "smoke test"}'
+    sql, explanation = _parse_response(raw)
+    assert sql == "SELECT 1"
+    assert explanation == "smoke test"
+
+
+def test_parse_response_strips_markdown_code_fences() -> None:
+    raw = '```json\n{"sql": "SELECT 1", "explanation": "fenced"}\n```'
+    sql, explanation = _parse_response(raw)
+    assert sql == "SELECT 1"
+    assert explanation == "fenced"
+
+
+def test_parse_response_falls_back_to_raw_text_on_invalid_json() -> None:
+    sql, explanation = _parse_response("I cannot answer this question.")
+    assert sql == ""
+    assert "cannot answer" in explanation
+
+
+async def test_translate_nl_to_sql_rejects_blank_question() -> None:
+    with pytest.raises(NL2SQLError, match="empty"):
+        await translate_nl_to_sql(
+            FakeRoutingDriver({}),  # type: ignore[arg-type]
+            provider=_StubProvider(),  # type: ignore[arg-type]
+            model="claude-sonnet-4-6",
+            question="   ",
+            schema="public",
+        )
+
+
+async def test_translate_nl_to_sql_rejects_max_tokens_above_hard_cap() -> None:
+    with pytest.raises(NL2SQLError, match="max_tokens"):
+        await translate_nl_to_sql(
+            FakeRoutingDriver({}),  # type: ignore[arg-type]
+            provider=_StubProvider(),  # type: ignore[arg-type]
+            model="claude-sonnet-4-6",
+            question="count widgets",
+            schema="public",
+            max_tokens=HARD_MAX_TOKENS + 1,
+        )
+
+
+async def test_translate_nl_to_sql_returns_generation_only_when_execute_false() -> None:
+    provider = _StubProvider(response='{"sql": "SELECT count(*) FROM public.widget", "explanation": "row count"}')
+    driver = FakeRoutingDriver(_routes_for_simple_schema())
+
+    result = await translate_nl_to_sql(
+        driver,  # type: ignore[arg-type]
+        provider=provider,  # type: ignore[arg-type]
+        model="claude-sonnet-4-6",
+        question="how many widgets are there?",
+        schema="public",
+        execute=False,
+    )
+
+    assert result.sql == "SELECT count(*) FROM public.widget"
+    assert result.explanation == "row count"
+    assert result.executed is False
+    assert result.rows == []
+    assert result.error is None
+    # Schema brief reached the model — sanity-check that the table name
+    # made it into the user prompt.
+    assert "public.widget" in provider.captured_user
+    assert "id: integer" in provider.captured_user
+
+
+async def test_translate_nl_to_sql_records_provider_and_model_on_the_result() -> None:
+    provider = _StubProvider(response='{"sql": "SELECT 1", "explanation": "smoke"}')
+
+    result = await translate_nl_to_sql(
+        FakeRoutingDriver(_routes_for_simple_schema()),  # type: ignore[arg-type]
+        provider=provider,  # type: ignore[arg-type]
+        model="my-model-id",
+        question="smoke",
+        schema="public",
+    )
+
+    assert result.model == "my-model-id"
+    assert result.provider == "stub"
+
+
+async def test_translate_nl_to_sql_reports_error_when_model_returns_no_sql() -> None:
+    provider = _StubProvider(response='{"sql": "", "explanation": "out of scope"}')
+
+    result = await translate_nl_to_sql(
+        FakeRoutingDriver(_routes_for_simple_schema()),  # type: ignore[arg-type]
+        provider=provider,  # type: ignore[arg-type]
+        model="m",
+        question="something orthogonal",
+        schema="public",
+    )
+
+    assert result.sql == ""
+    assert result.executed is False
+    assert result.error == "model returned no SQL"
+
+
+async def test_translate_nl_to_sql_executes_when_safe_and_returns_rows() -> None:
+    """The generated SELECT goes through SafeSqlDriver + run_select."""
+    provider = _StubProvider(response='{"sql": "SELECT id FROM widget", "explanation": "list ids"}')
+    # Routes: schema-brief queries (specific substrings), then a route
+    # for the user's SELECT that supplies the rows run_select sees.
+    routes = _routes_for_simple_schema()
+    routes["FROM widget"] = [{"id": 1}, {"id": 2}]
+    driver = FakeRoutingDriver(routes)
+
+    result = await translate_nl_to_sql(
+        driver,  # type: ignore[arg-type]
+        provider=provider,  # type: ignore[arg-type]
+        model="m",
+        question="list ids",
+        schema="public",
+        execute=True,
+    )
+
+    assert result.executed is True
+    assert result.rows == [{"id": 1}, {"id": 2}]
+    assert result.columns == ["id"]
+    assert result.row_count == 2
+    assert result.error is None
+
+
+async def test_translate_nl_to_sql_rejects_unsafe_sql_at_execution_layer() -> None:
+    """If the model hallucinates a DELETE, run_select's safety allowlist
+    catches it — the tool reports the error rather than executing."""
+    provider = _StubProvider(response='{"sql": "DELETE FROM widget", "explanation": "destructive"}')
+
+    result = await translate_nl_to_sql(
+        FakeRoutingDriver(_routes_for_simple_schema()),  # type: ignore[arg-type]
+        provider=provider,  # type: ignore[arg-type]
+        model="m",
+        question="wipe the table",
+        schema="public",
+        execute=True,
+    )
+
+    assert result.executed is False
+    assert result.sql == "DELETE FROM widget"
+    assert result.error is not None
+    # The SafeSqlDriver allowlist message ends up in `error` — we don't
+    # pin the exact wording (it's vendored), just that it surfaces.
+    assert result.rows == []
+
+
+def test_llm_provider_protocol_is_satisfied_by_the_concrete_classes() -> None:
+    # Structural check: the three concrete providers each match the
+    # Protocol surface (name + complete signature).
+    for provider in (
+        AnthropicProvider(api_key="x"),
+        OpenAIProvider(api_key="x"),
+        GeminiProvider(api_key="x"),
+    ):
+        assert isinstance(provider, LLMProvider)  # type: ignore[arg-type]
+        assert hasattr(provider, "complete")
+        assert provider.name in DEFAULT_MODELS

--- a/uv.lock
+++ b/uv.lock
@@ -632,6 +632,7 @@ name = "mcpg"
 version = "0.4.0"
 source = { editable = "." }
 dependencies = [
+    { name = "httpx" },
     { name = "mcp", extra = ["cli"] },
     { name = "pglast" },
     { name = "psycopg", extra = ["binary"] },
@@ -652,6 +653,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "httpx", specifier = ">=0.27" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.25.0" },
     { name = "pglast", specifier = "==7.11" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.3.2" },


### PR DESCRIPTION
## Summary

Adds a new `translate_nl_to_sql` tool that converts natural-language questions into read-only PostgreSQL queries using configurable LLM providers (Anthropic, OpenAI, or Google Gemini). The tool:

- Gathers schema context (tables, columns, foreign keys) and sends it to the LLM with a carefully crafted prompt
- Parses the LLM's JSON response (with fallback handling for malformed output)
- Optionally executes the generated SQL through the existing `SafeSqlDriver` allowlist, rejecting writes/DDL/multi-statement input even if the model produced them
- Returns structured results including the SQL, model explanation, and execution results (if requested)

Provider plumbing is intentionally thin: three concrete classes (`AnthropicProvider`, `OpenAIProvider`, `GeminiProvider`) talk directly to each vendor's HTTPS API via `httpx` with no SDK dependencies. The provider is selected via `MCPG_NL2SQL_PROVIDER` environment variable; API keys are read from `MCPG_NL2SQL_API_KEY` or fall back to vendor-conventional env vars (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`/`GOOGLE_API_KEY`).

## Roadmap

Completes Phase 10.2 (NL→SQL helper with multi-provider LLM support).

## Changes

- **`src/mcpg/nl2sql.py`** (new): Core NL→SQL translation logic
  - `LLMProvider` protocol for pluggable LLM backends
  - Three concrete provider implementations (Anthropic, OpenAI, Gemini)
  - `translate_nl_to_sql()` async function that orchestrates schema introspection, LLM calls, and optional execution
  - Schema brief builder that produces compact table/column/FK descriptions
  - Response parser with Markdown code-fence tolerance and graceful fallback on JSON parse errors
  - Comprehensive docstrings and safety documentation

- **`src/mcpg/config.py`** (modified): Configuration support
  - New settings fields: `nl2sql_provider`, `nl2sql_api_key`, `nl2sql_model`, `nl2sql_base_url`, `nl2sql_max_tokens`
  - Validation: provider must be one of the three supported vendors; API key is required when provider is set
  - Fallback logic: explicit `MCPG_NL2SQL_API_KEY` wins; otherwise checks vendor-conventional env vars
  - Hard cap enforcement on `max_tokens` (16,384) to prevent surprise billing
  - Credential masking in `__repr__` to prevent accidental logging

- **`src/mcpg/tools.py`** (modified): MCP tool registration
  - New `translate_nl_to_sql` tool that wires the config, builds the provider, and calls the core function
  - Proper error handling when provider/API key are not configured

- **`tests/unit/test_nl2sql.py`** (new): Comprehensive unit tests
  - Provider validation and factory tests
  - Response parsing (clean JSON, Markdown fences, invalid JSON fallback)
  - Input validation (blank question, max_tokens bounds)
  - Schema brief generation and prompt construction
  - Execution path with safety allowlist enforcement
  - Unsafe SQL rejection (DELETE, DDL, etc.)
  - Protocol compliance checks for concrete providers

- **`tests/unit/test_config.py`** (modified): Configuration tests
  - Provider validation and fallback logic
  - API key precedence (explicit > vendor-conventional)
  - Max tokens hard cap enforcement
  - Credential masking in repr

- **`pyproject.toml`** (modified): Explicit `httpx` dependency declaration

## Checklist

- [x] Tests added/updated first (TDD); suite passes locally
- [x] `ruff`, `ruff format`, and `mypy src/mcpg` pass
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] `docs/

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc