### PR TITLE
release: wire MCPg up to publish to PyPI on tag push (v0.5.1)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,10 +25,16 @@ jobs:
       - name: Sanity check — tag matches pyproject version
         # Tag is the source of truth for the release; pyproject must
         # already be bumped to match. Refusing here prevents the very
-        # common "tagged v0.5.1 but forgot to bump" footgun.
+        # common "tagged v0.5.1 but forgot to bump" footgun. Read the
+        # field through ``tomllib`` so a stray ``version =`` line in
+        # another table (or quote/spacing reshuffles) can't fool us.
         run: |
           TAG_VERSION="${GITHUB_REF_NAME#v}"
-          PYPROJECT_VERSION="$(grep -E '^version = ' pyproject.toml | head -1 | sed -E 's/version = "(.*)"/\1/')"
+          PYPROJECT_VERSION="$(python -c 'import tomllib, pathlib; print(tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"])')"
+          if [ -z "$PYPROJECT_VERSION" ]; then
+            echo "::error::Could not read project.version from pyproject.toml"
+            exit 1
+          fi
           if [ "$TAG_VERSION" != "$PYPROJECT_VERSION" ]; then
             echo "::error::Tag $GITHUB_REF_NAME (=$TAG_VERSION) does not match pyproject.toml version $PYPROJECT_VERSION"
             exit 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,155 @@
