### PR TITLE
docs(readme): revamp as a comprehensive user-facing manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@ graph queries, data movement, live ops, and more.
 
 ## Why MCPg
 
-- **Safe by default.** Read-only access mode. Every SQL statement parses
-  through a validated AST allowlist before execution. Identifier
-  interpolation flows through a strict `[A-Za-z_][A-Za-z0-9_]*` regex —
-  no string-concat queries anywhere in the codebase. Capabilities like
-  DDL, shell, and `LISTEN/NOTIFY` are off until you opt in.
+- **Safe by default.** Read-only access mode. Every user-supplied SQL
+  statement parses through a validated AST allowlist before execution.
+  Identifier interpolation flows through a strict
+  `[A-Za-z_][A-Za-z0-9_]*` regex — a design constraint that means
+  user input never reaches the database through string concatenation.
+  Capabilities like DDL, shell, and `LISTEN/NOTIFY` are off until you
+  opt in.
 - **One server, broad surface.** Application data access (queries, search,
   cursors, NL→SQL) *and* DBA-grade operations (health checks, index tuning,
   EXPLAIN analysis, locks, vacuum, dumps, replicas, migrations) in a
@@ -442,6 +444,6 @@ MIT — see [`LICENSE`](LICENSE). The vendored SQL-safety kernel at
 `src/mcpg/_vendor/sql/` is also MIT-licensed; see [`NOTICE`](NOTICE)
 for provenance.
 
-> **Disclaimer.** Best effort has been put into making MCPg production
-> grade, but it remains an actively developed project and may contain
-> issues. Refer to the License Terms for indemnity details.
+> **Disclaimer.** Best efforts have been made to bring MCPg to
+> production grade, but it remains an actively developed project and
+> may contain issues. See the License terms for indemnity details.

--- a/README.md
+++ b/README.md
@@ -1,159 +1,447 @@
 # MCPg
 
-A production-grade [Model Context Protocol](https://modelcontextprotocol.io)
-server for **PostgreSQL** — letting AI agents safely inspect, query, operate,
-and tune a Postgres database.\*
+**A production-grade [Model Context Protocol](https://modelcontextprotocol.io)
+server for PostgreSQL.** Lets AI agents safely inspect, query, operate, and
+tune a Postgres database — over 100 tools spanning catalog introspection,
+query intelligence, natural-language SQL, structural diffs, hybrid search,
+graph queries, data movement, live ops, and more.
 
-> **Status:** v0.5.0 released; trunk at **114 MCP tools**. Beyond
-> v0.5.0's surface (NL→SQL via Anthropic / OpenAI / Gemini,
-> per-request `SET ROLE` multi-tenancy, server-side cursors, hybrid
-> vector+FTS search, TimescaleDB wrappers, HTTP bearer-token auth,
-> Prometheus `/metrics`, RLS testing, FK cascade graphs, and the
-> rest of the Tier-A/B/C shortlist), trunk adds **Apache AGE graph
-> + Cypher** (six new tools — `list_graphs`, `describe_graph`,
-> `create_graph`, `drop_graph`, `run_cypher`,
-> `generate_graph_diagram`), **read-replica routing**
-> (`MCPG_REPLICA_URLS` round-robins read-only queries across
-> replicas with degraded-replica detection and primary fallback),
-> and **OIDC / JWT bearer-token validation**
-> (`MCPG_AUTH_MODE=oidc` swaps the static token for full JWT
-> validation against an OIDC issuer's JWKS, with optional role-claim
-> mapping that composes with the tenancy driver). CI matrix runs the
-> integration suite against **PostgreSQL 14, 15, 16, 17, and 18**.
-> See [`docs/cookbook.md`](docs/cookbook.md) for common agent
-> recipes, [`docs/tour.md`](docs/tour.md) for the tool tour,
-> [`CHANGELOG.md`](CHANGELOG.md) and
-> [`docs/PROGRESS.md`](docs/PROGRESS.md) for detail.
+[![PyPI version](https://img.shields.io/pypi/v/mcpg.svg)](https://pypi.org/project/mcpg/)
+[![Python versions](https://img.shields.io/pypi/pyversions/mcpg.svg)](https://pypi.org/project/mcpg/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![CI](https://github.com/devopam/MCPg/actions/workflows/ci.yml/badge.svg)](https://github.com/devopam/MCPg/actions/workflows/ci.yml)
 
-## Quick start
+---
+
+## Why MCPg
+
+- **Safe by default.** Read-only access mode. Every SQL statement parses
+  through a validated AST allowlist before execution. Identifier
+  interpolation flows through a strict `[A-Za-z_][A-Za-z0-9_]*` regex —
+  no string-concat queries anywhere in the codebase. Capabilities like
+  DDL, shell, and `LISTEN/NOTIFY` are off until you opt in.
+- **One server, broad surface.** Application data access (queries, search,
+  cursors, NL→SQL) *and* DBA-grade operations (health checks, index tuning,
+  EXPLAIN analysis, locks, vacuum, dumps, replicas, migrations) in a
+  single MCP server. Agents don't have to switch tools to switch tasks.
+- **PostgreSQL-native everything.** No ORM, no abstraction tax — uses
+  `psycopg3` directly, speaks every `pg_*` system view, integrates with
+  TimescaleDB, pgvector, PostGIS, Apache AGE, and `pg_stat_statements`
+  where they're available, and degrades gracefully when they aren't.
+- **Production-shaped, not demo-shaped.** Connection pooling, per-request
+  `SET ROLE` multi-tenancy, read-replica routing with degraded-host
+  detection, server-side cursors with dedicated connections,
+  rate-limiting, audit trail with regex redaction, PG TLS enforcement
+  on startup, OIDC JWT bearer auth, per-session statement / lock
+  timeouts.
+- **Observability built in.** Prometheus `/metrics` endpoint on the
+  HTTP transport surfaces `mcpg_tool_calls_total{tool,status}` +
+  `mcpg_tool_duration_seconds`. Every tool call records a structured
+  audit event with credential-redacted arguments.
+- **Test-driven, multi-version.** 800+ unit tests plus an integration
+  suite that runs against a real PostgreSQL container in CI — matrix
+  covers PG **14, 15, 16, 17, 18** on every push.
+
+---
+
+## Install
+
+### From PyPI (recommended)
+
+```bash
+pip install mcpg
+# or, in an isolated venv exposed globally:
+uv tool install mcpg
+```
+
+Verify:
+
+```bash
+mcpg --version
+```
+
+### Docker
+
+```bash
+docker build -t mcpg https://github.com/devopam/MCPg.git
+docker run --rm -p 8000:8000 \
+    -e MCPG_DATABASE_URL=postgresql://user:pass@host:5432/db \
+    -e MCPG_ACCESS_MODE=read-only \
+    mcpg
+```
+
+Multi-stage image: runtime stage drops the build toolchain, runs as
+`uid=10001 / gid=10001` with `nologin` shell, application files
+root-owned and read-only to the runtime user.
+
+### From source (developers)
 
 ```bash
 git clone https://github.com/devopam/MCPg && cd MCPg
 uv sync
-MCPG_DATABASE_URL=postgresql://localhost/mydb uv run mcpg
 ```
 
-See the [Installation Guide](docs/installation.md) and
-[User Guide](docs/user-guide.md) to get started.
+`uv sync` creates a venv with all runtime + dev dependencies and exposes
+the `mcpg` console script.
 
-## Goals
+More detail in the [Installation Guide](docs/installation.md).
 
-- **Safe by default** — read-only access mode, every SQL statement parsed and
-  validated; no string-interpolated queries.
-- **Broad scope** — both an application data access layer and a database
-  operations toolkit (health checks, index tuning, EXPLAIN analysis), gated by
-  an access mode.
-- **Test-driven** — every feature backed by tests against a real Postgres
-  (PG 14–17 in CI).
-- **Production-ready** — connection pooling, scalability, multi-tenancy,
-  thorough documentation.
+---
 
-## Capability surface
+## Quick start
+
+### Wire MCPg into Claude Desktop (stdio transport)
+
+Drop this into your `claude_desktop_config.json` (macOS:
+`~/Library/Application Support/Claude/claude_desktop_config.json`;
+Windows: `%APPDATA%\Claude\claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "mcpg": {
+      "command": "uvx",
+      "args": ["mcpg"],
+      "env": {
+        "MCPG_DATABASE_URL": "postgresql://user:pass@localhost:5432/mydb"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop. The MCPg toolset is now available to the model.
+You can ask Claude things like:
+
+> *"What schemas exist in this database? For each one, summarise the
+> three biggest tables."*
+
+> *"Why is this query slow?
+> `SELECT * FROM orders WHERE customer_id = 42 ORDER BY created_at DESC`"*
+
+### Run as an HTTP server (for IDE integrations, web apps, etc.)
+
+```bash
+MCPG_DATABASE_URL=postgresql://user:pass@localhost:5432/mydb \
+MCPG_TRANSPORT=streamable-http \
+MCPG_HTTP_PORT=8000 \
+mcpg
+```
+
+Then point any MCP-aware client at `http://localhost:8000`. Set
+`MCPG_HTTP_AUTH_TOKEN=...` for a static bearer, or
+`MCPG_AUTH_MODE=oidc` for full JWT validation against an OIDC issuer.
+
+---
+
+## Configuration
+
+MCPg is configured **entirely through environment variables** — no
+config file, no flags. The only required one is `MCPG_DATABASE_URL`;
+everything else has a safe default.
+
+### Common scenarios
+
+| Scenario | Set |
+|---|---|
+| Local exploration, read-only | `MCPG_DATABASE_URL` |
+| Read-write app data access | `MCPG_ACCESS_MODE=restricted` |
+| DBA toolkit (DDL, vacuum, etc.) | `MCPG_ACCESS_MODE=unrestricted` + `MCPG_ALLOW_DDL=true` |
+| HTTP transport with bearer auth | `MCPG_TRANSPORT=streamable-http` + `MCPG_HTTP_AUTH_TOKEN=…` |
+| Multi-tenant SaaS | `MCPG_DEFAULT_ROLE=tenant_a` + `MCPG_ALLOWED_ROLES=tenant_a,tenant_b,…` |
+| Read-replica fan-out | `MCPG_REPLICA_URLS=postgresql://…?sslmode=require,postgresql://…?sslmode=require` |
+| NL→SQL via Anthropic | `MCPG_NL2SQL_PROVIDER=anthropic` (uses `ANTHROPIC_API_KEY` automatically) |
+
+### Full reference
+
+#### Core
+
+| Variable | Default | Description |
+|---|---|---|
+| `MCPG_DATABASE_URL` | **required** | Primary PostgreSQL DSN. Supports URI (`postgresql://…`) and keyword (`host=… user=…`) forms. Remote hosts require `sslmode=require` (or stronger). |
+| `MCPG_ACCESS_MODE` | `read-only` | `read-only` \| `restricted` (allows write tools) \| `unrestricted` (also unlocks DBA tools when paired with the gate vars). |
+| `MCPG_TRANSPORT` | `stdio` | `stdio` (default, for Claude Desktop) \| `streamable-http` \| `sse`. |
+| `MCPG_LOG_LEVEL` | `INFO` | `DEBUG` \| `INFO` \| `WARNING` \| `ERROR` \| `CRITICAL`. |
+| `MCPG_HTTP_HOST` | `127.0.0.1` | Bind address for HTTP transports. Set to `0.0.0.0` inside containers. |
+| `MCPG_HTTP_PORT` | `8000` | Listen port for HTTP transports (1–65535). |
+
+#### Capability gates (opt-in for higher-blast-radius tools)
+
+| Variable | Default | Description |
+|---|---|---|
+| `MCPG_ALLOW_DDL` | `false` | Expose DDL tools (`run_ddl`, `create_graph`, `drop_graph`, hypertable tools, migration tools). Requires `MCPG_ACCESS_MODE=unrestricted`. |
+| `MCPG_ALLOW_SHELL` | `false` | Expose subprocess-backed tools (`dump_database`, `restore_database`, `run_pg_binary`). Required PG client binaries must be on `PATH`. |
+| `MCPG_ALLOW_LISTEN` | `false` | Expose `LISTEN/NOTIFY` tools (`subscribe_channel`, `poll_notifications`, `unsubscribe_channel`, `list_notification_subscriptions`). |
+
+#### Authentication (HTTP transports only)
+
+| Variable | Default | Description |
+|---|---|---|
+| `MCPG_AUTH_MODE` | `static` | `static` (compare bearer to `MCPG_HTTP_AUTH_TOKEN`) \| `oidc` (full JWT validation). |
+| `MCPG_HTTP_AUTH_TOKEN` | — | Required bearer token when `MCPG_AUTH_MODE=static`. Constant-time compare. |
+| `MCPG_OIDC_ISSUER` | — | OIDC issuer URL (required when `MCPG_AUTH_MODE=oidc`). |
+| `MCPG_OIDC_AUDIENCE` | — | Expected `aud` claim (required when `MCPG_AUTH_MODE=oidc`). |
+| `MCPG_OIDC_JWKS_URL` | discovered | Override JWKS endpoint (auto-discovered from issuer's `.well-known` otherwise). |
+| `MCPG_OIDC_ROLE_CLAIM` | — | JWT claim whose value becomes the per-request PG role (`SET LOCAL ROLE`). Composes with the tenancy driver. |
+
+#### Multi-tenancy (`SET ROLE`)
+
+| Variable | Default | Description |
+|---|---|---|
+| `MCPG_DEFAULT_ROLE` | — | Static PG role applied to every query. Identifier-validated. |
+| `MCPG_ALLOWED_ROLES` | — | Comma-separated allowlist. When set, the `X-MCPG-Role` header / OIDC role claim must be in this list. |
+
+#### Read replicas
+
+| Variable | Default | Description |
+|---|---|---|
+| `MCPG_REPLICA_URLS` | — | Comma-separated replica DSNs. `force_readonly` queries round-robin across healthy replicas; primary fallback on failure; 30 s degraded-replica retry window. |
+
+#### Pool / timeouts / TLS
+
+| Variable | Default | Description |
+|---|---|---|
+| `MCPG_POOL_MIN_SIZE` | `1` | Minimum pool connections. |
+| `MCPG_POOL_MAX_SIZE` | `5` | Maximum pool connections. Must be ≥ `MCPG_POOL_MIN_SIZE`. |
+| `MCPG_STATEMENT_TIMEOUT_MS` | `30000` | Per-session `statement_timeout` set on connection checkout. Runaway queries self-terminate. |
+| `MCPG_LOCK_TIMEOUT_MS` | `5000` | Per-session `lock_timeout`. Hanging lock waits self-terminate. |
+| `MCPG_ALLOW_INSECURE_TLS` | `false` | Bypass the startup TLS check that refuses remote DSNs without `sslmode=require` (or stronger). Loopback hosts are always exempt. |
+
+#### Subprocess tools (`MCPG_ALLOW_SHELL=true` only)
+
+| Variable | Default | Description |
+|---|---|---|
+| `MCPG_SHELL_TIMEOUT_SEC` | `60` | Max wall-clock for `pg_dump` / `pg_restore` / `psql` invocations. |
+| `MCPG_SHELL_MAX_OUTPUT_BYTES` | `67108864` | (64 MiB) Cap on captured stdout per subprocess call. |
+
+#### LISTEN/NOTIFY (`MCPG_ALLOW_LISTEN=true` only)
+
+| Variable | Default | Description |
+|---|---|---|
+| `MCPG_LISTEN_QUEUE_MAX` | `1000` | Per-channel buffer; oldest notifications dropped on overflow. |
+
+#### Audit
+
+| Variable | Default | Description |
+|---|---|---|
+| `MCPG_AUDIT_PERSIST` | `false` | When true, every `run_write` / `run_ddl` call persists to a `mcpg_audit.events` table (auto-created idempotently). |
+| `MCPG_AUDIT_REDACT_KEYS` | — | Comma-separated regex fragments added to the secret-name pattern (defaults already cover `password`, `passwd`, `secret`, `token`, `api[_-]?key`, `bearer`, `authorization`, `database_url`, `dsn`, `conninfo`). |
+
+#### Rate limiting
+
+| Variable | Default | Description |
+|---|---|---|
+| `MCPG_RATE_LIMIT_ENABLED` | `false` | Enable token-bucket per-tool rate limiting. |
+| `MCPG_RATE_LIMIT_MAX_REQUESTS` | `60` | Global cap per window across all tools. |
+| `MCPG_RATE_LIMIT_WINDOW_SECONDS` | `60` | Window length for the global quota. |
+| `MCPG_RATE_LIMIT_HEAVY_MAX` | `5` | Cap for heavy tools (`run_write`, `run_ddl`, `dump_database`, etc.). |
+| `MCPG_RATE_LIMIT_HEAVY_WINDOW` | `60` | Window length for the heavy-tool quota. |
+
+#### Natural-language SQL
+
+| Variable | Default | Description |
+|---|---|---|
+| `MCPG_NL2SQL_PROVIDER` | — | `anthropic` \| `openai` \| `gemini`. Unset disables `translate_nl_to_sql`. |
+| `MCPG_NL2SQL_API_KEY` | vendor fallback | Falls back to `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY` / `GOOGLE_API_KEY` depending on provider. |
+| `MCPG_NL2SQL_MODEL` | provider default | Override the default model (e.g. `claude-sonnet-4-6`, `gpt-4o-mini`, `gemini-2.5-flash`). |
+| `MCPG_NL2SQL_BASE_URL` | — | OpenAI-compatible endpoint override (Ollama, vLLM, OpenRouter, etc.). Only consulted for the `openai` provider. |
+| `MCPG_NL2SQL_MAX_TOKENS` | `2048` | Cap on generated tokens (hard limit: 16384). |
+
+---
+
+## Usage examples
+
+The MCP tools are invoked by the agent (Claude, Cursor, Continue, …)
+in response to your natural-language instructions. A handful of
+illustrative round-trips:
+
+### Inspect the schema
+
+> **You:** What tables live in the `public` schema, and which ones are
+> the biggest by row count?
+
+> **Agent (using `list_tables` + `summarize_table` × N):**
+> Six tables: `customers` (1.2M rows), `orders` (4.7M), `line_items`
+> (18.3M), `products` (340), `addresses` (1.4M), `audit_log`
+> (45.8M — the largest, accumulates without retention).
+
+### Diagnose a slow query
+
+> **You:** Why does
+> `SELECT * FROM orders o JOIN line_items l ON o.id = l.order_id WHERE o.created_at > now() - interval '7 days'`
+> take 8 seconds?
+
+> **Agent (using `why_is_this_slow` + `recommend_indexes`):**
+> `EXPLAIN ANALYZE` shows a sequential scan over `orders` (4.7M rows)
+> filtered by `created_at`. There's no index on `orders.created_at`.
+> Recommended:
+> `CREATE INDEX CONCURRENTLY orders_created_at_idx ON orders (created_at DESC);`
+> Expected improvement: ~95% reduction (index scan touches ~33K rows
+> instead of full table). Run `validate_migration` on it before applying
+> to confirm there's no locking surprise.
+
+### Translate plain English to SQL
+
+> **You:** Find customers who placed an order this month but never
+> in the previous three months — show me their email and current
+> lifetime spend.
+
+> **Agent (using `translate_nl_to_sql`):**
+> ```sql
+> SELECT c.email, SUM(l.price * l.quantity) AS lifetime_spend
+> FROM customers c
+> JOIN orders o ON o.customer_id = c.id
+> JOIN line_items l ON l.order_id = o.id
+> WHERE EXISTS (
+>   SELECT 1 FROM orders o2 WHERE o2.customer_id = c.id
+>     AND o2.created_at >= date_trunc('month', now()))
+>   AND NOT EXISTS (
+>   SELECT 1 FROM orders o3 WHERE o3.customer_id = c.id
+>     AND o3.created_at >= date_trunc('month', now()) - interval '3 months'
+>     AND o3.created_at <  date_trunc('month', now()))
+> GROUP BY c.email;
+> ```
+
+### Picture the schema
+
+> **You:** Draw me an ER diagram of the `public` schema.
+
+> **Agent (using `generate_schema_diagram`):** *Returns a Mermaid
+> diagram you can paste straight into GitHub / Notion / Obsidian.*
+
+### Audit the database
+
+> **You:** How healthy is this database right now?
+
+> **Agent (using `audit_database`):** Returns a graded report:
+> *Memory & I/O score 92 (GOOD), Transaction & Connection 78 (WARNING:
+> rollback rate 0.4%, look at app logs), Concurrency & Locks 60
+> (CRITICAL: 14 backends waiting), Cleanliness & Bloat 88 (GOOD), Slow
+> queries 70 (WARNING: top query template runs 5000×, mean 90 ms —
+> see `optimize_query`).*
+
+### Run a guarded write
+
+> **You:** Soft-delete every order older than 5 years.
+
+> **Agent (using `run_write` with `MCPG_AUDIT_PERSIST=true`):** Validates
+> the statement through the safe-SQL kernel, runs it inside a transaction,
+> returns affected row count, persists the call (sql + arguments —
+> with secrets regex-redacted — + status) to `mcpg_audit.events` for
+> after-the-fact review.
+
+For dozens more recipes — multi-tenant routing, RLS testing, NL→SQL,
+hybrid vector + FTS search, Apache AGE Cypher, TimescaleDB, ORM schema
+exports, server-side cursors — see [`docs/cookbook.md`](docs/cookbook.md).
+
+---
+
+## What's in the box
+
+Compact category list. For the full, current tool reference see
+[`docs/tools.md`](docs/tools.md); for a guided walkthrough see
+[`docs/tour.md`](docs/tour.md).
 
 - **Catalog introspection** — schemas, tables, columns, indexes,
   constraints, views, functions, triggers, sequences, partitions,
-  policies, roles, grants, enums, domains, composite types, foreign-data
-  wrappers, foreign servers, foreign tables, user mappings,
-  publications, subscriptions, foreign keys, extensions, generated
-  columns.
-- **Visualisation** — `generate_schema_diagram` (Mermaid ER) +
-  `generate_fk_cascade_graph` (Mermaid blast-radius graph of
-  ON DELETE / ON UPDATE CASCADE FKs) + `generate_graph_diagram`
-  (Mermaid view of an Apache AGE property graph).
-- **Structural diff** — `compare_schemas` returns a typed diff
-  between two schemas; `validate_migration` re-runs a candidate
-  against a transient sample of real rows so failures the diff
-  misses (NOT NULL on existing NULLs, CHECK violations, type
-  narrowings) surface before apply.
+  policies, roles, grants, enums, domains, composite types, FDWs,
+  publications, subscriptions, extensions, generated columns.
 - **Query intelligence** — `run_select`, `run_select_parallel`,
   `explain_query`, `analyze_query_plan`, `why_is_this_slow`,
   `recommend_indexes`, `analyze_workload`, `check_database_health`,
-  `detect_n_plus_one`.
-- **NL → SQL** — `translate_nl_to_sql` (Anthropic / OpenAI /
-  Gemini via `MCPG_NL2SQL_PROVIDER`). Generated SQL passes through
-  the same `SafeSqlDriver` allowlist as `run_select` before execution.
-- **Server-side cursors** — `open_cursor` / `fetch_cursor` /
-  `close_cursor` / `list_cursors` for pageable reads over millions
-  of rows; each cursor holds a dedicated connection so long-lived
-  cursors can't starve the main pool.
+  `detect_n_plus_one`, `audit_database`.
 - **Search** — `fuzzy_search` (trigram), `full_text_search`,
-  `vector_search` + `vector_range_search` + `hybrid_search`
-  (pgvector + FTS via reciprocal-rank fusion), `geo_search`
-  (PostGIS k-NN).
+  `vector_search`, `hybrid_search` (pgvector + FTS via RRF),
+  `geo_search` (PostGIS k-NN).
+- **Natural language → SQL** — `translate_nl_to_sql` (Anthropic,
+  OpenAI, or Gemini; output passes through the same safe-SQL kernel
+  as hand-written queries).
+- **Visualisation** — `generate_schema_diagram` (ER),
+  `generate_fk_cascade_graph` (blast-radius of `ON DELETE CASCADE`),
+  `generate_graph_diagram` (Apache AGE property graphs).
+- **Structural diff & migrations** — `compare_schemas`,
+  `validate_migration`, staged `prepare_migration` /
+  `complete_migration` / `cancel_migration` workflow.
 - **Apache AGE graph + Cypher** — `list_graphs`, `describe_graph`,
   `run_cypher`, `create_graph`, `drop_graph`, `generate_graph_diagram`.
-  Write tools gated under `MCPG_ALLOW_DDL`.
-- **Composite + advisor tools** — `summarize_table` (one-call snapshot),
+- **Composite + advisor tools** — `summarize_table`,
   `find_unused_objects`, `find_sensitive_columns` (PII heuristic),
-  `lint_naming_conventions`, `test_rls_for_role` (debug RLS as a
-  target role), `list_locks`, `find_blocking_chains`,
-  `read_pg_stat_io` (PG16+), `generate_test_data` (synthetic INSERT
-  generator).
-- **Live ops & maintenance** (gated) — `list_active_queries`,
+  `lint_naming_conventions`, `test_rls_for_role`, `list_locks`,
+  `find_blocking_chains`, `read_pg_stat_io` (PG16+),
+  `generate_test_data`.
+- **Live ops & maintenance** — `list_active_queries`,
   `run_maintenance` (VACUUM/ANALYZE), `cancel_query`,
   `terminate_backend`, `run_write`, `run_ddl`, `enable_extension`.
-- **Data movement** — `export_query` / `export_table` (in-process
-  CSV/JSON), `dump_database` / `restore_database` (subprocess gate),
-  `import_csv` / `import_json` (COPY FROM STDIN + parametrised
-  executemany), `copy_table_between_databases` (cross-DB pipeline).
-- **Event streams** (gated) — `subscribe_channel` /
-  `poll_notifications` / `unsubscribe_channel` /
-  `list_notification_subscriptions` bridge PostgreSQL `LISTEN` / `NOTIFY`
-  into the MCP tool-poll model.
-- **Staged migrations** (gated) — `prepare_migration` clones a target
-  schema into a shadow, applies the candidate SQL there, and surfaces
-  the structural diff for review; `validate_migration` applies the
-  candidate to a transient shadow with sample data; `complete_migration` /
-  `cancel_migration` / `list_pending_migrations` round out the workflow.
-- **TimescaleDB hypertables** (gated) — `list_hypertables`,
-  `list_chunks`, `create_hypertable`, `add_compression_policy`,
-  `add_retention_policy`. Degrade to `available=false` when the
-  extension isn't installed.
-- **ORM bridges** — eight read-only catalog → DSL exporters:
-  `generate_prisma_schema`, `generate_drizzle_schema`,
-  `generate_sqlalchemy_models`, `generate_sqlc_schema`,
-  `generate_diesel_schema`, `generate_jooq_config`,
-  `generate_ent_schemas`, `generate_ecto_schemas`.
-- **Observability** — Prometheus `/metrics` endpoint on the HTTP
-  transport + `get_metrics_exposition` MCP tool for stdio. Three
-  series: `mcpg_tool_calls_total{tool,status}` (counter),
-  `mcpg_tool_duration_seconds_*` (histogram).
-- **HTTP auth** — `MCPG_HTTP_AUTH_TOKEN` for static bearer (default
-  `MCPG_AUTH_MODE=static`); `MCPG_AUTH_MODE=oidc` for full JWT
-  validation against an OIDC issuer's JWKS, with optional
-  `MCPG_OIDC_ROLE_CLAIM` → PG role mapping.
-- **Multi-tenancy via `SET ROLE`** — `MCPG_DEFAULT_ROLE` (static)
-  and the `X-MCPG-Role` HTTP header drive a tenant driver that
-  wraps every query in `BEGIN ... SET LOCAL ROLE "<role>" ...` so
-  one MCPg process can serve N tenants from a single pool.
-- **Read-replica routing** — `MCPG_REPLICA_URLS` round-robins
-  `force_readonly` queries across replicas with degraded-replica
-  detection + primary fallback; `list_replicas` reports per-replica
-  health.
+- **Data movement** — `export_query` / `export_table` (CSV/JSON),
+  `dump_database` / `restore_database`, `import_csv` / `import_json`
+  (COPY FROM STDIN), `copy_table_between_databases`.
+- **Server-side cursors** — `open_cursor`, `fetch_cursor`,
+  `close_cursor`, `list_cursors` for pageable reads over millions
+  of rows.
+- **TimescaleDB** — `list_hypertables`, `list_chunks`,
+  `create_hypertable`, `add_compression_policy`,
+  `add_retention_policy`.
+- **ORM schema exporters** — Prisma, Drizzle, SQLAlchemy, sqlc,
+  Diesel, jOOQ, Ent, Ecto.
+- **Event streams** — `subscribe_channel`, `poll_notifications`,
+  `unsubscribe_channel`, `list_notification_subscriptions` bridging
+  PostgreSQL `LISTEN/NOTIFY` into the MCP poll model.
+- **Observability** — Prometheus `/metrics` endpoint +
+  `get_metrics_exposition` tool for stdio; structured audit trail
+  with regex-based credential redaction.
+
+---
 
 ## Documentation
 
-- [`docs/installation.md`](docs/installation.md) — Installation Guide
-- [`docs/user-guide.md`](docs/user-guide.md) — User Guide
-- [`docs/tour.md`](docs/tour.md) — compact tool tour (start here for discovery)
-- [`docs/cookbook.md`](docs/cookbook.md) — practical agent recipes (start here for common workflows)
-- [`docs/tools.md`](docs/tools.md) — reference for every MCP tool
-- [`docs/architecture.md`](docs/architecture.md) — Architecture Document
-- [`docs/security.md`](docs/security.md) — threat model and security controls
-- [`docs/scaling.md`](docs/scaling.md) — scaling characteristics and tuning
+- [`docs/installation.md`](docs/installation.md) — install + configure
+- [`docs/tour.md`](docs/tour.md) — guided tool tour
+- [`docs/cookbook.md`](docs/cookbook.md) — practical agent recipes
+- [`docs/tools.md`](docs/tools.md) — complete tool reference
+- [`docs/architecture.md`](docs/architecture.md) — how the pieces fit together
+- [`docs/scaling.md`](docs/scaling.md) — pool sizing, replicas, performance
+- [`docs/security-hardening.md`](docs/security-hardening.md) — security feature roadmap
+- [`docs/release-process.md`](docs/release-process.md) — how releases ship to PyPI
 - [`docs/adr/`](docs/adr/) — architecture decision records
-- [`PLAN.md`](PLAN.md) — master plan and phased roadmap
-- [`docs/PROGRESS.md`](docs/PROGRESS.md) — live progress tracker (resume point)
-- [`CONTRIBUTING.md`](CONTRIBUTING.md) — development setup and workflow
-- [`CHANGELOG.md`](CHANGELOG.md) — release notes
-- [`docs/release-notes-0.5.0.md`](docs/release-notes-0.5.0.md) — v0.5.0 release summary
-- [`docs/release-notes-0.4.0.md`](docs/release-notes-0.4.0.md) — v0.4.0 release summary
-- [`docs/release-notes-0.3.0.md`](docs/release-notes-0.3.0.md) — v0.3.0 release summary
+- Browse at **https://devopam.github.io/MCPg/**
+
+---
+
+## Security
+
+- Vulnerability reporting: see [`SECURITY.md`](SECURITY.md). 90-day
+  coordinated-disclosure window; reports to `devopam@gmail.com`.
+- Defence-in-depth: capability gates, SafeSQL kernel, identifier
+  allowlist, audit redaction, PG TLS enforcement at startup,
+  rate-limiting, OIDC JWT validation, per-session timeouts.
+- See [`docs/security-hardening.md`](docs/security-hardening.md) for
+  the living roadmap of shipped (✅) and queued (⬜) hardening items.
+
+---
+
+## Release notes & changelog
+
+See [`CHANGELOG.md`](CHANGELOG.md) for the full version history,
+[`docs/release-process.md`](docs/release-process.md) for how releases
+are cut, and the [GitHub Releases](https://github.com/devopam/MCPg/releases)
+page for downloadable artifacts.
+
+---
+
+## Contributing
+
+Pull requests welcome — see [`CONTRIBUTING.md`](CONTRIBUTING.md) for
+the dev-loop setup, test conventions, and the per-PR review
+checklist.
+
+---
 
 ## License
 
 MIT — see [`LICENSE`](LICENSE). The vendored SQL-safety kernel at
-`src/mcpg/_vendor/sql/` is also MIT-licensed; see
-[`NOTICE`](NOTICE) for provenance.
+`src/mcpg/_vendor/sql/` is also MIT-licensed; see [`NOTICE`](NOTICE)
+for provenance.
 
-\* : While best intent has been put to make it production grade, it is still a developmental project and is expected to have issues. Please refer to License Terms for details on indemnity. 
+> **Disclaimer.** Best effort has been put into making MCPg production
+> grade, but it remains an actively developed project and may contain
+> issues. Refer to the License Terms for indemnity details.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,112 +1,260 @@
 # MCPg Architecture
 
-How MCPg is built. This is a living document — it is updated as the
-architecture evolves. For the historical roadmap see [`../PLAN.md`](../PLAN.md);
-for individual decisions see [`adr/`](adr/).
+How MCPg is built. Describes the current shape; the running record
+of how it got there lives in [`../CHANGELOG.md`](../CHANGELOG.md)
+and the [`adr/`](adr/) directory.
+
+---
 
 ## Overview
 
 MCPg is a single-process, async ([`asyncio`](https://docs.python.org/3/library/asyncio.html))
-MCP server. An MCP client calls tools; each tool validates its input, runs
-read-only or read-write SQL against PostgreSQL through a connection pool, and
-returns a typed result. Every call is audited.
+MCP server. An MCP client connects via stdio or HTTP, calls tools,
+and gets typed results. Every call passes through three layers:
 
 ```
    MCP client ──stdio / streamable-HTTP / SSE──▶ AuditedFastMCP
-                                                      │  (audit every call)
-                                                      ▼
-                                            tool wrapper (mcpg.tools)
-                                                      │
-                                                      ▼
-                                   logic module (query / introspection / ...)
-                                                      │
-                                            SqlDriver / SafeSqlDriver
-                                                      │  psycopg3 pool
-                                                      ▼
+                                                       │  (rate limit + audit + metrics)
+                                                       ▼
+                                             tool wrapper (mcpg.tools)
+                                                       │  (capability gate via mcpg.policy)
+                                                       ▼
+                                    logic module (query / health / search / …)
+                                                       │
+                                            SqlDriver / SafeSqlDriver / TenantSqlDriver / RoutedSqlDriver
+                                                       │  psycopg3 pool + (optional) replica pools
+                                                       ▼
                                                  PostgreSQL
 ```
 
+Each layer has a focused responsibility — the tool wrapper
+translates the MCP call into a typed Python call, the logic module
+builds and runs the SQL, the driver stack validates / forces
+read-only / picks a pool / sets the tenant role.
+
+---
+
 ## Request lifecycle
 
-1. The client invokes a tool. `AuditedFastMCP.call_tool` (a `FastMCP`
-   subclass) wraps every invocation and records an audit event on success or
-   failure.
-2. The tool wrapper in `mcpg.tools` pulls the request's `AppContext` (settings
-   + database) from the server lifespan and obtains a `SqlDriver`.
-3. The wrapper delegates to a **logic module** — `query`, `introspection`,
-   `write`, `health`, `workload`, `indexing`, `textsearch`, `extensions` —
-   which builds and runs the SQL and maps rows to typed dataclasses.
-4. Read queries go through the vendored `SafeSqlDriver` (allowlist
-   validation, forced read-only); writes go through `SqlDriver` after
-   single-statement validation.
+1. The client invokes a tool. `AuditedFastMCP.call_tool` (a
+   `FastMCP[AppContext]` subclass) wraps every invocation:
+   - Checks the rate limiter (`mcpg.middleware.rate_limit`) when
+     `MCPG_RATE_LIMIT_ENABLED=true`.
+   - Records an audit event on completion (success or failure)
+     with the tool name, redacted arguments, and outcome.
+   - Updates the Prometheus counter + histogram
+     (`mcpg_tool_calls_total{tool,status}` /
+     `mcpg_tool_duration_seconds`).
+2. The tool wrapper in `mcpg.tools` pulls the request's
+   `AppContext` (settings + database + listen manager + cursor
+   manager) from the server lifespan and obtains a `SqlDriver`.
+3. The wrapper delegates to a **logic module** that builds and
+   runs the SQL and maps rows to typed dataclasses.
+4. The driver stack decides exactly which pool the SQL hits:
+   - **SafeSqlDriver** — agent-supplied SQL is parsed and
+     allowlisted via the vendored kernel before execution.
+   - **RoutedSqlDriver** — when `MCPG_REPLICA_URLS` is set,
+     `force_readonly=True` queries round-robin across healthy
+     replicas; writes always go to the primary.
+   - **TenantSqlDriver** — wraps a base driver to issue
+     `BEGIN ... SET LOCAL ROLE "<role>" ... <stmt> ... COMMIT`
+     when a static or per-request role is in play.
+5. The result is mapped to a typed result class and returned
+   through the tool wrapper. The audit hook records the outcome.
+
+---
 
 ## Module map
 
 | Module | Responsibility |
-|--------|----------------|
-| `mcpg.config` | Env-driven, validated `Settings` |
-| `mcpg.database` | Connection-pool lifecycle (`Database`) |
-| `mcpg.context` | `AppContext` shared with every tool |
-| `mcpg.server` | `FastMCP` bootstrap, `AuditedFastMCP`, transports, `run` |
-| `mcpg.policy` | Access-mode → capability permission table |
-| `mcpg.audit` | Audit-event records and redaction |
-| `mcpg.tools` | Thin MCP tool wrappers + `register_tools` |
-| `mcpg.introspection` | Schema/catalog inspection queries |
-| `mcpg.query` | Safe read-only query execution + plan analysis |
-| `mcpg.write` | Single-statement DML / DDL execution |
-| `mcpg.health` | Database health checks |
-| `mcpg.workload` | Slow-query analysis (`pg_stat_statements`) |
-| `mcpg.indexing` | Index recommendations |
-| `mcpg.textsearch` | Search: trigram fuzzy, full-text, pgvector, PostGIS |
-| `mcpg.extensions` | Extension management (`enable_extension`) |
-| `mcpg._vendor` | Vendored third-party code (see below) |
+|---|---|
+| `mcpg.config` | Env-driven, validated `Settings` (frozen dataclass). Validates TLS-required, role identifiers, OIDC settings; redacts secrets in `__repr__`. |
+| `mcpg.database` | Primary-connection-pool lifecycle (`Database`) and per-connection `statement_timeout` / `lock_timeout` setup. |
+| `mcpg.replicas` | Read-replica pool registry; degraded-replica tracking; routing logic. |
+| `mcpg.context` | `AppContext` — the per-server state shared with every tool wrapper. |
+| `mcpg.server` | `FastMCP` bootstrap, `AuditedFastMCP` subclass, transport selection, `run` entry point. |
+| `mcpg.http_runtime` | Streamable-HTTP / SSE transport bring-up: bearer auth, OIDC validation, security middleware, `/metrics` / `/healthz` / `/readyz` endpoints. |
+| `mcpg.oidc` | OIDC discovery + JWKS-backed JWT verification (asymmetric algorithms only). |
+| `mcpg.tenancy` | The `current_role` ContextVar that powers per-request `SET LOCAL ROLE`. |
+| `mcpg.middleware.rate_limit` | Token-bucket per-tool rate limiter. |
+| `mcpg.policy` | Access-mode → capability permission table. |
+| `mcpg.audit` | Tool-call audit logger + configurable secret-name regex redactor + the comprehensive `audit_database` DBA report. |
+| `mcpg.audit_trail` | Optional `mcpg_audit.events` table persistence for `run_write` / `run_ddl` records. |
+| `mcpg.tools` | Thin MCP tool wrappers + `register_tools` (consults `mcpg.policy` for capability gating). |
+| `mcpg.introspection` | Schema / catalog inspection queries (parameterised). |
+| `mcpg.query` | Safe read-only query execution + plan analysis. |
+| `mcpg.write` | Single-statement DML / DDL execution + optional schema-diff capture. |
+| `mcpg.health` | Database health checks. |
+| `mcpg.workload` | Slow-query analysis (`pg_stat_statements`). |
+| `mcpg.indexing` | Index recommendations. |
+| `mcpg.textsearch` | Search: trigram fuzzy, full-text, pgvector, PostGIS k-NN, hybrid (vector + FTS via RRF). |
+| `mcpg.vector_tuning` | pgvector advisors (HNSW vs IVFFlat, quantization, recall/speed). |
+| `mcpg.composite` | One-call aggregates: `summarize_table`, `why_is_this_slow`, `audit_database`. |
+| `mcpg.advisors` | Schema-quality advisors (PK, FK index, dup index, RLS, graph index, …). |
+| `mcpg.cursors` | Server-side cursor manager (one dedicated connection per cursor; 5-minute idle TTL). |
+| `mcpg.cypher` / `mcpg.graph` / `mcpg.graph_diagram` / `mcpg.graph_mgmt` | Apache AGE property graph + Cypher integration. |
+| `mcpg.migrations` | Staged migration workflow — shadow schema, structural diff, transient validation. |
+| `mcpg.nl2sql` | Natural-language → SQL via pluggable providers (Anthropic / OpenAI / Gemini). |
+| `mcpg.data_movement` | Export (`export_query` / `export_table`) and bulk-load (`import_csv` / `import_json` via COPY FROM STDIN). |
+| `mcpg.shell` | Subprocess wrappers (`dump_database` / `restore_database` / `copy_table_between_databases` / `run_pg_binary`). |
+| `mcpg.listen` | LISTEN/NOTIFY bridge (dedicated connection per subscription; bounded queue). |
+| `mcpg.cron` | `pg_cron` schedule / unschedule / update wrappers. |
+| `mcpg.partman` | `pg_partman` partition-management wrappers. |
+| `mcpg.timescale` | TimescaleDB hypertable / compression / retention wrappers. |
+| `mcpg.extensions` | Allowlisted `enable_extension`. |
+| `mcpg.diesel` / `mcpg.drizzle` / `mcpg.ecto` / `mcpg.ent` / `mcpg.prisma_export` / `mcpg.sqlalchemy_export` / `mcpg.sqlc_export` / `mcpg.jooq_export` | ORM schema exporters. |
+| `mcpg.observability` | Prometheus counters + histograms and `get_metrics_exposition`. |
+| `mcpg._vendor` | Vendored MIT-licensed `SafeSqlDriver` and connection-pool kernel (see below). |
 
-The `__main__` module is the `mcpg` console entry point.
+`mcpg.__main__` is the `mcpg` console entry point; handles the
+`--version` flag and falls through to `run(load_settings())`.
+
+---
 
 ## The vendored SQL-safety kernel
 
-`src/mcpg/_vendor/sql/` is a pinned copy of the SQL-safety subpackage from
-[`crystaldba/postgres-mcp`](https://github.com/crystaldba/postgres-mcp) (MIT).
-It provides `SafeSqlDriver` — a `pglast` AST allowlist validator — and the
-connection pool / driver. It is kept near-verbatim, excluded from the
-coverage gate and `mypy`, and re-synced via the procedure in
+`src/mcpg/_vendor/sql/` is a pinned copy of the SQL-safety
+subpackage from
+[`crystaldba/postgres-mcp`](https://github.com/crystaldba/postgres-mcp)
+(MIT). It provides `SafeSqlDriver` — a `pglast`-AST allowlist
+validator — and the base connection pool / driver.
+
+The kernel is kept near-verbatim, excluded from the coverage gate
+and `mypy`, and re-synced via the procedure in
 `src/mcpg/_vendor/README.md`. See [ADR-0001](adr/0001-build-approach.md).
+
+---
 
 ## Access-mode & capability model
 
-`mcpg.policy` maps each access mode to a set of capabilities
-(`READ`, `WRITE`, `DDL`). `register_tools` consults the policy so a tool is
-only exposed when its capability is permitted: reads in every mode, writes in
-`unrestricted`, DDL in `unrestricted` **and** with `MCPG_ALLOW_DDL`. There is
-no module-level mutable state — settings and the database live in the server
-lifespan's `AppContext`.
+`mcpg.policy` maps each access mode to a set of capabilities:
 
-## Security model
+| Access mode | Capabilities granted |
+|---|---|
+| `read-only` | `READ` |
+| `restricted` | `READ` |
+| `unrestricted` | `READ`, `WRITE` |
 
-Read-only by default; every agent-supplied SQL statement is parsed and
-allowlist-checked before execution; writes are validated as a single
-statement of an expected kind; identifiers in search tools are validated and
-quoted; credentials are redacted from logs. The full threat model is in
-[`security.md`](security.md).
+Additional gates within `unrestricted` add fine-grained
+capabilities:
+
+| Env var | Capability |
+|---|---|
+| `MCPG_ALLOW_DDL=true` | `DDL` |
+| `MCPG_ALLOW_SHELL=true` | `SHELL` |
+| `MCPG_ALLOW_LISTEN=true` | `LISTEN` |
+
+`register_tools` consults the policy so a tool is only exposed to
+the MCP client when its required capability is permitted. There is
+**no module-level mutable state** — settings, the database, the
+listen manager, and the cursor manager all live in the server
+lifespan's `AppContext`, passed to tools via `Context.lifespan_context`.
+
+---
+
+## Transport & HTTP middleware stack
+
+For `MCPG_TRANSPORT=streamable-http` or `sse`, `mcpg.http_runtime`
+constructs a Starlette app with this middleware stack (outermost
+first):
+
+1. **Bearer / OIDC authentication.** Static
+   (`MCPG_HTTP_AUTH_TOKEN` constant-time compare) or full JWT
+   validation against an OIDC issuer's JWKS. `/metrics` / `/healthz`
+   / `/readyz` are exempt by design.
+2. **Per-request role propagation.** Reads `X-MCPG-Role` (or the
+   OIDC role claim when `MCPG_OIDC_ROLE_CLAIM` is set), validates
+   against `MCPG_ALLOWED_ROLES`, and stashes the value in the
+   `current_role` ContextVar that the `TenantSqlDriver` reads.
+3. **The MCP transport handler** (FastMCP-provided).
+
+Plus three first-party endpoints under the same auth-exempt rules:
+
+- `GET /metrics` — Prometheus text format
+- `GET /healthz` — liveness
+- `GET /readyz` — readiness (verifies a pool connection)
+
+---
+
+## Security model (summary)
+
+Read-only by default; every agent-supplied SQL statement is parsed
+and allowlist-checked before execution; writes are validated as a
+single statement of an expected kind; identifiers everywhere flow
+through a `[A-Za-z_][A-Za-z0-9_]*` regex; credentials are redacted
+from logs and audit trail; PG TLS is enforced on startup; HTTP
+transports require a bearer token or OIDC JWT; per-session
+`statement_timeout` and `lock_timeout` are set on each pool
+checkout. The full threat model is in [`security.md`](security.md);
+the shipped-vs-queued roadmap is in
+[`security-hardening.md`](security-hardening.md).
+
+---
 
 ## Graceful degradation for optional extensions
 
-Tools that depend on an optional extension (`fuzzy_search` → `pg_trgm`,
-`analyze_workload` → `pg_stat_statements`) check for the extension first and
-return an `available: false` result instead of failing when it is absent.
-`describe_table` and `list_indexes` surface `pgvector` / index-method details
-when present without requiring the extension otherwise.
+Tools that depend on an optional extension check for it at call
+time and return an `available: false` result instead of failing
+when it's absent. Affected tools:
+
+| Tool | Required extension |
+|---|---|
+| `fuzzy_search` | `pg_trgm` |
+| `analyze_workload`, `detect_n_plus_one` | `pg_stat_statements` |
+| `vector_search`, `vector_range_search`, `hybrid_search`, `recommend_vector_*`, `analyze_vector_*` | `vector` (pgvector) |
+| `geo_search` | `postgis` |
+| `pg_cron.*` | `pg_cron` |
+| `partman.*` | `pg_partman` |
+| `list_hypertables`, `create_hypertable`, `add_compression_policy`, `add_retention_policy`, `list_chunks` | `timescaledb` |
+| `list_graphs`, `describe_graph`, `run_cypher`, `create_graph`, `drop_graph`, `generate_graph_diagram` | `age` (Apache AGE) |
+
+`describe_table` and `list_indexes` surface `pgvector` /
+index-method details when present without requiring the extension
+otherwise.
+
+---
 
 ## Testing approach
 
-MCPg is test-driven. Authored code is covered by unit tests (using fake
-drivers) under a coverage gate, and by integration tests that run against a
-real PostgreSQL. CI exercises the suite against PostgreSQL 14–17 on
-pgvector-enabled images. The vendored kernel keeps its own upstream tests.
+MCPg is test-driven across three suites:
+
+| Suite | Scope |
+|---|---|
+| `tests/unit/` | Fake-driver tests with a 90% coverage gate. Authored code only — the vendored kernel keeps its own tests. |
+| `tests/integration/` | Real PostgreSQL — requires `MCPG_TEST_DATABASE_URL`. CI matrix runs against PostgreSQL 14, 15, 16, 17, 18 on a pgvector + PostGIS + AGE-enabled image. |
+| `tests/vendor/` | The vendored kernel's own upstream tests, kept for adversarial SQL-injection coverage. |
+
+The integration container is built from
+`.github/ci-postgres.Dockerfile` and includes `pgvector`,
+`postgis`, `pg_trgm`, `pg_stat_statements`, and Apache `age`.
+
+---
 
 ## Configuration & deployment
 
-Configuration is entirely environment-variable driven (see the
-[Installation Guide](installation.md)). MCPg ships as a `uv` project and a
-Docker image. Scaling characteristics and tuning are documented in
-[`scaling.md`](scaling.md).
+Configuration is **entirely** environment-variable driven — no
+config file, no flags beyond `--version`. The full env-var
+reference is in the [README](../README.md#configuration); the
+narrative is in [`installation.md`](installation.md).
+
+MCPg ships as both a PyPI package (`pip install mcpg`) and a
+hardened multi-stage Docker image — the runtime stage drops the
+build toolchain, runs as `uid=10001 / gid=10001` with `nologin`,
+and keeps application files root-owned and read-only.
+
+Scaling characteristics, pool sizing, and observability guidance
+live in [`scaling.md`](scaling.md).
+
+---
+
+## See also
+
+- [`adr/`](adr/) — accepted architecture decision records.
+- [`tour.md`](tour.md) — tool discovery surface, grouped by
+  intent.
+- [`tools.md`](tools.md) — full per-tool reference.
+- [`security.md`](security.md) — threat model.
+- [`security-hardening.md`](security-hardening.md) — shipped vs
+  queued hardening roadmap.
+- [`scaling.md`](scaling.md) — load behaviour and tuning.
+- [`release-process.md`](release-process.md) — release playbook.

--- a/docs/feature-shortlist.md
+++ b/docs/feature-shortlist.md
@@ -1,202 +1,140 @@
-# Post-v0.4.0 feature shortlist
+# MCPg feature roadmap
 
-Candidates for new feature work, organised by area. Each entry shows
-rough effort (**S/M/L**), the user-facing value, and any prerequisite
-that might block it. Use this as a menu for prioritisation.
+Forward-looking candidates for new feature work, grouped by
+area. Each entry shows rough effort (**S** / **M** / **L**),
+user-facing value, and any prerequisite. Use this as a menu for
+prioritisation.
+
+Items that are already on `main` are deliberately **not** listed
+here — for what shipped when, see
+[`../CHANGELOG.md`](../CHANGELOG.md). For the live status of
+security-hardening items specifically, see
+[`security-hardening.md`](security-hardening.md).
 
 Effort scale (rough, single-session yardstick):
-- **S** = 1 module, 1 PR, ≤ 1 day equivalent
-- **M** = 2–3 modules or wider surface, 1–3 PRs
-- **L** = new infrastructure (background workers, transport changes,
-  cross-cutting refactors)
+
+- **S** — 1 module, 1 PR, ≤ 1 day equivalent
+- **M** — 2–3 modules or wider surface, 1–3 PRs
+- **L** — new infrastructure (background workers, transport
+  changes, cross-cutting refactors)
 
 ---
 
-## 1. Transport & deployment hardening
+## 1. Observability
 
 | # | Item | Effort | Value | Notes |
 |---|---|---|---|---|
-| 1.1 | **HTTP transport auth** (bearer / API key + middleware) | M | High | Currently `streamable-http` / `sse` have **no auth** — a real-world deployment blocker. Open question in PLAN.md §0.1. |
-| 1.2 | TLS / mTLS for HTTP transport | S | Medium | Mostly config + cert wiring. Often handled at the reverse-proxy layer instead. |
-| 1.3 | Rate limiting per client / per tool | M | Medium | Pairs naturally with 1.1. |
-| 1.4 | **Per-request `SET ROLE`** for multi-tenancy | M | High | Deferred in Phase 6.2 with a note that document-only is the v1 stance. Re-opens multi-tenant deployments. |
-| 1.5 | Multi-database support (one server, many DBs) | L | Medium | Today: one server = one `MCPG_DATABASE_URL`. Multi-DB means a tool param, a pool-per-DB, and rethinking gates. |
-| 1.6 | Read-replica routing for read tools | M | Low-Medium | Deferred in Phase 6.4. Marginal at MCPg's scale until 1.4 lands. |
+| 1.1 | OpenTelemetry spans per tool call | M | Medium-High | One span per `call_tool` + child spans for the actual query / subprocess. |
+| 1.2 | Structured JSON logging output toggle | S | Medium | Wraps the existing `mcpg.audit` logger. |
+| 1.3 | Slow-call logging from the MCP layer | S | Low | Per-tool latency log to flag slow MCPg-side calls (the existing `analyze_workload` covers PG-side timings). |
 
-## 2. Observability
+## 2. PostgreSQL feature coverage
 
 | # | Item | Effort | Value | Notes |
 |---|---|---|---|---|
-| 2.1 | **Prometheus `/metrics` endpoint** | S-M | High | Tool-call count / latency / error rate per tool. Pairs with the HTTP transport. |
-| 2.2 | **OpenTelemetry spans** per tool call | M | Medium-High | One span per `call_tool` + child spans for the actual query / subprocess. |
-| 2.3 | Structured JSON logging output | S | Medium | Optional — wraps the existing `mcpg.audit` logger. |
-| 2.4 | k8s-style `/healthz` + `/readyz` endpoints | S | Medium | Just on the HTTP transport. |
-| 2.5 | Slow-query logging from the MCP layer | S | Low | The existing `analyze_workload` already covers PG-side timings; this would be a per-tool latency log. |
+| 2.1 | Logical replication management writes (`create_publication`, `drop_publication`, `create_subscription`, `drop_subscription`) | M | Medium-High | Read tools already exist. Closes the loop on logical-replication ops; gated under `MCPG_ALLOW_DDL`. |
+| 2.2 | `pg_buffercache` integration (cache hit analysis at the buffer level) | S | Low-Medium | Niche. |
+| 2.3 | WAL inspection (`pg_walinspect`) | S | Low | Niche but useful for replication debugging. |
+| 2.4 | Deeper `pg_locks` walker — deadlock-cycle reconstruction beyond the current `find_blocking_chains` pair list | S-M | Medium | Live-ops complement. |
 
-## 3. Performance & scaling
-
-| # | Item | Effort | Value | Notes |
-|---|---|---|---|---|
-| 3.1 | **Server-side cursors** for streaming large `run_select` results | M | Medium-High | Listed as Phase 6.4 deferred work. Lets agents fetch result sets larger than `max_rows`. |
-| 3.2 | Connection-pool tuning advisor (recommend min/max from observed load) | S | Low-Medium | Reuses existing `check_database_health` plumbing. |
-| 3.3 | Bulk-update / bulk-delete tools (parametrised, gated) | S | Low | Sibling to `import_csv` for writes. |
-| 3.4 | Parallel query execution helper (`run_selects_parallel`) | S | Medium | Useful for an agent fanning out across schemas. |
-
-## 4. PostgreSQL feature coverage
+## 3. Developer experience
 
 | # | Item | Effort | Value | Notes |
 |---|---|---|---|---|
-| 4.1 | **Logical replication management writes** — `create_publication`, `drop_publication`, `create_subscription`, `drop_subscription` | M | Medium-High | Read tools already exist (Phase 16). Closes the loop on logical-replication ops. Gated under DDL. |
-| 4.2 | **TimescaleDB hypertable wrappers** | M | High | Most popular PG extension after pgvector/PostGIS. `create_hypertable`, `add_dimension`, `set_chunk_time_interval`, `compress_chunk`, retention policies. |
-| 4.3 | `pg_stat_io` exposure (PG 16+) | S | Medium | Big I/O visibility win on modern PG. |
-| 4.4 | `pg_buffercache` integration (cache hit analysis at the buffer level) | S | Low-Medium | Niche. |
-| 4.5 | `pg_locks` deep inspection / deadlock detector | S | Medium | Live-ops complement. |
-| 4.6 | WAL inspection (`pg_walinspect`) | S | Low | Niche but useful for replication debugging. |
-| 4.7 | Generated-column awareness in `describe_table` | S | Low-Medium | Currently we don't surface `GENERATED ALWAYS AS ...` columns specially. |
-| 4.8 | Row-level security policy tester (`would_this_row_be_visible_to_role`) | M | Medium | Hard-to-test feature; great agentic UX. |
+| 3.1 | Auto-generated tool examples in MCP tool descriptions | S | Low-Medium | Helps agents pick the right tool. |
+| 3.2 | Sample-data generator that writes (`seed_table_with_sample_data`) | M | Medium | Sibling of the current `generate_test_data` (synthetic INSERT statements; does not execute). Gated under WRITE. |
 
-## 5. Developer experience
+## 4. Security & compliance
 
-| # | Item | Effort | Value | Notes |
-|---|---|---|---|---|
-| 5.1 | **Cookbook of common agent flows** in docs (e.g. "review a migration", "find slow queries", "generate ORM models") | S | Medium-High | Pairs with the tour we just shipped. Pure docs. |
-| 5.2 | `summarize_table` composite tool (describe + sample rows + stats in one call) | S | High | Big agent UX win — replaces 4–5 tool calls with one. |
-| 5.3 | Sample-data generator (`seed_table_with_sample_data`, gated under WRITE) | M | Medium | Useful for shadow-migration testing and demos. |
-| 5.4 | Auto-generated tool examples in MCP tool descriptions | S | Low-Medium | Helps agents pick the right tool. |
-
-## 6. Security & compliance
+The full security-hardening roadmap (HTTP request limits, security
+headers, CORS allowlist, audit-log HMAC integrity chain, pluggable
+secrets backend, subprocess hardening, graceful shutdown) lives in
+[`security-hardening.md`](security-hardening.md). Forward items
+not covered there:
 
 | # | Item | Effort | Value | Notes |
 |---|---|---|---|---|
-| 6.1 | **Connection encryption verification tool** — reports `ssl=on/off` + cipher | S | Medium | One-liner check. |
-| 6.2 | Sensitive-column heuristic discovery (emails, phone, SSN, credit card by regex + name) | M | Medium-High | Pairs with audit + compliance workflows. |
-| 6.3 | Audit log retention / rotation policy | S | Medium | `mcpg_audit.events` grows unbounded today. |
-| 6.4 | IP allowlist for HTTP transport | S | Low | Tiny middleware. |
-| 6.5 | OIDC / SSO for HTTP transport | L | Medium | Bigger commitment than the simpler 1.1 bearer-token path. |
+| 4.1 | Connection-encryption verification tool — reports `ssl=on/off` + cipher per connection | S | Medium | Composes with the existing TLS-enforcement startup check. |
+| 4.2 | Audit-log retention / rotation policy in `mcpg_audit.events` | S | Medium | Grows unbounded today; a `prune_audit_events(older_than)` tool + a cron-friendly retention helper. |
+| 4.3 | IP allowlist for HTTP transport | S | Low | Tiny middleware. Often handled at the reverse-proxy layer instead. |
+| 4.4 | mTLS for the HTTP transport | S | Medium | Cert wiring; commonly done at the proxy layer. |
 
-## 7. Backups & DR
-
-| # | Item | Effort | Value | Notes |
-|---|---|---|---|---|
-| 7.1 | Scheduled logical backups via `pg_cron` + `dump_database` | S | Medium | Composes existing tools. |
-| 7.2 | WAL archive inspection | M | Low | Niche; only useful where WAL archiving is configured. |
-| 7.3 | Point-in-time recovery prep helpers | M | Low-Medium | Heavy lift for a narrow audience. |
-
-## 8. Schema design / quality
+## 5. Backups & DR
 
 | # | Item | Effort | Value | Notes |
 |---|---|---|---|---|
-| 8.1 | **Naming-convention linter** (snake_case, prefix conventions, FK suffix, ...) | S | Medium | Quick win. |
-| 8.2 | **Unused-table / unused-column finder** via `pg_stat_user_tables` | S | High | Excellent agent UX for "what can I drop?". |
-| 8.3 | Missing-index dead-code detector (sibling to `recommend_indexes` but for *over*-indexed) | S | Medium | Currently `recommend_indexes` only adds, never removes. |
-| 8.4 | N+1 query pattern detector via `pg_stat_statements` | M | Medium-High | Composes `analyze_workload` with grouping heuristics. |
-| 8.5 | FK cascade visualisation (diagram of what cascades from a delete) | S | Medium | Pairs with `generate_schema_diagram`. |
+| 5.1 | Scheduled logical backups via `pg_cron` + `dump_database` | S | Medium | Composes existing tools. |
+| 5.2 | WAL archive inspection | M | Low | Niche; only useful where WAL archiving is configured. |
+| 5.3 | Point-in-time recovery prep helpers | M | Low-Medium | Heavy lift for a narrow audience. |
 
-## 9. Migration ecosystem integration
+## 6. Schema design / quality
 
 | # | Item | Effort | Value | Notes |
 |---|---|---|---|---|
-| 9.1 | Alembic / Flyway / Liquibase migration script ingestion (parse + apply through `prepare_migration`) | M-L | Medium | Big agentic win for projects with existing migration history. |
-| 9.2 | Pre-deployment migration validation (target schema vs production snapshot) | M | High | Composes `compare_schemas` + shadow workflow. |
-| 9.3 | Migration history table integration (Alembic / Flyway / Diesel native tables) | S | Medium | Reads existing tooling's bookkeeping. |
-| 9.4 | Zero-downtime migration cookbook | S | Medium-High | Pure docs (patterns, not code). |
+| 6.1 | Over-indexed detector (sibling to `recommend_indexes` but for what to drop) | S | Medium | Currently `recommend_indexes` only adds, never removes. |
 
-## 10. AI / agent-specific
+## 7. Migration ecosystem integration
 
 | # | Item | Effort | Value | Notes |
 |---|---|---|---|---|
-| 10.1 | **`why_is_this_slow` composite tool** (EXPLAIN + active queries + locks + cache hit + suggestions in one call) | M | Very High | Agent magnet. |
-| 10.2 | Natural-language → SQL helper (gated, returns SQL + EXPLAIN for review before run) | M | High | Different shape than the existing tools — calls out to a model. |
-| 10.3 | Test-data factory (`generate_test_row_for(schema, table)` using catalog + heuristics) | M | Medium-High | Pairs with the shadow-migration workflow. |
-| 10.4 | Schema documentation generator (Markdown table reference from catalog) | S | Medium | Sibling of `generate_schema_diagram`. |
+| 7.1 | Alembic / Flyway / Liquibase migration-script ingestion (parse + apply through `prepare_migration`) | M-L | Medium | Big agentic win for projects with existing migration history. |
+| 7.2 | Pre-deployment migration validation (target schema vs production snapshot) | M | High | Composes `compare_schemas` + shadow workflow. |
+| 7.3 | Migration history table integration (read Alembic / Flyway / Diesel native tables) | S | Medium | Reads existing tooling's bookkeeping. |
+| 7.4 | Zero-downtime migration cookbook | S | Medium-High | Pure docs (patterns, not code). |
+
+## 8. AI / agent-specific
+
+| # | Item | Effort | Value | Notes |
+|---|---|---|---|---|
+| 8.1 | Test-data factory using catalog + heuristics (`generate_test_row_for(schema, table)`) | M | Medium-High | Pairs with the shadow-migration workflow. |
+| 8.2 | Schema-documentation generator (Markdown table reference from catalog) | S | Medium | Sibling of `generate_schema_diagram`. |
+
+## 9. pgvector extensions
+
+Building on the already-shipped `vector_search`,
+`vector_range_search`, `hybrid_search`, `recommend_vector_index`,
+`recommend_vector_quantization`, `analyze_vector_search`,
+`analyze_vector_table`, `describe_table` vector-dimension
+awareness, and HNSW/IVFFlat detection in `list_indexes`:
+
+| # | Item | Effort | Value | Notes |
+|---|---|---|---|---|
+| 9.1 | HNSW recall/speed tuner (`analyze_hnsw_recall`) — sweep `ef_search` against a ground-truth set, return recall@k curves | M | High | Lets agents pick the right speed/quality knob without manual tuning. |
+| 9.2 | `mmr_search` — Maximal Marginal Relevance re-ranking on top of vector_search for result diversity | S-M | Medium-High | Quality of agentic RAG flows. |
+| 9.3 | `cluster_vectors` — k-means cluster a vector column, return centroids + per-row labels | M | Medium-High | Exploration / segmentation tool. |
+| 9.4 | `detect_vector_outliers` — flag rows whose embedding is far from any cluster centroid | S-M | Medium-High | Data quality + content moderation. |
+| 9.5 | `monitor_embedding_drift` — compare distributional stats of vectors over time windows | M | Medium | Ops / model-quality monitoring. |
+| 9.6 | `import_vectors` — bulk-load embeddings from JSON/CSV with `vector(N)` column-type validation | S | Medium | Sibling of `import_csv` specialised for vector columns. |
+| 9.7 | `cross_table_similarity` — given a row in table A, find the k most similar rows in table B (different embedding source, same dim) | S | Medium | Useful for entity resolution / linking across tables. |
+| 9.8 | `analyze_distance_metric` — recommend cosine vs L2 vs inner-product based on vector-magnitude distribution | S | Medium | Concrete advice when the user hasn't decided yet. |
+| 9.9 | `monitor_index_build` — surface HNSW / IVFFlat build progress for long-running index creations | S | Medium | Lives next to `list_active_queries`; useful for big-table index work. |
+| 9.10 | `migrate_vector_to_halfvec` — DDL generator to convert a `vector(N)` column to `halfvec(N)` (or `bit`) safely | S-M | Medium | Pairs with `recommend_vector_quantization`. Uses the existing shadow workflow. |
+
+## 10. Multi-database support
+
+| # | Item | Effort | Value | Notes |
+|---|---|---|---|---|
+| 10.1 | One MCPg server, multiple `MCPG_DATABASE_URL`s — tool-level db selector | L | Medium | Today: one server = one DSN. Multi-DB means a per-tool param, a pool-per-DB, and rethinking gates. Big lift; no concrete demand yet. |
 
 ---
 
-## 11. pgvector extensions
+## Currently deferred (no commitments)
 
-Building on what's already shipped (`vector_search`,
-`recommend_vector_index`, `analyze_vector_search`,
-`analyze_vector_table`, `describe_table` vector-dimension awareness,
-HNSW/IVFFlat detection in `list_indexes`):
-
-| # | Item | Effort | Value | Notes |
-|---|---|---|---|---|
-| 11.1 | **`hybrid_search`** — combine vector + full-text scoring via reciprocal-rank fusion | M | Very High | Single biggest unmet need in agentic retrieval. Pairs the existing `vector_search` and `full_text_search` into one ranked result set. |
-| 11.2 | **`range_search`** — find rows within a distance threshold (not top-k) | S | High | Different query shape than k-NN; common for de-dup / similarity gating. |
-| 11.3 | **`recommend_vector_quantization`** — flag tables where `halfvec` (16-bit) or `bit` quantization would cut storage 2-32× | S-M | High | pgvector v0.7+. Compares dim × row-count × bytes vs working-set memory; concrete cost win. |
-| 11.4 | **HNSW recall/speed tuner** (`analyze_hnsw_recall`) — sweep `ef_search` against a ground-truth set, return recall@k curves | M | High | Lets agents pick the right speed/quality knob without manual tuning. |
-| 11.5 | **`mmr_search`** — Maximal Marginal Relevance re-ranking on top of vector_search for result diversity | S-M | Medium-High | Quality of agent RAG flows improves materially. |
-| 11.6 | **`cluster_vectors`** — k-means cluster a vector column, return centroids + per-row labels | M | Medium-High | Exploration / segmentation tool; uses ``cube_distance`` or in-memory clustering. |
-| 11.7 | **`detect_vector_outliers`** — flag rows whose embedding is far from any cluster centroid | S-M | Medium-High | Data quality + content moderation. |
-| 11.8 | **`monitor_embedding_drift`** — compare distributional stats of vectors over time windows | M | Medium | Ops / model-quality monitoring. |
-| 11.9 | **`import_vectors`** — bulk-load embeddings from JSON/CSV with `vector(N)` column-type validation | S | Medium | Sibling of `import_csv` specialised for vector columns. |
-| 11.10 | **`cross_table_similarity`** — given a row in table A, find the k most similar rows in table B (different embedding source, same dim) | S | Medium | Useful for entity resolution / linking across tables. |
-| 11.11 | **`analyze_distance_metric`** — heuristically recommend cosine vs L2 vs inner-product based on vector magnitude distribution | S | Medium | Concrete advice when the user hasn't decided yet. |
-| 11.12 | **`monitor_index_build`** — surface HNSW / IVFFlat build progress for long-running index creations | S | Medium | Lives next to `list_active_queries`; useful for big-table index work. |
-| 11.13 | **`migrate_vector_to_halfvec`** — generate the DDL to convert a `vector(N)` column to `halfvec(N)` (or `bit`) safely | S-M | Medium | Pairs with 11.3. Uses the existing migration shadow workflow for the structural review. |
-
-**Suggested pgvector picks for Tier A:**
-- **11.1 `hybrid_search`** (Very High value, M effort) — biggest agentic-RAG win
-- **11.3 `recommend_vector_quantization`** (High value, S-M effort) — concrete cost savings
-- **11.2 `range_search`** (High value, S effort) — quick win that fills a real gap
-
-These three would bring the pgvector tool surface from 4 → 7 and
-cover the most common gaps agentic-RAG workflows hit.
+- **Multi-database support** (10.1 above) — very ambitious;
+  preferred shape today is one MCPg instance per database.
+- **Backups & DR** beyond what `dump_database` /
+  `restore_database` already cover — narrow audience.
+- **Alembic / Flyway / Liquibase script ingestion** (7.1) — large
+  surface; `validate_migration` + `prepare_migration` already
+  cover the high-value reviewer workflow.
 
 ---
 
-## Suggested priority tiers
+## See also
 
-These are my recommendations to bucket the list — feel free to override.
-
-**Tier A — high-value, modest effort, unblock real deployments:**
-- 1.1 HTTP transport auth (M, High)
-- 2.1 Prometheus metrics (S-M, High)
-- 5.2 `summarize_table` composite tool (S, High)
-- 8.2 Unused-table / column finder (S, High)
-- 10.1 `why_is_this_slow` composite tool (M, Very High)
-- 4.2 TimescaleDB wrappers (M, High)
-- **11.1 Hybrid (vector + FTS) search** (M, Very High)
-- **11.3 Vector quantization advisor** (S-M, High)
-- **11.2 Vector range search** (S, High)
-
-**Tier B — strong UX or coverage wins:**
-- 1.4 Per-request `SET ROLE` multi-tenancy (M, High)
-- 4.1 Logical replication writes (M, Medium-High)
-- 5.1 Agent cookbook (S, Medium-High)
-- 6.2 Sensitive-column heuristics (M, Medium-High)
-- 8.4 N+1 detector (M, Medium-High)
-- 9.2 Migration validation against production snapshot (M, High)
-
-**Tier C — nice to have:**
-- 3.1 Server-side cursors (M, Medium-High)
-- 3.4 Parallel select helper (S, Medium)
-- 4.3 `pg_stat_io` (S, Medium)
-- 4.5 `pg_locks` deeper inspection (S, Medium)
-- 4.7 Generated columns (S, Low-Medium)
-- 4.8 RLS policy tester (M, Medium)
-- 8.1 Naming-convention linter (S, Medium)
-- 8.5 FK cascade visualisation (S, Medium)
-- 10.3 Test-data factory (M, Medium-High)
-
-**Shipped from "Defer for now":**
-- ✅ **1.6 Read-replica routing** — landed via PR #23; `MCPG_REPLICA_URLS`
-- ✅ **6.5 OIDC / SSO** — landed via PR #23; `MCPG_AUTH_MODE=oidc` with JWKS validation and role-claim → tenancy bridge
-- ✅ **10.2 NL → SQL** — landed via PR #21; `translate_nl_to_sql` with pluggable Anthropic / OpenAI / Gemini providers
-
-**Still deferred (no commitments):**
-- 1.5 Multi-database support — L; very ambitious, no clear use case yet
-- 7.x Backups & DR family — narrow audience; `dump_database` / `restore_database` already cover the basics via subprocess gate
-- 9.1 Migration script ingestion — big surface; `validate_migration` + `prepare_migration` already cover the high-value reviewer workflow
-
-**Bonus features shipped beyond the original shortlist:**
-- Apache AGE property graph + Cypher (PR #24): `list_graphs`,
-  `describe_graph`, `run_cypher`, `generate_graph_diagram`,
-  `create_graph`, `drop_graph`. Plus a `recommend_graph_indices`
-  advisor rule.
-- Cookbook (`docs/cookbook.md`) — 20 task-oriented recipes.
-- Production hardening across releases: per-cursor locks against
-  concurrent fetch / close, asyncio.to_thread for blocking JWKS
-  fetches, hard caps on cursors / parallel selects / NL→SQL tokens,
-  password obfuscation in `Settings.__repr__` for every secret-bearing
-  field.
+- [`security-hardening.md`](security-hardening.md) — security
+  hardening status with ✅ / 🟡 / ⬜ markers.
+- [`tour.md`](tour.md) and [`tools.md`](tools.md) — current tool
+  surface.
+- [`../CHANGELOG.md`](../CHANGELOG.md) — chronological record of
+  what shipped when.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,141 +1,320 @@
 # MCPg Installation Guide
 
-How to install and configure the MCPg PostgreSQL MCP server. This is a living
-document — it is updated as installation and configuration options change.
+How to install, configure, and verify MCPg. The complete
+`MCPG_*` environment-variable reference lives in the
+[README](../README.md#configuration); this guide focuses on
+**getting a working install** and the most common configuration
+paths.
+
+---
 
 ## Prerequisites
 
-- **Python 3.12 or newer**.
-- **PostgreSQL 14–18** reachable from where MCPg runs. (Older versions may
-  work but are not tested.)
-- **[uv](https://docs.astral.sh/uv/)** for installing from source.
-- Optionally **Docker**, to run MCPg as a container.
+- **Python 3.12 or newer** (3.12 + 3.13 are tested in CI).
+- **PostgreSQL 14–18** reachable from where MCPg runs. CI matrix
+  covers all five versions on every push. Older versions may work
+  but aren't tested.
+- A **least-privilege database role** for MCPg to connect with —
+  see [Database privileges](#database-privileges) below.
+- Optional, depending on path:
+  - **[uv](https://docs.astral.sh/uv/)** for source installs or for
+    `uv tool install mcpg`.
+  - **Docker** if you'd rather run MCPg in a container.
 
-## Install from PyPI (recommended)
+---
+
+## Install
+
+### Option 1 — From PyPI (recommended)
 
 ```bash
 pip install mcpg
-# or, if you prefer uv:
+```
+
+Or, with `uv`'s globally-isolated tool install:
+
+```bash
 uv tool install mcpg
 ```
 
-`pip install mcpg` puts the `mcpg` console script on your PATH and pulls
-the runtime deps (`mcp[cli]`, `psycopg[binary]`, `psycopg-pool`, `pglast`,
-`httpx`, `pyjwt[crypto]`). Verify with:
+Either path puts an `mcpg` console script on your `PATH` and pulls
+the runtime dependencies (`mcp[cli]`, `psycopg[binary]`,
+`psycopg-pool`, `pglast`, `httpx`, `pyjwt[crypto]`).
+
+Verify the install:
 
 ```bash
 mcpg --version
+# → mcpg 0.5.1
 ```
 
-`uv tool install mcpg` is the equivalent for the `uv` toolchain — it
-isolates MCPg in its own venv and exposes the `mcpg` script globally,
-without affecting other Python projects on the same machine.
-
-## Install from source
+### Option 2 — Docker
 
 ```bash
-git clone https://github.com/devopam/MCPg
-cd MCPg
-uv sync
-```
-
-`uv sync` creates a virtual environment and installs MCPg with the `mcpg`
-console script. Pick this path if you want to follow `main`, run the test
-suite, or develop against the codebase.
-
-## Install with Docker
-
-```bash
-docker build -t mcpg .
+docker build -t mcpg https://github.com/devopam/MCPg.git
 docker run --rm -p 8000:8000 \
     -e MCPG_DATABASE_URL=postgresql://user:pass@host:5432/db \
     -e MCPG_ACCESS_MODE=read-only \
     mcpg
 ```
 
-The image runs as an unprivileged user and defaults to the streamable-HTTP
-transport bound to `0.0.0.0:8000`.
+The image is a hardened multi-stage build: the runtime stage drops
+the build toolchain and runs as `uid=10001 / gid=10001` with a
+`nologin` shell. Application files are root-owned and read-only to
+the runtime user.
+
+### Option 3 — From source (developers)
+
+```bash
+git clone https://github.com/devopam/MCPg && cd MCPg
+uv sync
+uv run mcpg --version
+```
+
+`uv sync` creates a virtual environment with all runtime + dev
+dependencies. Pick this path to follow `main`, run the test suite,
+or contribute.
+
+---
+
+## Quick start
+
+The minimum to get running locally:
+
+```bash
+export MCPG_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/mydb
+mcpg
+```
+
+That starts MCPg on the **stdio** transport in **read-only** mode,
+ready to be consumed by an MCP client (Claude Desktop, Cursor,
+Continue, etc.). See the next section for how to wire it into a
+specific client.
+
+For HTTP-based clients:
+
+```bash
+export MCPG_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/mydb
+export MCPG_TRANSPORT=streamable-http
+export MCPG_HTTP_PORT=8000
+export MCPG_HTTP_AUTH_TOKEN=...    # optional but strongly recommended
+mcpg
+```
+
+---
+
+## Wire it into an MCP client
+
+### Claude Desktop (`stdio`)
+
+`claude_desktop_config.json` (macOS:
+`~/Library/Application Support/Claude/claude_desktop_config.json`;
+Windows: `%APPDATA%\Claude\claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "mcpg": {
+      "command": "uvx",
+      "args": ["mcpg"],
+      "env": {
+        "MCPG_DATABASE_URL": "postgresql://user:pass@localhost:5432/mydb",
+        "MCPG_ACCESS_MODE": "read-only"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop after editing the file. (If you've installed
+MCPg via `pip install mcpg`, you can use `"command": "mcpg"` with no
+`args`.)
+
+### Cursor, Continue, or any HTTP MCP client
+
+```bash
+export MCPG_DATABASE_URL=postgresql://user:pass@localhost:5432/mydb
+export MCPG_TRANSPORT=streamable-http
+export MCPG_HTTP_AUTH_TOKEN=<random_long_token>
+mcpg
+```
+
+Configure the client to connect to `http://<host>:8000/mcp` and
+send `Authorization: Bearer <random_long_token>`.
+
+For production HTTP deployments, prefer OIDC over a static token —
+set `MCPG_AUTH_MODE=oidc`, `MCPG_OIDC_ISSUER`, `MCPG_OIDC_AUDIENCE`,
+and optionally `MCPG_OIDC_ROLE_CLAIM` to map JWT claims to PG
+roles. The OIDC flow validates JWTs against the issuer's JWKS
+(asymmetric algorithms only — RS256/ES256 families).
+
+---
 
 ## Configuration
 
-MCPg is configured entirely through environment variables.
+MCPg is configured **entirely through environment variables**. The
+only required one is `MCPG_DATABASE_URL`; all others have safe
+defaults.
 
-**Core:**
+The full reference (all 38 `MCPG_*` variables, grouped by area, with
+defaults and descriptions) is in the
+[README](../README.md#configuration). The summaries below give you
+the minimum set per common scenario.
 
-| Variable             | Default       | Description |
-|----------------------|---------------|-------------|
-| `MCPG_DATABASE_URL`  | *(required)*  | PostgreSQL connection URL (`postgresql://user:pass@host:port/db`) |
-| `MCPG_ACCESS_MODE`   | `read-only`   | `read-only`, `restricted`, or `unrestricted` |
-| `MCPG_ALLOW_DDL`     | `false`       | Unlock `run_ddl`, `enable_extension`, migrations, TimescaleDB writes, AGE writes (also needs `unrestricted`) |
-| `MCPG_ALLOW_SHELL`   | `false`       | Unlock `dump_database`, `restore_database`, `copy_table_between_databases` (also needs `unrestricted`) |
-| `MCPG_ALLOW_LISTEN`  | `false`       | Unlock the LISTEN/NOTIFY family (also needs `unrestricted`) |
-| `MCPG_TRANSPORT`     | `stdio`       | `stdio`, `streamable-http`, or `sse` |
-| `MCPG_HTTP_HOST`     | `127.0.0.1`   | Bind host for the HTTP transports |
-| `MCPG_HTTP_PORT`     | `8000`        | Bind port for the HTTP transports |
-| `MCPG_POOL_MIN_SIZE` | `1`           | Minimum pooled connections |
-| `MCPG_POOL_MAX_SIZE` | `5`           | Maximum pooled connections (peak query concurrency) |
-| `MCPG_AUDIT_PERSIST` | `false`       | Write the audit trail to `mcpg.audit_events` table (otherwise in-memory only) |
-| `MCPG_LOG_LEVEL`     | `INFO`        | `DEBUG` / `INFO` / `WARNING` / `ERROR` / `CRITICAL` |
+### Common scenarios
 
-**HTTP authn + multi-tenancy (HTTP transports only):**
+| Scenario | Set |
+|---|---|
+| **Local exploration**, read-only | `MCPG_DATABASE_URL` |
+| **Read-write app access** | `MCPG_ACCESS_MODE=restricted` |
+| **DBA toolkit** (DDL, vacuum, etc.) | `MCPG_ACCESS_MODE=unrestricted` + `MCPG_ALLOW_DDL=true` |
+| **Dump / restore** subprocess tools | `MCPG_ACCESS_MODE=unrestricted` + `MCPG_ALLOW_SHELL=true` |
+| **`LISTEN/NOTIFY`** event streams | `MCPG_ACCESS_MODE=unrestricted` + `MCPG_ALLOW_LISTEN=true` |
+| **HTTP transport** with static bearer | `MCPG_TRANSPORT=streamable-http` + `MCPG_HTTP_AUTH_TOKEN=…` |
+| **HTTP transport** with OIDC | `MCPG_TRANSPORT=streamable-http` + `MCPG_AUTH_MODE=oidc` + `MCPG_OIDC_ISSUER=…` + `MCPG_OIDC_AUDIENCE=…` |
+| **Multi-tenant SaaS** | `MCPG_DEFAULT_ROLE=tenant_a` + `MCPG_ALLOWED_ROLES=tenant_a,tenant_b,…` |
+| **Read-replica fan-out** | `MCPG_REPLICA_URLS=postgresql://…?sslmode=require,postgresql://…?sslmode=require` |
+| **NL→SQL** via Anthropic | `MCPG_NL2SQL_PROVIDER=anthropic` (auto-uses `ANTHROPIC_API_KEY`) |
+| **Audit persistence** | `MCPG_AUDIT_PERSIST=true` |
+| **Prometheus metrics** | (always on for HTTP transports — `GET /metrics`) |
 
-| Variable | Default | Description |
-|---|---|---|
-| `MCPG_HTTP_AUTH_TOKEN` | unset | Static bearer token. Required when `MCPG_AUTH_MODE=static` (the default) and the HTTP transport is in use. |
-| `MCPG_AUTH_MODE` | `static` | `static` (constant-time token compare) or `oidc` (full JWT validation). |
-| `MCPG_OIDC_ISSUER` / `MCPG_OIDC_AUDIENCE` | unset | Required when `auth_mode=oidc`. The issuer's `/.well-known/openid-configuration` is fetched and cached at startup. |
-| `MCPG_OIDC_JWKS_URL` | unset | Optional override — skip OIDC discovery and point straight at the JWKS endpoint. |
-| `MCPG_OIDC_ROLE_CLAIM` | unset | When set, the named JWT claim becomes the per-request PG role (composes with multi-tenancy). |
-| `MCPG_DEFAULT_ROLE` | unset | Static default PG role for `SET LOCAL ROLE`-driven multi-tenancy. |
-| `MCPG_ALLOWED_ROLES` | empty | Comma-separated allowlist for `MCPG_DEFAULT_ROLE` and the `X-MCPG-Role` header / OIDC role claim. |
+### TLS enforcement (important)
 
-**Read-replica routing:**
+By default MCPg **refuses to start** if `MCPG_DATABASE_URL` (or any
+entry in `MCPG_REPLICA_URLS`) points at a **non-loopback host**
+without TLS enforcement. PostgreSQL's libpq accepts plaintext
+fallback under `sslmode=disable | allow | prefer` (and an unset
+`sslmode` defaults to `prefer`) — which means a misconfigured
+production DSN can leak credentials over the network without anyone
+noticing.
 
-| Variable | Default | Description |
-|---|---|---|
-| `MCPG_REPLICA_URLS` | unset | Comma-separated read-replica DSNs. When set, `force_readonly` queries round-robin across healthy replicas; writes always go to the primary. Failed replicas degrade for 30 s and self-heal. |
+To fix at the DSN level (recommended):
 
-**Natural-language → SQL (optional):**
+```
+postgresql://user:pass@db.example.com:5432/app?sslmode=require
+```
 
-| Variable | Default | Description |
-|---|---|---|
-| `MCPG_NL2SQL_PROVIDER` | unset | `anthropic`, `openai`, or `gemini`. Unset → `translate_nl_to_sql` reports unavailable. |
-| `MCPG_NL2SQL_API_KEY` | unset | API key. Falls back to `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY` / `GOOGLE_API_KEY` if unset. |
-| `MCPG_NL2SQL_MODEL` | provider-default | Override the model id (e.g. `claude-sonnet-4-6`, `gpt-4o-mini`, `gemini-2.0-flash`). |
-| `MCPG_NL2SQL_BASE_URL` | provider-default | OpenAI-compatible endpoint override (Ollama, vLLM, OpenRouter, ...). |
-| `MCPG_NL2SQL_MAX_TOKENS` | `2048` | Per-call response budget. Hard cap 16384. |
+…or `verify-ca` / `verify-full` for stricter validation. Loopback
+hosts (`localhost`, `127.0.0.1`, `::1`) are always exempt.
 
-**Listener tuning:**
+If you genuinely need to run plaintext for a temporary dev /
+internal use, the explicit opt-out is:
 
-| Variable | Default | Description |
-|---|---|---|
-| `MCPG_LISTEN_QUEUE_MAX` | `1000` | Max queued NOTIFY messages per subscription. |
-| `MCPG_SHELL_TIMEOUT_SEC` | `60` | Hard timeout for `dump_database` / `restore_database` / etc. |
-| `MCPG_SHELL_MAX_OUTPUT_BYTES` | `64 MiB` | Hard cap on subprocess output the agent receives. |
+```bash
+export MCPG_ALLOW_INSECURE_TLS=true
+```
 
-A missing or invalid variable causes a clear `configuration error` on
-startup, naming the offending variable. Credentials are never written to
-logs — the settings repr and the audit log redact them.
+The startup error message names exactly which DSN failed the check
+(including the replica index if it was one of your
+`MCPG_REPLICA_URLS` entries).
 
 ### Database privileges
 
-Connect MCPg with a **least-privilege database role** — ideally one granted
-only the privileges the workload needs. MCPg's access-mode enforcement is a
-second line of defence, not a substitute for correct database-side
-permissions. See [`security.md`](security.md).
+Connect MCPg with a **least-privilege database role** — ideally one
+granted only the privileges the workload needs.
+
+MCPg's access-mode enforcement (`read-only` / `restricted` /
+`unrestricted`) and capability gates (`MCPG_ALLOW_DDL` /
+`MCPG_ALLOW_SHELL` / `MCPG_ALLOW_LISTEN`) are a **second line of
+defence**, not a substitute for correct database-side permissions.
+A misconfigured `unrestricted + MCPG_ALLOW_DDL=true` deployment with
+a superuser DSN is by-design root access; ensure that combination
+matches operator intent.
+
+Typical setup for a read-only deployment:
+
+```sql
+CREATE ROLE mcpg_reader LOGIN PASSWORD 'change-me';
+GRANT CONNECT ON DATABASE mydb TO mcpg_reader;
+GRANT USAGE ON SCHEMA public TO mcpg_reader;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO mcpg_reader;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+    GRANT SELECT ON TABLES TO mcpg_reader;
+```
+
+See [`security.md`](security.md) for the full threat model and
+[`security-hardening.md`](security-hardening.md) for the shipped
+and queued hardening features.
+
+---
 
 ## Verify the installation
 
 ```bash
-MCPG_DATABASE_URL=postgresql://localhost/mydb uv run mcpg
+MCPG_DATABASE_URL=postgresql://localhost/mydb mcpg
 ```
 
-The server starts on the configured transport (`stdio` by default). To
-confirm it can reach the database, connect an MCP client and call
-`get_server_info` — see the [User Guide](user-guide.md).
+On stdio (the default), the server waits silently for an MCP
+client to attach. To exercise a tool round-trip, point a client at
+it and call `get_server_info` — see the
+[User Guide](user-guide.md#connecting-an-mcp-client).
+
+For HTTP transports, MCPg also exposes:
+
+- `GET /healthz` → liveness probe.
+- `GET /readyz` → readiness probe (verifies a pool connection).
+- `GET /metrics` → Prometheus-format metrics
+  (`mcpg_tool_calls_total{tool,status}` and
+  `mcpg_tool_duration_seconds_*`).
+
+---
+
+## Troubleshooting
+
+- **Startup error: "configuration error: …"**
+  A required env var is missing or invalid; the message names it.
+  See the [README env-var reference](../README.md#configuration).
+- **Startup error: "…points at a remote host … but its sslmode is
+  `prefer`"**
+  TLS enforcement caught a plaintext-capable DSN. Add
+  `?sslmode=require` to the DSN, or set
+  `MCPG_ALLOW_INSECURE_TLS=true` if it's intentional.
+- **`mcpg: command not found`** after a `pip install mcpg`
+  Your Python `bin/` is not on `PATH`. Either activate the venv or
+  use `python -m mcpg`.
+- **A write tool is missing**
+  Set `MCPG_ACCESS_MODE=unrestricted` plus the matching gate:
+  `MCPG_ALLOW_DDL=true` for DDL / migrations / extensions,
+  `MCPG_ALLOW_SHELL=true` for `dump_database` / `restore_database` /
+  `copy_table_between_databases`, `MCPG_ALLOW_LISTEN=true` for
+  `subscribe_channel` / `poll_notifications` / …
+- **`fuzzy_search` / `analyze_workload` / `vector_search` reports
+  `available: false`**
+  The corresponding PostgreSQL extension (`pg_trgm` /
+  `pg_stat_statements` / `vector` / `postgis` / `timescaledb` /
+  `age`) isn't installed in your database. MCPg degrades
+  gracefully rather than failing — install the extension when
+  ready.
+- **A query is rejected by `run_select`**
+  Only safe read-only statements pass the SafeSQL allowlist; writes,
+  DDL, and multi-statement input are refused by design. Use
+  `run_write` / `run_ddl` (under `unrestricted` mode) for those.
+- **Connection failures**
+  Verify `MCPG_DATABASE_URL` and that the database is reachable.
+  Errors are logged with the password redacted.
+- **`prepare_migration` refuses with "cannot run inside a
+  transaction"**
+  The candidate SQL contains a `CONCURRENTLY` / `VACUUM` /
+  `ALTER SYSTEM` statement. The staged-migration workflow always
+  wraps the candidate in `BEGIN ... COMMIT`; for those, use
+  `run_ddl` directly.
+- **`mcpg --version` doesn't print anything**
+  Pre-v0.5.1 builds shipped without the `--version` flag. Update
+  with `pip install --upgrade mcpg`.
+
+---
 
 ## Next steps
 
-- [User Guide](user-guide.md) — concepts, connecting a client, using the tools
-- [Tool Reference](tools.md) — every MCP tool and its parameters
-- [Architecture](architecture.md) — how MCPg is built
+- [User Guide](user-guide.md) — concepts, connecting clients, and a
+  feature-by-feature walkthrough.
+- [Tool Tour](tour.md) — compact discovery of every tool MCPg
+  registers, grouped by intent.
+- [Cookbook](cookbook.md) — task-oriented recipes for common
+  workflows.
+- [Tool Reference](tools.md) — exhaustive per-tool documentation.
+- [Security model](security.md) and the
+  [security hardening roadmap](security-hardening.md).
+- [Release process](release-process.md) — how new versions ship to
+  PyPI.
+- [Architecture](architecture.md) — module map and design.

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -1,72 +1,239 @@
-# MCPg Scaling Characteristics
+# MCPg scaling characteristics
 
-How MCPg behaves under load, and how to size it. Updated as the project
-evolves.
+How MCPg behaves under load, the levers you have to tune it, and
+the bottlenecks to plan around.
+
+---
 
 ## Execution model
 
-- MCPg is a single-process `asyncio` server. Tool calls are coroutines; CPU
-  work (SQL parsing/validation) runs on one event-loop thread.
-- Database work is I/O-bound and runs concurrently up to the connection
-  pool's `max_size`.
-- Each `run_select` / `explain_query` call constructs a `SafeSqlDriver` and
-  parses the SQL with `pglast` before execution — a small, bounded CPU cost
-  per call.
+- MCPg is a single-process `asyncio` server. Tool calls are
+  coroutines; CPU work (SQL parsing / validation) runs on a single
+  event-loop thread.
+- Database work is I/O-bound and runs concurrently up to the
+  connection pool's `max_size`.
+- Each `run_select` / `explain_query` / NL→SQL execution
+  constructs a `SafeSqlDriver` and parses the SQL with `pglast`
+  before execution — a small, bounded CPU cost per call.
+- For HTTP transports, Starlette + the FastMCP transport handler
+  share the same event loop; metrics / health endpoints are
+  separately cheap.
+
+---
 
 ## Connection pool sizing
 
 The pool is bounded by `MCPG_POOL_MIN_SIZE` / `MCPG_POOL_MAX_SIZE`
 (defaults `1` / `5`).
 
-- `max_size` is the ceiling on concurrent in-flight database queries. Set it
-  to the expected peak concurrency of the agent(s) using the server.
+- **`max_size`** is the ceiling on concurrent in-flight database
+  queries. Set it to the expected peak concurrency of the agent(s)
+  using the server.
 - Do not exceed what the PostgreSQL server can accommodate
-  (`max_connections`, shared across all clients). The `check_database_health`
-  tool reports connection utilisation.
-- `min_size` keeps warm connections ready; `1` is fine for light use, raise
-  it for latency-sensitive workloads.
+  (`max_connections`, shared across all clients). The
+  `check_database_health` tool reports current connection use.
+- **`min_size`** keeps warm connections ready; `1` is fine for
+  light use, raise it for latency-sensitive workloads to skip the
+  cold-start round-trip on first request.
+- Each checkout sets per-session `statement_timeout`
+  (`MCPG_STATEMENT_TIMEOUT_MS`, default 30 s) and `lock_timeout`
+  (`MCPG_LOCK_TIMEOUT_MS`, default 5 s) once and caches the fact;
+  subsequent checkouts on the same connection skip the `SET`.
+
+### Cursor pool overhead
+
+Each open server-side cursor holds a **dedicated connection**
+outside the main pool — for the cursor's lifetime. Long-lived
+cursors don't starve the main pool but do count against the
+PostgreSQL server's `max_connections`. The 5-minute idle TTL
+caps drift; `list_cursors()` makes the population visible.
+
+### Replica pool overhead
+
+Each entry in `MCPG_REPLICA_URLS` gets its own pool sized
+identically to the primary (`MCPG_POOL_MIN_SIZE` /
+`MCPG_POOL_MAX_SIZE`). Plan for `(1 + N_replicas) ×
+MCPG_POOL_MAX_SIZE` peak connections across the database fleet.
+
+---
+
+## Read-replica routing
+
+When `MCPG_REPLICA_URLS` is non-empty, every
+`force_readonly=True` query is round-robin-routed to a healthy
+replica. Failures fall back to the primary once and mark the
+replica degraded for 30 s.
+
+Capacity guidance:
+
+- `force_readonly=True` covers the majority of read tools
+  (`run_select`, introspection, search, health checks). Writes
+  always go to the primary.
+- Adding replicas linearly scales read capacity until the primary
+  becomes the bottleneck on write throughput or replication
+  bandwidth.
+- Routing decisions land in Prometheus
+  (`mcpg_tool_calls_total{tool="__replica_route",status="…"}`)
+  with statuses `primary` / `primary_no_healthy` / `fallback` /
+  `replica_<n>`.
+
+Monitor `list_replicas()` for the degraded flag, last error, and
+seconds-until-retry per replica.
+
+---
 
 ## Result-size bounds
 
 - `run_select` caps rows at `max_rows` (default 1000) and reports
-  `truncated`. This bounds memory and payload size per call.
-- Large reads should paginate with SQL `LIMIT`/`OFFSET`. Streaming via
-  server-side cursors is a planned post-1.0 enhancement.
+  `truncated`. Bounds memory and payload size per call.
+- `run_select_parallel` enforces `parallel_limit` (default 8) on
+  concurrent statements.
+- For result sets larger than `max_rows`, use **server-side
+  cursors** — `open_cursor` / `fetch_cursor(batch_size=…)` /
+  `close_cursor`. Each cursor's dedicated connection means even
+  million-row scans don't tie up the main pool, and `batch_size`
+  gives the agent backpressure.
+- Bulk exports (`export_query` / `export_table`) hit the same
+  `max_rows`-style limit (param `limit`, default 10000).
+- Bulk loads (`import_csv` / `import_json`) use `COPY FROM STDIN`
+  + parametrised `executemany`; throughput is database-bound.
+
+---
+
+## Subprocess workloads
+
+`dump_database` / `restore_database` / `copy_table_between_databases`
+spawn `pg_dump` / `psql` / `pg_restore` with:
+
+- **Wall-clock cap**: `MCPG_SHELL_TIMEOUT_SEC` (default 60 s).
+- **Output cap**: `MCPG_SHELL_MAX_OUTPUT_BYTES` (default 64 MiB).
+
+Subprocess CPU runs outside the event loop, so it doesn't block
+other tool calls — but the captured output sits in memory until
+the subprocess completes. Plan accordingly for big dumps.
+
+---
+
+## Rate limiting
+
+`MCPG_RATE_LIMIT_ENABLED=true` activates a token-bucket per-tool
+limiter:
+
+- **Global quota.** `MCPG_RATE_LIMIT_MAX_REQUESTS` per
+  `MCPG_RATE_LIMIT_WINDOW_SECONDS` across all tools (defaults
+  60 / 60 s).
+- **Heavy quota.** `MCPG_RATE_LIMIT_HEAVY_MAX` per
+  `MCPG_RATE_LIMIT_HEAVY_WINDOW` for `run_write`, `run_ddl`,
+  `dump_database`, `restore_database`, and similar (defaults
+  5 / 60 s).
+
+Rate-limited calls return an error immediately rather than
+queueing.
+
+---
 
 ## Measured baseline
 
-A baseline from `benchmarks/bench.py` — 2000 `run_select` calls of
-`SELECT 1`, concurrency 16, against a loopback PostgreSQL 16:
+A baseline from `benchmarks/bench.py` — 2000 `run_select` calls
+of `SELECT 1`, concurrency 16, against a loopback PostgreSQL 16:
 
-| Metric        | Value       |
-|---------------|-------------|
-| Throughput    | ~2,200 req/s |
-| Latency p50   | ~6.8 ms     |
-| Latency p95   | ~11 ms      |
+| Metric | Value |
+|---|---|
+| Throughput | ~2,200 req/s |
+| Latency p50 | ~6.8 ms |
+| Latency p95 | ~11 ms |
 
-This measures the MCPg query path (safety validation + pool + round-trip),
-not the MCP transport, against a trivial query on the same host. Real
-workloads with network latency and heavier queries will differ — re-run the
-benchmark against your own environment:
+This measures the MCPg query path (safety validation + pool +
+round-trip) against a trivial query on the same host — not the MCP
+transport, not network latency, not query complexity. Real
+workloads vary; re-run against your own environment:
 
 ```bash
 uv run python benchmarks/bench.py --requests 2000 --concurrency 16 \
     --database-url postgresql://...
 ```
 
+---
+
+## Observability for capacity planning
+
+The HTTP transport exposes Prometheus metrics at `GET /metrics`:
+
+- `mcpg_tool_calls_total{tool,status}` — counter; one of the
+  best signals for "is X being called too often / failing too
+  often". `status` ∈ `ok` / `error` plus the replica-routing
+  statuses noted above.
+- `mcpg_tool_duration_seconds_*` — histogram per tool; bucket
+  defaults are SDK-shaped (0.005, 0.01, 0.025, 0.05, 0.1, 0.25,
+  0.5, 1, 2.5, 5, 10 s).
+
+For stdio deployments, `get_metrics_exposition()` returns the same
+Prometheus payload as a string the agent can hand to a scrape
+target.
+
+Together with `check_database_health` and `audit_database`, these
+cover the three axes you need:
+
+- **MCPg-side load** — tool calls per second, latency percentiles
+  (Prometheus).
+- **Database-side load** — connections in use, cache hit ratio,
+  bloat, lock waits (`check_database_health` /
+  `audit_database`).
+- **Workload composition** — slow query templates from
+  `pg_stat_statements` (`analyze_workload`, `detect_n_plus_one`).
+
+---
+
 ## Bottlenecks & guidance
 
-- **Database round-trip latency dominates** for simple queries — co-locate
-  MCPg with the database, or accept network RTT in the latency figure.
-- **Pool saturation:** if concurrency exceeds `max_size`, calls queue. Raise
-  `MCPG_POOL_MAX_SIZE` (within `max_connections`).
-- **Large result sets:** rely on `max_rows` and SQL `LIMIT`; do not fetch
-  unbounded results.
-- **One event loop:** extremely high call rates are bounded by single-thread
-  CPU for SQL parsing. For very high throughput, run multiple MCPg instances
-  behind the streamable-HTTP transport.
+- **Database round-trip latency dominates** for simple queries —
+  co-locate MCPg with the database, or accept the network RTT in
+  the latency figure.
+- **Pool saturation.** If concurrency exceeds `max_size`, calls
+  queue on the pool. Raise `MCPG_POOL_MAX_SIZE` (within
+  `max_connections`), or add replicas if reads dominate.
+- **Single event loop.** Very high call rates are bounded by
+  single-thread CPU for SQL parsing. For very high throughput,
+  run multiple MCPg instances behind the streamable-HTTP transport
+  with a load balancer.
+- **Large result sets.** Use server-side cursors instead of
+  bumping `max_rows`. They give the agent backpressure and don't
+  buffer the whole result in MCPg memory.
+- **Heavy DBA tools** (`audit_database`, `analyze_workload`,
+  `dump_database`) are I/O-heavy on the database. Rate-limit them
+  via `MCPG_RATE_LIMIT_HEAVY_*` if an agent calls them on a tight
+  loop.
 
-## Planned (post-1.0)
+---
 
-Server-side cursors for large reads, read-replica routing for read scaling,
-and a soak-test profile — see `PLAN.md` Phase 6.
+## Horizontal scale-out shape
+
+For deployments needing more capacity than a single MCPg process
+can provide:
+
+1. **HTTP transport in front of a load balancer.** MCPg is
+   stateless aside from the audit logger and the open-cursor
+   table — a sticky session is needed only if your workflow
+   depends on a single client holding a cursor across calls
+   (otherwise round-robin works).
+2. **Replica pool for read fan-out.** `MCPG_REPLICA_URLS` is the
+   first lever for read-heavy workloads.
+3. **Tenant-per-database isolation.** When tenants run in
+   separate databases, run one MCPg instance per tenant with a
+   tenant-specific `MCPG_DATABASE_URL`. When tenants share a
+   database, the single-process `SET LOCAL ROLE` workflow
+   (`MCPG_DEFAULT_ROLE` / OIDC role claim / `X-MCPG-Role`) is
+   typically a better fit.
+
+---
+
+## See also
+
+- [README → Configuration](../README.md#configuration) for the
+  full env-var reference.
+- [`installation.md`](installation.md) for the install / deploy
+  paths.
+- [`user-guide.md`](user-guide.md) for the feature-by-feature
+  walkthrough, including replicas / cursors / rate limiting.
+- [`architecture.md`](architecture.md) for the module map and
+  the request lifecycle.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,15 +1,24 @@
 # MCPg Security Model
 
-This document describes MCPg's threat model and the controls that mitigate
-each threat. It reflects the implementation as of Phase 3; it is updated as
-the project evolves.
+MCPg's threat model and the controls that mitigate each threat.
+Living document — kept in step with the implementation as new
+mitigations land.
+
+**Related documents.** For *how to report* a vulnerability, see
+[`SECURITY.md`](../SECURITY.md) at the repo root. For the **living
+roadmap** of shipped (✅) vs queued (⬜) hardening features, see
+[`security-hardening.md`](security-hardening.md).
+
+---
 
 ## What MCPg is
 
-MCPg is an MCP server that exposes a PostgreSQL database to an AI agent
-through a fixed set of tools. The agent does not get a raw database
-connection — it can only call the tools MCPg registers, and every call is
-validated and audited.
+MCPg is an MCP server that exposes a PostgreSQL database to an AI
+agent through a fixed set of tools. The agent does not get a raw
+database connection — it can only call the tools MCPg registers,
+and every call is validated and audited.
+
+---
 
 ## Trust boundaries
 
@@ -18,110 +27,265 @@ validated and audited.
    (untrusted input)               (trusted code)          (the asset)
 ```
 
-- **The agent is untrusted.** Tool arguments — especially SQL text passed to
-  `run_select` / `explain_query` — are treated as hostile input.
+- **The agent is untrusted.** Tool arguments — especially SQL text
+  passed to `run_select` / `explain_query` / `open_cursor` / NL→SQL
+  generations — are treated as hostile input.
 - **MCPg is trusted code**, but it assumes its own configuration
-  (`MCPG_DATABASE_URL`, access mode) is set by a trusted operator.
-- **PostgreSQL is the asset** being protected. MCPg is one client of it; it
-  is not a substitute for correct database-side permissions (see below).
+  (`MCPG_DATABASE_URL`, access mode, capability gates, audit
+  redaction list) is set by a trusted operator.
+- **PostgreSQL is the asset** being protected. MCPg is one client
+  of it; it is not a substitute for correct database-side
+  permissions.
+
+---
 
 ## Assets
 
-1. Data in the database (confidentiality and integrity).
-2. The database connection string / credentials.
-3. Database availability.
+1. **Data in the database** — confidentiality and integrity.
+2. **Database credentials** — both the DSN MCPg uses and any
+   credentials nested in tool arguments / result payloads.
+3. **Database availability.**
+4. **The MCPg process itself** — its environment, its in-flight
+   connections, its audit trail.
+
+---
 
 ## Threats and mitigations
 
 ### T1 — SQL injection / unsafe statements
 
-The reference PostgreSQL MCP server was retired after a SQL-injection
-vulnerability. MCPg's mitigation:
+**Mitigation.**
 
-- All agent-supplied SQL runs through the vendored `SafeSqlDriver`, which
-  parses the statement with `pglast` (the real PostgreSQL grammar) and checks
-  every node against an allowlist. Statement stacking, comment escapes,
-  transaction-control escapes (`COMMIT`/`ROLLBACK`/`BEGIN`), DDL, DML,
-  `COPY`, and `DO` blocks are rejected **before execution**.
-- Queries also run under a forced read-only transaction.
-- This is locked in by an adversarial regression suite
-  (`tests/unit/test_sql_safety.py`).
-- Catalog introspection uses parameterised queries; no value is interpolated
-  into SQL text.
+- All agent-supplied SQL runs through the vendored `SafeSqlDriver`,
+  which parses the statement with `pglast` (the real PostgreSQL
+  grammar) and checks every AST node against an allowlist.
+  Statement stacking, comment escapes, transaction-control escapes
+  (`COMMIT` / `ROLLBACK` / `BEGIN`), DDL inside read paths, DML
+  inside read paths, `COPY`, and `DO` blocks are rejected
+  **before execution**.
+- Read queries also run under a forced read-only transaction.
+- Every interpolated identifier (schema / table / column / role
+  names) flows through a `[A-Za-z_][A-Za-z0-9_]*` regex — user
+  input never reaches the database through string concatenation.
+- Locked in by an adversarial regression suite
+  (`tests/unit/test_sql_safety.py` and the vendored kernel's own
+  tests).
+- Catalog introspection uses parameterised queries; no value is
+  interpolated into SQL text.
 
-### T2 — Unintended writes
+### T2 — Unintended writes / privilege escalation through tool surface
 
-- The access mode defaults to **read-only**. The `mcpg.policy` engine gates
-  which tools are registered: write tools (Phase 4) are exposed only in
-  `unrestricted` mode.
-- `run_select` and `explain_query` force read-only transactions regardless of
-  mode.
+**Mitigation.**
+
+- The access mode defaults to **read-only**. The `mcpg.policy`
+  engine gates which tools are registered: write tools are exposed
+  only in `unrestricted` mode.
+- DDL needs a second explicit opt-in (`MCPG_ALLOW_DDL`). Subprocess
+  tools need `MCPG_ALLOW_SHELL`; `LISTEN/NOTIFY` tools need
+  `MCPG_ALLOW_LISTEN`.
+- `run_select` and `explain_query` force read-only transactions
+  regardless of mode.
+- Generated SQL from `translate_nl_to_sql` is passed through the
+  same SafeSQL allowlist as hand-written SQL before any execution.
 
 ### T3 — Resource exhaustion / denial of service
 
-- Queries run with a per-query execution timeout.
-- `run_select` caps returned rows (`max_rows`, default 1000) and reports
-  truncation, bounding result size.
-- Connection use is bounded by the pool.
+**Mitigation.**
+
+- **Per-session statement timeout** (`MCPG_STATEMENT_TIMEOUT_MS`,
+  default 30 s) applied to every checked-out pool connection.
+  Runaway queries self-terminate.
+- **Per-session lock timeout** (`MCPG_LOCK_TIMEOUT_MS`, default
+  5 s). Hanging lock waits self-terminate.
+- **Result-row cap.** `run_select` caps returned rows
+  (`max_rows`, default 1000) and reports truncation.
+- **Subprocess caps.** `MCPG_SHELL_TIMEOUT_SEC` (default 60 s) and
+  `MCPG_SHELL_MAX_OUTPUT_BYTES` (default 64 MiB) bound shell-tool
+  runtime and output.
+- **Cursor caps.** Each server-side cursor holds a dedicated
+  connection but has a 5-minute idle TTL; `list_cursors()` makes
+  the population visible.
+- **NL→SQL caps.** `MCPG_NL2SQL_MAX_TOKENS` (default 2048, hard
+  limit 16384) bounds per-call output.
+- **Rate limiting** (`MCPG_RATE_LIMIT_ENABLED`). Token-bucket per
+  tool with a separate quota for heavy tools.
+- **Connection-pool ceiling** (`MCPG_POOL_MAX_SIZE`) bounds
+  concurrent DB load.
 
 ### T4 — Credential disclosure
 
-- `Settings.__repr__` redacts the database password.
-- Audit logging masks secret-named arguments and obfuscates connection-string
-  passwords embedded in argument values.
-- Connection errors are passed through the vendored password obfuscator.
+**Mitigation.**
 
-### T5 — Lack of attribution
+- `Settings.__repr__` redacts the database password, replica
+  passwords, HTTP auth token, and NL→SQL API key.
+- Audit logging masks values whose key name matches a configurable
+  case-insensitive regex (default: `password`, `passwd`, `secret`,
+  `token`, `api[_-]?key`, `bearer`, `authorization`,
+  `database_url`, `dsn`, `conninfo`; extend via
+  `MCPG_AUDIT_REDACT_KEYS`). Walks nested dicts / lists / tuples,
+  including result payloads (so a `RETURNING password` doesn't
+  leak).
+- String leaves are passed through the `obfuscate_password` helper
+  so an embedded DSN credential nested anywhere is scrubbed.
+- Connection errors are passed through the same obfuscator.
 
-- `AuditedFastMCP` records every tool invocation — name, redacted arguments,
-  and outcome (success or error) — to the `mcpg.audit` logger.
+### T5 — Plaintext database connection
+
+**Mitigation.**
+
+- **TLS enforcement on startup.** MCPg refuses to start if
+  `MCPG_DATABASE_URL` (or any entry in `MCPG_REPLICA_URLS`) points
+  at a non-loopback host with `sslmode=disable | allow | prefer`
+  (or unset — libpq's default is `prefer`, which falls back to
+  plaintext on TLS failure).
+- The DSN is parsed via `psycopg.conninfo.conninfo_to_dict`, so the
+  check covers URI DSNs, keyword DSNs (`host=… sslmode=…`), and
+  failover multi-host URIs (`postgresql://h1,h2/db`).
+- DSNs without an explicit host are also refused — libpq could
+  resolve `PGHOST` to a non-loopback default.
+- Loopback hosts (`localhost`, `127.0.0.1`, `::1`) are exempt.
+- Bypass: `MCPG_ALLOW_INSECURE_TLS=true` (explicit operator
+  opt-out for dev / internal use).
+- Replica-DSN errors identify the offending index
+  (`MCPG_REPLICA_URLS[1]`) for fast diagnosis.
+
+### T6 — Unauthenticated remote access (HTTP transports)
+
+**Mitigation.**
+
+- **Static bearer.** `MCPG_HTTP_AUTH_TOKEN` enforces
+  `Authorization: Bearer <token>` with `hmac.compare_digest`
+  constant-time comparison. `/metrics`, `/healthz`, `/readyz` are
+  exempt by design.
+- **OIDC JWT.** `MCPG_AUTH_MODE=oidc` swaps the static comparison
+  for full JWT validation against the configured issuer's JWKS.
+  Validates `iss` + `aud` + `exp` + `nbf` + signature with 30 s
+  clock leeway. **Only asymmetric algorithms** (RS256/RS384/RS512
+  + ES256/ES384/ES512) — HS-family is rejected by design to
+  preserve the OIDC trust model.
+- The OIDC discovery document and JWKS are fetched on first use
+  and cached.
+
+### T7 — Tenant-isolation bypass
+
+**Mitigation.**
+
+- **Per-request `SET LOCAL ROLE`.** MCPg supports a static
+  `MCPG_DEFAULT_ROLE` and per-request overrides via the
+  `X-MCPG-Role` HTTP header (or, with `MCPG_OIDC_ROLE_CLAIM`, the
+  named JWT claim). Each query is wrapped in
+  `BEGIN ... SET LOCAL ROLE "<role>" ... <stmt> ... COMMIT` so
+  RLS policies keyed on `current_user` isolate tenants correctly
+  from a single pooled connection.
+- `MCPG_ALLOWED_ROLES` provides an allowlist — header / claim
+  values not in the list are rejected with 403.
+- Role names are identifier-validated before being inlined into
+  `SET ROLE`.
+
+### T8 — Lack of attribution / audit gaps
+
+**Mitigation.**
+
+- `AuditedFastMCP` records **every** tool invocation — name,
+  redacted arguments, redacted result (for persisted entries), and
+  outcome (success / error code / error message) — to the
+  `mcpg.audit` logger.
+- With `MCPG_AUDIT_PERSIST=true`, every `run_write` and `run_ddl`
+  is also persisted to a `mcpg_audit.events` table for after-the-
+  fact queryability via `list_audit_events`.
+- For per-tenant attribution, combine `MCPG_DEFAULT_ROLE` /
+  `X-MCPG-Role` with `MCPG_AUDIT_PERSIST=true` so each row in
+  `mcpg_audit.events` carries the responsible role.
+
+### T9 — Supply-chain compromise
+
+**Mitigation.**
+
+- CI runs `bandit` (SAST) and `pip-audit --strict` (PyPI advisory
+  DB + OSV.dev) on every push. Vulnerable transitive dependencies
+  block merge.
+- Releases publish via PyPI **Trusted Publishing** (OIDC) — no
+  long-lived API tokens stored as GitHub Action secrets.
+- Production PyPI uploads gated on a maintainer reviewer approval
+  in the `pypi` GitHub environment.
+- Tags are GPG-signed; the publish workflow refuses to build if
+  the tag's version doesn't match `pyproject.toml`'s `version`.
+
+---
 
 ## Operator responsibilities (defence in depth)
 
-MCPg is not a replacement for database-side security. Operators should:
+MCPg is not a replacement for database-side security. Operators
+should:
 
-- Connect MCPg with a **least-privilege database role** — ideally one with
-  only the `SELECT` privileges the workload needs. MCPg's read-only
-  enforcement is a second line of defence, not the only one.
-- Use a dedicated role per deployment so audit logs and database logs can be
-  correlated.
-- For multi-tenant data, see "Multi-tenancy and Row-Level Security" below.
-- Configure where the `mcpg.audit` logger's records are shipped and retained.
+- **Use a least-privilege database role** — ideally one granted
+  only the privileges the workload needs. MCPg's access-mode
+  enforcement is a second line of defence, not the only one. A
+  superuser DSN combined with
+  `unrestricted + MCPG_ALLOW_DDL=true + MCPG_ALLOW_SHELL=true` is
+  by-design root access.
+- **Use a dedicated role per deployment** so audit logs and
+  database logs can be correlated.
+- **Enable TLS** on the database (`sslmode=require` / `verify-ca`
+  / `verify-full`); MCPg refuses to start without it for remote
+  hosts by default.
+- **For multi-tenant data**, prefer the `SET ROLE` workflow
+  (`MCPG_DEFAULT_ROLE` + `MCPG_ALLOWED_ROLES`, OIDC claim
+  mapping); fall back to one MCPg instance per tenant only when
+  the tenant boundary is at the database level.
+- **Ship audit-logger records** somewhere durable. The default
+  Python logger sends to stderr.
+- **Rotate the static-bearer `MCPG_HTTP_AUTH_TOKEN`** on the
+  cadence your environment requires.
+
+---
 
 ## Multi-tenancy and Row-Level Security
 
-PostgreSQL Row-Level Security (RLS) policies are evaluated against the
-**connecting role** (and session settings). MCPg connects with a *single*
-database role and pools those connections, so every agent request is, from
-the database's perspective, the same principal.
+PostgreSQL Row-Level Security (RLS) policies are evaluated against
+the **connecting role** (and session settings). Without
+per-request role switching, MCPg connects with a single database
+role and pools those connections, so every agent request would
+look like the same principal from the database's perspective —
+and RLS keyed on `current_user` would not isolate tenants.
 
-**Implication:** RLS that distinguishes tenants by `current_user` will *not*
-isolate tenants if MCPg connects with one shared role. Do not rely on MCPg
-alone for tenant isolation.
+**MCPg's mitigation:** the `SET LOCAL ROLE` workflow described in
+T7. Set `MCPG_DEFAULT_ROLE` for a static deployment, or wire HTTP
+clients / OIDC to send a per-request role and pair with
+`MCPG_ALLOWED_ROLES`. The tenant driver wraps every query in a
+transaction with `SET LOCAL ROLE`, so RLS sees the correct
+principal even on a shared pool.
 
-**Recommended deployment for multi-tenant databases:**
+When the tenant boundary is at the **database level** (separate
+databases per tenant, not separate roles), run one MCPg instance
+per tenant with a tenant-specific `MCPG_DATABASE_URL`.
 
-- Run **one MCPg instance per tenant**, each configured (`MCPG_DATABASE_URL`)
-  with a tenant-specific, least-privilege database role. RLS policies keyed on
-  that role then isolate the tenant correctly, and audit logs are per-tenant.
-- Alternatively, restrict each instance to a tenant-specific schema or
-  database via the connection URL and role privileges.
-
-**Planned enhancement (post-1.0):** an optional per-request role / session
-variable (`SET ROLE` or `SET app.tenant_id`) so a single MCPg instance can
-serve multiple tenants under RLS. This requires careful pooled-connection
-session-state management and is deliberately deferred — see `PLAN.md`.
-
-## Out of scope (current)
-
-- Authentication of the MCP client itself (relevant to the remote HTTP
-  transport; to be addressed before remote deployment is recommended).
-- Rate limiting per client.
-- Encryption configuration of the database connection (use `sslmode` in the
-  connection URL).
+---
 
 ## Reporting a vulnerability
 
-Open a security issue using the bug-report template, or contact the
-maintainers privately for sensitive reports. Do not disclose details
-publicly until a fix is available.
+See [`SECURITY.md`](../SECURITY.md) at the repo root for the
+full reporting policy. Summary:
+
+- Email `devopam@gmail.com` with the issue, impact, repro, and
+  MCPg version (`mcpg --version`).
+- You'll receive an acknowledgement within **3 business days**.
+- 90-day coordinated-disclosure window; critical issues ship
+  faster (typically within 14 days).
+- Reporters are credited in the release notes unless they prefer
+  otherwise.
+
+**Do not** file public issues for security reports.
+
+---
+
+## See also
+
+- [`security-hardening.md`](security-hardening.md) — living
+  roadmap of shipped (✅) vs queued (⬜) hardening features.
+- [`SECURITY.md`](../SECURITY.md) — vulnerability-reporting
+  policy.
+- [`architecture.md`](architecture.md) — the trust boundaries
+  rendered at the code-module level.
+- [`installation.md`](installation.md) — TLS-enforcement details +
+  least-privilege role setup.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -29,7 +29,7 @@ plumbing:
 | `MCPG_REPLICA_URLS` | Comma-separated read-replica DSNs. When set, `force_readonly` queries round-robin across healthy replicas; writes always go to the primary. |
 | `MCPG_NL2SQL_PROVIDER` / `MCPG_NL2SQL_API_KEY` / `MCPG_NL2SQL_MODEL` / `MCPG_NL2SQL_BASE_URL` / `MCPG_NL2SQL_MAX_TOKENS` | `translate_nl_to_sql` provider config (Anthropic / OpenAI / Gemini). |
 
-## Tool index (114 tools)
+## Tool index (117 tools)
 
 | Category | Tools |
 |---|---|
@@ -39,7 +39,7 @@ plumbing:
 | **Query intelligence** | `run_select`, `run_select_parallel`, `explain_query`, `analyze_query_plan`, `translate_nl_to_sql` |
 | **Server-side cursors** | `open_cursor`, `fetch_cursor`, `close_cursor`, `list_cursors` |
 | **Composite + diagnostic** | `summarize_table`, `why_is_this_slow`, `find_unused_objects`, `find_sensitive_columns`, `detect_n_plus_one`, `lint_naming_conventions`, `test_rls_for_role`, `list_locks`, `find_blocking_chains`, `read_pg_stat_io` |
-| **Health & tuning** | `check_database_health`, `analyze_workload`, `recommend_indexes`, `run_advisors` |
+| **Health & tuning** | `check_database_health`, `audit_database`, `analyze_workload`, `recommend_indexes`, `run_advisors` |
 | **Search** | `fuzzy_search`, `full_text_search`, `vector_search`, `vector_range_search`, `hybrid_search`, `geo_search` |
 | **Vector tuning advisors** | `recommend_vector_index`, `analyze_vector_search`, `analyze_vector_table`, `recommend_vector_quantization` |
 | **Apache AGE graph + Cypher** | `list_graphs`, `describe_graph`, `run_cypher`, `create_graph` (gated), `drop_graph` (gated) |
@@ -447,7 +447,7 @@ Lists rows from `mcpg_audit.events` (newest first). Returns `[]` when
 
 ## ORM-DSL exporters
 
-Every exporter is **read-only**. They share a v1 coverage boundary:
+Every exporter is **read-only**. They share a common coverage boundary:
 base tables, columns with PG-native types, primary keys, single-column
 intra-schema foreign keys, and enum types. Cross-schema FKs and
 composite FKs are documented v1 gaps for all of them. Views, foreign

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -1,12 +1,15 @@
 # MCPg tool tour
 
 A compact one-page tour of every tool MCPg exposes, organised by
-**what an agent typically wants to do**. Use this as a discovery surface;
-the full reference is in [`tools.md`](tools.md).
+**what an agent typically wants to do**. Use this as a discovery
+surface; the full reference is in [`tools.md`](tools.md), and
+task-oriented recipes live in [`cookbook.md`](cookbook.md).
 
-**114 tools** as of trunk (post-v0.5.0; +Apache AGE, replicas, OIDC).
-Numbers in `()` after each tool show roughly how parameters land —
-required ones first, common defaults afterwards.
+**117 tools** as of trunk. Each line shows the tool name + how its
+parameters land (required first, common defaults after). Capability
+gates are noted in section titles where they apply.
+
+---
 
 ## "What's in this database?"
 
@@ -38,7 +41,7 @@ list_publications()                  # logical replication
 list_subscriptions()
 list_extensions()
 list_available_extensions()
-list_generated_columns(schema)       # GENERATED ALWAYS AS ... STORED columns
+list_generated_columns(schema)       # GENERATED ALWAYS AS … STORED columns
 ```
 
 ## "Show me the shape"
@@ -48,15 +51,16 @@ Visualisation + structural diff.
 ```
 generate_schema_diagram(schema)                      # Mermaid ER text
 generate_fk_cascade_graph(schema, include_all=false) # Mermaid graph of CASCADE / SET NULL / SET DEFAULT FKs
-compare_schemas(left_schema, right_schema)           # added/removed/changed
+compare_schemas(left_schema, right_schema)           # added / removed / changed
 ```
 
 ## "Lint the schema"
 
 ```
-run_advisors(schema)                                 # PK / unindexed-FK / dup-index / nullable-tstz
-lint_naming_conventions(schema)                      # snake_case vs camelCase vs PascalCase outliers + index prefix rule
-find_sensitive_columns(schema)                       # PII / secret heuristic (credential / financial / contact / ... )
+run_advisors(schema)                                 # PK / unindexed-FK / dup-index / nullable-tstz / graph indices
+lint_naming_conventions(schema)                      # snake_case vs camelCase outliers + index prefix rule
+find_sensitive_columns(schema)                       # PII / secret heuristic
+find_unused_objects(schema)                          # zero-scan tables and user indexes
 ```
 
 ## "Test row-level security as a specific role"
@@ -77,10 +81,13 @@ translate_nl_to_sql(question, schema, execute=false) # NL → SQL via Anthropic 
 
 ## "Stream a huge result set" (server-side cursors)
 
+Each cursor owns a dedicated connection so long-lived cursors can't
+starve the main pool. 5-minute idle TTL.
+
 ```
 open_cursor(sql)                                     # validates via the run_select allowlist
 fetch_cursor(cursor_id, batch_size=100)              # exhausted=true → stop polling
-close_cursor(cursor_id)                              # idempotent; 5-min idle TTL anyway
+close_cursor(cursor_id)                              # idempotent
 list_cursors()                                       # show every open cursor
 ```
 
@@ -88,10 +95,9 @@ list_cursors()                                       # show every open cursor
 
 ```
 check_database_health()                              # connections + cache + dead tuples + invalid indexes + replication lag + bloat
+audit_database(schema, log_table=null)               # comprehensive 5-category DBA report with scores + top issues + recommendations
 analyze_workload(top_n=10)                           # slow queries from pg_stat_statements
 recommend_indexes()                                  # missing-index heuristics
-run_advisors(schema)                                 # aggregate of the above (per schema)
-find_unused_objects(schema)                          # zero-scan tables and user indexes
 list_active_queries()                                # who's running what right now
 list_locks(limit=100)                                # pg_locks joined with pg_stat_activity (waiters first)
 find_blocking_chains(limit=50)                       # (blocked, blocking) pairs via pg_blocking_pids
@@ -102,28 +108,30 @@ list_replicas()                                      # health of every read-repl
 
 ## "Tell me everything about this table / why is this query slow"
 
+Composite tools — one call replaces 5–10.
+
 ```
-summarize_table(schema, table, sample_rows=5)        # columns + PK + FKs + indexes + stats + sample, one call
-why_is_this_slow(sql)                                # EXPLAIN + plan analysis + locks + cache + suggestions, one call
+summarize_table(schema, table, sample_rows=5)        # columns + PK + FKs + indexes + stats + sample
+why_is_this_slow(sql)                                # EXPLAIN + plan analysis + locks + cache + index suggestions
 ```
 
 ## "Search for something"
 
 ```
-fuzzy_search(schema, table, column, query)           # pg_trgm trigram
-full_text_search(schema, table, column, query)       # tsvector / tsquery
+fuzzy_search(schema, table, column, query)                                # pg_trgm trigram
+full_text_search(schema, table, column, query)                            # tsvector / tsquery, web-search syntax
 vector_search(schema, table, column, query_vector, k=10, operator="<->")  # pgvector k-NN
 vector_range_search(schema, table, column, query_vector, max_distance)    # pgvector threshold
 hybrid_search(schema, table, vector_col, text_col, query_vector, text_query)
-                                                     # vector + FTS fused via RRF
-geo_search(schema, table, column, lon, lat, k=10)    # PostGIS k-NN
+                                                                          # vector + FTS fused via RRF
+geo_search(schema, table, column, lon, lat, k=10)                         # PostGIS k-NN
 ```
 
 ## "Tune pgvector"
 
 ```
-recommend_vector_index(schema, table, column)        # HNSW vs IVFFlat heuristics
-recommend_vector_quantization(schema)                # vector -> halfvec storage advisor
+recommend_vector_index(schema, table, column)                             # HNSW vs IVFFlat heuristics
+recommend_vector_quantization(schema)                                     # vector → halfvec / bit storage advisor
 analyze_vector_search(schema, table, column, query_vector)
 analyze_vector_table(schema, table)
 ```
@@ -164,7 +172,7 @@ list_notification_subscriptions()
 prepare_migration(name, target_schema, candidate_sql, ttl_minutes=60)
                                                      # returns id + shadow + diff
 validate_migration(target_schema, candidate_sql, sample_rows_per_table=100)
-                                                     # applies to a transient shadow with real-shape sample data
+                                                     # applies to a transient shadow with sampled real data
 complete_migration(migration_id)                     # applies to target
 cancel_migration(migration_id)                       # drops shadow
 list_pending_migrations()
@@ -187,9 +195,9 @@ generate_ent_schemas(schema)                         # one .go per table (Go)
 generate_ecto_schemas(schema, app_module="MyApp")    # one .ex per table (Elixir)
 ```
 
-All eight share v1 coverage: base tables, columns, primary keys,
-single-column intra-schema FKs, enums. Cross-schema and composite FKs
-are documented gaps.
+All eight cover: base tables, columns, primary keys, single-column
+intra-schema FKs, and enums. Cross-schema and composite FKs are
+documented gaps.
 
 ## "Write to the database" (`unrestricted` mode)
 
@@ -211,7 +219,7 @@ enable_extension(name)                               # allowlisted extensions on
 ```
 pg_cron.schedule(name, schedule, command)
 pg_cron.unschedule(name_or_id)
-pg_cron.update(name_or_id, ...)
+pg_cron.update(name_or_id, …)
 ```
 
 ## "Manage partitions" (`unrestricted` + `MCPG_ALLOW_DDL=true` + pg_partman installed)
@@ -258,8 +266,12 @@ list_replicas()                                             # per-replica health
 ```
 list_audit_events(limit=100, tool=null)              # MCPG_AUDIT_PERSIST=true required
 get_server_info()                                    # version, mode, transport, DB state
-get_metrics_exposition()                             # Prometheus text-format snapshot
 ```
+
+The `mcpg --version` shell flag (also `-V`) prints the version when
+you're filing a bug report.
+
+---
 
 ## Reading more
 
@@ -267,5 +279,6 @@ get_metrics_exposition()                             # Prometheus text-format sn
 - [`tools.md`](tools.md) — full parameter / return shape per tool.
 - [`user-guide.md`](user-guide.md) — narrative walkthrough.
 - [`security.md`](security.md) — threat model + access-mode boundaries.
+- [`security-hardening.md`](security-hardening.md) — shipped vs queued hardening roadmap.
 - [`architecture.md`](architecture.md) — design + module map.
 - [`adr/`](adr/) — accepted architecture decision records.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,46 +1,87 @@
 # MCPg User Guide
 
-How to use the MCPg PostgreSQL MCP server once it is installed. This is a
-living document — it is updated as features are added.
+How to use MCPg once it's installed. For getting it installed see
+[`installation.md`](installation.md); for the full per-tool
+parameters see [`tools.md`](tools.md); for short task-shaped
+recipes see [`cookbook.md`](cookbook.md).
 
-For installation and configuration, see the
-[Installation Guide](installation.md). For the exact parameters of each tool,
-see the [Tool Reference](tools.md).
+This guide is the narrative walkthrough — read it top-to-bottom the
+first time, skim it as a reference after.
+
+---
+
+## Contents
+
+1. [What MCPg is](#what-mcpg-is)
+2. [Access modes & capability gates](#access-modes--capability-gates)
+3. [Connecting an MCP client](#connecting-an-mcp-client)
+4. [Working with the tools](#working-with-the-tools)
+5. [Multi-tenancy](#multi-tenancy)
+6. [Read-replica routing](#read-replica-routing)
+7. [Natural-language SQL](#natural-language-sql)
+8. [Server-side cursors](#server-side-cursors)
+9. [Data movement](#data-movement)
+10. [Reactive workflows: LISTEN / NOTIFY](#reactive-workflows-listen--notify)
+11. [Staged migrations](#staged-migrations)
+12. [ORM bridges](#orm-bridges)
+13. [Audit trail](#audit-trail)
+14. [Observability](#observability)
+15. [Rate limiting](#rate-limiting)
+16. [Security defaults](#security-defaults)
+17. [Troubleshooting](#troubleshooting)
+
+---
 
 ## What MCPg is
 
-MCPg is an MCP server that exposes a PostgreSQL database to an AI agent
-through a fixed, audited set of tools. The agent never gets a raw database
-connection — it can only call the tools MCPg registers, and every call is
-validated and logged.
+MCPg is an MCP server that exposes a PostgreSQL database to an AI
+agent through a fixed, audited set of **117 tools**. The agent never
+gets a raw database connection — it can only call the tools MCPg
+registers, every call is validated, and every call is logged. MCPg
+runs as a single async process and ships as both a PyPI package
+(`pip install mcpg`) and a hardened Docker image.
 
-## Access modes
+---
 
-The `MCPG_ACCESS_MODE` setting decides which tools are available:
+## Access modes & capability gates
 
-| Mode           | Tools available |
-|----------------|-----------------|
-| `read-only`    | introspection, querying, health & tuning (all read-only) |
-| `restricted`   | same as read-only (reserved for tighter execution limits) |
-| `unrestricted` | the above **plus** `run_write`, and — with `MCPG_ALLOW_DDL=true` — `run_ddl` and `enable_extension` |
+The `MCPG_ACCESS_MODE` setting decides the **default** tool surface;
+additional **capability gates** unlock higher-blast-radius families
+within `unrestricted` mode.
 
-Read-only is the default. Writes and DDL are deliberately gated; DDL needs a
-second explicit opt-in (`MCPG_ALLOW_DDL`).
+| Mode | What's exposed |
+|---|---|
+| `read-only` (default) | Catalog introspection, querying, search, health, EXPLAIN — all read-only. |
+| `restricted` | Same as `read-only`. Reserved for future tighter execution limits. |
+| `unrestricted` | The above **plus** writes: `run_write`, `run_maintenance`, `cancel_query`, `terminate_backend`. |
+
+Within `unrestricted`, the gate vars decide which additional
+families come along:
+
+| Gate | Unlocks |
+|---|---|
+| `MCPG_ALLOW_DDL=true` | `run_ddl`, `enable_extension`, hypertable tools (`create_hypertable`, `add_compression_policy`, `add_retention_policy`), AGE graph DDL (`create_graph`, `drop_graph`), staged migrations (`prepare_migration` / `complete_migration` / `cancel_migration` / `validate_migration` / `list_pending_migrations`). |
+| `MCPG_ALLOW_SHELL=true` | Subprocess tools — `dump_database`, `restore_database`, `copy_table_between_databases`. Requires the PostgreSQL client binaries (`pg_dump` / `pg_restore` / `psql`) on `PATH`. |
+| `MCPG_ALLOW_LISTEN=true` | `subscribe_channel`, `poll_notifications`, `unsubscribe_channel`, `list_notification_subscriptions`. |
+
+Read-only is the default because the typical agent workflow is
+**inspect first, modify second**. Each gate is a deliberate opt-in
+so an experimentation deployment can't drop a table by accident.
+
+---
 
 ## Connecting an MCP client
 
-### stdio (local clients, e.g. Claude Desktop)
-
-Add MCPg to the client's MCP server configuration:
+### stdio (Claude Desktop and other local clients)
 
 ```json
 {
   "mcpServers": {
     "mcpg": {
-      "command": "uv",
-      "args": ["run", "mcpg"],
+      "command": "uvx",
+      "args": ["mcpg"],
       "env": {
-        "MCPG_DATABASE_URL": "postgresql://localhost/mydb",
+        "MCPG_DATABASE_URL": "postgresql://user:pass@localhost:5432/mydb",
         "MCPG_ACCESS_MODE": "read-only"
       }
     }
@@ -48,144 +89,435 @@ Add MCPg to the client's MCP server configuration:
 }
 ```
 
-### Streamable HTTP (remote clients)
+(Use `"command": "mcpg"` with no `args` if you've done a
+`pip install mcpg` on the system Python.)
 
-Set `MCPG_TRANSPORT=streamable-http` and connect the client to
-`http://<host>:<port>/mcp`. Authentication of remote clients is not yet
-provided — see [`security.md`](security.md) before exposing MCPg remotely.
+### Streamable HTTP (Cursor, Continue, custom web clients, etc.)
+
+```bash
+export MCPG_DATABASE_URL=postgresql://user:pass@localhost:5432/mydb
+export MCPG_TRANSPORT=streamable-http
+export MCPG_HTTP_AUTH_TOKEN=<random_long_token>
+mcpg
+```
+
+Then point the client at `http://<host>:8000/mcp` and have it send
+`Authorization: Bearer <random_long_token>`.
+
+For production, prefer OIDC over a static token — set:
+
+```bash
+export MCPG_AUTH_MODE=oidc
+export MCPG_OIDC_ISSUER=https://your-issuer/
+export MCPG_OIDC_AUDIENCE=mcpg
+# Optional — map a JWT claim to the per-request PG role:
+export MCPG_OIDC_ROLE_CLAIM=pg_role
+```
+
+OIDC validates every request's JWT against the issuer's JWKS
+(asymmetric algorithms only — RS256/RS384/RS512 + ES256/ES384/ES512).
+
+---
 
 ## Working with the tools
 
-The tools group into a few workflows. Full parameters are in the
-[Tool Reference](tools.md).
+The tools group into a few common workflows. Full discovery surface
+is in [`tour.md`](tour.md); long-form parameters in
+[`tools.md`](tools.md); task-shaped recipes in
+[`cookbook.md`](cookbook.md).
 
-### Explore the schema
+### Explore a schema
 
-`list_schemas` → `list_tables` → `describe_table` map out the database.
-`list_indexes` shows a table's indexes and their access method;
-`list_extensions` and `list_available_extensions` show what extensions are
-installed or available. `describe_table` reports the dimension of `pgvector`
-`vector(N)` columns.
+`list_schemas` → `list_tables` → `describe_table` maps a database.
+`list_indexes` shows a table's indexes and their access method
+(B-tree / GIN / HNSW / IVFFlat / GiST / BRIN). `list_extensions`
+and `list_available_extensions` show what extensions are installed
+or available; `describe_table` reports the dimension of a
+`pgvector` `vector(N)` column.
+
+For a one-call snapshot use `summarize_table(schema, table)` —
+columns + PK + FKs + indexes + stats + sample rows, all in one
+round-trip. Excellent agent UX.
 
 ### Query data
 
-`run_select` runs a read-only SQL query — it is validated against a safety
-allowlist, executed read-only, and capped at `max_rows` (default 1000) with a
-`truncated` flag. `explain_query` returns a query's execution plan;
-`analyze_query_plan` summarises that plan (cost, node types, sequential
-scans).
+`run_select(sql, max_rows=1000)` runs a read-only SQL query —
+validated against the SafeSQL allowlist, executed under a forced
+read-only transaction, and capped with a `truncated` flag.
+`run_select_parallel(statements)` fans out concurrently with
+per-statement error isolation.
+
+`explain_query(sql)` returns a query plan; `analyze_query_plan(sql)`
+summarises it (cost, node types, sequential scans);
+`why_is_this_slow(sql)` rolls EXPLAIN + active queries + locks +
+cache + index suggestions into one call.
 
 ### Search
 
-`fuzzy_search` ranks a text column by trigram similarity (needs `pg_trgm`).
-`full_text_search` ranks documents with PostgreSQL's built-in full-text
-search and accepts web-search syntax (quoted phrases, `or`, `-`).
-`vector_search` finds the rows nearest to a query vector (needs `pgvector`),
-and `geo_search` finds the rows nearest to a lon/lat point (needs `postgis`).
+`fuzzy_search` (trigram, needs `pg_trgm`), `full_text_search`
+(tsvector / tsquery, web-search syntax), `vector_search` (pgvector
+k-NN, choose `<->` / `<#>` / `<=>` operator), `vector_range_search`
+(distance threshold), `hybrid_search` (vector + FTS via
+reciprocal-rank fusion), `geo_search` (PostGIS k-NN over a
+geography column).
+
+For vector index sizing: `recommend_vector_index` (HNSW vs IVFFlat)
+and `recommend_vector_quantization` (vector → halfvec / bit
+storage advisor).
 
 ### Diagnose and tune
 
-`check_database_health` reports connection use, cache hit ratio, vacuum
-backlog, and invalid indexes. `analyze_workload` surfaces the slowest queries
-(needs `pg_stat_statements`). `recommend_indexes` flags large
-sequentially-scanned tables and suggests index types per column.
+- `check_database_health` — connections, cache hit ratio, dead
+  tuples, invalid indexes, replication lag, bloat.
+- `audit_database(schema)` — comprehensive 5-category DBA report
+  (Memory & I/O, Transactions & Connections, Concurrency & Locks,
+  Cleanliness & Bloat, Slow Queries) with per-metric scores, top
+  issues, and prescriptive recommendations.
+- `analyze_workload` — slowest query templates from
+  `pg_stat_statements`.
+- `recommend_indexes` — missing-index heuristics.
+- `find_unused_objects(schema)` — zero-scan tables and user
+  indexes; great for "what can I drop?".
+- `detect_n_plus_one(min_calls=100)` — walks
+  `pg_stat_statements` looking for ORM lazy-load loops.
 
-### Change data (unrestricted mode)
+### Change data (`unrestricted` mode)
 
-`run_write` executes a single `INSERT`/`UPDATE`/`DELETE` — add a `RETURNING`
-clause to get affected rows back. `run_ddl` runs a single DDL statement, and
-`enable_extension` enables an allowlisted extension; both need
+- `run_write(sql)` — one `INSERT` / `UPDATE` / `DELETE`. Add a
+  `RETURNING` clause to get affected rows back.
+- `run_ddl(sql)` (`MCPG_ALLOW_DDL=true`) — one DDL statement; can
+  optionally snapshot the structural diff for an `audit_database`
+  follow-up.
+- `enable_extension(name)` — allowlisted extensions only.
+
+### Visualise
+
+- `generate_schema_diagram(schema)` — Mermaid ER, paste-ready into
+  GitHub / Notion / Obsidian.
+- `generate_fk_cascade_graph(schema)` — Mermaid blast-radius graph
+  of `ON DELETE CASCADE` / `SET NULL` / `SET DEFAULT` FKs.
+- `generate_graph_diagram(graph_name)` — Mermaid view of an Apache
+  AGE property graph.
+
+---
+
+## Multi-tenancy
+
+MCPg supports **per-request PostgreSQL role switching** via
+`SET LOCAL ROLE` so one process can safely serve many tenants from
+a single pool.
+
+```bash
+# Static default role applied to every query that doesn't override:
+export MCPG_DEFAULT_ROLE=tenant_a
+
+# Allowlist — when set, the X-MCPG-Role header / OIDC claim must
+# be in the list (otherwise 403):
+export MCPG_ALLOWED_ROLES=tenant_a,tenant_b,tenant_c
+```
+
+HTTP requests override the default by sending
+`X-MCPG-Role: tenant_b`. OIDC deployments override via
+`MCPG_OIDC_ROLE_CLAIM` — the named JWT claim's value becomes the
+per-request role automatically.
+
+Role names are identifier-validated
+(`[A-Za-z_][A-Za-z0-9_]*`) so they're safe to inline into
+`SET LOCAL ROLE "<name>"`.
+
+RLS policies keyed on `current_user` then isolate tenants
+correctly, and the audit trail records which role ran each call.
+
+---
+
+## Read-replica routing
+
+```bash
+export MCPG_REPLICA_URLS=postgresql://u:p@replica-1/db?sslmode=require,postgresql://u:p@replica-2/db?sslmode=require
+```
+
+When `MCPG_REPLICA_URLS` is non-empty, every `force_readonly=true`
+query is round-robin-routed to a healthy replica; writes always go
+to the primary. Replica failures fall back to the primary once and
+mark the replica degraded for 30 s before re-trying.
+
+Each replica has its own connection pool; per-request `SET LOCAL
+ROLE` composes across replicas (each replica's pool gets its own
+`TenantSqlDriver`).
+
+`list_replicas()` reports per-replica index, password-obfuscated
+DSN, degraded flag, last error, and seconds-until-retry. Routing
+decisions land in the Prometheus `mcpg_tool_calls_total` counter
+under the synthetic tool name `__replica_route` with statuses
+`primary` / `primary_no_healthy` / `fallback` / `replica_<n>`.
+
+---
+
+## Natural-language SQL
+
+```bash
+export MCPG_NL2SQL_PROVIDER=anthropic    # or: openai | gemini
+export ANTHROPIC_API_KEY=…                # the provider's standard env var
+```
+
+`translate_nl_to_sql(question, schema, execute=false)` asks the
+configured provider to produce SQL for the supplied natural-language
+question, given the named schema's catalog. The generated SQL is
+passed through the **same SafeSQL allowlist** as any hand-written
+query before any optional execution.
+
+| `MCPG_NL2SQL_PROVIDER` | API-key env (auto-detected) | Default model |
+|---|---|---|
+| `anthropic` | `ANTHROPIC_API_KEY` | provider's recent Claude Sonnet |
+| `openai` | `OPENAI_API_KEY` | `gpt-4o-mini` |
+| `gemini` | `GEMINI_API_KEY` → `GOOGLE_API_KEY` | provider's recent Gemini Flash |
+
+Override the model with `MCPG_NL2SQL_MODEL` and point at an
+OpenAI-compatible self-hosted endpoint (Ollama, vLLM, OpenRouter)
+with `MCPG_NL2SQL_BASE_URL` — works with the `openai` provider.
+The per-call response budget is capped by `MCPG_NL2SQL_MAX_TOKENS`
+(default 2048, hard limit 16384).
+
+---
+
+## Server-side cursors
+
+For pageable reads over millions of rows.
+
+```
+open_cursor(sql) → { cursor_id: "mcpg_e3a91f", … }
+fetch_cursor(cursor_id, batch_size=100) → { rows: [...], exhausted: false }
+fetch_cursor(cursor_id, batch_size=100) → { rows: [...], exhausted: true }   # stop polling
+close_cursor(cursor_id)                                                       # idempotent
+list_cursors()
+```
+
+Each cursor holds a **dedicated connection** so long-lived cursors
+don't starve the main pool. Cursors auto-close after a 5-minute
+idle timeout. The opening SQL passes through the same SafeSQL
+allowlist as `run_select`, so cursors can only read.
+
+---
+
+## Data movement
+
+Five tools, three blast-radius tiers:
+
+- **In-process exports** (no opt-in needed):
+  `export_query(sql, format="csv|json")`,
+  `export_table(schema, table, format="csv|json", limit=10000)`.
+- **In-process imports** (`unrestricted`): bulk-load via
+  `COPY … FROM STDIN` + parametrised `executemany`.
+  `import_csv(schema, table, content, header=true, delimiter=",")`,
+  `import_json(schema, table, content)`.
+- **Subprocess dump / restore**
+  (`unrestricted` + `MCPG_ALLOW_SHELL=true`): `dump_database`,
+  `restore_database`, `copy_table_between_databases` shell out to
+  `pg_dump` / `psql` / `pg_restore` with hard timeouts
+  (`MCPG_SHELL_TIMEOUT_SEC`, default 60 s) and output caps
+  (`MCPG_SHELL_MAX_OUTPUT_BYTES`, default 64 MiB).
+
+---
+
+## Reactive workflows: LISTEN / NOTIFY
+
+`subscribe_channel(channel)` opens a PG `LISTEN` on a dedicated
+connection and returns a `subscription_id`. `poll_notifications(id,
+timeout_ms=0, max_messages=100)` drains the per-sub bounded queue,
+optionally waiting up to `timeout_ms`. `unsubscribe_channel(id)`
+removes the subscription; `list_notification_subscriptions()`
+reports the active ones.
+
+Queue size cap: `MCPG_LISTEN_QUEUE_MAX` (default 1000); overflow
+drops the oldest message and surfaces `dropped_count` on the next
+poll. Requires `MCPG_ACCESS_MODE=unrestricted` +
+`MCPG_ALLOW_LISTEN=true`.
+
+---
+
+## Staged migrations
+
+`prepare_migration(name, target_schema, candidate_sql,
+ttl_minutes=60)` clones the target schema's structure into a shadow,
+applies the candidate SQL there, and runs `compare_schemas` so you
+can review the structural diff. `validate_migration` separately
+applies the candidate to a transient shadow seeded with sampled
+real data so failures the diff misses (NOT NULL on existing NULLs,
+CHECK violations, type narrowings) surface before apply.
+
+`complete_migration(id)` applies to the target;
+`cancel_migration(id)` drops the shadow without applying.
+`list_pending_migrations()` shows what's staged.
+
+All staged-migration tools require `unrestricted` +
 `MCPG_ALLOW_DDL=true`.
 
-## Optional extensions
+---
 
-Some tools rely on optional PostgreSQL extensions. They **degrade
-gracefully**: if the extension is not installed, the tool returns
-`available: false` rather than failing.
+## ORM bridges
 
-| Tool                | Needs extension |
-|---------------------|-----------------|
-| `fuzzy_search`      | `pg_trgm` |
-| `analyze_workload`  | `pg_stat_statements` |
-| `vector_search`     | `vector` (pgvector) |
-| `geo_search`        | `postgis` |
-| `pg_cron.*`         | `pg_cron` |
-| `partman.*`         | `pg_partman` |
+Eight read-only exporters generate a starting schema/model file
+from the live PG catalog:
 
-In `unrestricted` + `MCPG_ALLOW_DDL` mode, `enable_extension` can install an
-allowlisted extension.
+- `generate_prisma_schema` (TypeScript / Prisma)
+- `generate_drizzle_schema` (TypeScript / Drizzle)
+- `generate_sqlalchemy_models` (Python / SQLAlchemy 2.0)
+- `generate_sqlc_schema` (Go / sqlc)
+- `generate_diesel_schema` (Rust / Diesel)
+- `generate_jooq_config` (Java / jOOQ codegen XML)
+- `generate_ent_schemas` (Go / Ent — one file per table)
+- `generate_ecto_schemas` (Elixir / Ecto — one file per table)
 
-## Data movement (post-0.3.0)
+All eight cover: base tables, columns, primary keys, single-column
+intra-schema FKs, and enums. Cross-schema and composite FKs are
+documented gaps.
 
-Five tools cover moving data in / out of the database:
+---
 
-- **In-process exports**: `export_query` / `export_table` serialise rows
-  to CSV or JSON. Read-only, no opt-in.
-- **In-process imports**: `import_csv` / `import_json` bulk-load via
-  `COPY ... FROM STDIN` and parametrised `executemany`. Require
-  `unrestricted` (WRITE capability).
-- **Subprocess dump / restore**: `dump_database` / `restore_database`
-  shell out to `pg_dump` / `psql` / `pg_restore`. Require `unrestricted` +
-  `MCPG_ALLOW_SHELL=true`.
-- **Cross-DB copy**: `copy_table_between_databases` pipes `pg_dump` on
-  one URL into `pg_restore` on another. Same opt-in.
+## Audit trail
 
-## Reactive workflows: LISTEN/NOTIFY (post-0.3.0)
+Every tool call — success or failure — is logged to the
+`mcpg.audit` Python logger with the tool name, **redacted**
+arguments (see below), and outcome. Configure where that logger's
+records are shipped via your deployment's logging stack.
 
-`subscribe_channel` opens a PG `LISTEN` on a dedicated connection and
-returns a subscription id; `poll_notifications` drains the per-sub
-bounded queue with an optional wait; `unsubscribe_channel` removes the
-subscription; `list_notification_subscriptions` reports the active
-ones. Requires `unrestricted` + `MCPG_ALLOW_LISTEN=true`. The
-`MCPG_LISTEN_QUEUE_MAX` env var caps queue size (default 1000); overflow
-drops the oldest message and surfaces `dropped_count` on the next poll.
+### Persistence
 
-## Staged migrations (post-0.3.0)
+With `MCPG_AUDIT_PERSIST=true`, every `run_write` and `run_ddl` is
+**also** persisted to a `mcpg_audit.events` table (auto-created
+idempotently on first write) with redacted arguments + result +
+status. Query the table via the `list_audit_events` tool.
 
-`prepare_migration` clones the target schema's structure into a shadow,
-applies your candidate SQL there, and runs `compare_schemas` so you
-review the structural diff. `complete_migration` lands it on the
-target. `cancel_migration` drops the shadow without applying.
-`list_pending_migrations` shows what's staged. Requires `unrestricted`
-+ `MCPG_ALLOW_DDL=true` (the existing DDL gate; no new env var).
+### Redaction
 
-## ORM bridges (post-0.3.0)
+Argument values are masked when their **key name** matches a
+case-insensitive regex (matched via `re.search`, so `password`
+also covers `PGPASSWORD`, `user_password`, `app.password`).
+Default patterns:
 
-Eight read-only exporters generate a starting schema/model file from
-the live PG catalog: `generate_prisma_schema`, `generate_drizzle_schema`,
-`generate_sqlalchemy_models`, `generate_sqlc_schema`,
-`generate_diesel_schema`, `generate_jooq_config`, `generate_ent_schemas`,
-`generate_ecto_schemas`. All share a v1 coverage boundary (base tables,
-columns, PKs, single-column intra-schema FKs, enums). See
-[`tools.md`](tools.md#orm-dsl-exporters) for details per exporter.
+```
+password, passwd, secret, token, api[_-]?key, bearer,
+authorization, database_url, dsn, conninfo
+```
 
-## Auditing
+Extend the pattern list via `MCPG_AUDIT_REDACT_KEYS` (comma-separated
+regex fragments). Walks nested dicts / lists / tuples so credentials
+buried in result payloads are masked too.
 
-Every tool call — success or failure — is logged to the `mcpg.audit` logger
-with the tool name, arguments (secrets masked), and outcome. Configure where
-that logger's records are shipped in your deployment's logging setup.
+String leaves are passed through the `obfuscate_password` helper so
+an embedded connection-string credential nested anywhere is
+scrubbed.
 
-With `MCPG_AUDIT_PERSIST=true`, every `run_write` and `run_ddl` is **also**
-persisted to `mcpg_audit.events` (auto-created) with the redacted arguments
-+ result + status. Query the table via the `list_audit_events` tool.
+---
+
+## Observability
+
+The HTTP transports expose:
+
+- `GET /metrics` — Prometheus text-format snapshot. Two series:
+  - `mcpg_tool_calls_total{tool,status}` — counter; `status` ∈
+    `ok` / `error` / `primary` / `fallback` / `replica_<n>` /
+    `primary_no_healthy` (the last four come from the synthetic
+    `__replica_route` tool).
+  - `mcpg_tool_duration_seconds_*` — histogram per tool.
+- `GET /healthz` — liveness probe.
+- `GET /readyz` — readiness probe (verifies a pool connection).
+
+For stdio deployments, the `get_metrics_exposition()` MCP tool
+returns the same Prometheus payload as a string the agent can hand
+to a scrape target.
+
+---
+
+## Rate limiting
+
+```bash
+export MCPG_RATE_LIMIT_ENABLED=true
+export MCPG_RATE_LIMIT_MAX_REQUESTS=60       # global cap per window
+export MCPG_RATE_LIMIT_WINDOW_SECONDS=60     # window length
+export MCPG_RATE_LIMIT_HEAVY_MAX=5           # cap for heavy tools
+export MCPG_RATE_LIMIT_HEAVY_WINDOW=60       # heavy-window length
+```
+
+Token-bucket per-tool rate limiting. "Heavy" tools include
+`run_write`, `run_ddl`, `dump_database`, `restore_database`, and
+similarly expensive operations. A rate-limited call returns an
+error immediately rather than queueing.
+
+---
+
+## Security defaults
+
+MCPg ships with defence-in-depth defaults:
+
+- **Read-only access mode by default.** Writes and DDL need
+  explicit opt-in.
+- **SafeSQL allowlist.** Every agent-supplied SQL statement parses
+  through the vendored `SafeSqlDriver` (built on `pglast`) — only
+  whitelisted AST nodes pass through. Statement stacking, comment
+  escapes, transaction-control escapes, DDL inside `run_select`,
+  `COPY`, and `DO` blocks are refused **before execution**.
+- **Identifier allowlist.** Every interpolated identifier (schema
+  / table / column / role names) goes through a
+  `[A-Za-z_][A-Za-z0-9_]*` regex.
+- **PG TLS enforcement on startup.** MCPg refuses to start if
+  `MCPG_DATABASE_URL` (or any `MCPG_REPLICA_URLS` entry) points
+  at a non-loopback host without `sslmode=require` (or stronger).
+  Use `MCPG_ALLOW_INSECURE_TLS=true` to opt out for non-prod.
+- **Per-session timeouts** (`MCPG_STATEMENT_TIMEOUT_MS`, default
+  30 s; `MCPG_LOCK_TIMEOUT_MS`, default 5 s) self-terminate
+  runaway queries and lock waits.
+- **HTTP authn.** Static bearer (`MCPG_HTTP_AUTH_TOKEN`) with
+  constant-time compare, or OIDC JWT validation against the
+  issuer's JWKS (asymmetric algorithms only).
+- **Audit redaction** as documented above.
+- **Multi-tenancy via `SET ROLE`.** One process can serve many
+  tenants without the RLS-meets-pool footgun.
+
+See [`security.md`](security.md) for the full threat model and
+[`security-hardening.md`](security-hardening.md) for the living
+roadmap of shipped (✅) and queued (⬜) hardening items.
+
+---
 
 ## Troubleshooting
 
-- **"configuration error" on start** — a required/invalid environment
-  variable; the message names it. See the [Installation Guide](installation.md).
-- **A write tool is missing** — set `MCPG_ACCESS_MODE=unrestricted` (and
-  `MCPG_ALLOW_DDL=true` for `run_ddl` / `enable_extension` / migration tools;
-  `MCPG_ALLOW_SHELL=true` for `dump_database` / `restore_database` /
-  `copy_table_between_databases`; `MCPG_ALLOW_LISTEN=true` for the
-  LISTEN/NOTIFY tools).
-- **`analyze_workload` / `fuzzy_search` report `available: false`** — the
-  required extension is not installed in the target database.
-- **A query is rejected** — `run_select` only permits safe read-only
-  statements; writes, DDL, and multi-statement input are refused by design.
-- **Connection failures** — verify `MCPG_DATABASE_URL` and that the database
-  is reachable; errors are reported with the password redacted.
-- **`prepare_migration` refuses with "cannot run inside a transaction"** —
-  the candidate SQL contains a `CONCURRENTLY` / `VACUUM` / `ALTER SYSTEM`
-  statement. The staged-migration workflow always wraps the candidate in
-  a SET LOCAL transaction; run those statements directly via `run_ddl`
-  instead.
+- **`mcpg: configuration error: …`** — A required `MCPG_*` env var
+  is missing or invalid; the message names it. See the
+  [README env-var reference](../README.md#configuration).
+- **`MCPG_DATABASE_URL points at a remote host (…) but its sslmode
+  is 'prefer'`** — The TLS enforcement guard caught a
+  plaintext-capable DSN. Add `?sslmode=require` to the DSN or
+  set `MCPG_ALLOW_INSECURE_TLS=true` if intentional.
+- **A write tool is missing.** Set `MCPG_ACCESS_MODE=unrestricted`
+  plus the matching gate (`MCPG_ALLOW_DDL=true`,
+  `MCPG_ALLOW_SHELL=true`, or `MCPG_ALLOW_LISTEN=true`).
+- **`fuzzy_search` / `analyze_workload` / `vector_search` reports
+  `available: false`.** The corresponding extension isn't
+  installed in the target DB. MCPg degrades gracefully — install
+  when ready.
+- **A query is rejected.** `run_select` only permits safe read-only
+  statements; writes, DDL, and multi-statement input are refused
+  by design. Use `run_write` / `run_ddl` (under `unrestricted`
+  mode) instead.
+- **`prepare_migration` refuses with "cannot run inside a
+  transaction"** — the candidate SQL contains a
+  `CONCURRENTLY` / `VACUUM` / `ALTER SYSTEM` statement. The
+  staged-migration workflow always wraps the candidate in a
+  transaction; for those, use `run_ddl` directly.
+- **Rate-limit errors.** With `MCPG_RATE_LIMIT_ENABLED=true`,
+  exceeding the per-tool quota returns
+  "Rate limit exceeded for tool '<name>'". Wait the window out
+  or raise `MCPG_RATE_LIMIT_*` defaults.
+- **Replica request fell back to primary.** Check `list_replicas()`
+  — the affected replica will be `degraded=true` with
+  `last_error` and `seconds_until_retry`. The 30 s window
+  auto-clears once the replica is healthy.
+- **JWT was rejected.** OIDC validates against `iss` + `aud` +
+  `exp` + `nbf` + signature, with 30 s clock leeway. Confirm
+  `MCPG_OIDC_ISSUER` + `MCPG_OIDC_AUDIENCE` match what your IdP
+  is minting; check that the JWT algorithm is asymmetric (HS-family
+  is rejected by design).
+- **`audit_database` returns `pg_stat_statements: Not Installed`**.
+  Add `pg_stat_statements` to `shared_preload_libraries`,
+  restart Postgres, then `CREATE EXTENSION pg_stat_statements;`.


### PR DESCRIPTION
## Summary

Rewrites `README.md` from a 159-line status snapshot into a 447-line
user manual organised around what readers actually want to know.
Per the brief: changelog content out, benefits + install + configure
+ usage in.

The "Status: v0.5.0 released; trunk at 114 tools…" callout that read
as an inline changelog is gone — `CHANGELOG.md` and the GitHub
Releases page are now the single source of truth for what's shipped;
the README just links to them.

## Sections (after)

1. **Hero + badges** — PyPI version, Python versions, License, CI status.
2. **Why MCPg** — six benefit paragraphs (safe-by-default,
   one-server-broad-surface, PG-native, production-shaped,
   observable, test-driven). No competitor mentions.
3. **Install** — three paths (PyPI / Docker / source) with the
   recommended one first.
4. **Quick start** — two complete worked setups: Claude Desktop
   stdio with the `claude_desktop_config.json` snippet, and the
   streamable-HTTP transport for IDE / web clients.
5. **Configuration** — a **"Common scenarios"** cheatsheet table
   mapping intents to minimum env vars, then the **full reference**
   of all 38 `MCPG_*` env vars grouped into 9 sub-tables:
   - Core
   - Capability gates
   - Authentication (HTTP transports)
   - Multi-tenancy (`SET ROLE`)
   - Read replicas
   - Pool / timeouts / TLS
   - Subprocess tools
   - LISTEN/NOTIFY
   - Audit
   - Rate limiting
   - Natural-language SQL
6. **Usage examples** — six diverse "You say → Agent does" round-trips
   covering schema introspection, slow-query diagnosis, NL→SQL,
   schema visualisation, DBA health audit, guarded writes. Links to
   `docs/cookbook.md` for the long tail.
7. **What's in the box** — compact 15-bullet category summary
   (down from 80 bullets); full reference defers to
   `docs/tools.md` + `docs/tour.md`.
8. **Documentation index** with the new `https://devopam.github.io/MCPg/`
   URL.
9. **Security / Release notes / Contributing / License** — short
   pointer sections.

## Test plan

- [x] All 14 relative links in the new README resolve against files
      actually on `main` (verified via `grep -oE` + file existence test).
- [x] All 38 `MCPG_*` env vars from `src/mcpg/config.py` are
      documented in the table.
- [x] GitHub will render the README on the project page; line count
      is 447 (manageable, scrollable, has TOC structure via headings).
- [ ] **Maintainer to spot-check:**
  - Hero badges resolve (PyPI shows v0.5.1, license MIT, CI green).
  - The Claude Desktop JSON snippet matches your usual config path.
  - The six worked usage examples land for your audience tone-wise.
  - The "Common scenarios" cheatsheet covers the deployments you most
    often see in the wild.
- [ ] **Optional follow-ups** if you want them in this PR or a
      separate one:
  - Add a short "What's new in v0.5.1" callout under the badges
    (would defeat the move-changelog-out-of-readme goal — only do
    this if you want a stable "latest release" line).
  - Add a small Mermaid architecture diagram up top (cayman theme
    on the github.io site renders these inline).
  - Add a Discord / discussion link if there's a community channel.

No code changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Revamp README into a comprehensive, user-focused manual that explains MCPg’s value, installation, configuration, and usage while delegating detailed references to dedicated docs.

Documentation:
- Replace the status-style README with a structured user manual covering benefits, installation options, quick starts for stdio and HTTP, configuration cheatsheets, and usage examples.
- Document all MCPG_* environment variables in grouped reference tables, including security, auth, pooling, replicas, audit, rate limiting, and NL→SQL settings.
- Condense the in-README tool catalogue into a compact category summary and point readers to the tool tour, cookbook, and tools reference for full details.
- Add badges, documentation index links (including the GitHub Pages docs site), and concise sections for security, release notes, contributing, and licensing.