### PR TITLE
docs(pages): publish github.io site via Jekyll cayman theme

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,71 @@
+# Jekyll config for the MCPg GitHub Pages site.
+# Site URL: https://devopam.github.io/MCPg/
+#
+# GitHub Pages serves from `main` branch / root. README.md becomes
+# the homepage; everything under docs/ is rendered into the published
+# site automatically.
+
+title: MCPg
+description: A production-grade PostgreSQL Model Context Protocol (MCP) server.
+url: https://devopam.github.io
+baseurl: /MCPg
+
+# Cayman is GitHub's default project-page theme — clean, mobile-friendly,
+# minimal chrome around the prose. Used by countless Python project sites.
+theme: jekyll-theme-cayman
+
+# Tells the cayman theme where the "View on GitHub" button should point.
+repository: devopam/MCPg
+
+# Hide cayman's default "Download .zip / .tar.gz" buttons — for a
+# packaged project, the install path is `pip install mcpg`, not a
+# tarball download.
+show_downloads: false
+
+# Plugins listed here are part of the GitHub Pages allowlist
+# (see https://pages.github.com/versions/). No Gemfile needed.
+plugins:
+  # Rewrites `[text](docs/x.md)`-style links so they resolve on the
+  # published site without us having to edit the source markdown. Key:
+  # the same links still work on the GitHub repo view.
+  - jekyll-relative-links
+  # Lets README.md / docs/*.md be served without YAML front matter.
+  - jekyll-optional-front-matter
+  # Adds <title>, meta description, og:tags from `title` / `description`
+  # above and from each page's first H1.
+  - jekyll-seo-tag
+  # Generates /sitemap.xml automatically.
+  - jekyll-sitemap
+
+relative_links:
+  enabled: true
+  collections: true
+
+optional_front_matter:
+  remove_originals: true
+
+# Keep the published site lean — code, tests, build artefacts, and
+# IDE/CI cruft don't belong on the documentation surface.
+exclude:
+  - .github/
+  - .gitignore
+  - .pre-commit-config.yaml
+  - .ruff_cache/
+  - .pytest_cache/
+  - .mypy_cache/
+  - .venv/
+  - Dockerfile
+  - LICENSE
+  - NOTICE
+  - PLAN.md
+  - benchmarks/
+  - dist/
+  - pyproject.toml
+  - scratch/
+  - src/
+  - tests/
+  - uv.lock
+  - vendor/
+
+# Pretty URLs (so /MCPg/docs/installation/ rather than /MCPg/docs/installation.html).
+permalink: pretty

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,55 @@
+---
+title: Documentation
+---
+
+# MCPg documentation
+
+A landing page for the published docs. Items are grouped roughly by
+"first read this", "then this", "and reach for these when you need
+them" — pick the section that matches what you're trying to do.
+
+## Get started
+
+- [**Installation**](installation.md) — `pip install mcpg`, the
+  Docker image, and what the environment variables mean.
+- [**Tour**](tour.md) — a guided walkthrough of every MCP tool MCPg
+  ships, grouped by capability area.
+- [**Cookbook**](cookbook.md) — short, copy-pasteable recipes for
+  the common workflows (read-replica routing, NL→SQL,
+  OIDC bearer auth, RLS, hybrid search, …).
+
+## Reference
+
+- [**Tools**](tools.md) — every MCP tool MCPg exposes, including
+  the capability gates that need to be on.
+- [**Architecture**](architecture.md) — how the pieces fit together
+  (server, drivers, replicas, cursors, audit, transports).
+- [**Scaling guide**](scaling.md) — pool sizing, replica fan-out,
+  observability, performance tuning notes.
+
+## Operate
+
+- [**Security hardening roadmap**](security-hardening.md) — shipped
+  vs queued security features.
+- [**Release process**](release-process.md) — the playbook for
+  cutting a new MCPg release to PyPI.
+- [**User guide**](user-guide.md) — end-user-facing reference.
+
+## Project history
+
+- [**Comparison matrix**](comparison-matrix.md) — MCPg against
+  other PostgreSQL MCP servers.
+- [**Feature shortlist**](feature-shortlist.md) — what's planned.
+- [**Progress log**](PROGRESS.md) — chronological build log.
+- Release notes:
+  [v0.5.0](release-notes-0.5.0.md) ·
+  [v0.4.0](release-notes-0.4.0.md) ·
+  [v0.3.0](release-notes-0.3.0.md) ·
+  see [CHANGELOG](../CHANGELOG.md) for v0.5.1 and beyond.
+- [**Architecture Decision Records**](adr/) — the durable design
+  decisions, one ADR per choice.
+
+---
+
+For the project source, issue tracker, and contribution guidelines,
+head to [github.com/devopam/MCPg](https://github.com/devopam/MCPg).


### PR DESCRIPTION
## Summary

Publishes the MCPg documentation site at **https://devopam.github.io/MCPg/**
via the Jekyll cayman theme. GitHub Pages settings (which you already
configured: `main` branch, `/` root) are left untouched — this PR just
adds the config that turns those settings into a real site.

Once merged, GitHub rebuilds on the main commit and the site goes
live automatically. No further clicks in Settings → Pages needed.

## What lands

### `_config.yml` (repo root)
- **Theme:** `jekyll-theme-cayman` — GitHub's default project theme,
  clean and mobile-friendly. Used widely by Python project sites.
- **Plugins** (all on the GitHub Pages allowlist — no Gemfile):
  - `jekyll-relative-links` — rewrites markdown links like
    `[installation](docs/installation.md)` so they resolve on the
    published site **and** keep working on the GitHub repo view.
    Key benefit: no edits to README or any existing `docs/*.md`
    needed for links to work everywhere.
  - `jekyll-optional-front-matter` — README and docs don't need YAML
    front matter to render.
  - `jekyll-seo-tag` — adds `<title>` / meta-description / og:tags.
  - `jekyll-sitemap` — generates `/sitemap.xml`.
- **Pretty URLs:** `/MCPg/docs/installation/` rather than `…installation.html`.
- **Repository button:** `repository: devopam/MCPg` wires up cayman's
  "View on GitHub" link.
- **`show_downloads: false`** — hides the "Download .zip / .tar.gz"
  buttons (this is a packaged project; install path is `pip install mcpg`).
- **`exclude:`** — code, tests, build artefacts, IDE/CI cruft kept out of
  the published surface (`src/`, `tests/`, `pyproject.toml`, `uv.lock`,
  `Dockerfile`, `scratch/`, `benchmarks/`, `.github/`, etc.).

### `docs/index.md`
Curated landing page for `/MCPg/docs/`. Groups the existing docs by
intent (get started / reference / operate / project history) instead
of letting GitHub Pages 404 on the bare directory. All links are
relative `.md` paths the `jekyll-relative-links` plugin rewrites for
the published site.

## What does NOT change

- README content (it becomes the homepage as-is, with cayman's banner chrome)
- Any existing `docs/*.md` content
- The Pages source setting (still `main` / root, as you configured)

## After merge

1. The Pages build kicks off automatically on the merge commit. Watch
   it at the green check at the top-right of the commit on `main` →
   the "pages build and deployment" workflow.
2. About a minute later the site is live. Hard-refresh
   https://devopam.github.io/MCPg/ to bypass the CDN cache.
3. If anything renders oddly, the easiest fixes are in `_config.yml`
   (theme swap, exclude tweak) and don't need a new release.

## Future polish (optional, separate PRs if you want)
- Add a logo / favicon (cayman supports both via `_includes` overrides).
- Switch to `just-the-docs` (community theme via `remote_theme:`) if
  you want a left sidebar with hierarchical nav — would be a 2-line
  change to `_config.yml`.
- Custom domain (`mcpg.dev` or similar) — drop a `CNAME` file at root
  + DNS record. Today's setup is forward-compatible.

## Test plan
- [x] `_config.yml` validates as Jekyll-on-Pages compatible
      (theme + plugins are all on the allowlist).
- [x] `docs/index.md` links are all relative `.md` paths
      the plugin rewrites correctly.
- [ ] **Maintainer to verify after merge:**
  - https://devopam.github.io/MCPg/ renders the README content.
  - https://devopam.github.io/MCPg/docs/ renders the new index.
  - A few sample links from README → installation/tour/cookbook resolve.
  - "View on GitHub" button in the header points at the repo.

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_