### PR TITLE
security: PG TLS enforcement, regex audit redaction, pip-audit CI fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,15 @@ jobs:
           python-version: "3.12"
           enable-cache: true
       - run: uv sync --frozen
-      - name: Dependency audit
-        run: uv audit
+      # pip-audit consults the PyPI advisory DB + OSV.dev for known
+      # CVEs in resolved dependencies. ``--strict`` upgrades warnings
+      # to failures so a vulnerable transitive dep blocks merge. We
+      # audit the uv-resolved requirements (runtime deps only, project
+      # excluded — the editable install of mcpg itself isn't on PyPI).
+      - name: Dependency audit (pip-audit)
+        run: |
+          uv export --no-dev --no-emit-project --format requirements-txt > /tmp/mcpg-reqs.txt
+          uv run pip-audit --strict --disable-pip -r /tmp/mcpg-reqs.txt
       - name: Bandit static analysis (SAST)
         run: uv run bandit -r src/mcpg --skip B101,B608,B110 -ll
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,11 @@ repos:
         require_serial: true
       - id: bandit
         name: bandit (sast)
-        entry: uv run bandit -r src/mcpg
+        # Match CI flags exactly so a clean local commit also passes
+        # `security` in .github/workflows/ci.yml. Bandit doesn't
+        # auto-discover [tool.bandit] from pyproject.toml; the skips
+        # have to be passed on the command line.
+        entry: uv run bandit -r src/mcpg --skip B101,B608,B110 -ll
         language: system
         types: [python]
         pass_filenames: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,17 @@ adheres to [Semantic Versioning](https://semver.org/).
   start when `MCPG_DATABASE_URL` (or any entry in
   `MCPG_REPLICA_URLS`) points at a non-loopback host with an
   `sslmode` of `disable` / `allow` / `prefer` (or no `sslmode` set —
-  libpq's default falls back to plaintext). The check is bypassed
-  with the explicit opt-out `MCPG_ALLOW_INSECURE_TLS=true` for
-  development-only deployments. Loopback hosts (`localhost`,
-  `127.0.0.1`, `::1`) are exempt.
+  libpq's default falls back to plaintext). Uses
+  `psycopg.conninfo.conninfo_to_dict` so the check covers both URI
+  DSNs and keyword/value DSNs (e.g. `host=db sslmode=disable`) plus
+  failover multi-host URIs (e.g. `postgresql://h1,h2/db`); the
+  earlier `urllib.parse`-based path silently bypassed the check on
+  both shapes. DSNs with no explicit host are refused too — libpq
+  can resolve `PGHOST` to a non-loopback default. Bypassed with the
+  explicit opt-out `MCPG_ALLOW_INSECURE_TLS=true`. Loopback hosts
+  (`localhost`, `127.0.0.1`, `::1`) are exempt. Replica errors
+  identify the offending index (`MCPG_REPLICA_URLS[1]`) for
+  diagnostics.
 
 - **Tool-argument audit redaction upgraded to regex pattern match.**
   `mcpg.audit.redact_arguments` and the persisted audit-trail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,49 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Security
+
+- **PG TLS enforcement at startup.** `load_settings` now refuses to
+  start when `MCPG_DATABASE_URL` (or any entry in
+  `MCPG_REPLICA_URLS`) points at a non-loopback host with an
+  `sslmode` of `disable` / `allow` / `prefer` (or no `sslmode` set —
+  libpq's default falls back to plaintext). The check is bypassed
+  with the explicit opt-out `MCPG_ALLOW_INSECURE_TLS=true` for
+  development-only deployments. Loopback hosts (`localhost`,
+  `127.0.0.1`, `::1`) are exempt.
+
+- **Tool-argument audit redaction upgraded to regex pattern match.**
+  `mcpg.audit.redact_arguments` and the persisted audit-trail
+  walker (`mcpg.audit_trail._redact`) now share a case-insensitive
+  regex matched via `re.search` against argument key names, so
+  `password` also masks `PGPASSWORD` / `user_password` /
+  `app.password`. Default patterns: `password`, `passwd`, `secret`,
+  `token`, `api[_-]?key`, `bearer`, `authorization`, `database_url`,
+  `dsn`, `conninfo`. Operators extend the list via
+  `MCPG_AUDIT_REDACT_KEYS` (comma-separated regex fragments). Walks
+  nested dicts / lists / tuples so credentials buried in result
+  payloads are masked too.
+
+- **Supply-chain CI hardening (dependency audit fix).** The
+  `security` job in `.github/workflows/ci.yml` was invoking
+  `uv audit` — a subcommand `uv` does not provide — so the
+  dependency-vulnerability step has been a silent no-op since it
+  was added. Replaced with `pip-audit --strict` over the
+  `uv export`-resolved runtime requirements; the existing bandit
+  SAST step is unchanged. Adds `pip-audit>=2.7` to the `dev`
+  dependency group.
+
+- **Vulnerability-reporting policy + hardening roadmap shipped.**
+  New `SECURITY.md` at the repo root documents supported versions,
+  the reporting address (`devopam@gmail.com`), the 3-business-day
+  acknowledgement target, and the 90-day coordinated-disclosure
+  window. New `docs/security-hardening.md` is a living checklist
+  of robust-security features with status indicators
+  (`✅` shipped / `🟡` partial / `⬜` queued) covering what's on
+  `main` today plus the queued items (HTTP request limits +
+  security headers, audit-log HMAC chain, pluggable secrets
+  backend, subprocess hardening, graceful shutdown).
+
 ### Changed
 
 - **License: relicensed from AGPL-3.0-or-later to MIT.** New `LICENSE`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,62 @@
+# Security Policy
+
+## Supported versions
+
+Only the latest minor release line receives security fixes. Currently:
+
+| Version | Supported          |
+|---------|--------------------|
+| 0.5.x   | :white_check_mark: |
+| 0.4.x   | :x:                |
+| <0.4    | :x:                |
+
+If you're running an older release, **upgrade first** — most security
+fixes ride a minor-version bump.
+
+## Reporting a vulnerability
+
+**Please do not file public issues for security reports.**
+
+Email `devopam@gmail.com` with:
+
+- A description of the issue and its impact
+- Steps to reproduce (proof-of-concept code is welcome)
+- The MCPg version (`uv run mcpg --version` or `mcpg --version`)
+- The PostgreSQL version (`SELECT version()`)
+- Whether you've checked the issue against the latest trunk
+
+You'll receive an acknowledgement within **3 business days**. Confirmed
+issues get a CVE assignment where appropriate, a fix on a private
+branch, and a coordinated release. Reporters are credited in the
+release notes unless they prefer otherwise.
+
+## Scope
+
+**In scope:**
+
+- The MCPg server code under `src/mcpg/` (excluding `src/mcpg/_vendor/`)
+- Authentication & authorisation paths (bearer-token, OIDC,
+  multi-tenancy `SET LOCAL ROLE`)
+- The capability gates that restrict tool surfaces by access mode
+- SQL injection paths in any tool MCPg ships
+- Audit trail integrity and credential redaction
+- Rate limiter bypasses
+
+**Out of scope:**
+
+- Vulnerabilities in PostgreSQL itself
+- Vulnerabilities in the vendored SQL-safety kernel at
+  `src/mcpg/_vendor/sql/` — those go upstream to
+  `crystaldba/postgres-mcp`
+- Issues that require an attacker already to have `unrestricted`
+  access mode AND `MCPG_ALLOW_DDL=true` (that combination is
+  by-design root access)
+- Vulnerabilities in third-party Python dependencies — report
+  directly to the upstream project; we'll bump when they patch
+- Bugs that only affect feature branches not on `main`
+
+## Disclosure timeline
+
+We aim for a 90-day coordinated disclosure window from acknowledgement.
+Critical vulnerabilities ship faster (typically within 14 days of
+confirmation). The reporter is consulted on timing.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,7 +48,7 @@ release notes unless they prefer otherwise.
 - Vulnerabilities in the vendored SQL-safety kernel at
   `src/mcpg/_vendor/sql/` — those go upstream to
   `crystaldba/postgres-mcp`
-- Issues that require an attacker already to have `unrestricted`
+- Issues that require an attacker to already have `unrestricted`
   access mode AND `MCPG_ALLOW_DDL=true` (that combination is
   by-design root access)
 - Vulnerabilities in third-party Python dependencies — report

--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -127,7 +127,7 @@ left in place.
 request body size limit, no per-request timeout, no
 `Content-Security-Policy` / `X-Frame-Options` /
 `Strict-Transport-Security` / `Referrer-Policy` headers, and no
-configurable CORS allow-list.
+configurable CORS allowlist.
 
 **Solution.** New `_SecurityHeadersMiddleware` adds the headers
 unconditionally (operators can disable per header via env). New

--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -1,0 +1,228 @@
+# MCPg security hardening — roadmap
+
+This is a **living checklist** of robust-security features for MCPg.
+Each item has a status, the operator-facing knobs it introduces, and
+notes on the implementation plan.
+
+For vulnerability reporting / disclosure policy, see
+[`SECURITY.md`](../SECURITY.md) at the repo root.
+
+| Status | Meaning |
+|---|---|
+| ✅ | Shipped on `main`. Tests pin behaviour. |
+| 🟡 | Partial — designed and a subset shipped. |
+| ⬜ | Pending — designed; implementation queued. |
+
+---
+
+## Already shipped
+
+### ✅ Capability gates (per-tool access control)
+`MCPG_ACCESS_MODE=read-only|restricted|unrestricted` plus the
+`MCPG_ALLOW_DDL` / `MCPG_ALLOW_SHELL` / `MCPG_ALLOW_LISTEN` opt-ins
+gate which tools appear in the listing. Documented in
+[`docs/tools.md`](tools.md).
+
+### ✅ Static bearer-token auth for HTTP transports
+`MCPG_HTTP_AUTH_TOKEN` enforces `Authorization: Bearer <token>` with
+constant-time comparison via `hmac.compare_digest`. `/metrics`,
+`/healthz`, `/readyz` exempt by design.
+
+### ✅ OIDC / JWT bearer-token validation
+`MCPG_AUTH_MODE=oidc` replaces static comparison with full JWT
+validation against the configured issuer's JWKS. Asymmetric algorithms
+only (RS256-RS512 + ES256-ES512); HS-family explicitly excluded.
+
+### ✅ Per-request multi-tenancy via `SET LOCAL ROLE`
+Static (`MCPG_DEFAULT_ROLE`) plus per-request override
+(`X-MCPG-Role` HTTP header / `MCPG_OIDC_ROLE_CLAIM` from the JWT).
+Allowlist via `MCPG_ALLOWED_ROLES`. Role names identifier-validated.
+
+### ✅ Read-replica routing
+`MCPG_REPLICA_URLS` round-robins read-only queries to healthy
+replicas with degraded-replica detection. Failures don't bubble up
+to the tool layer.
+
+### ✅ SQL injection prevention
+All identifier interpolation gated by
+`[A-Za-z_][A-Za-z0-9_]*` allowlist; user queries flow through
+`SafeSqlDriver`'s parse-and-validate path before execution.
+
+### ✅ Password obfuscation in logs and `repr`
+`Settings.__repr__` redacts credentials from `database_url`,
+`replica_urls`, `http_auth_token`, `nl2sql_api_key`, OIDC fields.
+
+### ✅ Per-tool rate limiting
+`MCPG_RATE_LIMIT_*` family enforces global + heavy-tool quotas on
+each `call_tool` invocation. Token-bucket implementation in
+`mcpg.middleware.rate_limit`.
+
+### ✅ Audit trail
+`mcpg.audit` records each tool call with status + arguments. Optional
+persistence via `MCPG_AUDIT_PERSIST` to a `mcpg.audit_events` table.
+
+---
+
+## This release
+
+### ✅ PG TLS enforcement
+**Problem.** A misconfigured deployment can connect to a remote PG
+over plaintext (`sslmode=disable`) without anyone noticing.
+
+**Solution.** On startup, parse `MCPG_DATABASE_URL` (and every entry
+in `MCPG_REPLICA_URLS`). If the host is non-loopback AND the
+`sslmode` query parameter is one of `disable` / `allow` / `prefer`,
+refuse to start unless `MCPG_ALLOW_INSECURE_TLS=true` is set
+(explicit override for explicitly-non-prod deployments).
+
+**Env vars added:**
+- `MCPG_ALLOW_INSECURE_TLS=true` (opt-out override; default off)
+
+**Implementation:** `mcpg/config.py` — new validator runs at the
+end of `load_settings`. Tests in `tests/unit/test_config.py`.
+
+### ✅ Sensitive-argument redaction in audit
+**Problem.** Tool arguments today are recorded verbatim in the audit
+trail. A tool that takes `MCPG_HTTP_AUTH_TOKEN` as an arg, or
+`api_key`, would persist that secret in the audit table.
+
+**Solution.** Replace the exact-name allowlist with a case-insensitive
+regex matched by `re.search`, so `password` also catches `PGPASSWORD` /
+`user_password` / `app.password`. Default pattern set: `password`,
+`passwd`, `secret`, `token`, `api[_-]?key`, `bearer`, `authorization`,
+`database_url`, `dsn`, `conninfo`. The matched value is replaced with
+the existing `****` mask (consistent with `obfuscate_password`).
+Walks nested dicts / lists / tuples — a `RETURNING password` payload
+buried in a result row is masked too. Pattern list extensible via
+`MCPG_AUDIT_REDACT_KEYS` (comma-separated regex fragments).
+
+**Env vars added:**
+- `MCPG_AUDIT_REDACT_KEYS` — comma-separated regex list to extend
+  the default pattern set.
+
+**Implementation:** `mcpg/audit.py` — `_redact_value` helper +
+`configure_redaction(env)` re-arm hook called from `load_settings`.
+`mcpg/audit_trail.py` shares the same pattern via `_is_secret_key`.
+Tests pin the default patterns + the extension knob.
+
+### ✅ Supply-chain CI hardening
+**Problem.** The existing `security` job in `.github/workflows/ci.yml`
+invoked `uv audit` — a subcommand `uv` does not provide — so the
+dependency-audit step has been silently failing on every push. The
+SAST (bandit) step ran but its companion was a no-op.
+
+**Solution.** Replace the broken `uv audit` step with
+`uv run pip-audit --strict --disable-pip` (PyPI + OSV.dev advisory
+sources, warnings upgraded to failures so a vulnerable transitive dep
+blocks merge), and add `pip-audit>=2.7` to the `dev` dependency
+group. The `bandit -r src/mcpg --skip B101,B608,B110 -ll` step is
+left in place.
+
+---
+
+## Queued (next focused PRs)
+
+### ⬜ HTTP hardening (request limits + security headers + CORS)
+**Problem.** The streamable-http / sse transports today have no
+request body size limit, no per-request timeout, no
+`Content-Security-Policy` / `X-Frame-Options` /
+`Strict-Transport-Security` / `Referrer-Policy` headers, and no
+configurable CORS allow-list.
+
+**Solution.** New `_SecurityHeadersMiddleware` adds the headers
+unconditionally (operators can disable per header via env). New
+`_RequestSizeLimitMiddleware` rejects bodies above
+`MCPG_HTTP_MAX_BODY_BYTES` (default 1 MiB) with 413. New
+`MCPG_HTTP_ALLOWED_ORIGINS` (comma list) drives CORS via Starlette's
+`CORSMiddleware`.
+
+**Env vars to add:** `MCPG_HTTP_MAX_BODY_BYTES`,
+`MCPG_HTTP_REQUEST_TIMEOUT_SECONDS`, `MCPG_HTTP_ALLOWED_ORIGINS`,
+`MCPG_HTTP_HSTS_MAX_AGE` (default 31536000).
+
+**Effort:** medium (one new middleware module + 6-8 tests).
+
+### ⬜ Audit log integrity (HMAC chain + verifier tool)
+**Problem.** An attacker with write access to `mcpg.audit_events`
+can truncate, alter, or insert events undetected.
+
+**Solution.** Each event carries an HMAC over `(prev_hmac ||
+serialised_event)` keyed by `MCPG_AUDIT_HMAC_KEY`. A new
+`verify_audit_chain` MCP tool walks the chain and reports the first
+break. Persistence schema gains `prev_hmac` + `event_hmac` columns.
+
+**Env vars to add:** `MCPG_AUDIT_HMAC_KEY` (required when
+`MCPG_AUDIT_PERSIST=true` AND integrity is enabled),
+`MCPG_AUDIT_INTEGRITY=true|false`.
+
+**Effort:** medium (schema migration + HMAC computation +
+verifier tool + 5-7 tests).
+
+### ⬜ Pluggable secrets backend
+**Problem.** API keys for the NL→SQL providers, OIDC client
+secrets (future), and the static bearer token all live in env vars.
+Deployments that use HashiCorp Vault / AWS Secrets Manager / GCP
+Secret Manager have to inject them through their orchestrator
+sidecar rather than letting MCPg fetch them directly.
+
+**Solution.** Define a `SecretsProvider` protocol; ship four
+implementations: `env` (today), `file` (mount a JSON / YAML file
+of name→value), `vault` (HashiCorp), `aws` (Secrets Manager),
+`gcp` (Secret Manager). The active provider is picked by
+`MCPG_SECRETS_BACKEND`. Settings that today read env vars route
+through `provider.get(name)`.
+
+**Env vars to add:** `MCPG_SECRETS_BACKEND=env|file|vault|aws|gcp`,
+plus backend-specific (e.g. `VAULT_ADDR`, `VAULT_TOKEN`,
+`MCPG_SECRETS_FILE_PATH`, `AWS_SECRETS_MANAGER_REGION`).
+
+**Effort:** large (4 new optional dep families behind extras like
+`mcpg[vault]`, `mcpg[aws-secrets]`; ~150 LOC core + per-backend
+integrations + 12+ tests).
+
+### ⬜ Subprocess hardening
+**Problem.** `pg_dump` / `pg_restore` / `psql` subprocesses
+inherit the parent's full environment + PATH. A malicious entry
+on PATH could shim one of these binaries.
+
+**Solution.** Compose subprocess env explicitly:
+- Resolve the binary's absolute path at startup; refuse if outside
+  `MCPG_SUBPROCESS_BIN_ALLOWLIST`.
+- Spawn with a minimal env: `PGHOST` / `PGPORT` / `PGUSER` /
+  `PGPASSWORD` / `PGSSLMODE` / `LANG` / `TZ` only.
+- Drop into a temp working directory.
+- Apply CPU + memory ulimits where the platform supports them
+  (`resource.setrlimit` on Linux/macOS).
+
+**Env vars to add:** `MCPG_SUBPROCESS_BIN_ALLOWLIST` (paths),
+`MCPG_SUBPROCESS_CPU_SECONDS`, `MCPG_SUBPROCESS_MEMORY_MB`.
+
+**Effort:** medium (~100 LOC + cross-platform conditionals + 6-8
+tests).
+
+### ⬜ Graceful shutdown
+**Problem.** On SIGTERM today the server exits immediately,
+abandoning in-flight tool calls and any open cursors.
+
+**Solution.** Lifespan exit hook drains the in-flight tool count,
+closes every open cursor via `CursorManager.close_all`, flushes the
+audit trail, then exits. Configurable max-drain window
+(`MCPG_SHUTDOWN_DRAIN_SECONDS`, default 30).
+
+**Env vars to add:** `MCPG_SHUTDOWN_DRAIN_SECONDS=30`.
+
+**Effort:** small (~40 LOC + 3-4 tests).
+
+---
+
+## Posture summary
+
+| Area | Today | After this PR | After roadmap |
+|---|---|---|---|
+| Authn | Static + OIDC | Same | + secrets backend for keys |
+| Authz | Capability gates + tenancy | Same | Same |
+| Transport security | bearer token | + PG TLS enforcement | + HTTP hardening |
+| Audit | Recorded | + arg redaction | + integrity chain |
+| Supply chain | Manual deps | + CI bandit + pip-audit | Same |
+| Lifecycle | Hard exit | Same | Graceful shutdown |
+| Subprocess | Default env | Same | Hardened spawn |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
     "mypy>=1.15.0",
     "pre-commit>=4.0.0",
     "bandit>=1.7.8",
+    "pip-audit>=2.7",
 ]
 
 [tool.pytest.ini_options]

--- a/src/mcpg/audit.py
+++ b/src/mcpg/audit.py
@@ -72,7 +72,13 @@ def configure_redaction(env: Mapping[str, str] | None = None) -> None:
     _secret_name_re = _compile_secret_name_pattern(source.get("MCPG_AUDIT_REDACT_KEYS"))
 
 
-def _is_secret_key(name: str) -> bool:
+def is_secret_key(name: str) -> bool:
+    """Return True when ``name`` matches the configured secret-name pattern.
+
+    Public so other audit-adjacent modules (notably
+    :mod:`mcpg.audit_trail`) can share the same key-match decision
+    instead of reaching into a private helper.
+    """
     return bool(_secret_name_re.search(name))
 
 
@@ -96,7 +102,7 @@ def _redact_value(value: Any) -> Any:
     (``int`` / ``bool`` / ``None``) pass through unchanged.
     """
     if isinstance(value, dict):
-        return {k: _MASK if isinstance(k, str) and _is_secret_key(k) else _redact_value(v) for k, v in value.items()}
+        return {k: _MASK if isinstance(k, str) and is_secret_key(k) else _redact_value(v) for k, v in value.items()}
     if isinstance(value, list):
         return [_redact_value(item) for item in value]
     if isinstance(value, tuple):

--- a/src/mcpg/audit.py
+++ b/src/mcpg/audit.py
@@ -11,6 +11,9 @@ from __future__ import annotations
 
 import datetime
 import logging
+import os
+import re
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -20,9 +23,57 @@ from mcpg._vendor.sql import SqlDriver, obfuscate_password
 
 audit_logger = logging.getLogger("mcpg.audit")
 
-# Argument names whose values are masked wholesale, regardless of content.
-_SECRET_KEYS = frozenset({"password", "secret", "token", "database_url", "dsn", "conninfo"})
+# Names whose VALUES are credentials and must be masked before the
+# arguments dict is logged or persisted. Each entry is a regex matched
+# case-insensitively via ``re.search`` against the argument key — a
+# substring match by default, so ``password`` also catches
+# ``PGPASSWORD``, ``user_password`` and ``app.password``. Operators
+# extend the list via ``MCPG_AUDIT_REDACT_KEYS`` (comma-separated
+# regex fragments).
+_DEFAULT_SECRET_NAME_PATTERNS: tuple[str, ...] = (
+    r"password",
+    r"passwd",
+    r"secret",
+    r"token",
+    r"api[_-]?key",
+    r"bearer",
+    r"authorization",
+    r"database_url",
+    r"dsn",
+    r"conninfo",
+)
 _MASK = "****"
+
+
+def _compile_secret_name_pattern(extra: str | None) -> re.Pattern[str]:
+    patterns = list(_DEFAULT_SECRET_NAME_PATTERNS)
+    if extra:
+        for raw in extra.split(","):
+            stripped = raw.strip()
+            if stripped:
+                patterns.append(stripped)
+    return re.compile("|".join(patterns), re.IGNORECASE)
+
+
+# Pattern is recomputable so ``configure_redaction`` can swap in an
+# extended list at server start without restarting the process.
+_secret_name_re: re.Pattern[str] = _compile_secret_name_pattern(os.environ.get("MCPG_AUDIT_REDACT_KEYS"))
+
+
+def configure_redaction(env: Mapping[str, str] | None = None) -> None:
+    """Reload the secret-name pattern from ``MCPG_AUDIT_REDACT_KEYS``.
+
+    Idempotent. ``load_settings`` calls this once with the validated env
+    mapping; tests call it directly to flip the pattern without
+    mutating the process environment.
+    """
+    global _secret_name_re
+    source = os.environ if env is None else env
+    _secret_name_re = _compile_secret_name_pattern(source.get("MCPG_AUDIT_REDACT_KEYS"))
+
+
+def _is_secret_key(name: str) -> bool:
+    return bool(_secret_name_re.search(name))
 
 
 @dataclass(frozen=True, slots=True)
@@ -35,21 +86,35 @@ class AuditEvent:
     error: str | None = None
 
 
-def redact_arguments(arguments: dict[str, Any]) -> dict[str, Any]:
-    """Return a copy of tool arguments with sensitive values masked.
+def _redact_value(value: Any) -> Any:
+    """Recursively mask credentials in dicts, lists, tuples, and strings.
 
-    Arguments named like a credential are masked entirely; string arguments
-    have any embedded connection-string password obfuscated.
+    Mapping keys whose name matches the configured secret-name pattern
+    have their value masked wholesale. String leaves pass through
+    ``obfuscate_password`` so an embedded DSN credential nested
+    arbitrarily deep is still scrubbed. Non-string scalars
+    (``int`` / ``bool`` / ``None``) pass through unchanged.
     """
-    safe: dict[str, Any] = {}
-    for key, value in arguments.items():
-        if key.lower() in _SECRET_KEYS:
-            safe[key] = _MASK
-        elif isinstance(value, str):
-            safe[key] = obfuscate_password(value)
-        else:
-            safe[key] = value
-    return safe
+    if isinstance(value, dict):
+        return {k: _MASK if isinstance(k, str) and _is_secret_key(k) else _redact_value(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_redact_value(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_redact_value(item) for item in value)
+    if isinstance(value, str):
+        return obfuscate_password(value)
+    return value
+
+
+def redact_arguments(arguments: dict[str, Any]) -> dict[str, Any]:
+    """Return a deep copy of tool arguments with sensitive values masked.
+
+    Arguments named like a credential (per the configured pattern, see
+    :func:`configure_redaction`) are masked entirely; string leaves have
+    any embedded connection-string password obfuscated; nested dicts /
+    lists / tuples are walked recursively.
+    """
+    return _redact_value(arguments)  # type: ignore[no-any-return]
 
 
 def record(event: AuditEvent) -> None:

--- a/src/mcpg/audit_trail.py
+++ b/src/mcpg/audit_trail.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from mcpg._vendor.sql import SqlDriver, obfuscate_password
-from mcpg.audit import _is_secret_key
+from mcpg.audit import is_secret_key
 
 AUDIT_SCHEMA = "mcpg_audit"
 AUDIT_TABLE = "events"
@@ -64,7 +64,7 @@ def _redact(value: Any) -> Any:
     Non-string scalars (ints, bools, None) pass through unchanged.
     """
     if isinstance(value, dict):
-        return {k: _MASK if isinstance(k, str) and _is_secret_key(k) else _redact(v) for k, v in value.items()}
+        return {k: _MASK if isinstance(k, str) and is_secret_key(k) else _redact(v) for k, v in value.items()}
     if isinstance(value, list):
         return [_redact(item) for item in value]
     if isinstance(value, tuple):

--- a/src/mcpg/audit_trail.py
+++ b/src/mcpg/audit_trail.py
@@ -22,13 +22,12 @@ from dataclasses import dataclass
 from typing import Any
 
 from mcpg._vendor.sql import SqlDriver, obfuscate_password
+from mcpg.audit import _is_secret_key
 
 AUDIT_SCHEMA = "mcpg_audit"
 AUDIT_TABLE = "events"
 _QUALIFIED = f"{AUDIT_SCHEMA}.{AUDIT_TABLE}"
 
-# Argument keys whose values should never be persisted unredacted.
-_SECRET_KEYS = frozenset({"password", "secret", "token", "database_url", "dsn", "conninfo"})
 _MASK = "****"
 
 
@@ -65,7 +64,7 @@ def _redact(value: Any) -> Any:
     Non-string scalars (ints, bools, None) pass through unchanged.
     """
     if isinstance(value, dict):
-        return {k: _MASK if k.lower() in _SECRET_KEYS else _redact(v) for k, v in value.items()}
+        return {k: _MASK if isinstance(k, str) and _is_secret_key(k) else _redact(v) for k, v in value.items()}
     if isinstance(value, list):
         return [_redact(item) for item in value]
     if isinstance(value, tuple):

--- a/src/mcpg/config.py
+++ b/src/mcpg/config.py
@@ -158,36 +158,54 @@ class Settings:
 # `prefer` try TLS but fall back to plaintext on failure. Only
 # `require` / `verify-ca` / `verify-full` actually guarantee TLS.
 _INSECURE_SSLMODES = frozenset({"disable", "allow", "prefer"})
-_LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1", ""})
+# Hosts that don't require TLS — a connection to one of these can't
+# leave the box. An *empty* host (i.e. unset in the DSN) is NOT in
+# this set: libpq falls back to ``PGHOST`` then to a default that
+# may not be loopback, so we refuse to second-guess it and demand
+# an explicit ``MCPG_ALLOW_INSECURE_TLS=true`` override instead.
+_LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
 
 
 def _require_tls_or_loopback(var: str, dsn: str) -> None:
     """Refuse a non-loopback DSN that doesn't enforce TLS.
 
+    Uses ``psycopg.conninfo.conninfo_to_dict`` (rather than
+    ``urllib.parse``) so the check handles every connection-string
+    format libpq itself does — key-value strings
+    (``host=db sslmode=disable``) and multi-host URIs
+    (``postgresql://h1,h2/db``) included.
+
     Bypassable via ``MCPG_ALLOW_INSECURE_TLS=true``; the caller
     consults that knob before invoking this validator.
     """
-    from urllib.parse import parse_qs, urlsplit
+    from psycopg.conninfo import conninfo_to_dict
 
     try:
-        parts = urlsplit(dsn)
-    except ValueError as exc:
-        # Not a parseable URL — let the actual psycopg connect raise
-        # its own clearer error rather than block startup here.
-        raise ConfigError(f"{var} is not a valid URL: {exc}") from None
-    host = (parts.hostname or "").lower()
-    if host in _LOOPBACK_HOSTS:
+        params = conninfo_to_dict(dsn)
+    except Exception as exc:
+        raise ConfigError(f"{var} is not a valid PostgreSQL connection string: {exc}") from None
+
+    # ``host`` may be a comma-separated list of failover candidates;
+    # libpq treats each entry independently. We treat the DSN as
+    # remote if ANY listed host is non-loopback — partial coverage
+    # would be a footgun.
+    raw_host = str(params.get("host", "")).strip()
+    hosts = [h.strip().lower().strip("[]") for h in raw_host.split(",") if h.strip()]
+    if not hosts:
+        raise ConfigError(
+            f"{var} has no explicit host; libpq will fall back to PGHOST / a default "
+            f"that may not be loopback. Set host=localhost / 127.0.0.1 in the DSN, "
+            f"or pass MCPG_ALLOW_INSECURE_TLS=true to override."
+        )
+    remote_hosts = [h for h in hosts if h not in _LOOPBACK_HOSTS]
+    if not remote_hosts:
         return
-    # Default libpq behaviour when sslmode is unset is `prefer`, which
-    # WILL fall back to plaintext on TLS failure — so an unset value
-    # is unsafe for remote hosts, exactly the same as `prefer`.
-    sslmode_values = parse_qs(parts.query).get("sslmode", ["prefer"])
-    sslmode = sslmode_values[-1].lower() if sslmode_values else "prefer"
+    sslmode = str(params.get("sslmode", "prefer")).strip().lower()
     if sslmode in _INSECURE_SSLMODES:
         raise ConfigError(
-            f"{var} points at a remote host ({host}) but its sslmode is {sslmode!r}; "
-            f"set sslmode=require (or verify-ca / verify-full) in the URL, "
-            f"or pass MCPG_ALLOW_INSECURE_TLS=true to override."
+            f"{var} points at a remote host ({', '.join(remote_hosts)}) but its sslmode "
+            f"is {sslmode!r}; set sslmode=require (or verify-ca / verify-full) in the "
+            f"connection string, or pass MCPG_ALLOW_INSECURE_TLS=true to override."
         )
 
 
@@ -457,8 +475,9 @@ def load_settings(env: Mapping[str, str] | None = None) -> Settings:
     # sockets are a different threat model and require their own
     # operator opt-in to be reachable from outside the box anyway.
     if not allow_insecure_tls:
-        for label, dsn in (("MCPG_DATABASE_URL", database_url), *(("MCPG_REPLICA_URLS", u) for u in replica_urls)):
-            _require_tls_or_loopback(label, dsn)
+        _require_tls_or_loopback("MCPG_DATABASE_URL", database_url)
+        for idx, replica_dsn in enumerate(replica_urls):
+            _require_tls_or_loopback(f"MCPG_REPLICA_URLS[{idx}]", replica_dsn)
 
     # Re-arm the audit-trail redaction pattern with the operator's
     # MCPG_AUDIT_REDACT_KEYS extension (if any) so the very first audit

--- a/src/mcpg/config.py
+++ b/src/mcpg/config.py
@@ -110,6 +110,10 @@ class Settings:
     rate_limit_window_seconds: int = 60
     rate_limit_heavy_max: int = 5
     rate_limit_heavy_window: int = 60
+    # When True, MCPg accepts a database / replica URL whose sslmode is
+    # disable / allow / prefer even for non-loopback hosts. Off by default
+    # so a misconfigured production deployment fails closed at startup.
+    allow_insecure_tls: bool = False
 
     def __repr__(self) -> str:
         # Never let credentials reach logs or tracebacks.
@@ -144,7 +148,46 @@ class Settings:
             f"rate_limit_max_requests={self.rate_limit_max_requests}, "
             f"rate_limit_window_seconds={self.rate_limit_window_seconds}, "
             f"rate_limit_heavy_max={self.rate_limit_heavy_max}, "
-            f"rate_limit_heavy_window={self.rate_limit_heavy_window})"
+            f"rate_limit_heavy_window={self.rate_limit_heavy_window}, "
+            f"allow_insecure_tls={self.allow_insecure_tls})"
+        )
+
+
+# sslmode values that don't enforce a TLS-protected connection.
+# Per psycopg / libpq docs: `disable` accepts plaintext, `allow` and
+# `prefer` try TLS but fall back to plaintext on failure. Only
+# `require` / `verify-ca` / `verify-full` actually guarantee TLS.
+_INSECURE_SSLMODES = frozenset({"disable", "allow", "prefer"})
+_LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1", ""})
+
+
+def _require_tls_or_loopback(var: str, dsn: str) -> None:
+    """Refuse a non-loopback DSN that doesn't enforce TLS.
+
+    Bypassable via ``MCPG_ALLOW_INSECURE_TLS=true``; the caller
+    consults that knob before invoking this validator.
+    """
+    from urllib.parse import parse_qs, urlsplit
+
+    try:
+        parts = urlsplit(dsn)
+    except ValueError as exc:
+        # Not a parseable URL — let the actual psycopg connect raise
+        # its own clearer error rather than block startup here.
+        raise ConfigError(f"{var} is not a valid URL: {exc}") from None
+    host = (parts.hostname or "").lower()
+    if host in _LOOPBACK_HOSTS:
+        return
+    # Default libpq behaviour when sslmode is unset is `prefer`, which
+    # WILL fall back to plaintext on TLS failure — so an unset value
+    # is unsafe for remote hosts, exactly the same as `prefer`.
+    sslmode_values = parse_qs(parts.query).get("sslmode", ["prefer"])
+    sslmode = sslmode_values[-1].lower() if sslmode_values else "prefer"
+    if sslmode in _INSECURE_SSLMODES:
+        raise ConfigError(
+            f"{var} points at a remote host ({host}) but its sslmode is {sslmode!r}; "
+            f"set sslmode=require (or verify-ca / verify-full) in the URL, "
+            f"or pass MCPG_ALLOW_INSECURE_TLS=true to override."
         )
 
 
@@ -404,6 +447,26 @@ def load_settings(env: Mapping[str, str] | None = None) -> Settings:
     if (raw := env.get("MCPG_RATE_LIMIT_HEAVY_WINDOW")) is not None:
         rate_limit_heavy_window = _parse_positive_int("MCPG_RATE_LIMIT_HEAVY_WINDOW", raw)
 
+    allow_insecure_tls = False
+    if (raw := env.get("MCPG_ALLOW_INSECURE_TLS")) is not None:
+        allow_insecure_tls = _parse_bool("MCPG_ALLOW_INSECURE_TLS", raw)
+
+    # PG TLS enforcement: refuse plaintext to remote hosts unless the
+    # operator has explicitly opted in. Loopback ("localhost",
+    # "127.0.0.1", "::1") is exempt — local sockets / Unix-domain
+    # sockets are a different threat model and require their own
+    # operator opt-in to be reachable from outside the box anyway.
+    if not allow_insecure_tls:
+        for label, dsn in (("MCPG_DATABASE_URL", database_url), *(("MCPG_REPLICA_URLS", u) for u in replica_urls)):
+            _require_tls_or_loopback(label, dsn)
+
+    # Re-arm the audit-trail redaction pattern with the operator's
+    # MCPG_AUDIT_REDACT_KEYS extension (if any) so the very first audit
+    # event the server records honours the configured list.
+    from mcpg.audit import configure_redaction
+
+    configure_redaction(env)
+
     return Settings(
         database_url=database_url,
         access_mode=access_mode,
@@ -439,4 +502,5 @@ def load_settings(env: Mapping[str, str] | None = None) -> Settings:
         rate_limit_window_seconds=rate_limit_window_seconds,
         rate_limit_heavy_max=rate_limit_heavy_max,
         rate_limit_heavy_window=rate_limit_heavy_window,
+        allow_insecure_tls=allow_insecure_tls,
     )

--- a/tests/unit/test_audit_redaction.py
+++ b/tests/unit/test_audit_redaction.py
@@ -1,0 +1,105 @@
+"""Tests for the tool-invocation audit redactor in :mod:`mcpg.audit`.
+
+Covers the secret-name regex (default patterns + the
+``MCPG_AUDIT_REDACT_KEYS`` extension knob), recursive walking of
+nested arguments, and the wiring from ``load_settings`` into the
+process-level redaction pattern.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mcpg import audit
+from mcpg.config import load_settings
+
+_DB_URL = "postgresql://u:p@localhost/db"
+
+
+@pytest.fixture(autouse=True)
+def _reset_pattern() -> None:
+    """Reset the module pattern between tests so extensions don't leak."""
+    audit.configure_redaction({})
+
+
+def test_redact_arguments_masks_default_secret_keys() -> None:
+    redacted = audit.redact_arguments({"sql": "SELECT 1", "password": "hunter2", "api_key": "sk-abc", "token": "tk"})
+    assert redacted["password"] == "****"
+    assert redacted["api_key"] == "****"
+    assert redacted["token"] == "****"
+    # Non-credential keys pass through.
+    assert redacted["sql"] == "SELECT 1"
+
+
+def test_redact_arguments_matches_keys_case_insensitively() -> None:
+    redacted = audit.redact_arguments({"PGPASSWORD": "hunter2", "Bearer": "abc", "AUTHORIZATION": "xyz"})
+    assert redacted["PGPASSWORD"] == "****"
+    assert redacted["Bearer"] == "****"
+    assert redacted["AUTHORIZATION"] == "****"
+
+
+def test_redact_arguments_matches_keys_as_substrings() -> None:
+    # ``user_password`` and ``app.api_key`` both contain a default
+    # pattern as a substring.
+    redacted = audit.redact_arguments({"user_password": "hunter2", "app.api_key": "sk-abc"})
+    assert redacted["user_password"] == "****"
+    assert redacted["app.api_key"] == "****"
+
+
+def test_redact_arguments_walks_nested_dicts_lists_tuples() -> None:
+    payload = {
+        "rows": [
+            {"id": 1, "password": "hunter2"},
+            {"id": 2, "token": "tk_abc"},
+        ],
+        "creds": ({"api_key": "sk-x"},),
+        "schema": "app",
+    }
+    redacted = audit.redact_arguments(payload)
+    assert redacted["rows"][0]["password"] == "****"
+    assert redacted["rows"][1]["token"] == "****"
+    assert redacted["creds"][0]["api_key"] == "****"
+    # Tuple type is preserved through the walk.
+    assert isinstance(redacted["creds"], tuple)
+    # Non-sensitive scalars pass through.
+    assert redacted["schema"] == "app"
+    assert redacted["rows"][0]["id"] == 1
+
+
+def test_redact_arguments_obfuscates_dsn_password_in_string_leaves() -> None:
+    redacted = audit.redact_arguments({"url": "postgresql://u:hunter2@host/db"})
+    assert "hunter2" not in redacted["url"]
+    assert "****" in redacted["url"]
+
+
+def test_redact_arguments_passes_through_non_string_scalars() -> None:
+    redacted = audit.redact_arguments({"limit": 100, "active": True, "result": None})
+    assert redacted == {"limit": 100, "active": True, "result": None}
+
+
+def test_configure_redaction_picks_up_extra_keys_from_env_var() -> None:
+    audit.configure_redaction({"MCPG_AUDIT_REDACT_KEYS": "session_id,csrf"})
+    redacted = audit.redact_arguments({"session_id": "abc123", "csrf": "xyz", "password": "hunter2"})
+    assert redacted["session_id"] == "****"
+    assert redacted["csrf"] == "****"
+    # Defaults still apply on top of the extensions.
+    assert redacted["password"] == "****"
+
+
+def test_configure_redaction_accepts_regex_fragments() -> None:
+    # The extension knob takes regex fragments, so the operator can
+    # match a family of keys with one entry.
+    audit.configure_redaction({"MCPG_AUDIT_REDACT_KEYS": "user_id_\\d+"})
+    redacted = audit.redact_arguments({"user_id_42": "alice", "user_id_99": "bob"})
+    assert redacted["user_id_42"] == "****"
+    assert redacted["user_id_99"] == "****"
+
+
+def test_load_settings_arms_the_audit_redaction_pattern() -> None:
+    # ``load_settings`` is the canonical configuration entry point; it
+    # must propagate MCPG_AUDIT_REDACT_KEYS into the audit module so
+    # the very first tool call honours the extended pattern.
+    load_settings({"MCPG_DATABASE_URL": _DB_URL, "MCPG_AUDIT_REDACT_KEYS": "tenant_secret"})
+    redacted = audit.redact_arguments({"tenant_secret": "abc", "ordinary": "value"})
+    assert redacted["tenant_secret"] == "****"
+    assert redacted["ordinary"] == "value"

--- a/tests/unit/test_audit_redaction.py
+++ b/tests/unit/test_audit_redaction.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import pytest
 
-from mcpg import audit
+from mcpg import audit, audit_trail
 from mcpg.config import load_settings
 
 _DB_URL = "postgresql://u:p@localhost/db"
@@ -101,5 +101,16 @@ def test_load_settings_arms_the_audit_redaction_pattern() -> None:
     # the very first tool call honours the extended pattern.
     load_settings({"MCPG_DATABASE_URL": _DB_URL, "MCPG_AUDIT_REDACT_KEYS": "tenant_secret"})
     redacted = audit.redact_arguments({"tenant_secret": "abc", "ordinary": "value"})
+    assert redacted["tenant_secret"] == "****"
+    assert redacted["ordinary"] == "value"
+
+
+def test_load_settings_pattern_also_reaches_audit_trail_redact() -> None:
+    # ``mcpg.audit_trail._redact`` shares the same ``is_secret_key``
+    # predicate as the in-memory logger, so the
+    # ``MCPG_AUDIT_REDACT_KEYS`` extension must scrub keys before they
+    # land in ``mcpg_audit.events`` too.
+    load_settings({"MCPG_DATABASE_URL": _DB_URL, "MCPG_AUDIT_REDACT_KEYS": "tenant_secret"})
+    redacted = audit_trail._redact({"tenant_secret": "abc", "ordinary": "value"})
     assert redacted["tenant_secret"] == "****"
     assert redacted["ordinary"] == "value"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -445,3 +445,53 @@ def test_loopback_aliases_are_treated_as_local() -> None:
 def test_allow_insecure_tls_appears_in_repr() -> None:
     settings = load_settings({"MCPG_DATABASE_URL": _DB_URL})
     assert "allow_insecure_tls=False" in repr(settings)
+
+
+def test_keyvalue_dsn_with_insecure_sslmode_is_rejected() -> None:
+    # libpq accepts keyword/value DSNs (host=... sslmode=...). The
+    # previous urllib-based check failed to extract the host and
+    # silently treated the DSN as loopback. Use a key-value form to
+    # pin the conninfo_to_dict path.
+    with pytest.raises(ConfigError, match=r"db\.example\.com"):
+        load_settings({"MCPG_DATABASE_URL": "host=db.example.com sslmode=disable user=u password=p dbname=app"})
+
+
+def test_multi_host_uri_with_insecure_sslmode_is_rejected() -> None:
+    # ``postgresql://h1,h2/db`` is libpq's failover syntax. The
+    # comma breaks urllib's host extraction; conninfo_to_dict keeps
+    # the host list intact. Any non-loopback entry should fail the
+    # validator.
+    with pytest.raises(ConfigError, match="host1"):
+        load_settings({"MCPG_DATABASE_URL": "postgresql://u:p@host1,host2:5432,5432/app?sslmode=disable"})
+
+
+def test_dsn_without_explicit_host_is_rejected() -> None:
+    # An empty host means libpq falls back to ``PGHOST`` or a default
+    # that may not be loopback. Refuse unless the operator explicitly
+    # opts in.
+    with pytest.raises(ConfigError, match="no explicit host"):
+        load_settings({"MCPG_DATABASE_URL": "postgresql:///app?sslmode=disable"})
+
+
+def test_dsn_without_explicit_host_is_accepted_when_allow_insecure_tls_is_true() -> None:
+    settings = load_settings(
+        {
+            "MCPG_DATABASE_URL": "postgresql:///app",
+            "MCPG_ALLOW_INSECURE_TLS": "true",
+        }
+    )
+    assert settings.allow_insecure_tls is True
+
+
+def test_replica_url_error_includes_index_for_diagnostics() -> None:
+    # Multiple replicas with one misconfigured entry — the error
+    # message must identify WHICH replica is at fault.
+    with pytest.raises(ConfigError, match=r"MCPG_REPLICA_URLS\[1\]"):
+        load_settings(
+            {
+                "MCPG_DATABASE_URL": _DB_URL,
+                "MCPG_REPLICA_URLS": (
+                    "postgresql://u:p@replica-1/db?sslmode=require, postgresql://u:p@replica-2/db?sslmode=disable"
+                ),
+            }
+        )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -312,12 +312,14 @@ def test_replica_urls_parses_comma_separated_list() -> None:
     settings = load_settings(
         {
             "MCPG_DATABASE_URL": _DB_URL,
-            "MCPG_REPLICA_URLS": ("postgresql://u:p@replica-1/db, postgresql://u:p@replica-2/db"),
+            "MCPG_REPLICA_URLS": (
+                "postgresql://u:p@replica-1/db?sslmode=require, postgresql://u:p@replica-2/db?sslmode=require"
+            ),
         }
     )
     assert settings.replica_urls == (
-        "postgresql://u:p@replica-1/db",
-        "postgresql://u:p@replica-2/db",
+        "postgresql://u:p@replica-1/db?sslmode=require",
+        "postgresql://u:p@replica-2/db?sslmode=require",
     )
 
 
@@ -330,7 +332,7 @@ def test_replica_repr_obfuscates_passwords() -> None:
     settings = load_settings(
         {
             "MCPG_DATABASE_URL": _DB_URL,
-            "MCPG_REPLICA_URLS": "postgresql://u:supersecret@replica/db",
+            "MCPG_REPLICA_URLS": "postgresql://u:supersecret@replica/db?sslmode=require",
         }
     )
     rendered = repr(settings)
@@ -383,3 +385,63 @@ def test_oidc_settings_parse_when_complete() -> None:
 def test_oidc_blank_individual_settings_raise() -> None:
     with pytest.raises(ConfigError, match="MCPG_OIDC_ISSUER"):
         load_settings({"MCPG_DATABASE_URL": _DB_URL, "MCPG_OIDC_ISSUER": "   "})
+
+
+# --- PG TLS enforcement (security hardening) -----------------------------
+
+
+def test_loopback_database_url_without_sslmode_is_accepted() -> None:
+    # Default ``_DB_URL`` points at localhost without sslmode set;
+    # the existing test suite relies on this path staying clean.
+    settings = load_settings({"MCPG_DATABASE_URL": _DB_URL})
+    assert settings.allow_insecure_tls is False
+    assert settings.database_url == _DB_URL
+
+
+def test_remote_database_url_without_sslmode_is_rejected() -> None:
+    with pytest.raises(ConfigError, match="sslmode"):
+        load_settings({"MCPG_DATABASE_URL": "postgresql://u:p@db.example.com:5432/app"})
+
+
+@pytest.mark.parametrize("mode", ["disable", "allow", "prefer"])
+def test_remote_database_url_with_insecure_sslmode_is_rejected(mode: str) -> None:
+    with pytest.raises(ConfigError, match=mode):
+        load_settings({"MCPG_DATABASE_URL": f"postgresql://u:p@db.example.com/app?sslmode={mode}"})
+
+
+@pytest.mark.parametrize("mode", ["require", "verify-ca", "verify-full"])
+def test_remote_database_url_with_enforced_sslmode_is_accepted(mode: str) -> None:
+    settings = load_settings({"MCPG_DATABASE_URL": f"postgresql://u:p@db.example.com/app?sslmode={mode}"})
+    assert f"sslmode={mode}" in settings.database_url
+
+
+def test_remote_database_url_is_accepted_when_allow_insecure_tls_is_true() -> None:
+    settings = load_settings(
+        {
+            "MCPG_DATABASE_URL": "postgresql://u:p@db.example.com/app?sslmode=disable",
+            "MCPG_ALLOW_INSECURE_TLS": "true",
+        }
+    )
+    assert settings.allow_insecure_tls is True
+
+
+def test_insecure_replica_url_is_rejected() -> None:
+    with pytest.raises(ConfigError, match="MCPG_REPLICA_URLS"):
+        load_settings(
+            {
+                "MCPG_DATABASE_URL": _DB_URL,
+                "MCPG_REPLICA_URLS": "postgresql://u:p@replica.example.com/app?sslmode=disable",
+            }
+        )
+
+
+def test_loopback_aliases_are_treated_as_local() -> None:
+    # ``127.0.0.1`` and ``::1`` are local sockets; the validator must
+    # not require sslmode for them.
+    for host in ("127.0.0.1", "[::1]"):
+        load_settings({"MCPG_DATABASE_URL": f"postgresql://u:p@{host}:5432/app"})
+
+
+def test_allow_insecure_tls_appears_in_repr() -> None:
+    settings = load_settings({"MCPG_DATABASE_URL": _DB_URL})
+    assert "allow_insecure_tls=False" in repr(settings)

--- a/uv.lock
+++ b/uv.lock
@@ -102,6 +102,33 @@ wheels = [
 ]
 
 [[package]]
+name = "boolean-py"
+version = "5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/cf/85379f13b76f3a69bca86b60237978af17d6aa0bc5998978c3b8cf05abb2/boolean_py-5.0.tar.gz", hash = "sha256:60cbc4bad079753721d32649545505362c754e121570ada4658b852a3a318d95", size = 37047, upload-time = "2025-04-03T10:39:49.734Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/ca/78d423b324b8d77900030fa59c4aa9054261ef0925631cd2501dd015b7b7/boolean_py-5.0-py3-none-any.whl", hash = "sha256:ef28a70bd43115208441b53a045d1549e2f0ec6e3d08a9d142cbc41c1938e8d9", size = 26577, upload-time = "2025-04-03T10:39:48.449Z" },
+]
+
+[[package]]
+name = "cachecontrol"
+version = "0.14.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "msgpack" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/f6/c972b32d80760fb79d6b9eeb0b3010a46b89c0b23cf6329417ff7886cd22/cachecontrol-0.14.4.tar.gz", hash = "sha256:e6220afafa4c22a47dd0badb319f84475d79108100d04e26e8542ef7d3ab05a1", size = 16150, upload-time = "2025-11-14T04:32:13.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/79/c45f2d53efe6ada1110cf6f9fca095e4ff47a0454444aefdde6ac4789179/cachecontrol-0.14.4-py3-none-any.whl", hash = "sha256:b7ac014ff72ee199b5f8af1de29d60239954f223e948196fa3d84adaffc71d2b", size = 22247, upload-time = "2025-11-14T04:32:11.733Z" },
+]
+
+[package.optional-dependencies]
+filecache = [
+    { name = "filelock" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.5.20"
 source = { registry = "https://pypi.org/simple" }
@@ -408,6 +435,31 @@ wheels = [
 ]
 
 [[package]]
+name = "cyclonedx-python-lib"
+version = "11.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "license-expression" },
+    { name = "packageurl-python" },
+    { name = "py-serializable" },
+    { name = "sortedcontainers" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/0d/64f02d3fd9c116d6f50a540d04d1e4f2e3c487f5062d2db53733ddb25917/cyclonedx_python_lib-11.7.0.tar.gz", hash = "sha256:fb1bc3dedfa31208444dbd743007f478ab6984010a184e5bd466bffd969e936e", size = 1411174, upload-time = "2026-03-17T15:19:16.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/09/fe0e3bc32bd33707c519b102fc064ad2a2ce5a1b53e2be38b86936b476b1/cyclonedx_python_lib-11.7.0-py3-none-any.whl", hash = "sha256:02fa4f15ddbba21ac9093039f8137c0d1813af7fe88b760c5dcd3311a8da2178", size = 513041, upload-time = "2026-03-17T15:19:14.369Z" },
+]
+
+[[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -600,6 +652,18 @@ wheels = [
 ]
 
 [[package]]
+name = "license-expression"
+version = "30.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boolean-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/71/d89bb0e71b1415453980fd32315f2a037aad9f7f70f695c7cec7035feb13/license_expression-30.4.4.tar.gz", hash = "sha256:73448f0aacd8d0808895bdc4b2c8e01a8d67646e4188f887375398c761f340fd", size = 186402, upload-time = "2025-07-22T11:13:32.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/40/791891d4c0c4dab4c5e187c17261cedc26285fd41541577f900470a45a4d/license_expression-30.4.4-py3-none-any.whl", hash = "sha256:421788fdcadb41f049d2dc934ce666626265aeccefddd25e162a26f23bcbf8a4", size = 120615, upload-time = "2025-07-22T11:13:31.217Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -661,6 +725,7 @@ dev = [
     { name = "bandit" },
     { name = "docker" },
     { name = "mypy" },
+    { name = "pip-audit" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -684,6 +749,7 @@ dev = [
     { name = "bandit", specifier = ">=1.7.8" },
     { name = "docker", specifier = ">=7.1.0" },
     { name = "mypy", specifier = ">=1.15.0" },
+    { name = "pip-audit", specifier = ">=2.7" },
     { name = "pre-commit", specifier = ">=4.0.0" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
@@ -698,6 +764,50 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "msgpack"
+version = "1.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/f2/bfb55a6236ed8725a96b0aa3acbd0ec17588e6a2c3b62a93eb513ed8783f/msgpack-1.1.2.tar.gz", hash = "sha256:3b60763c1373dd60f398488069bcdc703cd08a711477b5d480eecc9f9626f47e", size = 173581, upload-time = "2025-10-08T09:15:56.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/bd/8b0d01c756203fbab65d265859749860682ccd2a59594609aeec3a144efa/msgpack-1.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:70a0dff9d1f8da25179ffcf880e10cf1aad55fdb63cd59c9a49a1b82290062aa", size = 81939, upload-time = "2025-10-08T09:15:01.472Z" },
+    { url = "https://files.pythonhosted.org/packages/34/68/ba4f155f793a74c1483d4bdef136e1023f7bcba557f0db4ef3db3c665cf1/msgpack-1.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:446abdd8b94b55c800ac34b102dffd2f6aa0ce643c55dfc017ad89347db3dbdb", size = 85064, upload-time = "2025-10-08T09:15:03.764Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/60/a064b0345fc36c4c3d2c743c82d9100c40388d77f0b48b2f04d6041dbec1/msgpack-1.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c63eea553c69ab05b6747901b97d620bb2a690633c77f23feb0c6a947a8a7b8f", size = 417131, upload-time = "2025-10-08T09:15:05.136Z" },
+    { url = "https://files.pythonhosted.org/packages/65/92/a5100f7185a800a5d29f8d14041f61475b9de465ffcc0f3b9fba606e4505/msgpack-1.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:372839311ccf6bdaf39b00b61288e0557916c3729529b301c52c2d88842add42", size = 427556, upload-time = "2025-10-08T09:15:06.837Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/87/ffe21d1bf7d9991354ad93949286f643b2bb6ddbeab66373922b44c3b8cc/msgpack-1.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2929af52106ca73fcb28576218476ffbb531a036c2adbcf54a3664de124303e9", size = 404920, upload-time = "2025-10-08T09:15:08.179Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/41/8543ed2b8604f7c0d89ce066f42007faac1eaa7d79a81555f206a5cdb889/msgpack-1.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:be52a8fc79e45b0364210eef5234a7cf8d330836d0a64dfbb878efa903d84620", size = 415013, upload-time = "2025-10-08T09:15:09.83Z" },
+    { url = "https://files.pythonhosted.org/packages/41/0d/2ddfaa8b7e1cee6c490d46cb0a39742b19e2481600a7a0e96537e9c22f43/msgpack-1.1.2-cp312-cp312-win32.whl", hash = "sha256:1fff3d825d7859ac888b0fbda39a42d59193543920eda9d9bea44d958a878029", size = 65096, upload-time = "2025-10-08T09:15:11.11Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/ec/d431eb7941fb55a31dd6ca3404d41fbb52d99172df2e7707754488390910/msgpack-1.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1de460f0403172cff81169a30b9a92b260cb809c4cb7e2fc79ae8d0510c78b6b", size = 72708, upload-time = "2025-10-08T09:15:12.554Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/31/5b1a1f70eb0e87d1678e9624908f86317787b536060641d6798e3cf70ace/msgpack-1.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:be5980f3ee0e6bd44f3a9e9dea01054f175b50c3e6cdb692bc9424c0bbb8bf69", size = 64119, upload-time = "2025-10-08T09:15:13.589Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/31/b46518ecc604d7edf3a4f94cb3bf021fc62aa301f0cb849936968164ef23/msgpack-1.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4efd7b5979ccb539c221a4c4e16aac1a533efc97f3b759bb5a5ac9f6d10383bf", size = 81212, upload-time = "2025-10-08T09:15:14.552Z" },
+    { url = "https://files.pythonhosted.org/packages/92/dc/c385f38f2c2433333345a82926c6bfa5ecfff3ef787201614317b58dd8be/msgpack-1.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:42eefe2c3e2af97ed470eec850facbe1b5ad1d6eacdbadc42ec98e7dcf68b4b7", size = 84315, upload-time = "2025-10-08T09:15:15.543Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/68/93180dce57f684a61a88a45ed13047558ded2be46f03acb8dec6d7c513af/msgpack-1.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1fdf7d83102bf09e7ce3357de96c59b627395352a4024f6e2458501f158bf999", size = 412721, upload-time = "2025-10-08T09:15:16.567Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ba/459f18c16f2b3fc1a1ca871f72f07d70c07bf768ad0a507a698b8052ac58/msgpack-1.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fac4be746328f90caa3cd4bc67e6fe36ca2bf61d5c6eb6d895b6527e3f05071e", size = 424657, upload-time = "2025-10-08T09:15:17.825Z" },
+    { url = "https://files.pythonhosted.org/packages/38/f8/4398c46863b093252fe67368b44edc6c13b17f4e6b0e4929dbf0bdb13f23/msgpack-1.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:fffee09044073e69f2bad787071aeec727183e7580443dfeb8556cbf1978d162", size = 402668, upload-time = "2025-10-08T09:15:19.003Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ce/698c1eff75626e4124b4d78e21cca0b4cc90043afb80a507626ea354ab52/msgpack-1.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5928604de9b032bc17f5099496417f113c45bc6bc21b5c6920caf34b3c428794", size = 419040, upload-time = "2025-10-08T09:15:20.183Z" },
+    { url = "https://files.pythonhosted.org/packages/67/32/f3cd1667028424fa7001d82e10ee35386eea1408b93d399b09fb0aa7875f/msgpack-1.1.2-cp313-cp313-win32.whl", hash = "sha256:a7787d353595c7c7e145e2331abf8b7ff1e6673a6b974ded96e6d4ec09f00c8c", size = 65037, upload-time = "2025-10-08T09:15:21.416Z" },
+    { url = "https://files.pythonhosted.org/packages/74/07/1ed8277f8653c40ebc65985180b007879f6a836c525b3885dcc6448ae6cb/msgpack-1.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:a465f0dceb8e13a487e54c07d04ae3ba131c7c5b95e2612596eafde1dccf64a9", size = 72631, upload-time = "2025-10-08T09:15:22.431Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/db/0314e4e2db56ebcf450f277904ffd84a7988b9e5da8d0d61ab2d057df2b6/msgpack-1.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:e69b39f8c0aa5ec24b57737ebee40be647035158f14ed4b40e6f150077e21a84", size = 64118, upload-time = "2025-10-08T09:15:23.402Z" },
+    { url = "https://files.pythonhosted.org/packages/22/71/201105712d0a2ff07b7873ed3c220292fb2ea5120603c00c4b634bcdafb3/msgpack-1.1.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e23ce8d5f7aa6ea6d2a2b326b4ba46c985dbb204523759984430db7114f8aa00", size = 81127, upload-time = "2025-10-08T09:15:24.408Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/9f/38ff9e57a2eade7bf9dfee5eae17f39fc0e998658050279cbb14d97d36d9/msgpack-1.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6c15b7d74c939ebe620dd8e559384be806204d73b4f9356320632d783d1f7939", size = 84981, upload-time = "2025-10-08T09:15:25.812Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a9/3536e385167b88c2cc8f4424c49e28d49a6fc35206d4a8060f136e71f94c/msgpack-1.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:99e2cb7b9031568a2a5c73aa077180f93dd2e95b4f8d3b8e14a73ae94a9e667e", size = 411885, upload-time = "2025-10-08T09:15:27.22Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/40/dc34d1a8d5f1e51fc64640b62b191684da52ca469da9cd74e84936ffa4a6/msgpack-1.1.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:180759d89a057eab503cf62eeec0aa61c4ea1200dee709f3a8e9397dbb3b6931", size = 419658, upload-time = "2025-10-08T09:15:28.4Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ef/2b92e286366500a09a67e03496ee8b8ba00562797a52f3c117aa2b29514b/msgpack-1.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:04fb995247a6e83830b62f0b07bf36540c213f6eac8e851166d8d86d83cbd014", size = 403290, upload-time = "2025-10-08T09:15:29.764Z" },
+    { url = "https://files.pythonhosted.org/packages/78/90/e0ea7990abea5764e4655b8177aa7c63cdfa89945b6e7641055800f6c16b/msgpack-1.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8e22ab046fa7ede9e36eeb4cfad44d46450f37bb05d5ec482b02868f451c95e2", size = 415234, upload-time = "2025-10-08T09:15:31.022Z" },
+    { url = "https://files.pythonhosted.org/packages/72/4e/9390aed5db983a2310818cd7d3ec0aecad45e1f7007e0cda79c79507bb0d/msgpack-1.1.2-cp314-cp314-win32.whl", hash = "sha256:80a0ff7d4abf5fecb995fcf235d4064b9a9a8a40a3ab80999e6ac1e30b702717", size = 66391, upload-time = "2025-10-08T09:15:32.265Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f1/abd09c2ae91228c5f3998dbd7f41353def9eac64253de3c8105efa2082f7/msgpack-1.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:9ade919fac6a3e7260b7f64cea89df6bec59104987cbea34d34a2fa15d74310b", size = 73787, upload-time = "2025-10-08T09:15:33.219Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/b0/9d9f667ab48b16ad4115c1935d94023b82b3198064cb84a123e97f7466c1/msgpack-1.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:59415c6076b1e30e563eb732e23b994a61c159cec44deaf584e5cc1dd662f2af", size = 66453, upload-time = "2025-10-08T09:15:34.225Z" },
+    { url = "https://files.pythonhosted.org/packages/16/67/93f80545eb1792b61a217fa7f06d5e5cb9e0055bed867f43e2b8e012e137/msgpack-1.1.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:897c478140877e5307760b0ea66e0932738879e7aa68144d9b78ea4c8302a84a", size = 85264, upload-time = "2025-10-08T09:15:35.61Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/33c8a24959cf193966ef11a6f6a2995a65eb066bd681fd085afd519a57ce/msgpack-1.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a668204fa43e6d02f89dbe79a30b0d67238d9ec4c5bd8a940fc3a004a47b721b", size = 89076, upload-time = "2025-10-08T09:15:36.619Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/6b/62e85ff7193663fbea5c0254ef32f0c77134b4059f8da89b958beb7696f3/msgpack-1.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5559d03930d3aa0f3aacb4c42c776af1a2ace2611871c84a75afe436695e6245", size = 435242, upload-time = "2025-10-08T09:15:37.647Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/47/5c74ecb4cc277cf09f64e913947871682ffa82b3b93c8dad68083112f412/msgpack-1.1.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70c5a7a9fea7f036b716191c29047374c10721c389c21e9ffafad04df8c52c90", size = 432509, upload-time = "2025-10-08T09:15:38.794Z" },
+    { url = "https://files.pythonhosted.org/packages/24/a4/e98ccdb56dc4e98c929a3f150de1799831c0a800583cde9fa022fa90602d/msgpack-1.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f2cb069d8b981abc72b41aea1c580ce92d57c673ec61af4c500153a626cb9e20", size = 415957, upload-time = "2025-10-08T09:15:40.238Z" },
+    { url = "https://files.pythonhosted.org/packages/da/28/6951f7fb67bc0a4e184a6b38ab71a92d9ba58080b27a77d3e2fb0be5998f/msgpack-1.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d62ce1f483f355f61adb5433ebfd8868c5f078d1a52d042b0a998682b4fa8c27", size = 422910, upload-time = "2025-10-08T09:15:41.505Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/03/42106dcded51f0a0b5284d3ce30a671e7bd3f7318d122b2ead66ad289fed/msgpack-1.1.2-cp314-cp314t-win32.whl", hash = "sha256:1d1418482b1ee984625d88aa9585db570180c286d942da463533b238b98b812b", size = 75197, upload-time = "2025-10-08T09:15:42.954Z" },
+    { url = "https://files.pythonhosted.org/packages/15/86/d0071e94987f8db59d4eeb386ddc64d0bb9b10820a8d82bcd3e53eeb2da6/msgpack-1.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:5a46bf7e831d09470ad92dff02b8b1ac92175ca36b087f904a0519857c6be3ff", size = 85772, upload-time = "2025-10-08T09:15:43.954Z" },
+    { url = "https://files.pythonhosted.org/packages/81/f2/08ace4142eb281c12701fc3b93a10795e4d4dc7f753911d836675050f886/msgpack-1.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d99ef64f349d5ec3293688e91486c5fdb925ed03807f64d98d205d2713c60b46", size = 70868, upload-time = "2025-10-08T09:15:44.959Z" },
 ]
 
 [[package]]
@@ -763,6 +873,15 @@ wheels = [
 ]
 
 [[package]]
+name = "packageurl-python"
+version = "0.17.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/d6/3b5a4e3cfaef7a53869a26ceb034d1ff5e5c27c814ce77260a96d50ab7bb/packageurl_python-0.17.6.tar.gz", hash = "sha256:1252ce3a102372ca6f86eb968e16f9014c4ba511c5c37d95a7f023e2ca6e5c25", size = 50618, upload-time = "2025-11-24T15:20:17.998Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/2f/c7277b7615a93f51b5fbc1eacfc1b75e8103370e786fd8ce2abf6e5c04ab/packageurl_python-0.17.6-py3-none-any.whl", hash = "sha256:31a85c2717bc41dd818f3c62908685ff9eebcb68588213745b14a6ee9e7df7c9", size = 36776, upload-time = "2025-11-24T15:20:16.962Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -818,6 +937,61 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/cb/ce22a7618624f41fab0a9d79d178b4e6584c31d529aca9df9b1bf5f8d11d/pglast-7.11-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7f3a84ad6f7dacdadb679354a685f0af1f201f4e68384e730542efa350d2fb4f", size = 6035975, upload-time = "2025-12-15T10:14:36.4Z" },
     { url = "https://files.pythonhosted.org/packages/e5/16/73458b71d8b58de83d040dd5607bc6437aee44fec3bd75b165f75b80c794/pglast-7.11-cp314-cp314t-win32.whl", hash = "sha256:60aeb1f39a4f1f586a1cb17bfa4df393ad110a5765643ae3be62f57fff32bf2c", size = 1346069, upload-time = "2025-12-15T10:14:37.799Z" },
     { url = "https://files.pythonhosted.org/packages/f6/d7/ddf8b9545905dd3daa8e4366d569a87ea4ea1596c5eda7306fab826844dd/pglast-7.11-cp314-cp314t-win_amd64.whl", hash = "sha256:4cca2ac4b8bd794ca3b4398167020abc0fbcdd1ef8f17aef6ade6f9272e70bf1", size = 1436680, upload-time = "2025-12-15T10:14:39.252Z" },
+]
+
+[[package]]
+name = "pip"
+version = "26.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/48/cb9b7a682f6fe01a4221e1728941dd4ac3cd9090a17db3779d6ff490b602/pip-26.1.1.tar.gz", hash = "sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78", size = 1840400, upload-time = "2026-05-04T19:02:21.248Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/eb/fea4d1d51c49832120f7f285d07306db3960f423a2612c6057caf3e8196f/pip-26.1.1-py3-none-any.whl", hash = "sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb", size = 1812777, upload-time = "2026-05-04T19:02:18.9Z" },
+]
+
+[[package]]
+name = "pip-api"
+version = "0.0.34"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pip" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/f1/ee85f8c7e82bccf90a3c7aad22863cc6e20057860a1361083cd2adacb92e/pip_api-0.0.34.tar.gz", hash = "sha256:9b75e958f14c5a2614bae415f2adf7eeb54d50a2cfbe7e24fd4826471bac3625", size = 123017, upload-time = "2024-07-09T20:32:30.641Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/f7/ebf5003e1065fd00b4cbef53bf0a65c3d3e1b599b676d5383ccb7a8b88ba/pip_api-0.0.34-py3-none-any.whl", hash = "sha256:8b2d7d7c37f2447373aa2cf8b1f60a2f2b27a84e1e9e0294a3f6ef10eb3ba6bb", size = 120369, upload-time = "2024-07-09T20:32:29.099Z" },
+]
+
+[[package]]
+name = "pip-audit"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachecontrol", extra = ["filecache"] },
+    { name = "cyclonedx-python-lib" },
+    { name = "packaging" },
+    { name = "pip-api" },
+    { name = "pip-requirements-parser" },
+    { name = "platformdirs" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "tomli" },
+    { name = "tomli-w" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/89/0e999b413facab81c33d118f3ac3739fd02c0622ccf7c4e82e37cebd8447/pip_audit-2.10.0.tar.gz", hash = "sha256:427ea5bf61d1d06b98b1ae29b7feacc00288a2eced52c9c58ceed5253ef6c2a4", size = 53776, upload-time = "2025-12-01T23:42:40.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/f3/4888f895c02afa085630a3a3329d1b18b998874642ad4c530e9a4d7851fe/pip_audit-2.10.0-py3-none-any.whl", hash = "sha256:16e02093872fac97580303f0848fa3ad64f7ecf600736ea7835a2b24de49613f", size = 61518, upload-time = "2025-12-01T23:42:39.193Z" },
+]
+
+[[package]]
+name = "pip-requirements-parser"
+version = "32.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/2a/63b574101850e7f7b306ddbdb02cb294380d37948140eecd468fae392b54/pip-requirements-parser-32.0.1.tar.gz", hash = "sha256:b4fa3a7a0be38243123cf9d1f3518da10c51bdb165a2b2985566247f9155a7d3", size = 209359, upload-time = "2022-12-21T15:25:22.732Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/d0/d04f1d1e064ac901439699ee097f58688caadea42498ec9c4b4ad2ef84ab/pip_requirements_parser-32.0.1-py3-none-any.whl", hash = "sha256:4659bc2a667783e7a15d190f6fccf8b2486685b6dba4c19c3876314769c57526", size = 35648, upload-time = "2022-12-21T15:25:21.046Z" },
 ]
 
 [[package]]
@@ -922,6 +1096,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/82/7a23d26039827ecd4ebe93905651029ddd307c5182ad59296dfb6f67b528/psycopg_pool-3.3.1.tar.gz", hash = "sha256:b10b10b7a175d5cc1592147dc5b7eec8a9e0834eb3ed2c4a92c858e2f51eb63c", size = 31661, upload-time = "2026-05-01T23:31:59.809Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/37/ed/89c2c620af0e1660354cd8aabf9f5b21f911597ce22acb37c805d6c86bc8/psycopg_pool-3.3.1-py3-none-any.whl", hash = "sha256:2af5b432941c4c9ad5c87b3fa410aec910ec8f7c122855897983a06c45f2e4b5", size = 40023, upload-time = "2026-05-01T23:31:53.136Z" },
+]
+
+[[package]]
+name = "py-serializable"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "defusedxml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/21/d250cfca8ff30c2e5a7447bc13861541126ce9bd4426cd5d0c9f08b5547d/py_serializable-2.1.0.tar.gz", hash = "sha256:9d5db56154a867a9b897c0163b33a793c804c80cee984116d02d49e4578fc103", size = 52368, upload-time = "2025-07-21T09:56:48.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/bf/7595e817906a29453ba4d99394e781b6fabe55d21f3c15d240f85dd06bb1/py_serializable-2.1.0-py3-none-any.whl", hash = "sha256:b56d5d686b5a03ba4f4db5e769dc32336e142fc3bd4d68a8c25579ebb0a67304", size = 23045, upload-time = "2025-07-21T09:56:46.848Z" },
 ]
 
 [[package]]
@@ -1058,6 +1244,15 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
 ]
 
 [[package]]
@@ -1383,6 +1578,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
 name = "sse-starlette"
 version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1415,6 +1619,60 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e9/88/35e4d27d9177d7df76d060e0a18f69c6c5794c96960c94042e20a12c8ba2/stevedore-5.8.0.tar.gz", hash = "sha256:b49867b32ca3016e94100e68dbf26e72aa7b8708d0a3f73c08aeb220370ac715", size = 514710, upload-time = "2026-05-18T09:15:27.731Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f5/ac/19f9941c74add59d17694930ec8105d5eddeee4ce56dd8632b765ca16d6c/stevedore-5.8.0-py3-none-any.whl", hash = "sha256:88eede9e66ca80e34085b9174e2327da2c61ac91f24f70e41c3ad76e4bb4872b", size = 54553, upload-time = "2026-05-18T09:15:25.82Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Three security-hardening landings + the vulnerability-reporting policy
and a living hardening roadmap.

* **PG TLS enforcement.** `load_settings` refuses to start when
  `MCPG_DATABASE_URL` or any `MCPG_REPLICA_URLS` entry points at a
  non-loopback host with sslmode `disable` / `allow` / `prefer` (or
  unset — libpq's default falls back to plaintext). Bypass via
  `MCPG_ALLOW_INSECURE_TLS=true`; loopback hosts are exempt.

* **Audit-argument redaction upgraded to regex.** `mcpg.audit` and
  `mcpg.audit_trail` now share a case-insensitive regex matched via
  `re.search`, so `password` also masks `PGPASSWORD` /
  `user_password`. Default pattern set covers password / passwd /
  secret / token / api[_-]?key / bearer / authorization /
  database_url / dsn / conninfo. Operators extend via
  `MCPG_AUDIT_REDACT_KEYS` (comma-separated regex fragments).
  `redact_arguments` now walks nested dicts / lists / tuples.

* **pip-audit fix in CI.** The existing `security` job invoked
  `uv audit` — a subcommand `uv` does not provide — so dep-audit
  has been a silent no-op. Replaced with `pip-audit --strict` over
  `uv export`-resolved runtime deps. Bandit SAST step unchanged.
  Adds `pip-audit>=2.7` to dev deps.

* **Pre-commit bandit hook fix.** The local hook was running bandit
  without the skip flags configured in pyproject.toml's
  `[tool.bandit]` (bandit doesn't auto-discover them), so it flagged
  every pre-existing B101/B608/B110 site and was unusable. Brought
  in line with the CI invocation.

* `SECURITY.md` policy doc (reporting flow, scope, 90-day window).
  `docs/security-hardening.md` living roadmap with ✅ / 🟡 / ⬜
  status, covering what's on `main` plus the queued items.

## Summary by Sourcery

Enforce secure PostgreSQL TLS configuration by default, strengthen audit-log redaction, harden supply-chain and static-analysis checks in CI, and document the project’s security posture and vulnerability-reporting process.

New Features:
- Add configurable PG TLS enforcement that blocks non-loopback database and replica URLs using insecure or unset sslmode unless explicitly overridden.
- Introduce regex-based, recursively applied audit redaction that masks a broader set of credential-like argument keys and supports operator extensions via MCPG_AUDIT_REDACT_KEYS.

Bug Fixes:
- Fix the CI dependency-audit step so it runs a real vulnerability scan using pip-audit instead of a no-op uv audit invocation.
- Align the pre-commit Bandit hook with CI flags so local runs respect configured skip rules and avoid spurious findings.

Enhancements:
- Surface the allow_insecure_tls flag in runtime settings and repr to make TLS posture observable.
- Share a single credential-key matcher between in-memory audit logging and the persisted audit trail to keep redaction behaviour consistent.

Build:
- Add pip-audit to development dependencies to support the CI vulnerability scan.

CI:
- Update the security workflow to export locked runtime dependencies with uv and scan them using pip-audit in strict mode.
- Adjust the Bandit SAST step in CI to match the updated pre-commit configuration.

Documentation:
- Add SECURITY.md describing supported versions, security-reporting contacts, scope, and disclosure timelines.
- Add docs/security-hardening.md as a living roadmap of shipped and planned security-hardening measures, including the new TLS and audit-redaction controls.

Tests:
- Extend configuration tests to cover PG TLS enforcement semantics, loopback exemptions, and the allow_insecure_tls escape hatch.
- Add dedicated tests for audit redaction to verify default patterns, regex-based key matching, recursive traversal, and integration with load_settings.

Chores:
- Update the changelog with the new security features, CI hardening, and documentation additions.