+name: Publish
+
+on:
+  push:
+    tags: ["v*.*.*"]
+
+# OIDC token exchange with PyPI Trusted Publishing. ``id-token: write``
+# is the privilege the action trades for a one-time PyPI upload
+# credential; ``contents: read`` is the source checkout.
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build:
+    name: Build sdist + wheel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+          enable-cache: true
+      - run: uv sync --frozen
+      - name: Sanity check — tag matches pyproject version
+        # Tag is the source of truth for the release; pyproject must
+        # already be bumped to match. Refusing here prevents the very
+        # common "tagged v0.5.1 but forgot to bump" footgun.
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PYPROJECT_VERSION="$(grep -E '^version = ' pyproject.toml | head -1 | sed -E 's/version = "(.*)"/\1/')"
+          if [ "$TAG_VERSION" != "$PYPROJECT_VERSION" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME (=$TAG_VERSION) does not match pyproject.toml version $PYPROJECT_VERSION"
+            exit 1
+          fi
+      - name: Build
+        run: uv run python -m build
+      - name: Inspect rendered metadata
+        run: uv run twine check dist/*
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish-testpypi:
+    name: Publish → TestPyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/project/mcpg/
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  smoke-testpypi:
+    name: Smoke-test TestPyPI install
+    needs: publish-testpypi
+    runs-on: ubuntu-latest
+    steps:
+      # ``uv export`` needs the source tree; the smoke install
+      # itself runs against the published artifact.
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+          enable-cache: true
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install runtime deps from real PyPI (anti-confusion)
+        # TestPyPI is a public sandbox; combining its index with
+        # ``--extra-index-url=pypi`` lets an attacker shadow our
+        # deps with a higher-numbered fake (dependency confusion).
+        # Step 1 pins real PyPI only, dep list canonically derived
+        # from pyproject.toml.
+        run: |
+          uv export --no-dev --no-emit-project --no-hashes \
+            --format requirements-txt > /tmp/mcpg-deps.txt
+          python -m pip install -r /tmp/mcpg-deps.txt
+      - name: Wait for TestPyPI to index the upload
+        # Trusted Publishing returns 200 the moment the file lands,
+        # but the simple index is eventually consistent (~30s typical).
+        run: |
+          VER="${GITHUB_REF_NAME#v}"
+          for i in $(seq 1 12); do
+            if curl -fsSL "https://test.pypi.org/pypi/mcpg/${VER}/json" >/dev/null 2>&1; then
+              echo "TestPyPI sees mcpg==${VER}"
+              exit 0
+            fi
+            echo "TestPyPI not ready (attempt $i/12)..."
+            sleep 10
+          done
+          echo "::error::TestPyPI never reported mcpg==${VER}"
+          exit 1
+      - name: Install mcpg from TestPyPI (no deps)
+        run: |
+          VER="${GITHUB_REF_NAME#v}"
+          python -m pip install --no-deps \
+            --index-url https://test.pypi.org/simple/ \
+            "mcpg==${VER}"
+      - name: Import + CLI smoke
+        run: |
+          python -c "import mcpg; print(mcpg.__version__)"
+          mcpg --version
+
+  publish-pypi:
+    name: Publish → PyPI (gated on maintainer approval)
+    needs: smoke-testpypi
+    runs-on: ubuntu-latest
+    # The ``pypi`` environment is configured with a required
+    # reviewer (the maintainer). The workflow pauses on this job
+    # until that approval click lands; that's the last chance to
+    # cancel a bad release after TestPyPI smoke passed.
+    environment:
+      name: pypi
+      url: https://pypi.org/project/mcpg/
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: Create GitHub Release
+    needs: publish-pypi
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Cut release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VER="${GITHUB_REF_NAME#v}"
+          # Pull the matching section out of CHANGELOG.md as the
+          # release body. Falls back to a stub if the section is
+          # missing so the release still ships — the maintainer can
+          # edit the body afterwards on the GitHub side.
+          awk "/^## \[${VER}\]/,/^## \[/" CHANGELOG.md | sed '$d' > /tmp/notes.md
+          [ -s /tmp/notes.md ] || echo "See CHANGELOG.md" > /tmp/notes.md
+          gh release create "$GITHUB_REF_NAME" dist/* \
+            --title "MCPg ${GITHUB_REF_NAME}" \
+            --notes-file /tmp/notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,61 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-05-29
+
+Inaugural PyPI release. Three landings since 0.5.0: security
+hardening, license switch to MIT, and the packaging surface needed
+to publish to PyPI.
+
+### Added
+
+- **`mcpg --version` (`mcpg -V`) flag.** Prints `mcpg <version>` so
+  bug reporters can paste the line `SECURITY.md` asks for. Backed
+  by `mcpg.__version__`.
+
+- **PyPI publishing pipeline.** New `.github/workflows/publish.yml`
+  triggers on `v*.*.*` tag pushes and runs: build → twine check →
+  TestPyPI upload → install-smoke against the published TestPyPI
+  artifact (deps resolved from real PyPI first, then `mcpg` with
+  `--no-deps` from TestPyPI — closes a dependency-confusion vector)
+  → reviewer-gated PyPI upload via Trusted Publishing OIDC → cut a
+  GitHub Release with notes pulled from `CHANGELOG.md`. The full
+  playbook lives at `docs/release-process.md`.
+
+- **`pyproject.toml` packaging metadata.** Adds `authors`,
+  `maintainers`, `keywords`, `classifiers`, `[project.urls]`
+  (Homepage / Documentation / Repository / Issues / Changelog /
+  Release notes / Security), and `[tool.hatch.build.targets.sdist]`
+  to keep the sdist tight. Adds `build>=1.2` + `twine>=5.1` to the
+  `dev` dep group.
+
+- **"Install from PyPI" section in `docs/installation.md`.**
+  Covers both `pip install mcpg` and `uv tool install mcpg`.
+
 ### Security
+
+- **PG TLS enforcement at startup.** `load_settings` now refuses to
+  start when `MCPG_DATABASE_URL` (or any entry in
+  `MCPG_REPLICA_URLS`) points at a non-loopback host with an
+  `sslmode` of `disable` / `allow` / `prefer` (or no `sslmode` set —
+  libpq's default falls back to plaintext). Uses
+  `psycopg.conninfo.conninfo_to_dict` so the check covers both URI
+  DSNs and keyword/value DSNs (e.g. `host=db sslmode=disable`) plus
+  failover multi-host URIs (e.g. `postgresql://h1,h2/db`); the
+  earlier `urllib.parse`-based path silently bypassed the check on
+  both shapes. DSNs with no explicit host are refused too — libpq
+  can resolve `PGHOST` to a non-loopback default. Bypassed with the
+  explicit opt-out `MCPG_ALLOW_INSECURE_TLS=true`. Loopback hosts
+  (`localhost`, `127.0.0.1`, `::1`) are exempt. Replica errors
+  identify the offending index (`MCPG_REPLICA_URLS[1]`) for
+  diagnostics.
+
+  > **Upgrade note.** This is a default-tightening change. Any
+  > deployment already configured with a remote DSN whose `sslmode`
+  > is `disable` / `allow` / `prefer` (or unset) will fail to
+  > start after upgrade. Either set `sslmode=require` (or
+  > `verify-ca` / `verify-full`) in the DSN — strongly recommended —
+  > or opt out with `MCPG_ALLOW_INSECURE_TLS=true`.
 
 - **PG TLS enforcement at startup.** `load_settings` now refuses to
   start when `MCPG_DATABASE_URL` (or any entry in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,22 +80,6 @@ to publish to PyPI.
   > `verify-ca` / `verify-full`) in the DSN — strongly recommended —
   > or opt out with `MCPG_ALLOW_INSECURE_TLS=true`.
 
-- **PG TLS enforcement at startup.** `load_settings` now refuses to
-  start when `MCPG_DATABASE_URL` (or any entry in
-  `MCPG_REPLICA_URLS`) points at a non-loopback host with an
-  `sslmode` of `disable` / `allow` / `prefer` (or no `sslmode` set —
-  libpq's default falls back to plaintext). Uses
-  `psycopg.conninfo.conninfo_to_dict` so the check covers both URI
-  DSNs and keyword/value DSNs (e.g. `host=db sslmode=disable`) plus
-  failover multi-host URIs (e.g. `postgresql://h1,h2/db`); the
-  earlier `urllib.parse`-based path silently bypassed the check on
-  both shapes. DSNs with no explicit host are refused too — libpq
-  can resolve `PGHOST` to a non-loopback default. Bypassed with the
-  explicit opt-out `MCPG_ALLOW_INSECURE_TLS=true`. Loopback hosts
-  (`localhost`, `127.0.0.1`, `::1`) are exempt. Replica errors
-  identify the offending index (`MCPG_REPLICA_URLS[1]`) for
-  diagnostics.
-
 - **Tool-argument audit redaction upgraded to regex pattern match.**
   `mcpg.audit.redact_arguments` and the persisted audit-trail
   walker (`mcpg.audit_trail._redact`) now share a case-insensitive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,24 @@ to publish to PyPI.
 - **"Install from PyPI" section in `docs/installation.md`.**
   Covers both `pip install mcpg` and `uv tool install mcpg`.
 
+- **Per-session `statement_timeout` / `lock_timeout`** (PR #32).
+  Every checked-out pool connection has
+  `statement_timeout=MCPG_STATEMENT_TIMEOUT_MS` (default 30000) and
+  `lock_timeout=MCPG_LOCK_TIMEOUT_MS` (default 5000) applied once
+  per connection via a single batched `SET` — runaway queries and
+  hanging lock waits self-terminate without operator intervention.
+  Applies to the primary pool and every replica pool.
+
+### Changed
+
+- **Hardened multi-stage Docker image** (PR #32). New runtime stage
+  drops the build toolchain entirely; runs as a non-root user
+  (`uid=10001 / gid=10001`) with a `nologin` shell. Application
+  files stay owned by root and read-only to the `mcpg` user so a
+  remote-code-execution bug can't modify the application on disk
+  to persist. Entrypoint switches from `uv run` to `python -m mcpg`
+  for a smaller process tree.
+
 ### Security
 
 - **PG TLS enforcement at startup.** `load_settings` now refuses to

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,10 +6,30 @@ document — it is updated as installation and configuration options change.
 ## Prerequisites
 
 - **Python 3.12 or newer**.
-- **PostgreSQL 14–17** reachable from where MCPg runs. (Older versions may
+- **PostgreSQL 14–18** reachable from where MCPg runs. (Older versions may
   work but are not tested.)
 - **[uv](https://docs.astral.sh/uv/)** for installing from source.
 - Optionally **Docker**, to run MCPg as a container.
+
+## Install from PyPI (recommended)
+
+```bash
+pip install mcpg
+# or, if you prefer uv:
+uv tool install mcpg
+```
+
+`pip install mcpg` puts the `mcpg` console script on your PATH and pulls
+the runtime deps (`mcp[cli]`, `psycopg[binary]`, `psycopg-pool`, `pglast`,
+`httpx`, `pyjwt[crypto]`). Verify with:
+
+```bash
+mcpg --version
+```
+
+`uv tool install mcpg` is the equivalent for the `uv` toolchain — it
+isolates MCPg in its own venv and exposes the `mcpg` script globally,
+without affecting other Python projects on the same machine.
 
 ## Install from source
 
@@ -20,7 +40,8 @@ uv sync
 ```
 
 `uv sync` creates a virtual environment and installs MCPg with the `mcpg`
-console script. A PyPI package is planned for a future release.
+console script. Pick this path if you want to follow `main`, run the test
+suite, or develop against the codebase.
 
 ## Install with Docker
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,48 @@
 [project]
 name = "mcpg"
-version = "0.5.0"
+version = "0.5.1"
 description = "A production-grade PostgreSQL Model Context Protocol (MCP) server."
 readme = "README.md"
 requires-python = ">=3.12"
 license = "MIT"
 license-files = ["LICENSE", "src/mcpg/_vendor/LICENSE"]
+authors = [
+    {name = "Devopam Mittra", email = "devopam@gmail.com"},
+]
+maintainers = [
+    {name = "Devopam Mittra", email = "devopam@gmail.com"},
+]
+keywords = [
+    "postgresql",
+    "postgres",
+    "mcp",
+    "model-context-protocol",
+    "ai-agents",
+    "llm-tools",
+    "database",
+    "claude",
+    "anthropic",
+    "dba",
+    "sql",
+    "rag",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: SQL",
+    "Topic :: Database",
+    "Topic :: Database :: Database Engines/Servers",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: System :: Systems Administration",
+    "Typing :: Typed",
+]
 
 dependencies = [
     "mcp[cli]>=1.25.0",
@@ -21,6 +58,18 @@ dependencies = [
     "pyjwt[crypto]>=2.8",
 ]
 
+# Powers the "Project links" sidebar on https://pypi.org/project/mcpg/.
+# Order is preserved on the page; first entry doubles as the page header
+# "Homepage" link.
+[project.urls]
+Homepage = "https://github.com/devopam/MCPg"
+Documentation = "https://github.com/devopam/MCPg#documentation"
+Repository = "https://github.com/devopam/MCPg"
+Issues = "https://github.com/devopam/MCPg/issues"
+Changelog = "https://github.com/devopam/MCPg/blob/main/CHANGELOG.md"
+"Release notes" = "https://github.com/devopam/MCPg/releases"
+Security = "https://github.com/devopam/MCPg/blob/main/SECURITY.md"
+
 [project.scripts]
 mcpg = "mcpg.__main__:main"
 
@@ -30,6 +79,20 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/mcpg"]
+
+# Keep the sdist tight — ship the source tree + the prose a user
+# actually wants when they unpack from PyPI, and leave dev-only
+# noise (tests / CI / IDE / VCS cruft) on GitHub.
+[tool.hatch.build.targets.sdist]
+include = [
+    "src/mcpg",
+    "README.md",
+    "LICENSE",
+    "NOTICE",
+    "CHANGELOG.md",
+    "SECURITY.md",
+    "pyproject.toml",
+]
 
 [dependency-groups]
 dev = [
@@ -42,6 +105,10 @@ dev = [
     "pre-commit>=4.0.0",
     "bandit>=1.7.8",
     "pip-audit>=2.7",
+    # PyPI packaging toolchain — build the sdist/wheel, lint the
+    # rendered metadata, push to PyPI in the publish workflow.
+    "build>=1.2",
+    "twine>=5.1",
 ]
 
 [tool.pytest.ini_options]

--- a/src/mcpg/__init__.py
+++ b/src/mcpg/__init__.py
@@ -1,3 +1,3 @@
 """MCPg — a PostgreSQL Model Context Protocol server."""
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/src/mcpg/__main__.py
+++ b/src/mcpg/__main__.py
@@ -8,6 +8,7 @@ import sys
 if sys.platform == "win32":
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
+from mcpg import __version__
 from mcpg.config import ConfigError, load_settings
 from mcpg.server import run
 
@@ -18,6 +19,11 @@ def main() -> int:
     Returns:
         A process exit code: 0 on clean shutdown, 1 on a configuration error.
     """
+    # SECURITY.md asks bug reporters to include ``mcpg --version`` in
+    # their report; this is the surface that gives them an answer.
+    if len(sys.argv) > 1 and sys.argv[1] in {"--version", "-V"}:
+        print(f"mcpg {__version__}")
+        return 0
     try:
         settings = load_settings()
     except ConfigError as exc:

--- a/uv.lock
+++ b/uv.lock
@@ -111,6 +111,20 @@ wheels = [
 ]
 
 [[package]]
+name = "build"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "os_name == 'nt'" },
+    { name = "packaging" },
+    { name = "pyproject-hooks" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/e0/df5e171f685f82f37b12e1f208064e24244911079d7b767447d1af7e0d70/build-1.5.0.tar.gz", hash = "sha256:302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647", size = 89796, upload-time = "2026-04-30T03:18:25.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl", hash = "sha256:13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f", size = 26018, upload-time = "2026-04-30T03:18:23.644Z" },
+]
+
+[[package]]
 name = "cachecontrol"
 version = "0.14.4"
 source = { registry = "https://pypi.org/simple" }
@@ -483,6 +497,15 @@ wheels = [
 ]
 
 [[package]]
+name = "docutils"
+version = "0.23"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/a4/5180d9afc57e8fca05601dd652bdff19604c218814037fe90ffc7625a50a/docutils-0.23.tar.gz", hash = "sha256:746f5060322511280a1e50eb76846ed6bf2342984b2ac04dc42caa1a8d78799e", size = 2303823, upload-time = "2026-05-27T17:41:06.934Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/91/30151a39f7570f448ed84529390628a651d7f27c87d73c9b887f8189695e/docutils-0.23-py3-none-any.whl", hash = "sha256:25d013af9bf23bc1c7b2b093dff4208166c53a94786c9e447808335ef1185fea", size = 634701, upload-time = "2026-05-27T17:40:58.442Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.29.0"
 source = { registry = "https://pypi.org/simple" }
@@ -538,6 +561,18 @@ wheels = [
 ]
 
 [[package]]
+name = "id"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/04/c2156091427636080787aac190019dc64096e56a23b7364d3c1764ee3a06/id-1.6.1.tar.gz", hash = "sha256:d0732d624fb46fd4e7bc4e5152f00214450953b9e772c182c1c22964def1a069", size = 18088, upload-time = "2026-02-04T16:19:41.26Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/77/de194443bf38daed9452139e960c632b0ef9f9a5dd9ce605fdf18ca9f1b1/id-1.6.1-py3-none-any.whl", hash = "sha256:f5ec41ed2629a508f5d0988eda142e190c9c6da971100612c4de9ad9f9b237ca", size = 14689, upload-time = "2026-02-04T16:19:40.051Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.19"
 source = { registry = "https://pypi.org/simple" }
@@ -565,6 +600,48 @@ wheels = [
 ]
 
 [[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/cf/ea4ef2920830dea3f5ab2ea4da6fb67724e6dca80ee2553788c3607243d0/jaraco_functools-4.5.0.tar.gz", hash = "sha256:3bb5665ea4a020cf78a7040e89154c77edadb3ca74f366479669c5999aa70b03", size = 20272, upload-time = "2026-05-15T21:34:10.025Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/9a/982e48afcffcd727a9144506720ffd4224b6b7e355c98641866f38b7c043/jaraco_functools-4.5.0-py3-none-any.whl", hash = "sha256:79ce39246eddbde4b3a03b77ea5f0f7878dc669b166a66cf3fa8e266aa3fa2f4", size = 10594, upload-time = "2026-05-15T21:34:08.595Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -589,6 +666,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "keyring"
+version = "25.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
 ]
 
 [[package]]
@@ -708,7 +802,7 @@ cli = [
 
 [[package]]
 name = "mcpg"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
@@ -723,6 +817,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "bandit" },
+    { name = "build" },
     { name = "docker" },
     { name = "mypy" },
     { name = "pip-audit" },
@@ -731,6 +826,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "twine" },
 ]
 
 [package.metadata]
@@ -747,6 +843,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "bandit", specifier = ">=1.7.8" },
+    { name = "build", specifier = ">=1.2" },
     { name = "docker", specifier = ">=7.1.0" },
     { name = "mypy", specifier = ">=1.15.0" },
     { name = "pip-audit", specifier = ">=2.7" },
@@ -755,6 +852,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "ruff", specifier = ">=0.14.0" },
+    { name = "twine", specifier = ">=5.1" },
 ]
 
 [[package]]
@@ -764,6 +862,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "11.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/1d/f4da6f02cdffe04d6362210b807146a26044c88d839208aec273bb0d9184/more_itertools-11.1.0.tar.gz", hash = "sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d", size = 145772, upload-time = "2026-05-22T14:14:29.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl", hash = "sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192", size = 72226, upload-time = "2026-05-22T14:14:28.824Z" },
 ]
 
 [[package]]
@@ -861,6 +968,40 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "nh3"
+version = "0.3.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/5f/1d19bdc7d27238e37f3672cdc02cb77c56a4a86d140cd4f4f23c90df6e16/nh3-0.3.5.tar.gz", hash = "sha256:45855e14ff056064fec77133bfcf7cd691838168e5e17bbef075394954dc9dc8", size = 20743, upload-time = "2026-04-25T10:44:16.066Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/b0/8587ac42a9627ab88e7e221601f1dfccbf4db80b2a29222ea63266dc9abc/nh3-0.3.5-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:23a312224875f72cd16bde417f49071451877e29ef646a60e50fcb69407cc18a", size = 1420126, upload-time = "2026-04-25T10:43:39.834Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1b/1dbc4d0c43f12e8c1784ede17eaee6f061d4fbe5505757c65c49b2ceab95/nh3-0.3.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:387abd011e81959d5a35151a11350a0795c6edeb53ebfa02d2e882dc01299263", size = 793943, upload-time = "2026-04-25T10:43:41.363Z" },
+    { url = "https://files.pythonhosted.org/packages/47/9f/d6758d7a14ee964bf439cc35ae4fa24a763a93399c8ef6f22bd11d532d29/nh3-0.3.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:48f45e3e914be93a596431aa143dedf1582557bf41a58153c296048d6e3798c9", size = 841150, upload-time = "2026-04-25T10:43:43.007Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/36/d5d1ae8374612c98f390e1ea7c610fa6c9716259a03bbf4d15b269f40073/nh3-0.3.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0a09f51806fd51b4fedbf9ea2b61fef388f19aef0d62fe51199d41648be14588", size = 1008415, upload-time = "2026-04-25T10:43:44.324Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8f/d13a9c3fd2d9c131a2a281737380e9379eb0f8c33fea24c2b923aaafbb15/nh3-0.3.5-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:c357f1d042c67f135a5e6babb2b0e3b9d9224ff4a3543240f597767b01384ffd", size = 1092706, upload-time = "2026-04-25T10:43:45.653Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/57/2f3add7f8680fcc896afa6a675cb2bab09982853ee8af40bad621f6b61c4/nh3-0.3.5-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:38748140bf76383ab7ce2dce0ad4cb663855d8fbc9098f7f3483673d09616a17", size = 1048346, upload-time = "2026-04-25T10:43:46.974Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/c3/2f9e4ffa82863074d1361bfe949bc46393d91b3411579dfbbd090b24cac5/nh3-0.3.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:84bdeb082544fbcb77a12c034dd77d7da0556fdc0727b787eb6214b958c15e29", size = 1029038, upload-time = "2026-04-25T10:43:48.569Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/10/2804deb3f3315184c9cae41702e293c87524b5a21f766b07d7fe3ffbcfbb/nh3-0.3.5-cp314-cp314t-win32.whl", hash = "sha256:c3aae321f67ae66cff2a627115f106a377d4475d10b0e13d97959a13486b9a88", size = 603263, upload-time = "2026-04-25T10:43:49.851Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a2/f6685248b49f7548fc9a8c335ab3a52f68610b72e8a61576447151e4e2e6/nh3-0.3.5-cp314-cp314t-win_amd64.whl", hash = "sha256:c88605d8d468f7fc1b31e06129bc91d6c96f6c621776c9b504a0da9beac9df5f", size = 616866, upload-time = "2026-04-25T10:43:51.005Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b6/d8c9018635d4acfefde6b68470daa510eed715a350cbaa2f928ba0609f81/nh3-0.3.5-cp314-cp314t-win_arm64.whl", hash = "sha256:72c5bdedec27fa33de6a5326346ea8aa3fe54f6ac294d54c4b204fb66a9f1e79", size = 602566, upload-time = "2026-04-25T10:43:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/85/30/d162e99746a2fb1d98bb0ef23af3e201b156cf09f7de867c7390c8fe1c06/nh3-0.3.5-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:3bb854485c9b33e5bb143ff3e49e577073bc6bc320f0ff8fc316dd89c0d3c101", size = 1442393, upload-time = "2026-04-25T10:43:53.556Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8c/072120d506978ab053e1732d0efa7c86cb478fee0ee098fda0ac0d31cb34/nh3-0.3.5-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50d401ab2d8e86d59e2126e3ab2a2f45840c405842b626d9a51624b3a33b6878", size = 837722, upload-time = "2026-04-25T10:43:55.073Z" },
+    { url = "https://files.pythonhosted.org/packages/52/86/d4e06e28c5ad1c4b065f89737d02631bd49f1660b6ebcf17a87ffcd201da/nh3-0.3.5-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:acfd354e61accbe4c74f8017c6e397a776916dfe47c48643cf7fd84ade826f93", size = 822872, upload-time = "2026-04-25T10:43:56.581Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/62/50659255213f241ec5797ae7427464c969397373e83b3659372b341ae869/nh3-0.3.5-cp38-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:52d877980d7ca01dc3baf3936bf844828bc6f332962227a684ed79c18cce14c3", size = 1100031, upload-time = "2026-04-25T10:43:58.098Z" },
+    { url = "https://files.pythonhosted.org/packages/00/7a/a12ae77593b2fcf3be25df7bc1c01967d0de448bdb4b6c7ec80fe4f5a74f/nh3-0.3.5-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:207c01801d3e9bb8ec08f08689346bdd30ce15b8bf60013a925d08b5388962a4", size = 1057669, upload-time = "2026-04-25T10:43:59.328Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/71/5647dc04c0233192a3956fc91708822b21403a06508cacf78083c68e7bf0/nh3-0.3.5-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea232933394d1d58bf7c4bb348dc4660eae6604e1ae81cd2ba6d9ed80d390f3b", size = 914795, upload-time = "2026-04-25T10:44:00.52Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/0e/bf298920729f216adcb002acf7ea01b90842603d2e4e2ce9b900d9ee8fab/nh3-0.3.5-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fe3a787dc76b50de6bee54ef242f26c41dfe47654428e3e94f0fae5bb6dd2cc1", size = 806976, upload-time = "2026-04-25T10:44:01.743Z" },
+    { url = "https://files.pythonhosted.org/packages/85/01/26761e1dc2b848e65a62c19e5d39ad446283287cd4afddc89f364ab86bc9/nh3-0.3.5-cp38-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:488928988caad25ba14b1eb5bc74e25e21f3b5e40341d956f3ce4a8bc19460dc", size = 834904, upload-time = "2026-04-25T10:44:03.454Z" },
+    { url = "https://files.pythonhosted.org/packages/33/53/0766113e679540ac1edc1b82b1295aecd321eeb75d6fead70109a838b6ee/nh3-0.3.5-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2c069570b06aa848457713ad7af4a9905691291548c4466a9ad78ee95808382b", size = 857159, upload-time = "2026-04-25T10:44:05.003Z" },
+    { url = "https://files.pythonhosted.org/packages/58/36/734d353dfaf292fed574b8b3092f0ef79dc6404f3879f7faaa61a4701fad/nh3-0.3.5-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:eeedc90ed8c42c327e8e10e621ccfa314fc6cce35d5929f4297ff1cdb89667c4", size = 1018600, upload-time = "2026-04-25T10:44:06.18Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/aa/d9c59c1b49669fcb7bababa55df82385f029ad5c2651f583c3a1141cfdd1/nh3-0.3.5-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:de8e8621853b6470fe928c684ee0d3f39ea8086cebafe4c416486488dea7b68d", size = 1103530, upload-time = "2026-04-25T10:44:07.68Z" },
+    { url = "https://files.pythonhosted.org/packages/90/b0/cdd210bfb8d9d43fb02fc3c868336b9955934d8e15e66eb1d15a147b8af0/nh3-0.3.5-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:6ea58cc44d274c643b83547ca9654a0b1a817609b160601356f76a2b744c49ad", size = 1061754, upload-time = "2026-04-25T10:44:09.362Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/cb/7a39e72e668c8445bdd95e494b3e21cfdddc68329be8ea3522c8befb46c4/nh3-0.3.5-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e49c9b564e6bcb03ecd2f057213df9a0de15a95812ac9db9600b590db23d3ae9", size = 1040938, upload-time = "2026-04-25T10:44:10.775Z" },
+    { url = "https://files.pythonhosted.org/packages/af/4c/fc2f9ed208a3801a319f59b5fea03cdc20cf3bd8af14be930d3a8de01224/nh3-0.3.5-cp38-abi3-win32.whl", hash = "sha256:559e4c73b689e9a7aa97ac9760b1bc488038d7c1a575aa4ab5a0e19ee9630c0f", size = 611445, upload-time = "2026-04-25T10:44:12.317Z" },
+    { url = "https://files.pythonhosted.org/packages/db/1a/e4c9b5e2ae13e6092c9ec16d8ca30646cb01fcdea245f36c5b08fd21fbd5/nh3-0.3.5-cp38-abi3-win_amd64.whl", hash = "sha256:45e6a65dc88a300a2e3502cb9c8e6d1d6b831d6fba7470643333609c6aab1f30", size = 626502, upload-time = "2026-04-25T10:44:13.682Z" },
+    { url = "https://files.pythonhosted.org/packages/80/7c/19cd0671d1ba2762fb388fc149697d20d0568ccfeef833b11280a619e526/nh3-0.3.5-cp38-abi3-win_arm64.whl", hash = "sha256:8f85285700a18e9f3fc5bff41fe573fa84f81542ef13b48a89f9fecca0474d3b", size = 611069, upload-time = "2026-04-25T10:44:14.934Z" },
 ]
 
 [[package]]
@@ -1256,6 +1397,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyproject-hooks"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1346,6 +1496,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1392,6 +1551,20 @@ wheels = [
 ]
 
 [[package]]
+name = "readme-renderer"
+version = "44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "nh3" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/a9/104ec9234c8448c4379768221ea6df01260cd6c2ce13182d4eac531c8342/readme_renderer-44.0.tar.gz", hash = "sha256:8712034eabbfa6805cacf1402b4eeb2a73028f72d1166d6f5cb7f9c047c5d1e1", size = 32056, upload-time = "2024-07-08T15:00:57.805Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/67/921ec3024056483db83953ae8e48079ad62b92db7880013ca77632921dd0/readme_renderer-44.0-py3-none-any.whl", hash = "sha256:2fbca89b81a08526aadf1357a8c2ae889ec05fb03f5da67f9769c9a592166151", size = 13310, upload-time = "2024-07-08T15:00:56.577Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1418,6 +1591,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "requests-toolbelt"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
+]
+
+[[package]]
+name = "rfc3986"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/40/1520d68bfa07ab5a6f065a186815fb6610c86fe957bc065754e47f7b0840/rfc3986-2.0.0.tar.gz", hash = "sha256:97aacf9dbd4bfd829baad6e6309fa6573aaf1be3f6fa735c8ab05e46cecb261c", size = 49026, upload-time = "2022-01-10T00:52:30.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl", hash = "sha256:50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd", size = 31326, upload-time = "2022-01-10T00:52:29.594Z" },
 ]
 
 [[package]]
@@ -1569,6 +1763,19 @@ wheels = [
 ]
 
 [[package]]
+name = "secretstorage"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "jeepney" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1673,6 +1880,26 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
+]
+
+[[package]]
+name = "twine"
+version = "6.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "id" },
+    { name = "keyring", marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'" },
+    { name = "packaging" },
+    { name = "readme-renderer" },
+    { name = "requests" },
+    { name = "requests-toolbelt" },
+    { name = "rfc3986" },
+    { name = "rich" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/a8/949edebe3a82774c1ec34f637f5dd82d1cf22c25e963b7d63771083bbee5/twine-6.2.0.tar.gz", hash = "sha256:e5ed0d2fd70c9959770dce51c8f39c8945c574e18173a7b81802dab51b4b75cf", size = 172262, upload-time = "2025-09-04T15:43:17.255Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl", hash = "sha256:418ebf08ccda9a8caaebe414433b0ba5e25eb5e4a927667122fbe8f829f985d8", size = 42727, upload-time = "2025-09-04T15:43:15.994Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implementation side of the playbook landed in #30. After this merges,
`git tag v0.5.1 && git push --tags` triggers the full pipeline:
build → twine check → TestPyPI → install-smoke → reviewer-gated PyPI
upload → GitHub Release. Bumps the package to **v0.5.1** so the tag
is real on merge.

## What lands

### `.github/workflows/publish.yml`
The publish pipeline. Triggers on `v*.*.*` tag pushes.

- **`build`** — sanity-checks that the tag (`v0.5.1`) matches
  `pyproject.toml`'s `version` before producing the artifacts. Then
  `python -m build` + `twine check`.
- **`publish-testpypi`** — Trusted Publishing (OIDC). No API tokens
  ever stored as GitHub secrets.
- **`smoke-testpypi`** — installs from the just-published TestPyPI
  artifact in a two-step flow that closes the dependency-confusion
  vector Gemini caught against the playbook in #30:
  1. Deps from real PyPI only, canonically derived via `uv export`
     from `pyproject.toml`.
  2. `mcpg` itself with `--no-deps` from TestPyPI.
  Includes a 12×10s poll loop for TestPyPI's simple-index to catch
  up after the upload (eventual consistency, ~30s typical). Smoke
  asserts `import mcpg; print(mcpg.__version__)` and `mcpg --version`.
- **`publish-pypi`** — gated on the `pypi` environment's
  required-reviewer check. Maintainer's last chance to cancel a bad
  release after smoke passed.
- **`github-release`** — cuts the GitHub Release with notes pulled
  from the matching `CHANGELOG.md` section.

### `pyproject.toml`
- `version` 0.5.0 → 0.5.1.
- New `authors`, `maintainers`, `keywords`, `classifiers`,
  `[project.urls]` (Homepage / Documentation / Repository / Issues
  / Changelog / Release notes / Security).
- New `[tool.hatch.build.targets.sdist]` — sdist now contains
  `src/mcpg/` + `README.md` + `LICENSE` + `NOTICE` + `CHANGELOG.md` +
  `SECURITY.md` + `pyproject.toml` only. No tests / docs / .github / IDE cruft.
- `build>=1.2` + `twine>=5.1` added to the `dev` dep group so the
  publish workflow's tooling is locked alongside everything else.

### `docs/installation.md`
New "Install from PyPI (recommended)" section covering both
`pip install mcpg` and `uv tool install mcpg`. Existing
"Install from source" stays as the developer flow.

### `mcpg --version` / `-V`
New CLI flag — `SECURITY.md` asks bug reporters to include this
line, and the smoke step in the workflow uses it. Backed by
`mcpg.__version__` (which is now bumped in lockstep with `pyproject.toml`).

## Upgrade note for v0.5.1

v0.5.1 carries the PG-TLS default-tightening from #29 (the actual
hardening landing). Operators with a remote DSN whose `sslmode` is
`disable` / `allow` / `prefer` (or unset) will fail to start after
upgrade. Either set `sslmode=require` (recommended) or opt out via
`MCPG_ALLOW_INSECURE_TLS=true`. CHANGELOG carries this upgrade note
prominently in the `[0.5.1]` section.

## Test plan

- [x] `uv run python -m build` — clean sdist + wheel.
- [x] `uv run twine check dist/*` — PASSED both artifacts.
- [x] PKG-INFO eyeballed: classifiers, project URLs, license, deps
      all render correctly.
- [x] sdist trim confirmed via `tar tzf` — no tests/, docs/, .github/.
- [x] `mcpg --version` and `mcpg -V` both print `mcpg 0.5.1`.
- [x] `ruff check` / `ruff format --check` / `mypy src/mcpg` /
      `bandit -r src/mcpg --skip B101,B608,B110 -ll` all clean.
- [x] `pytest tests/unit -q` — 885 tests pass.
- [ ] **Maintainer pre-merge checklist:**
  - Trusted Publisher registered on
    <https://test.pypi.org/manage/account/publishing/> with
    project `mcpg`, owner `devopam`, repo `MCPg`, workflow
    `publish.yml`, environment `testpypi`.
  - Same on <https://pypi.org/manage/account/publishing/> with
    environment `pypi`.
  - GitHub `pypi` environment created with required-reviewer rule
    on the maintainer's account; `testpypi` environment created
    without restrictions.

After all four boxes are checked, merging this PR and pushing
`git tag -s v0.5.1 -m "MCPg v0.5.1" && git push origin v0.5.1`
ships the inaugural PyPI release.

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Set up automated publishing of the mcpg package to TestPyPI and PyPI on version tag pushes and cut the inaugural v0.5.1 release, including CLI and packaging updates needed for distribution.

New Features:
- Add a `mcpg --version` / `mcpg -V` CLI flag backed by `mcpg.__version__` for easier diagnostics and support.
- Support installing mcpg directly from PyPI as the recommended path, alongside the existing from-source flow.

Enhancements:
- Update project metadata in `pyproject.toml` with authors, maintainers, keywords, classifiers, and project URLs suitable for PyPI.
- Configure a tight sdist build that ships only the source tree and key top-level documentation files.
- Document support for PostgreSQL 18 in the installation requirements.

Build:
- Add `build` and `twine` to the development dependency group to standardize the PyPI packaging toolchain.

CI:
- Introduce a `publish` GitHub Actions workflow that on version tag pushes builds artifacts, verifies metadata, publishes to TestPyPI, smoke-tests the published artifact, then publishes to PyPI via Trusted Publishing and creates a GitHub Release.

Documentation:
- Add an "Install from PyPI (recommended)" section to the installation guide, including `pip` and `uv tool` usage, and refine from-source installation guidance.