### PR TITLE
v0.5.0: 33 new tools, NL→SQL, multi-tenancy, cursors, auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-27
+
+Thirty-three new MCP tools and four major runtime features, closing
+the full `docs/feature-shortlist.md` (**Tier A + Tier B + Tier C**)
+plus an NL→SQL helper. Brings the total MCP tool surface from **74
+to 107** and adds: HTTP transport bearer-token auth, Prometheus
+`/metrics`, TimescaleDB wrappers, hybrid (vector + FTS) search,
+per-request `SET ROLE` multi-tenancy, server-side cursors, RLS
+testing, synthetic test-data generation, FK cascade graphs, and a
+natural-language → SQL helper.
+
+### Headline features
+
+- **Per-request multi-tenancy.** `MCPG_DEFAULT_ROLE` + `X-MCPG-Role`
+  header drive a `TenantSqlDriver` that wraps every query in
+  `BEGIN ... SET LOCAL ROLE "<role>" ...` so one MCPg process can
+  serve N tenants from a single connection pool. Role names
+  validated, allowlist via `MCPG_ALLOWED_ROLES`.
+- **HTTP transport bearer-token auth + Prometheus `/metrics`.**
+  `MCPG_HTTP_AUTH_TOKEN` gates the streamable-http / sse surface;
+  `/metrics`, `/healthz`, `/readyz` are exempt so a Prometheus
+  scraper doesn't hold the MCP credential.
+- **NL→SQL.** `translate_nl_to_sql` sends a schema brief to a
+  pluggable LLM provider (Anthropic / OpenAI / Gemini), parses the
+  JSON response, and optionally executes the generated SQL through
+  the existing `SafeSqlDriver` allowlist.
+- **Server-side cursors** via a `CursorManager` holding dedicated
+  per-cursor connections — pageable reads through millions of rows
+  without starving the main pool.
+
 ### Added
 
 - **Tier-A milestone closed** — three picks from
@@ -45,6 +75,103 @@ adheres to [Semantic Versioning](https://semver.org/).
     `available=False` when the `timescaledb` extension is missing —
     same pattern as the existing pg_trgm / pgvector / postgis
     integrations.
+
+- **Tier-B milestone closed** — four picks from the feature shortlist
+  shipped together. Tool surface 90 → 93 plus the runtime tenancy
+  feature.
+  - **`find_sensitive_columns`** (6.2). Scans `pg_attribute` for
+    columns whose names or types look like they hold PII / secrets:
+    seven categories (credential, financial, contact, identifier,
+    health, government_id, location) with high / medium / low
+    confidence. Pure heuristic — no row sampling. Lives in
+    `mcpg.advisors`.
+  - **`detect_n_plus_one`** (8.4). Walks `pg_stat_statements` for
+    the classic N+1 shape: query templates called hundreds-to-
+    thousands of times, each returning ≤ `max_rows_per_call` rows
+    and accumulating ≥ `min_total_ms` of wall-clock time. Sorted
+    by total time desc; degrades to `available=false` on databases
+    without `pg_stat_statements`.
+  - **`validate_migration`** (9.2). Applies `candidate_sql` to a
+    TRANSIENT shadow of `target_schema` pre-populated with up to
+    `sample_rows_per_table` rows from each base table. Catches
+    failure modes a structural diff misses: NOT NULL added to a
+    column with NULLs, CHECK constraints violated by live rows,
+    type narrowings that fail. Always drops the shadow before
+    returning. Gated under MIGRATE.
+  - **Per-request `SET ROLE` multi-tenancy** (1.4). New
+    `mcpg.tenancy.TenantSqlDriver` subclasses the vendored driver
+    and wraps every query in an explicit transaction with
+    `SET LOCAL ROLE "<role>"`. Role resolved per-request from the
+    `X-MCPG-Role` header (HTTP only) or falls back to
+    `MCPG_DEFAULT_ROLE`. Role names validated against
+    `[A-Za-z_][A-Za-z0-9_]*`; `MCPG_ALLOWED_ROLES` configures an
+    allowlist enforced both at startup (default must be in it) and
+    per request (403 if not in it). `SET LOCAL` auto-resets at txn
+    end — no state leak into the pool. `_TenantRoleMiddleware` sits
+    above bearer auth so unauthenticated requests can't reach the
+    role parser.
+
+- **Tier-C milestone closed** — every remaining pick from the
+  shortlist. Tool surface 93 → 106 (13 new tools), plus a small
+  follow-up fix.
+  - **Catalog readers** — `list_generated_columns` (4.7) reads
+    `pg_attribute.attgenerated` for stored-generated columns;
+    `list_locks` + `find_blocking_chains` (4.5, new module
+    `mcpg.locks`) join `pg_locks` / `pg_blocking_pids` with
+    `pg_stat_activity`; `read_pg_stat_io` (4.3, new module
+    `mcpg.io_stats`) wraps the PG16+ I/O stats view (degrades on
+    14/15).
+  - **`lint_naming_conventions`** (8.1, new module `mcpg.naming`).
+    Detects the majority case style per schema and per table
+    (snake_case / camelCase / PascalCase / SCREAMING_SNAKE), flags
+    outliers, plus an index-prefix rule.
+  - **`generate_fk_cascade_graph`** (8.5). Mermaid `graph LR` of
+    foreign-key cascade chains; only CASCADE / SET NULL / SET
+    DEFAULT FKs by default. Cross-schema targets get their schema
+    prefix preserved.
+  - **`run_select_parallel`** (3.4). Up to `parallel_limit`
+    concurrent SELECTs via `asyncio.gather`; each goes through the
+    same safety allowlist as `run_select`; one bad query doesn't
+    abort the others.
+  - **Server-side cursors** (3.1, new module `mcpg.cursors`). Four
+    tools — `open_cursor`, `fetch_cursor`, `close_cursor`,
+    `list_cursors`. Each cursor holds a DEDICATED psycopg
+    connection (not a pool checkout) inside a `READ ONLY`
+    transaction, with a per-cursor `asyncio.Lock` so concurrent
+    fetch / close on the same cursor can't corrupt the wire
+    protocol. Hard cap of 16 concurrent cursors; 5-min idle TTL
+    with lazy sweep.
+  - **`test_rls_for_role`** (4.8, new module `mcpg.rls`). Runs a
+    SELECT as a target role inside `READ ONLY` + `SET LOCAL ROLE`,
+    reports applicable policies, visible row count, and a bounded
+    sample. Identifier-validated.
+  - **`generate_test_data`** (10.3, new module `mcpg.test_data`).
+    Produces synthetic INSERT statements honouring column type,
+    NOT NULL, DEFAULT. Deterministic with a seed; covers numeric /
+    text / boolean / date / timestamp / json / uuid types.
+    Unsupported types (geometry, hstore, vector, ...) listed in
+    `skipped_columns`. Does NOT execute — returns SQL for review.
+
+- **NL → SQL helper** (shortlist 10.2). New `mcpg.nl2sql` module
+  with a pluggable `LLMProvider` (Anthropic / OpenAI / Gemini)
+  speaking each vendor's HTTPS API via `httpx` — no SDK dependency.
+  `translate_nl_to_sql(question, schema, execute=False, ...)`
+  gathers a compact schema brief (tables, columns, FKs), asks the
+  configured model to emit JSON with `sql` + `explanation`, and —
+  when `execute=true` — passes the generated SQL through
+  `SafeSqlDriver` before running. Writes / DDL / multi-statement
+  input rejected even if the model produced them. New settings:
+  `MCPG_NL2SQL_PROVIDER` / `MCPG_NL2SQL_API_KEY` (with vendor-env
+  fallbacks) / `MCPG_NL2SQL_MODEL` / `MCPG_NL2SQL_BASE_URL` /
+  `MCPG_NL2SQL_MAX_TOKENS` (hard cap 16384). API key never appears
+  in `repr(Settings)`.
+
+- **Agent cookbook** (`docs/cookbook.md`). Practical recipes for
+  common workflows: schema discovery, slow-query diagnosis,
+  migration safety, cursor streaming, multi-tenancy, NL→SQL,
+  observability scraping, RLS testing, data import / export,
+  ORM model emission, TimescaleDB inspection. Linked from the
+  README and the docs index.
 
 - Three new agent-UX-focused tools (more Tier-A picks). Tool surface
   81 → 84. All read-only.

--- a/README.md
+++ b/README.md
@@ -4,16 +4,18 @@ A production-grade [Model Context Protocol](https://modelcontextprotocol.io)
 server for **PostgreSQL** — letting AI agents safely inspect, query, operate,
 and tune a Postgres database.\*
 
-> **Status:** v0.4.0 released; trunk at **90 MCP tools**. Covers deep catalog
-> introspection, index intelligence, full-text/trigram/vector/geospatial
-> search, live ops, gated maintenance, Mermaid ER diagrams, structural
-> schema diff, **subprocess-driven data movement (pg_dump/pg_restore/psql),
-> LISTEN/NOTIFY bridge, staged-migration shadow workflow, and ORM-DSL
-> exporters for Prisma / Drizzle / SQLAlchemy 2.0 / sqlc**. CI matrix runs
-> the integration suite against **PostgreSQL 14, 15, 16, 17, and 18**. See
-> [`CHANGELOG.md`](CHANGELOG.md) and [`docs/PROGRESS.md`](docs/PROGRESS.md)
-> for detail; [`PLAN.md`](PLAN.md) §11 has the post-0.3.0 roadmap. The
-> Batches A–G plan is now **fully shipped**.
+> **Status:** v0.4.0 released; trunk at **107 MCP tools** with v0.5.0
+> in prep. Beyond v0.4.0's catalog / search / live-ops surface, v0.5.0
+> adds **HTTP transport bearer-token auth, Prometheus `/metrics`,
+> TimescaleDB wrappers, hybrid (vector + FTS) search, sensitive-column
+> heuristics, an N+1 detector, transient-shadow migration validation,
+> per-request `SET ROLE` multi-tenancy, server-side cursors,
+> RLS testing, synthetic test-data generation, FK cascade graphs, and
+> a natural-language → SQL helper (Anthropic / OpenAI / Gemini)**. CI
+> matrix runs the integration suite against **PostgreSQL 14, 15, 16,
+> 17, and 18**. See [`docs/cookbook.md`](docs/cookbook.md) for common
+> agent recipes, [`CHANGELOG.md`](CHANGELOG.md) and
+> [`docs/PROGRESS.md`](docs/PROGRESS.md) for detail.
 
 ## Quick start
 
@@ -82,6 +84,7 @@ See the [Installation Guide](docs/installation.md) and
 - [`docs/installation.md`](docs/installation.md) — Installation Guide
 - [`docs/user-guide.md`](docs/user-guide.md) — User Guide
 - [`docs/tour.md`](docs/tour.md) — compact tool tour (start here for discovery)
+- [`docs/cookbook.md`](docs/cookbook.md) — practical agent recipes (start here for common workflows)
 - [`docs/tools.md`](docs/tools.md) — reference for every MCP tool
 - [`docs/architecture.md`](docs/architecture.md) — Architecture Document
 - [`docs/security.md`](docs/security.md) — threat model and security controls
@@ -91,6 +94,7 @@ See the [Installation Guide](docs/installation.md) and
 - [`docs/PROGRESS.md`](docs/PROGRESS.md) — live progress tracker (resume point)
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — development setup and workflow
 - [`CHANGELOG.md`](CHANGELOG.md) — release notes
+- [`docs/release-notes-0.5.0.md`](docs/release-notes-0.5.0.md) — v0.5.0 release summary
 - [`docs/release-notes-0.4.0.md`](docs/release-notes-0.4.0.md) — v0.4.0 release summary
 - [`docs/release-notes-0.3.0.md`](docs/release-notes-0.3.0.md) — v0.3.0 release summary
 

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -1,0 +1,435 @@
+# MCPg agent cookbook
+
+Practical recipes for common workflows. Each recipe is a sequence of
+MCPg tool calls in the order an agent should issue them, with notes
+on why and what to expect back. Pair with [`tour.md`](tour.md) for
+discovery and [`tools.md`](tools.md) for the full reference.
+
+These recipes assume an MCP client (Claude Desktop, Claude Code, an
+in-house agent) already has MCPg connected and can call tools by name.
+Tool args are shown as `name(arg=value, ...)` — what you'd put in a
+tool-call JSON payload.
+
+---
+
+## 1. "I just got handed a new database. What's in it?"
+
+Walk the catalog top-down, starting at schemas and drilling into the
+biggest / hottest tables.
+
+```text
+list_schemas(include_system=false)              # what schemas exist
+list_tables(schema="app")                       # tables + views per schema
+list_extensions()                                # is pgvector / PostGIS / TimescaleDB in play?
+list_roles(include_system=false)                # who can do what
+```
+
+Once you know which schema matters:
+
+```text
+list_foreign_keys(schema="app")                  # relationships at a glance
+generate_schema_diagram(schema="app")            # Mermaid ER diagram to paste
+generate_fk_cascade_graph(schema="app")          # blast-radius graph of ON DELETE CASCADE chains
+```
+
+For a specific table:
+
+```text
+summarize_table(schema="app", table="orders")    # one call: columns + PK/FK + indexes + storage + sample
+```
+
+`summarize_table` replaces four-to-five round trips (`describe_table` +
+`list_indexes` + `list_constraints` + stats). Use it instead of
+piecing the view together by hand.
+
+---
+
+## 2. "Why is THIS query slow?"
+
+```text
+why_is_this_slow(sql="SELECT ... FROM orders WHERE ...")
+```
+
+That's the headline call. It does NOT execute the query — it walks
+`EXPLAIN (FORMAT JSON)`, snapshots concurrent backends + blocking
+pairs, reads the cluster cache-hit ratio, and returns a categorised
+diagnosis.
+
+When you want to look deeper:
+
+```text
+analyze_query_plan(sql="...")                    # raw plan tree + node-type summary
+list_active_queries()                            # what else is running right now
+find_blocking_chains()                           # who's waiting on whom (pg_blocking_pids)
+list_locks(limit=50)                             # ordered with WAITERS first
+read_pg_stat_io()                                # PG16+ I/O stats (degrades on PG 14/15)
+```
+
+For workload-level investigation (the slow patterns, not one query):
+
+```text
+analyze_workload(limit=10)                       # top by mean_exec_time (pg_stat_statements)
+detect_n_plus_one(min_calls=100)                 # classic ORM lazy-load loop detector
+```
+
+---
+
+## 3. "I need to recommend / test indexes."
+
+```text
+recommend_indexes(min_live_tuples=10000)         # tables with heavy seq scans
+find_unused_objects(schema="app")                # zero-scan indexes + cold tables to drop
+```
+
+Cross-reference. Drop nothing without re-reading `find_unused_objects`
+after the database has been hot for a meaningful period — fresh stats
+produce false positives.
+
+`recommend_vector_quantization()` flags `vector(N)` columns that could
+halve their storage with `halfvec(N)` on pgvector ≥ 0.7.
+
+---
+
+## 4. "Safely test a migration before applying."
+
+The shadow-schema workflow. Two tools and a diff:
+
+```text
+prepare_migration(name="add_orders_index",
+                  target_schema="app",
+                  candidate_sql="CREATE INDEX idx_orders_user ON orders(user_id);",
+                  ttl_minutes=60)
+# → { id, shadow_schema, ttl_expires_at, diff: { tables_added, ... } }
+```
+
+Read the `diff` — that's what `complete_migration` will land on the
+target. To check the candidate against real-shape data BEFORE applying:
+
+```text
+validate_migration(target_schema="app",
+                   candidate_sql="ALTER TABLE orders ALTER COLUMN total SET NOT NULL;",
+                   sample_rows_per_table=500)
+# → { table_stats, candidate_applied, error }
+```
+
+Catches the failure modes a pure structural diff misses: NOT NULL
+added to a column with existing NULLs, CHECK constraints violated by
+live rows, type narrowings that fail on real values, triggers that
+error against actual data. `validate_migration` runs on a TRANSIENT
+shadow that's dropped before returning — no persistent state.
+
+When the diff + validation both look good:
+
+```text
+complete_migration(migration_id="<from prepare>")  # apply on target
+# or
+cancel_migration(migration_id="<from prepare>")    # drop the shadow
+```
+
+`list_pending_migrations()` shows everything still in the
+`prepared` window.
+
+Requires unrestricted mode + `MCPG_ALLOW_DDL=true`.
+
+---
+
+## 5. "Stream a very large result set."
+
+Server-side cursors. Open, fetch in batches, close.
+
+```text
+open_cursor(sql="SELECT * FROM events WHERE created_at > '2026-01-01'")
+# → { cursor_id: "mcpg_e3a91f", ... }
+
+fetch_cursor(cursor_id="mcpg_e3a91f", batch_size=500)
+# → { rows: [...], exhausted: false }
+
+fetch_cursor(cursor_id="mcpg_e3a91f", batch_size=500)
+# → { rows: [...], exhausted: true }   ← stop polling here
+
+close_cursor(cursor_id="mcpg_e3a91f")
+```
+
+Each open cursor holds a dedicated connection (NOT a pool checkout)
+so it can't starve other tools. Hard cap of 16 concurrent cursors per
+server; default 5-min idle TTL. `list_cursors()` shows every open
+cursor with `rows_returned` so far.
+
+---
+
+## 6. "Run several independent queries in parallel."
+
+Dashboard fan-out: many small SELECTs for counters / aggregates.
+
+```text
+run_select_parallel(statements=[
+    "SELECT count(*) FROM orders WHERE status = 'pending'",
+    "SELECT count(*) FROM orders WHERE status = 'shipped'",
+    "SELECT count(*) FROM users WHERE last_login > now() - interval '7 days'",
+    "SELECT sum(amount) FROM payments WHERE created_at > now() - interval '24 hours'",
+])
+# → { outcomes: [{ index, success, result, error }, ...] }
+```
+
+Each statement is validated by the same safety allowlist as
+`run_select`; one bad query does not abort the others. Default
+concurrency limit is 8.
+
+---
+
+## 7. "Find sensitive data before sharing the schema."
+
+```text
+find_sensitive_columns(schema="app")
+# → { columns: [{ table, column, categories: ["credential" | "pii" | ...], confidence, reasons }] }
+```
+
+Categories: `credential` (passwords / tokens / API keys),
+`financial` (card numbers / IBAN), `contact` (email / phone),
+`identifier` (DOB / name), `health` (HIPAA-scope), `government_id`
+(SSN / passport), `location` (postal / IP).
+
+Confidence: `high` (very specific name, e.g. `password_hash`),
+`medium` (common pattern, e.g. `email_address`), `low` (broad
+pattern). Filter by `high` first for an initial review pass.
+
+This is a SIGNAL, not a verdict — a column named `email_template_id`
+matches the email pattern but isn't itself an email address.
+
+---
+
+## 8. "What can a specific role actually read?"
+
+Row-level security debug.
+
+```text
+test_rls_for_role(schema="app", table="orders", role="readonly_app",
+                  sample_size=10)
+# → { rls_enabled, active_policies: [{ name, command, using_expression, ... }],
+#     rows_visible, sample: [...] }
+```
+
+Runs as the target role inside a `READ ONLY` transaction with
+`SET LOCAL ROLE` — no writes can leak. The `active_policies` list
+is filtered to policies that actually apply to the given role (so
+PUBLIC-targeted policies + role-specific ones, not unrelated ones).
+
+---
+
+## 9. "Hook up Prometheus."
+
+Two paths.
+
+**Network scrape** (preferred): MCPg's HTTP transport exposes
+`/metrics` on the same port as MCP. Configure your scraper:
+
+```yaml
+- job_name: mcpg
+  static_configs: [{ targets: ['mcpg-host:8000'] }]
+```
+
+The bearer-token middleware (if `MCPG_HTTP_AUTH_TOKEN` is set) exempts
+`/metrics`, so the scraper doesn't need the MCP credential.
+
+**Over the MCP protocol** (when running stdio):
+
+```text
+get_metrics_exposition()
+# → "# HELP mcpg_tool_calls_total ...\n..."
+```
+
+Returns the exact same text-exposition format. Three series:
+`mcpg_tool_calls_total{tool,status}`, `mcpg_tool_duration_seconds_bucket`,
+and the matching `_sum` / `_count`.
+
+---
+
+## 10. "Multi-tenant — serve N roles from one MCPg."
+
+Static config, applies to every query:
+
+```bash
+MCPG_DEFAULT_ROLE=app_tenant_42
+```
+
+Per-request, HTTP transport only:
+
+```http
+X-MCPG-Role: app_tenant_42
+Authorization: Bearer <MCPG_HTTP_AUTH_TOKEN>
+```
+
+The gateway maps an authenticated user to a PG role and forwards the
+request with that header. MCPg validates the role identifier against
+`[A-Za-z_][A-Za-z0-9_]*`, checks it against the optional
+`MCPG_ALLOWED_ROLES` allowlist, and issues `SET LOCAL ROLE "<role>"`
+inside every query's transaction. `SET LOCAL` auto-resets at txn end
+— no state leaks back into the pool.
+
+---
+
+## 11. "Natural language to SQL."
+
+```text
+translate_nl_to_sql(question="how many orders were shipped last week?",
+                    schema="app",
+                    execute=true,
+                    table_filter=["orders"])
+# → { sql, explanation, executed, rows, columns, row_count }
+```
+
+Requires `MCPG_NL2SQL_PROVIDER` + API key set at startup
+(anthropic / openai / gemini). The tool sends a compact schema brief
+(tables, columns, FKs) to the configured LLM, parses the JSON
+response, and — when `execute=true` — passes the generated SQL
+through `SafeSqlDriver`'s allowlist before running it. A model that
+hallucinates a `DELETE` is rejected at the safety layer, not run.
+
+`table_filter` narrows the schema brief to a known subset when the
+question is clearly scoped — useful on large schemas.
+
+For a quick review pattern: call with `execute=false`, read the
+`sql`, then call `run_select` if it looks right.
+
+---
+
+## 12. "Bring data in / out."
+
+**Export a query as CSV / JSON**:
+
+```text
+export_query(sql="SELECT id, name FROM widget WHERE active = true",
+             format="csv")
+# → { bytes_written, payload (base64), format }
+```
+
+**Export a whole table**:
+
+```text
+export_table(schema="app", table="orders", format="json")
+```
+
+**Import CSV** (unrestricted mode):
+
+```text
+import_csv(schema="app", table="staging_events", payload_base64="...")
+# → { rows_inserted, ... }
+```
+
+**Cross-database copy** — pipeline between two libpq URIs:
+
+```text
+copy_table_between_databases(
+    source_database_url="postgresql://src/...",
+    target_database_url="postgresql://dst/...",
+    schema="app", table="orders", format="csv")
+```
+
+For full database snapshots, prefer the subprocess tools
+(`dump_database` / `restore_database`); they shell out to `pg_dump`
+and `pg_restore` so binary objects and roles survive the trip. Both
+gated under `MCPG_ALLOW_SHELL=true`.
+
+---
+
+## 13. "Emit ORM models from the live schema."
+
+Eight catalog → DSL exporters:
+
+```text
+generate_prisma_schema(schema="app")
+generate_drizzle_schema(schema="app")
+generate_sqlalchemy_models(schema="app")
+generate_sqlc_schema(schema="app")
+generate_diesel_schema(schema="app")
+generate_jooq_config(schema="app")
+generate_ent_schemas(schema="app")
+generate_ecto_schemas(schema="app")
+```
+
+Each returns a string of ORM-specific DSL ready to paste into a
+project. They read the catalog only — your database stays untouched.
+
+---
+
+## 14. "Listen / notify bridge."
+
+Postgres `LISTEN`/`NOTIFY` adapted to the MCP poll model. Requires
+`MCPG_ALLOW_LISTEN=true`.
+
+```text
+subscribe_channel(channel="orders_placed")
+poll_notifications(channel="orders_placed")          # pulls queued messages
+poll_notifications(channel="orders_placed", timeout_sec=5)   # blocks up to 5s
+unsubscribe_channel(channel="orders_placed")
+list_notification_subscriptions()                     # current state
+```
+
+The listener owns a single dedicated PG connection that auto-reconnects
+on drop; subscriptions survive transient outages.
+
+---
+
+## 15. "Inspect TimescaleDB hypertables."
+
+When the `timescaledb` extension is installed:
+
+```text
+list_hypertables()
+list_chunks(schema="app", table="metrics")
+create_hypertable(schema="app", table="metrics", time_column="ts")
+add_compression_policy(schema="app", table="metrics", compress_after="14 days")
+add_retention_policy(schema="app", table="metrics", drop_after="90 days")
+```
+
+All write tools gated under unrestricted mode + `MCPG_ALLOW_DDL`.
+Identifiers and interval expressions are allowlist-validated before
+inlining into SQL.
+
+---
+
+## 16. "Generate synthetic data for staging."
+
+```text
+generate_test_data(schema="app", table="widget", rows=100, seed=42)
+# → { statements: ["INSERT INTO ... VALUES (...);", ...], skipped_columns: [...] }
+```
+
+Returns INSERT statements — does NOT execute. The agent reviews and
+runs via `run_write` if desired. Foreign keys are NOT resolved
+(documented limitation): pre-seed referenced rows or drop the FK
+temporarily. Deterministic with a seed; supports numeric / text /
+boolean / date / timestamp / json / uuid types. Unsupported types
+(geometry, hstore, vector, ...) are listed in `skipped_columns`.
+
+---
+
+## 17. "Lint the schema."
+
+```text
+run_advisors(schema="app")                       # PK / FK / duplicate-index / nullable-tstz
+lint_naming_conventions(schema="app")            # case-style + index prefix
+find_sensitive_columns(schema="app")             # PII / secrets
+find_unused_objects(schema="app")                # cold tables + dead indexes
+```
+
+Combine these for a one-shot schema-health report an agent can
+present to a reviewer.
+
+---
+
+## Tool-call ordering tips
+
+* **Read before write.** Every write-class tool (`run_write`,
+  `run_ddl`, the migration family, `import_*`, `add_*_policy`) has a
+  read sibling that lets the agent confirm shape first.
+* **Use the composites first.** `summarize_table`, `why_is_this_slow`,
+  `find_unused_objects` collapse what would otherwise be 4-5 round
+  trips. Reach for those before piecing the answer together by hand.
+* **Filter, then drill.** Schema-level tools take a `schema=` arg;
+  large catalogs respond faster when you scope. The NL→SQL helper
+  takes `table_filter=` for the same reason.
+* **Capability gates fail closed.** A tool isn't `available=false` —
+  it isn't listed at all. If `run_write` doesn't appear, the active
+  access mode forbids it. Restart MCPg with a wider mode (and the
+  matching `MCPG_ALLOW_*` opt-in) when you need it.

--- a/docs/release-notes-0.5.0.md
+++ b/docs/release-notes-0.5.0.md
@@ -1,0 +1,185 @@
+# MCPg v0.5.0 — release notes
+
+**Released:** 2026-05-27
+**Tool surface:** 74 → **107**  (+33)
+**Tests:** 874 pass / 106 skipped
+**CI:** PG 14 / 15 / 16 / 17 / 18
+
+This release closes the **entire `docs/feature-shortlist.md`** — every
+pick from Tier A, Tier B, and Tier C — plus a natural-language → SQL
+helper that was in the "Defer for now" bucket. Six PRs landed on top
+of v0.4.0:
+
+| PR | Theme | Tools added |
+|----|-------|-------------|
+| #18 | Tier A: HTTP auth + Prometheus + TimescaleDB + pgvector + composites + advisors | +16 |
+| #19 | Tier B: PII heuristic + N+1 detector + migration validation + `SET ROLE` multi-tenancy | +3 + runtime |
+| #20 | Tier C: catalog readers + naming linter + FK cascade graph + parallel select + server-side cursors + RLS tester + test-data factory | +13 |
+| #21 | NL → SQL via Anthropic / OpenAI / Gemini | +1 |
+
+## Headlines
+
+### NL → SQL (`translate_nl_to_sql`)
+
+The headline new capability. Send a natural-language question; MCPg
+gathers a compact schema brief (tables, columns, foreign keys), asks
+the configured LLM provider to translate, parses the JSON response,
+and — when `execute=true` — passes the generated SQL through the
+existing `SafeSqlDriver` safety allowlist before running it.
+
+```text
+translate_nl_to_sql(question="how many orders shipped last week?",
+                    schema="app",
+                    execute=true)
+```
+
+Pluggable provider: `MCPG_NL2SQL_PROVIDER=anthropic|openai|gemini`.
+HTTPS calls go through `httpx` directly — no SDK dependencies. The
+OpenAI path accepts `MCPG_NL2SQL_BASE_URL` so it can target Ollama,
+vLLM, LM Studio, OpenRouter, or any other OpenAI-compatible gateway.
+
+Safety: hard 16384 max_tokens cap; identifier-validated schema /
+table filter; writes / DDL / multi-statement input rejected at the
+execution layer regardless of what the model produced.
+
+### Per-request `SET ROLE` multi-tenancy
+
+One MCPg process now serves N tenants from one connection pool.
+Two paths:
+
+* Static: `MCPG_DEFAULT_ROLE=app_tenant_42` applies to every query.
+* Per-request: HTTP requests can send `X-MCPG-Role: <role>`; the
+  middleware validates the identifier, checks the optional
+  `MCPG_ALLOWED_ROLES` allowlist (403 if missing), and stashes the
+  role in a `ContextVar`. The new `TenantSqlDriver` reads the var
+  and wraps every query in `BEGIN ... SET LOCAL ROLE "<role>" ...`
+  so the role auto-resets at txn end. No state leak into the pool.
+
+The tenant middleware sits above the bearer-auth middleware in the
+stack so unauthenticated requests can't reach the role parser.
+
+### HTTP transport bearer-token auth + Prometheus `/metrics`
+
+`MCPG_HTTP_AUTH_TOKEN` gates the streamable-http / sse transports.
+Missing or wrong token → 401 with `WWW-Authenticate: Bearer
+realm="mcpg"`. `/metrics`, `/healthz`, `/readyz` are exempt so
+Prometheus / load balancer / k8s probes don't need the MCP token.
+
+`/metrics` emits the standard text-exposition format (v0.0.4) with
+three series:
+* `mcpg_tool_calls_total{tool, status}` (counter)
+* `mcpg_tool_duration_seconds_bucket{tool, le}` (histogram)
+* `mcpg_tool_duration_seconds_sum/_count{tool}`
+
+Zero runtime dependency — the format is rendered in-process.
+`get_metrics_exposition` returns the same payload over MCP for stdio
+deployments.
+
+### Server-side cursors
+
+Four tools — `open_cursor` / `fetch_cursor` / `close_cursor` /
+`list_cursors` — let an agent page through millions of rows without
+loading them all. Each open cursor holds a **dedicated** psycopg
+connection (NOT a pool checkout) so N long-lived cursors can't
+starve the pool other tools use. SQL validated by the same allowlist
+as `run_select`; opened in a `READ ONLY` transaction.
+
+Per-cursor `asyncio.Lock` serialises concurrent fetch / close on the
+same cursor — psycopg AsyncConnection isn't safe for concurrent task
+access. Hard cap of 16 concurrent cursors; default 5-minute idle TTL
+with lazy sweep.
+
+### TimescaleDB
+
+Five new tools — read (`list_hypertables`, `list_chunks`) plus DDL
+writes (`create_hypertable`, `add_compression_policy`,
+`add_retention_policy`). Every interval / identifier is
+allowlist-validated before being inlined into SQL. Each tool
+degrades to `available=false` when the extension is missing.
+
+### pgvector advanced search
+
+* `hybrid_search` fuses vector + FTS rankings via reciprocal-rank
+  fusion (RRF). Closes the biggest unmet need in agentic RAG: pure
+  vector misses keyword / identifier hits, pure FTS misses semantic
+  synonyms.
+* `vector_range_search` finds every row within `max_distance` of a
+  query vector (not top-k).
+* `recommend_vector_quantization` flags `vector(N)` columns that
+  could halve their storage on pgvector ≥ 0.7 by switching to
+  `halfvec(N)`.
+
+### Composite + advisor tools
+
+* `summarize_table` — one-stop snapshot replacing 4-5 round trips
+  (columns + PK/FK + indexes + storage + sample).
+* `why_is_this_slow` — `EXPLAIN (FORMAT JSON)` + concurrent-query
+  snapshot + blocking pairs + cache hit ratio + categorised
+  suggestions, all without executing the query.
+* `find_unused_objects` — `pg_stat_user_*` scan for zero-scan tables
+  / indexes, with the context needed to decide drops.
+
+### Tier-B + Tier-C surface (+17 tools)
+
+* `find_sensitive_columns` — PII / secret heuristic across seven
+  categories (credential / financial / contact / identifier / health
+  / government_id / location).
+* `detect_n_plus_one` — `pg_stat_statements` walker for ORM
+  lazy-load loops.
+* `validate_migration` — apply a candidate against a transient
+  shadow with real-shape sample data; catches what a structural diff
+  misses (NULL violations, CHECK failures, type narrowings, trigger
+  errors).
+* `lint_naming_conventions` — majority-style detection + index
+  prefix rule.
+* `generate_fk_cascade_graph` — Mermaid graph of blast-radius FK
+  chains.
+* `run_select_parallel` — concurrent fan-out with per-statement
+  error isolation.
+* `test_rls_for_role` — RLS debugging as a target role inside
+  `READ ONLY` + `SET LOCAL ROLE`.
+* `generate_test_data` — synthetic INSERT statements for seeding.
+* `list_generated_columns`, `list_locks`, `find_blocking_chains`,
+  `read_pg_stat_io` — catalog / runtime readers.
+
+## New env vars
+
+| Variable | Purpose |
+|----------|---------|
+| `MCPG_HTTP_AUTH_TOKEN` | Bearer token enforced on HTTP transports. |
+| `MCPG_DEFAULT_ROLE` | Static PG role applied to every query. |
+| `MCPG_ALLOWED_ROLES` | Comma-separated allowlist for `X-MCPG-Role` + default. |
+| `MCPG_NL2SQL_PROVIDER` | One of `anthropic`, `openai`, `gemini`. |
+| `MCPG_NL2SQL_API_KEY` | API key (or vendor-conventional fallback). |
+| `MCPG_NL2SQL_MODEL` | Override the default model id. |
+| `MCPG_NL2SQL_BASE_URL` | Self-hosted gateway for OpenAI-compatible. |
+| `MCPG_NL2SQL_MAX_TOKENS` | Per-call budget (≤ 16384). |
+
+## Backwards compatibility
+
+* `Settings.__repr__` adds the new fields; the API-key field renders
+  as `'set'` / `'unset'` and never leaks the actual value.
+* `AppContext` gained a `cursor_manager` field. Direct constructors
+  in your own tests need it. `create_server()` accepts an optional
+  `cursor_manager=` arg the same way it does for `database=` and
+  `listen_manager=`.
+* The vendored `SqlDriver` is unchanged. `TenantSqlDriver` subclasses
+  it; it's only instantiated when tenancy is configured, so the
+  zero-overhead path is preserved for non-tenant deployments.
+
+## Test plan
+
+* `uv run pytest` — 874 passed / 106 skipped
+* `uv run ruff check .` + `uv run ruff format --check .` — clean
+* `uv run mypy src` — no issues in 50 source files
+* CI matrix PG 14 / 15 / 16 / 17 / 18 — all green on the merge commits
+
+## Acknowledgements
+
+Gemini Code Assist reviewed every PR in this release and surfaced
+several real issues that were fixed before merge — notably the
+hybrid_search row-key bug, the TimescaleDB case-folding hazard, the
+cursor concurrency hazard, the NL→SQL parse-non-dict crash, and the
+brace-in-question format crash. Two findings (RLS bypass + multi-
+statement result failure) were verified empirically and replied to
+on-thread.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcpg"
-version = "0.4.0"
+version = "0.5.0"
 description = "A production-grade PostgreSQL Model Context Protocol (MCP) server."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/mcpg/__init__.py
+++ b/src/mcpg/__init__.py
@@ -1,3 +1,3 @@
 """MCPg — a PostgreSQL Model Context Protocol server."""
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/uv.lock
+++ b/uv.lock
@@ -629,7 +629,7 @@ cli = [
 
 [[package]]
 name = "mcpg"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Release v0.5.0 closes the entire `docs/feature-shortlist.md` (Tier A + B + C) plus an NL→SQL helper. Expands the MCP tool surface from 74 to **107 tools** (+33) and adds four major runtime features:

1. **Per-request `SET ROLE` multi-tenancy** — one MCPg process serves N tenants from a single pool via `MCPG_DEFAULT_ROLE` + `X-MCPG-Role` header, with role validation and `SET LOCAL` auto-reset.
2. **HTTP transport bearer-token auth + Prometheus `/metrics`** — `MCPG_HTTP_AUTH_TOKEN` gates the streamable-http/sse surface; `/metrics`, `/healthz`, `/readyz` are exempt for scraper access.
3. **Natural-language → SQL** — `translate_nl_to_sql` sends a schema brief to a pluggable LLM (Anthropic / OpenAI / Gemini), parses JSON response, and optionally executes through `SafeSqlDriver`.
4. **Server-side cursors** — `open_cursor` / `fetch_cursor` / `close_cursor` / `list_cursors` with dedicated per-cursor connections, hard cap of 16, 5-min idle TTL.

### New tools by category

**Tier A (16 tools):** HTTP auth middleware, Prometheus metrics, TimescaleDB (5 tools: hypertables, chunks, compression/retention policies), pgvector advanced search (hybrid_search, vector_range_search, recommend_vector_quantization), composite advisors (summarize_table, why_is_this_slow, find_unused_objects), run_advisors.

**Tier B (3 tools + runtime):** find_sensitive_columns (PII/secret heuristic), detect_n_plus_one (ORM lazy-load detector), validate_migration (transient-shadow testing), plus TenantSqlDriver for per-request role switching.

**Tier C (13 tools):** Catalog readers (list_generated_columns, list_locks, find_blocking_chains, read_pg_stat_io), lint_naming_conventions, generate_fk_cascade_graph, run_select_parallel, server-side cursors (4 tools), test_rls_for_role, generate_test_data.

**NL→SQL (1 tool):** translate_nl_to_sql with pluggable LLM providers and safety-layer execution gating.

### Documentation

- **`docs/cookbook.md`** — 17 practical recipes covering schema discovery, slow-query diagnosis, migration safety, cursor streaming, multi-tenancy, NL→SQL, observability, RLS testing, data import/export, ORM emission, TimescaleDB inspection.
- **`docs/release-notes-0.5.0.md`** — detailed feature breakdown, env vars, backwards compatibility notes, test plan.
- **`README.md`** — updated status line and links to cookbook.

### Configuration

New environment variables:
- `MCPG_HTTP_AUTH_TOKEN` — bearer token for HTTP transports
- `MCPG_DEFAULT_ROLE` — static PG role for all queries
- `MCPG_ALLOWED_ROLES` — comma-separated allowlist for role validation
- `MCPG_NL2SQL_PROVIDER` — anthropic | openai | gemini
- `MCPG_NL2SQL_API_KEY` — LLM API key (vendor env fallbacks supported)
- `MCPG_NL2SQL_MODEL` — override default model ID
- `MCPG_NL2SQL_BASE_URL` — self-hosted OpenAI-compatible gateway
- `MCPG_NL2SQL_MAX_TOKENS` — per-call budget (≤ 16384)

### Backwards compatibility

- `Settings.__repr__` adds new fields; API keys render as `'set'`/`'unset'`.
- `AppContext` gained `cursor_manager

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc