### PR TITLE
feat(nl2sql): multi-provider routing + auto-discovery + per-call provider arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Multi-provider routing for `translate_nl_to_sql`.** MCPg now
+  auto-discovers every configured NL→SQL provider from the
+  environment at startup (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`,
+  `GEMINI_API_KEY` / `GOOGLE_API_KEY`) — each one becomes callable
+  through the tool, not just the configured default. The tool gains
+  an optional `provider="anthropic"|"openai"|"gemini"` argument so a
+  caller can route per-call across configured providers; without it,
+  MCPg falls back to `MCPG_NL2SQL_PROVIDER` (the default), then to
+  the first available in preference order **anthropic → openai →
+  gemini**. `get_server_info` surfaces `nl2sql_default_provider` and
+  `nl2sql_available_providers` so agents can introspect.
+
+  Enables the "one MCPg server, many MCP clients" deployment shape:
+  set every vendor key on the host, run one MCPg over HTTP, let each
+  agent / IDE pick its preferred LLM per call.
+
+### Changed
+
+- **`Settings.nl2sql_api_key` (single value) → `Settings.nl2sql_api_keys`
+  (tuple of `(provider, key)` pairs).** Backward-incompatible only
+  for code that imports `Settings` directly — the env-var surface
+  stays compatible: `MCPG_NL2SQL_PROVIDER` + vendor-conventional env
+  vars still work as before, and `MCPG_NL2SQL_API_KEY` (when set)
+  still supplies the key for the configured default provider.
+  `MCPG_NL2SQL_API_KEY` now requires `MCPG_NL2SQL_PROVIDER` to also
+  be set (MCPg can't tell which provider a stray key belongs to);
+  startup fails with a clear message if only the key is set.
+
+- **`MCPG_NL2SQL_PROVIDER` is now optional** when at least one
+  vendor key is in the env — MCPg auto-picks a default. Setting it
+  explicitly still pins the default.
+
 ## [0.5.1] - 2026-05-29
 
 Inaugural PyPI release. Three landings since 0.5.0: security

--- a/README.md
+++ b/README.md
@@ -152,7 +152,8 @@ everything else has a safe default.
 | HTTP transport with bearer auth | `MCPG_TRANSPORT=streamable-http` + `MCPG_HTTP_AUTH_TOKEN=…` |
 | Multi-tenant SaaS | `MCPG_DEFAULT_ROLE=tenant_a` + `MCPG_ALLOWED_ROLES=tenant_a,tenant_b,…` |
 | Read-replica fan-out | `MCPG_REPLICA_URLS=postgresql://…?sslmode=require,postgresql://…?sslmode=require` |
-| NL→SQL via Anthropic | `MCPG_NL2SQL_PROVIDER=anthropic` (uses `ANTHROPIC_API_KEY` automatically) |
+| NL→SQL — single provider | Set `ANTHROPIC_API_KEY` (or `OPENAI_API_KEY` / `GEMINI_API_KEY`). MCPg auto-picks the default. |
+| NL→SQL — multiple providers, caller picks | Set all vendor keys you want active. Each call to `translate_nl_to_sql` can pass `provider="anthropic"\|"openai"\|"gemini"`. |
 
 ### Full reference
 
@@ -241,12 +242,24 @@ everything else has a safe default.
 
 #### Natural-language SQL
 
+MCPg auto-discovers every configured provider from the environment at
+startup. Set as many of `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` /
+`GEMINI_API_KEY` (or `GOOGLE_API_KEY`) as you have — each becomes
+callable. When `MCPG_NL2SQL_PROVIDER` is unset, MCPg picks the default
+in preference order **anthropic → openai → gemini**. The
+`translate_nl_to_sql` tool accepts an optional `provider="…"` argument
+so a caller can route between providers per call; `get_server_info`
+reports which are available.
+
 | Variable | Default | Description |
 |---|---|---|
-| `MCPG_NL2SQL_PROVIDER` | — | `anthropic` \| `openai` \| `gemini`. Unset disables `translate_nl_to_sql`. |
-| `MCPG_NL2SQL_API_KEY` | vendor fallback | Falls back to `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY` / `GOOGLE_API_KEY` depending on provider. |
-| `MCPG_NL2SQL_MODEL` | provider default | Override the default model (e.g. `claude-sonnet-4-6`, `gpt-4o-mini`, `gemini-2.5-flash`). |
-| `MCPG_NL2SQL_BASE_URL` | — | OpenAI-compatible endpoint override (Ollama, vLLM, OpenRouter, etc.). Only consulted for the `openai` provider. |
+| `ANTHROPIC_API_KEY` | — | Vendor-conventional key for Anthropic / Claude. |
+| `OPENAI_API_KEY` | — | Vendor-conventional key for OpenAI. |
+| `GEMINI_API_KEY` or `GOOGLE_API_KEY` | — | Vendor-conventional key for Google / Gemini. |
+| `MCPG_NL2SQL_PROVIDER` | auto-picked | `anthropic` \| `openai` \| `gemini`. Pins the default provider used when the tool is called without `provider=`. When unset and any vendor key is in the env, MCPg auto-picks anthropic → openai → gemini. |
+| `MCPG_NL2SQL_API_KEY` | — | Explicit key for the configured `MCPG_NL2SQL_PROVIDER`. Overrides the vendor-conventional env var for that provider only. Requires `MCPG_NL2SQL_PROVIDER` to be set. |
+| `MCPG_NL2SQL_MODEL` | provider default | Override the default model (e.g. `claude-sonnet-4-6`, `gpt-4o-mini`, `gemini-2.5-flash`). Applies only to the default provider. |
+| `MCPG_NL2SQL_BASE_URL` | — | OpenAI-compatible endpoint override (Ollama, vLLM, OpenRouter). Applies only when the default provider is `openai`. |
 | `MCPG_NL2SQL_MAX_TOKENS` | `2048` | Cap on generated tokens (hard limit: 16384). |
 
 ---

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -174,7 +174,8 @@ the minimum set per common scenario.
 | **HTTP transport** with OIDC | `MCPG_TRANSPORT=streamable-http` + `MCPG_AUTH_MODE=oidc` + `MCPG_OIDC_ISSUER=…` + `MCPG_OIDC_AUDIENCE=…` |
 | **Multi-tenant SaaS** | `MCPG_DEFAULT_ROLE=tenant_a` + `MCPG_ALLOWED_ROLES=tenant_a,tenant_b,…` |
 | **Read-replica fan-out** | `MCPG_REPLICA_URLS=postgresql://…?sslmode=require,postgresql://…?sslmode=require` |
-| **NL→SQL** via Anthropic | `MCPG_NL2SQL_PROVIDER=anthropic` (auto-uses `ANTHROPIC_API_KEY`) |
+| **NL→SQL** — single provider | Set `ANTHROPIC_API_KEY` (or `OPENAI_API_KEY` / `GEMINI_API_KEY`). MCPg auto-picks the default. |
+| **NL→SQL** — multi-provider routing | Set all the vendor keys you want active; callers pass `provider="anthropic"\|"openai"\|"gemini"` per call. |
 | **Audit persistence** | `MCPG_AUDIT_PERSIST=true` |
 | **Prometheus metrics** | (always on for HTTP transports — `GET /metrics`) |
 

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -76,7 +76,8 @@ run_select(sql, max_rows=1000)
 run_select_parallel(statements, parallel_limit=8)    # concurrent fan-out; one bad query doesn't abort the rest
 explain_query(sql, format="json")
 analyze_query_plan(sql)                              # walks the EXPLAIN tree
-translate_nl_to_sql(question, schema, execute=false) # NL → SQL via Anthropic / OpenAI / Gemini
+translate_nl_to_sql(question, schema, provider=null, execute=false)
+                                                     # NL → SQL; provider routes per call across configured Anthropic / OpenAI / Gemini
 ```
 
 ## "Stream a huge result set" (server-side cursors)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -255,26 +255,68 @@ under the synthetic tool name `__replica_route` with statuses
 
 ## Natural-language SQL
 
-```bash
-export MCPG_NL2SQL_PROVIDER=anthropic    # or: openai | gemini
-export ANTHROPIC_API_KEY=…                # the provider's standard env var
-```
+`translate_nl_to_sql(question, schema, provider=None, execute=false)`
+asks an LLM provider to produce read-only SQL for the supplied
+natural-language question, given the named schema's catalog. The
+generated SQL is passed through the **same SafeSQL allowlist** as
+any hand-written query before any optional execution.
 
-`translate_nl_to_sql(question, schema, execute=false)` asks the
-configured provider to produce SQL for the supplied natural-language
-question, given the named schema's catalog. The generated SQL is
-passed through the **same SafeSQL allowlist** as any hand-written
-query before any optional execution.
+### Provider configuration
 
-| `MCPG_NL2SQL_PROVIDER` | API-key env (auto-detected) | Default model |
+MCPg auto-discovers every configured provider from the environment at
+startup. Set as many of these as you want active — each becomes
+callable through the tool:
+
+| Provider | Set in env | Default model |
 |---|---|---|
 | `anthropic` | `ANTHROPIC_API_KEY` | provider's recent Claude Sonnet |
 | `openai` | `OPENAI_API_KEY` | `gpt-4o-mini` |
-| `gemini` | `GEMINI_API_KEY` → `GOOGLE_API_KEY` | provider's recent Gemini Flash |
+| `gemini` | `GEMINI_API_KEY` (falls back to `GOOGLE_API_KEY`) | provider's recent Gemini Flash |
 
-Override the model with `MCPG_NL2SQL_MODEL` and point at an
-OpenAI-compatible self-hosted endpoint (Ollama, vLLM, OpenRouter)
-with `MCPG_NL2SQL_BASE_URL` — works with the `openai` provider.
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...      # configures anthropic
+export OPENAI_API_KEY=sk-...             # configures openai too
+# Both available; MCPg auto-picks anthropic as the default
+# (preference order: anthropic → openai → gemini).
+```
+
+To pin a specific default, set `MCPG_NL2SQL_PROVIDER` explicitly:
+
+```bash
+export MCPG_NL2SQL_PROVIDER=openai       # default is now openai
+```
+
+`MCPG_NL2SQL_API_KEY` (when set) supplies the key for the configured
+default provider; it requires `MCPG_NL2SQL_PROVIDER` to also be set so
+MCPg knows which provider it's for.
+
+### Per-call routing
+
+Multiple providers configured? Any caller can route per-call by
+passing the optional `provider=` argument:
+
+```
+translate_nl_to_sql(question, schema, provider="anthropic")
+translate_nl_to_sql(question, schema, provider="openai")
+translate_nl_to_sql(question, schema, provider="gemini")
+translate_nl_to_sql(question, schema)              # uses default
+```
+
+This is the recommended shape for **one MCPg server, many MCP
+clients** — set every vendor key on the host, run one MCPg over the
+HTTP transport, let each agent / IDE pick its preferred LLM per call.
+`get_server_info()` reports `nl2sql_default_provider` and
+`nl2sql_available_providers` so a caller can introspect.
+
+### Model + endpoint overrides
+
+Override the default provider's model with `MCPG_NL2SQL_MODEL`, or
+point at an OpenAI-compatible self-hosted endpoint (Ollama, vLLM,
+OpenRouter) with `MCPG_NL2SQL_BASE_URL`. Both apply **only** when the
+call targets the default provider — an explicit `provider="openai"`
+call when the default is `anthropic` falls back to OpenAI's default
+model + endpoint, since the operator's overrides are
+provider-specific.
 The per-call response budget is capped by `MCPG_NL2SQL_MAX_TOKENS`
 (default 2048, hard limit 16384).
 

--- a/src/mcpg/config.py
+++ b/src/mcpg/config.py
@@ -95,13 +95,23 @@ class Settings:
     # failure the call falls back to the primary once and the
     # replica is degraded for 30s.
     replica_urls: tuple[str, ...] = ()
-    # NL→SQL helper. ``nl2sql_provider`` is one of "anthropic", "openai",
-    # "gemini"; unset means the tool reports unavailable. ``nl2sql_api_key``
-    # falls back to ANTHROPIC_API_KEY / OPENAI_API_KEY / GEMINI_API_KEY /
-    # GOOGLE_API_KEY when not set explicitly. ``nl2sql_base_url`` lets the
-    # OpenAI path target a self-hosted endpoint (Ollama, vLLM, OpenRouter).
+    # NL→SQL helper.
+    # ``nl2sql_provider`` is the DEFAULT provider used when the
+    # ``translate_nl_to_sql`` tool is called without an explicit ``provider``
+    # argument. ``nl2sql_api_keys`` is the full set of (provider, key) pairs
+    # MCPg discovered at startup — every configured provider is callable
+    # via the tool's ``provider=`` argument, not just the default. Operators
+    # set ``ANTHROPIC_API_KEY`` / ``OPENAI_API_KEY`` / ``GEMINI_API_KEY`` (or
+    # ``GOOGLE_API_KEY``) in the env and MCPg makes each one available; when
+    # ``MCPG_NL2SQL_PROVIDER`` is unset, MCPg picks a default in preference
+    # order anthropic → openai → gemini. ``MCPG_NL2SQL_API_KEY``, when set,
+    # supplies the key for the configured default provider (and requires
+    # ``MCPG_NL2SQL_PROVIDER`` to be set so MCPg knows which provider to
+    # assign it to). ``nl2sql_model`` / ``nl2sql_base_url`` apply only when
+    # the call uses the default provider; an explicit ``provider=`` override
+    # falls back to that provider's default model.
     nl2sql_provider: str | None = None
-    nl2sql_api_key: str | None = None
+    nl2sql_api_keys: tuple[tuple[str, str], ...] = ()
     nl2sql_model: str | None = None
     nl2sql_base_url: str | None = None
     nl2sql_max_tokens: int = 2048
@@ -142,7 +152,7 @@ class Settings:
             f"allowed_roles={self.allowed_roles!r}, "
             f"replica_urls={tuple(obfuscate_password(u) for u in self.replica_urls)!r}, "
             f"nl2sql_provider={self.nl2sql_provider!r}, "
-            f"nl2sql_api_key={'set' if self.nl2sql_api_key else 'unset'!r}, "
+            f"nl2sql_api_keys={sorted(p for p, _ in self.nl2sql_api_keys)!r}, "
             f"nl2sql_model={self.nl2sql_model!r}, "
             f"nl2sql_base_url={self.nl2sql_base_url!r}, "
             f"nl2sql_max_tokens={self.nl2sql_max_tokens}, "
@@ -406,28 +416,60 @@ def load_settings(env: Mapping[str, str] | None = None) -> Settings:
             raise ConfigError(f"MCPG_NL2SQL_PROVIDER must be one of: anthropic, openai, gemini (got {raw!r})")
         nl2sql_provider = candidate
 
-    # API key falls back to the vendor's conventional env var so users
-    # don't have to duplicate it. Order matters when multiple are set;
-    # the explicit MCPG_NL2SQL_API_KEY always wins.
-    nl2sql_api_key: str | None = None
+    # Discover every provider whose conventional vendor env var is set.
+    # Each becomes callable via ``translate_nl_to_sql(provider=...)``,
+    # not just the configured default. Operator can also point one
+    # provider at an explicit key via ``MCPG_NL2SQL_API_KEY`` —
+    # which always wins over the vendor-conventional fallback.
+    api_keys: dict[str, str] = {}
+    if anthropic_key := (env.get("ANTHROPIC_API_KEY") or "").strip():
+        api_keys["anthropic"] = anthropic_key
+    if openai_key := (env.get("OPENAI_API_KEY") or "").strip():
+        api_keys["openai"] = openai_key
+    gemini_key = (env.get("GEMINI_API_KEY") or "").strip() or (env.get("GOOGLE_API_KEY") or "").strip()
+    if gemini_key:
+        api_keys["gemini"] = gemini_key
+
     if (raw := env.get("MCPG_NL2SQL_API_KEY")) is not None:
         stripped = raw.strip()
         if not stripped:
             raise ConfigError("MCPG_NL2SQL_API_KEY must not be blank when set")
-        nl2sql_api_key = stripped
-    elif nl2sql_provider == "anthropic":
-        nl2sql_api_key = (env.get("ANTHROPIC_API_KEY") or "").strip() or None
-    elif nl2sql_provider == "openai":
-        nl2sql_api_key = (env.get("OPENAI_API_KEY") or "").strip() or None
-    elif nl2sql_provider == "gemini":
-        # Either GEMINI_API_KEY or the more common GOOGLE_API_KEY.
-        nl2sql_api_key = (env.get("GEMINI_API_KEY") or "").strip() or (env.get("GOOGLE_API_KEY") or "").strip() or None
+        if nl2sql_provider is None:
+            raise ConfigError(
+                "MCPG_NL2SQL_API_KEY is set but MCPG_NL2SQL_PROVIDER is not — "
+                "MCPg can't tell which provider this key is for. Either set "
+                "MCPG_NL2SQL_PROVIDER (anthropic|openai|gemini) too, or drop "
+                "MCPG_NL2SQL_API_KEY and use the vendor-conventional env var "
+                "(ANTHROPIC_API_KEY / OPENAI_API_KEY / GEMINI_API_KEY) so the "
+                "provider is implicit."
+            )
+        # Explicit key targets the configured default provider.
+        api_keys[nl2sql_provider] = stripped
 
-    if nl2sql_provider is not None and nl2sql_api_key is None:
+    # Auto-pick a default when MCPG_NL2SQL_PROVIDER is unset but at
+    # least one vendor key is present. Preference order is documented
+    # in README + docs/user-guide.md.
+    if nl2sql_provider is None and api_keys:
+        for candidate in ("anthropic", "openai", "gemini"):
+            if candidate in api_keys:
+                nl2sql_provider = candidate
+                break
+
+    if nl2sql_provider is not None and nl2sql_provider not in api_keys:
+        vendor_var = {
+            "anthropic": "ANTHROPIC_API_KEY",
+            "openai": "OPENAI_API_KEY",
+            "gemini": "GEMINI_API_KEY (or GOOGLE_API_KEY)",
+        }[nl2sql_provider]
         raise ConfigError(
             f"MCPG_NL2SQL_PROVIDER={nl2sql_provider!r} but no API key found; "
-            "set MCPG_NL2SQL_API_KEY (or the vendor's conventional env var)"
+            f"set {vendor_var} in the environment, or set MCPG_NL2SQL_API_KEY "
+            "explicitly."
         )
+
+    # Settings expects a stable, immutable order so the repr is stable
+    # too — sort by provider name.
+    nl2sql_api_keys = tuple(sorted(api_keys.items()))
 
     nl2sql_model: str | None = None
     if (raw := env.get("MCPG_NL2SQL_MODEL")) is not None:
@@ -536,7 +578,7 @@ def load_settings(env: Mapping[str, str] | None = None) -> Settings:
         allowed_roles=allowed_roles,
         replica_urls=replica_urls,
         nl2sql_provider=nl2sql_provider,
-        nl2sql_api_key=nl2sql_api_key,
+        nl2sql_api_keys=nl2sql_api_keys,
         nl2sql_model=nl2sql_model,
         nl2sql_base_url=nl2sql_base_url,
         nl2sql_max_tokens=nl2sql_max_tokens,

--- a/src/mcpg/config.py
+++ b/src/mcpg/config.py
@@ -14,6 +14,7 @@ from enum import StrEnum
 from os import environ
 
 from mcpg._vendor.sql import obfuscate_password
+from mcpg.nl2sql import VENDOR_ENV_VAR_HINT
 
 # PG role names must be safe identifiers — we inline them into
 # ``SET ROLE "<name>"`` so anything outside ``[A-Za-z_][A-Za-z0-9_]*``
@@ -456,15 +457,10 @@ def load_settings(env: Mapping[str, str] | None = None) -> Settings:
                 break
 
     if nl2sql_provider is not None and nl2sql_provider not in api_keys:
-        vendor_var = {
-            "anthropic": "ANTHROPIC_API_KEY",
-            "openai": "OPENAI_API_KEY",
-            "gemini": "GEMINI_API_KEY (or GOOGLE_API_KEY)",
-        }[nl2sql_provider]
         raise ConfigError(
             f"MCPG_NL2SQL_PROVIDER={nl2sql_provider!r} but no API key found; "
-            f"set {vendor_var} in the environment, or set MCPG_NL2SQL_API_KEY "
-            "explicitly."
+            f"set {VENDOR_ENV_VAR_HINT[nl2sql_provider]} in the environment, "
+            "or set MCPG_NL2SQL_API_KEY explicitly."
         )
 
     # Settings expects a stable, immutable order so the repr is stable

--- a/src/mcpg/nl2sql.py
+++ b/src/mcpg/nl2sql.py
@@ -49,6 +49,17 @@ DEFAULT_MODELS: dict[str, str] = {
     "gemini": "gemini-2.0-flash",
 }
 
+# Human-readable env-var hint per provider, used in error messages
+# when MCPg needs to tell the operator which env var to set to
+# enable a given provider. Single source of truth so the wording
+# stays consistent between startup validation (config.py) and
+# runtime tool errors (tools.py).
+VENDOR_ENV_VAR_HINT: dict[str, str] = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "gemini": "GEMINI_API_KEY (or GOOGLE_API_KEY)",
+}
+
 # Conservative budget — NL→SQL responses are usually a few hundred
 # tokens of JSON. Override via ``MCPG_NL2SQL_MAX_TOKENS``.
 DEFAULT_MAX_TOKENS = 2048

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -74,6 +74,8 @@ class ServerInfo:
     access_mode: str
     transport: str
     database_connected: bool
+    nl2sql_default_provider: str | None
+    nl2sql_available_providers: list[str]
 
 
 def build_server_info(app: AppContext) -> ServerInfo:
@@ -83,6 +85,8 @@ def build_server_info(app: AppContext) -> ServerInfo:
         access_mode=app.settings.access_mode.value,
         transport=app.settings.transport.value,
         database_connected=app.database.is_connected,
+        nl2sql_default_provider=app.settings.nl2sql_provider,
+        nl2sql_available_providers=[p for p, _ in app.settings.nl2sql_api_keys],
     )
 
 
@@ -1329,45 +1333,73 @@ def _register_query(server: FastMCP[AppContext]) -> None:
         name="translate_nl_to_sql",
         description=(
             "Translate a natural-language question into a read-only "
-            "PostgreSQL query against `schema`. The configured LLM "
-            "provider (anthropic / openai / gemini, set via "
-            "MCPG_NL2SQL_PROVIDER) sees a compact brief of the schema "
-            "(tables, columns, foreign keys) and is instructed to "
-            "return JSON with `sql` and `explanation`. When "
-            "execute=true, the generated SQL goes through the SAME "
-            "safety allowlist as run_select before running — writes / "
-            "DDL / multi-statement input are rejected even if the "
-            "model produced them. Returns the SQL, model rationale, "
-            "and (when executed) rows / columns / row_count. "
-            "table_filter narrows the brief to a known subset when "
-            "the question is clearly scoped. When the server isn't "
-            "configured with a provider + API key, returns an error "
-            "rather than guessing."
+            "PostgreSQL query against `schema`. The LLM provider "
+            "(anthropic / openai / gemini) sees a compact brief of "
+            "the schema (tables, columns, foreign keys) and is "
+            "instructed to return JSON with `sql` and `explanation`. "
+            "When execute=true, the generated SQL goes through the "
+            "SAME safety allowlist as run_select before running — "
+            "writes / DDL / multi-statement input are rejected even "
+            "if the model produced them. Returns the SQL, model "
+            "rationale, and (when executed) rows / columns / "
+            "row_count. table_filter narrows the brief to a known "
+            "subset when the question is clearly scoped. "
+            "`provider`, when supplied, selects which configured "
+            "LLM provider to call (use this to route between "
+            "anthropic / openai / gemini per-call when multiple are "
+            "configured); when omitted, MCPg uses the default "
+            "(MCPG_NL2SQL_PROVIDER, otherwise the first available "
+            "in preference order anthropic → openai → gemini). Call "
+            "get_server_info to see which providers are configured."
         ),
     )
     async def translate_nl_to_sql(
         ctx: _Ctx,
         question: str,
         schema: str,
+        provider: str | None = None,
         execute: bool = False,
         table_filter: list[str] | None = None,
         max_rows: int = query.DEFAULT_MAX_ROWS,
     ) -> dict[str, Any]:
         settings = ctx.request_context.lifespan_context.settings
-        if settings.nl2sql_provider is None or settings.nl2sql_api_key is None:
+        api_keys = dict(settings.nl2sql_api_keys)
+
+        chosen = (provider or settings.nl2sql_provider or "").strip().lower() or None
+        if chosen is None:
             raise nl2sql.NL2SQLError(
-                "translate_nl_to_sql is not configured; set MCPG_NL2SQL_PROVIDER "
-                "and MCPG_NL2SQL_API_KEY (or the vendor's conventional env var)"
+                "translate_nl_to_sql has no provider configured. Set one of "
+                "ANTHROPIC_API_KEY / OPENAI_API_KEY / GEMINI_API_KEY (or "
+                "GOOGLE_API_KEY) in the environment, or pass provider=... in "
+                "the call."
             )
-        provider = nl2sql.build_provider(
-            settings.nl2sql_provider,
-            settings.nl2sql_api_key,
-            base_url=settings.nl2sql_base_url,
-        )
-        model = settings.nl2sql_model or nl2sql.DEFAULT_MODELS[settings.nl2sql_provider]
+        if not nl2sql.is_valid_provider(chosen):
+            raise nl2sql.NL2SQLError(f"unknown NL→SQL provider {chosen!r}; supported: anthropic, openai, gemini")
+        api_key = api_keys.get(chosen)
+        if api_key is None:
+            configured = sorted(api_keys) or ["(none)"]
+            vendor_var = {
+                "anthropic": "ANTHROPIC_API_KEY",
+                "openai": "OPENAI_API_KEY",
+                "gemini": "GEMINI_API_KEY (or GOOGLE_API_KEY)",
+            }[chosen]
+            raise nl2sql.NL2SQLError(
+                f"provider {chosen!r} is not configured (currently configured: "
+                f"{', '.join(configured)}). Set {vendor_var} in the environment, "
+                "or pick a configured provider via the provider= argument."
+            )
+
+        # The operator's MCPG_NL2SQL_MODEL / MCPG_NL2SQL_BASE_URL overrides
+        # only apply when this call uses the default provider — overriding
+        # an Anthropic-shaped model id on an OpenAI call would just break.
+        is_default = chosen == settings.nl2sql_provider
+        model = settings.nl2sql_model if (is_default and settings.nl2sql_model) else nl2sql.DEFAULT_MODELS[chosen]
+        base_url = settings.nl2sql_base_url if is_default else None
+
+        llm = nl2sql.build_provider(chosen, api_key, base_url=base_url)
         result = await nl2sql.translate_nl_to_sql(
             _driver(ctx),
-            provider=provider,
+            provider=llm,
             model=model,
             question=question,
             schema=schema,

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -1367,26 +1367,27 @@ def _register_query(server: FastMCP[AppContext]) -> None:
 
         chosen = (provider or settings.nl2sql_provider or "").strip().lower() or None
         if chosen is None:
+            # No provider arg AND no default configured AND no vendor keys
+            # in the env — provider= alone can't fix this, the operator
+            # needs to set at least one vendor API key.
             raise nl2sql.NL2SQLError(
-                "translate_nl_to_sql has no provider configured. Set one of "
-                "ANTHROPIC_API_KEY / OPENAI_API_KEY / GEMINI_API_KEY (or "
-                "GOOGLE_API_KEY) in the environment, or pass provider=... in "
-                "the call."
+                "translate_nl_to_sql has no provider configured. Set at "
+                "least one of ANTHROPIC_API_KEY / OPENAI_API_KEY / "
+                "GEMINI_API_KEY (or GOOGLE_API_KEY) in the server's "
+                "environment. The tool's provider= argument selects "
+                "between providers that are already configured — it can't "
+                "supply credentials on its own."
             )
         if not nl2sql.is_valid_provider(chosen):
             raise nl2sql.NL2SQLError(f"unknown NL→SQL provider {chosen!r}; supported: anthropic, openai, gemini")
         api_key = api_keys.get(chosen)
         if api_key is None:
             configured = sorted(api_keys) or ["(none)"]
-            vendor_var = {
-                "anthropic": "ANTHROPIC_API_KEY",
-                "openai": "OPENAI_API_KEY",
-                "gemini": "GEMINI_API_KEY (or GOOGLE_API_KEY)",
-            }[chosen]
             raise nl2sql.NL2SQLError(
                 f"provider {chosen!r} is not configured (currently configured: "
-                f"{', '.join(configured)}). Set {vendor_var} in the environment, "
-                "or pick a configured provider via the provider= argument."
+                f"{', '.join(configured)}). Set {nl2sql.VENDOR_ENV_VAR_HINT[chosen]} "
+                "in the environment, or pick a configured provider via the "
+                "provider= argument."
             )
 
         # The operator's MCPG_NL2SQL_MODEL / MCPG_NL2SQL_BASE_URL overrides

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -194,7 +194,7 @@ def test_default_role_must_appear_in_allowed_roles_when_both_set() -> None:
 def test_nl2sql_defaults_to_unset_and_zero_overhead() -> None:
     settings = load_settings({"MCPG_DATABASE_URL": _DB_URL})
     assert settings.nl2sql_provider is None
-    assert settings.nl2sql_api_key is None
+    assert settings.nl2sql_api_keys == ()
     assert settings.nl2sql_model is None
     assert settings.nl2sql_max_tokens == 2048
 
@@ -229,7 +229,7 @@ def test_nl2sql_explicit_api_key_wins_over_vendor_fallback() -> None:
             "ANTHROPIC_API_KEY": "vendor-fallback",
         }
     )
-    assert settings.nl2sql_api_key == "explicit-key"
+    assert dict(settings.nl2sql_api_keys)["anthropic"] == "explicit-key"
 
 
 def test_nl2sql_falls_back_to_anthropic_api_key_env() -> None:
@@ -240,7 +240,7 @@ def test_nl2sql_falls_back_to_anthropic_api_key_env() -> None:
             "ANTHROPIC_API_KEY": "fallback",
         }
     )
-    assert settings.nl2sql_api_key == "fallback"
+    assert dict(settings.nl2sql_api_keys)["anthropic"] == "fallback"
 
 
 def test_nl2sql_falls_back_to_openai_api_key_env() -> None:
@@ -251,7 +251,7 @@ def test_nl2sql_falls_back_to_openai_api_key_env() -> None:
             "OPENAI_API_KEY": "fallback",
         }
     )
-    assert settings.nl2sql_api_key == "fallback"
+    assert dict(settings.nl2sql_api_keys)["openai"] == "fallback"
 
 
 def test_nl2sql_falls_back_to_gemini_or_google_api_key_env() -> None:
@@ -262,18 +262,18 @@ def test_nl2sql_falls_back_to_gemini_or_google_api_key_env() -> None:
             "GOOGLE_API_KEY": "google-fallback",
         }
     )
-    assert settings.nl2sql_api_key == "google-fallback"
+    assert dict(settings.nl2sql_api_keys)["gemini"] == "google-fallback"
 
     settings = load_settings(
         {
             "MCPG_DATABASE_URL": _DB_URL,
             "MCPG_NL2SQL_PROVIDER": "gemini",
             "GEMINI_API_KEY": "gemini-fallback",
-            # GOOGLE_API_KEY also set — GEMINI wins because it's checked first.
+            # GOOGLE_API_KEY also set — GEMINI_API_KEY wins because it's checked first.
             "GOOGLE_API_KEY": "google-fallback",
         }
     )
-    assert settings.nl2sql_api_key == "gemini-fallback"
+    assert dict(settings.nl2sql_api_keys)["gemini"] == "gemini-fallback"
 
 
 def test_nl2sql_rejects_max_tokens_above_hard_cap() -> None:
@@ -298,7 +298,93 @@ def test_nl2sql_api_key_never_appears_in_repr() -> None:
     )
     rendered = repr(settings)
     assert "sk-not-a-real-key-secret" not in rendered
-    assert "nl2sql_api_key='set'" in rendered
+    # The repr surfaces only the list of configured providers, not the keys.
+    assert "nl2sql_api_keys=['anthropic']" in rendered
+
+
+# --- multi-provider behaviour (the "one server, many IDEs" shape) -------
+
+
+def test_nl2sql_auto_picks_anthropic_when_only_its_vendor_key_present() -> None:
+    # Operator hasn't set MCPG_NL2SQL_PROVIDER; only ANTHROPIC_API_KEY in env.
+    # MCPg auto-picks anthropic as the default.
+    settings = load_settings(
+        {
+            "MCPG_DATABASE_URL": _DB_URL,
+            "ANTHROPIC_API_KEY": "sk-ant-…",
+        }
+    )
+    assert settings.nl2sql_provider == "anthropic"
+    assert dict(settings.nl2sql_api_keys) == {"anthropic": "sk-ant-…"}
+
+
+def test_nl2sql_auto_picks_in_preference_order_anthropic_openai_gemini() -> None:
+    # All three keys present, no explicit provider — default to anthropic.
+    settings = load_settings(
+        {
+            "MCPG_DATABASE_URL": _DB_URL,
+            "ANTHROPIC_API_KEY": "sk-ant",
+            "OPENAI_API_KEY": "sk-oa",
+            "GEMINI_API_KEY": "sk-gm",
+        }
+    )
+    assert settings.nl2sql_provider == "anthropic"
+    assert sorted(dict(settings.nl2sql_api_keys)) == ["anthropic", "gemini", "openai"]
+
+    # Drop anthropic — falls through to openai.
+    settings = load_settings(
+        {
+            "MCPG_DATABASE_URL": _DB_URL,
+            "OPENAI_API_KEY": "sk-oa",
+            "GEMINI_API_KEY": "sk-gm",
+        }
+    )
+    assert settings.nl2sql_provider == "openai"
+
+    # Drop both — falls through to gemini.
+    settings = load_settings(
+        {
+            "MCPG_DATABASE_URL": _DB_URL,
+            "GEMINI_API_KEY": "sk-gm",
+        }
+    )
+    assert settings.nl2sql_provider == "gemini"
+
+
+def test_nl2sql_explicit_provider_overrides_preference_order() -> None:
+    # All three configured, operator pins openai as the default.
+    settings = load_settings(
+        {
+            "MCPG_DATABASE_URL": _DB_URL,
+            "MCPG_NL2SQL_PROVIDER": "openai",
+            "ANTHROPIC_API_KEY": "sk-ant",
+            "OPENAI_API_KEY": "sk-oa",
+            "GEMINI_API_KEY": "sk-gm",
+        }
+    )
+    assert settings.nl2sql_provider == "openai"
+    # All three remain accessible via the tool's `provider=` arg.
+    assert sorted(dict(settings.nl2sql_api_keys)) == ["anthropic", "gemini", "openai"]
+
+
+def test_nl2sql_api_key_without_provider_is_rejected() -> None:
+    # Without MCPG_NL2SQL_PROVIDER, MCPg can't know which provider
+    # MCPG_NL2SQL_API_KEY is for — refuse to start with a clear message.
+    with pytest.raises(ConfigError, match="MCPG_NL2SQL_API_KEY is set but MCPG_NL2SQL_PROVIDER"):
+        load_settings(
+            {
+                "MCPG_DATABASE_URL": _DB_URL,
+                "MCPG_NL2SQL_API_KEY": "stray",
+            }
+        )
+
+
+def test_nl2sql_no_keys_means_tool_reports_no_provider() -> None:
+    # No vendor keys, no MCPG_NL2SQL_PROVIDER — Settings reports unset
+    # and the tool will error at call time (not at startup).
+    settings = load_settings({"MCPG_DATABASE_URL": _DB_URL})
+    assert settings.nl2sql_provider is None
+    assert settings.nl2sql_api_keys == ()
 
 
 # --- replica routing (Phase 1.6) -----------------------------------------

--- a/tests/unit/test_nl2sql_routing.py
+++ b/tests/unit/test_nl2sql_routing.py
@@ -1,0 +1,125 @@
+"""Tool-level tests for the `translate_nl_to_sql` provider routing.
+
+The lower-level :func:`mcpg.nl2sql.translate_nl_to_sql` is covered in
+:mod:`test_nl2sql`; this file specifically exercises the **tool
+wrapper's** provider-selection logic — the bit that consults
+``Settings.nl2sql_api_keys`` and dispatches a call to the matching
+provider via ``provider=``.
+
+Success-path tests would need to mock out the LLM HTTP call, which
+is unrelated to routing — covered separately in `test_nl2sql`.
+These tests focus on the resolution + error paths.
+"""
+
+from __future__ import annotations
+
+import pytest
+from _fakes import FakeDatabase, FakeDriver
+from mcp.shared.memory import create_connected_server_and_client_session
+
+from mcpg.config import load_settings
+from mcpg.server import create_server
+
+
+def _settings_with(env_extra: dict[str, str]) -> object:
+    return load_settings({"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db", **env_extra})
+
+
+async def test_translate_nl_to_sql_errors_clearly_when_no_provider_configured() -> None:
+    settings = _settings_with({})
+    server = create_server(settings, database=FakeDatabase(FakeDriver()))  # type: ignore[arg-type]
+    async with create_connected_server_and_client_session(server) as client:
+        result = await client.call_tool(
+            "translate_nl_to_sql",
+            {"question": "How many widgets?", "schema": "public"},
+        )
+
+    assert result.isError is True
+    msg = "\n".join(block.text for block in result.content if hasattr(block, "text"))
+    assert "no provider configured" in msg
+    assert "ANTHROPIC_API_KEY" in msg
+
+
+async def test_translate_nl_to_sql_errors_when_caller_picks_unconfigured_provider() -> None:
+    # Anthropic is configured; the caller asks for openai (which isn't).
+    settings = _settings_with({"ANTHROPIC_API_KEY": "sk-ant"})
+    server = create_server(settings, database=FakeDatabase(FakeDriver()))  # type: ignore[arg-type]
+    async with create_connected_server_and_client_session(server) as client:
+        result = await client.call_tool(
+            "translate_nl_to_sql",
+            {"question": "x", "schema": "public", "provider": "openai"},
+        )
+
+    assert result.isError is True
+    msg = "\n".join(block.text for block in result.content if hasattr(block, "text"))
+    assert "'openai' is not configured" in msg
+    assert "anthropic" in msg  # tells the caller what IS configured
+    assert "OPENAI_API_KEY" in msg
+
+
+async def test_translate_nl_to_sql_errors_on_unknown_provider_name() -> None:
+    settings = _settings_with({"ANTHROPIC_API_KEY": "sk-ant"})
+    server = create_server(settings, database=FakeDatabase(FakeDriver()))  # type: ignore[arg-type]
+    async with create_connected_server_and_client_session(server) as client:
+        result = await client.call_tool(
+            "translate_nl_to_sql",
+            {"question": "x", "schema": "public", "provider": "perplexity"},
+        )
+
+    assert result.isError is True
+    msg = "\n".join(block.text for block in result.content if hasattr(block, "text"))
+    assert "unknown NL→SQL provider" in msg
+    assert "anthropic" in msg
+
+
+async def test_get_server_info_surfaces_default_and_available_providers() -> None:
+    settings = _settings_with(
+        {
+            "ANTHROPIC_API_KEY": "sk-ant",
+            "OPENAI_API_KEY": "sk-oa",
+            "MCPG_NL2SQL_PROVIDER": "openai",
+        }
+    )
+    server = create_server(settings, database=FakeDatabase(FakeDriver()))  # type: ignore[arg-type]
+    async with create_connected_server_and_client_session(server) as client:
+        result = await client.call_tool("get_server_info", {})
+
+    assert result.isError is False
+    info = result.structuredContent
+    assert info is not None
+    assert info["nl2sql_default_provider"] == "openai"
+    assert sorted(info["nl2sql_available_providers"]) == ["anthropic", "openai"]
+
+
+@pytest.mark.parametrize(
+    ("env", "expected_default"),
+    [
+        ({"ANTHROPIC_API_KEY": "x"}, "anthropic"),
+        ({"OPENAI_API_KEY": "x"}, "openai"),
+        ({"GEMINI_API_KEY": "x"}, "gemini"),
+        ({"GOOGLE_API_KEY": "x"}, "gemini"),
+        # All three present, no explicit pin → preference order anthropic.
+        (
+            {
+                "ANTHROPIC_API_KEY": "x",
+                "OPENAI_API_KEY": "x",
+                "GEMINI_API_KEY": "x",
+            },
+            "anthropic",
+        ),
+        # OpenAI + Gemini, no anthropic → openai wins.
+        (
+            {"OPENAI_API_KEY": "x", "GEMINI_API_KEY": "x"},
+            "openai",
+        ),
+    ],
+)
+async def test_default_provider_resolution_via_get_server_info(env: dict[str, str], expected_default: str) -> None:
+    settings = _settings_with(env)
+    server = create_server(settings, database=FakeDatabase(FakeDriver()))  # type: ignore[arg-type]
+    async with create_connected_server_and_client_session(server) as client:
+        result = await client.call_tool("get_server_info", {})
+
+    info = result.structuredContent
+    assert info is not None
+    assert info["nl2sql_default_provider"] == expected_default

--- a/tests/unit/test_nl2sql_routing.py
+++ b/tests/unit/test_nl2sql_routing.py
@@ -17,11 +17,11 @@ import pytest
 from _fakes import FakeDatabase, FakeDriver
 from mcp.shared.memory import create_connected_server_and_client_session
 
-from mcpg.config import load_settings
+from mcpg.config import Settings, load_settings
 from mcpg.server import create_server
 
 
-def _settings_with(env_extra: dict[str, str]) -> object:
+def _settings_with(env_extra: dict[str, str]) -> Settings:
     return load_settings({"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db", **env_extra})
 
 
@@ -55,6 +55,32 @@ async def test_translate_nl_to_sql_errors_when_caller_picks_unconfigured_provide
     assert "'openai' is not configured" in msg
     assert "anthropic" in msg  # tells the caller what IS configured
     assert "OPENAI_API_KEY" in msg
+
+
+@pytest.mark.parametrize("provider_arg", ["Anthropic", " ANTHROPIC ", "  anthropic\t"])
+async def test_translate_nl_to_sql_normalises_provider_arg_case_and_whitespace(provider_arg: str) -> None:
+    # Anthropic is the only configured provider. A mixed-case /
+    # whitespace-padded `provider=` should still resolve to it — the
+    # caller getting an "unknown provider" or "not configured" error
+    # because of stray whitespace would be surprising. Hitting the same
+    # code path as the lower-case form means we don't get one of those
+    # errors; we get an "openai is not configured" error only when the
+    # name itself is wrong.
+    settings = _settings_with({"ANTHROPIC_API_KEY": "sk-ant"})
+    server = create_server(settings, database=FakeDatabase(FakeDriver()))  # type: ignore[arg-type]
+    async with create_connected_server_and_client_session(server) as client:
+        # We can't easily assert success here without mocking the LLM
+        # HTTP call, but we CAN assert that the resolution step doesn't
+        # error on case / whitespace — i.e. we don't get an
+        # "unknown provider" or "not configured" message. Any error we
+        # do see should be from the downstream HTTP call.
+        result = await client.call_tool(
+            "translate_nl_to_sql",
+            {"question": "x", "schema": "public", "provider": provider_arg},
+        )
+        msg = "\n".join(block.text for block in result.content if hasattr(block, "text"))
+        assert "unknown NL→SQL provider" not in msg
+        assert "is not configured" not in msg
 
 
 async def test_translate_nl_to_sql_errors_on_unknown_provider_name() -> None:

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -77,6 +77,8 @@ def test_build_server_info_reports_static_facts() -> None:
         access_mode="read-only",
         transport="stdio",
         database_connected=False,
+        nl2sql_default_provider=None,
+        nl2sql_available_providers=[],
     )
 
 


### PR DESCRIPTION
## Why

Testing surfaced that with the previous single-provider model, an
operator had to pick `MCPG_NL2SQL_PROVIDER=anthropic` (or `openai`,
or `gemini`) **at startup**, and every `translate_nl_to_sql` call
went through that one provider. The goal: **one MCPg server,
multiple MCP clients (Claude Desktop, Cursor, Continue, …), each
picking its own LLM per call** without per-tenant restarts.

## What

### Auto-discovery
MCPg scans for **all three vendor keys** at startup:
- `ANTHROPIC_API_KEY`
- `OPENAI_API_KEY`
- `GEMINI_API_KEY` (or `GOOGLE_API_KEY`)

Every key found becomes a **callable provider**. Set as many as you
want active.

### Optional default
`MCPG_NL2SQL_PROVIDER` is now **optional**. When unset, MCPg
auto-picks the default in preference order **anthropic → openai →
gemini**. Setting it explicitly still pins the default.

### Per-call routing
The tool gains an optional `provider="…"` argument:

```
translate_nl_to_sql(question, schema, provider="anthropic")
translate_nl_to_sql(question, schema, provider="openai")
translate_nl_to_sql(question, schema)              # uses default
```

Invalid / unconfigured provider → clear error listing which
providers ARE available.

### Introspection
`get_server_info` now surfaces `nl2sql_default_provider` and
`nl2sql_available_providers`. Agents can ask MCPg what's reachable
before picking.

### Tightened validation
`MCPG_NL2SQL_API_KEY` now requires `MCPG_NL2SQL_PROVIDER` to also
be set — without it MCPg can't tell which provider an anonymous key
belongs to. Refuses to start with a clear message instead of doing
the wrong thing silently.

## Backward compatibility

**Env-var surface is compatible** with the prior shape:
- `MCPG_NL2SQL_PROVIDER=anthropic` + `ANTHROPIC_API_KEY=…` → works exactly as before.
- `MCPG_NL2SQL_PROVIDER=anthropic` + `MCPG_NL2SQL_API_KEY=…` → works exactly as before.

**Settings class API is breaking**: `Settings.nl2sql_api_key: str |
None` → `Settings.nl2sql_api_keys: tuple[tuple[str, str], ...]`.
Only matters for code that imports `Settings` directly. Settings is
not part of the public API surface for end users — operators
interact only with env vars.

## Test plan

- [x] **7 existing nl2sql config tests** updated for the new keyed shape.
- [x] **5 new config tests** added for: auto-discovery,
      preference-order default, explicit-provider pin, multi-key
      coexistence, MCPG_NL2SQL_API_KEY-without-provider rejection.
- [x] **6 new tool-level tests** in
      `tests/unit/test_nl2sql_routing.py` via the MCP client harness:
      no-provider-configured error, caller-picks-unconfigured-provider
      error, unknown-provider-name error,
      `get_server_info` introspection (both fields), parametric
      default-resolution matrix.
- [x] **901 unit tests pass** in 22 s. ruff / ruff-format / mypy /
      bandit all clean.
- [ ] Maintainer to confirm the docs read clearly + the proposed
      behaviour matches what you wanted.

## Docs touched

- `README.md` — NL→SQL config section rewritten around
  auto-discovery + per-call routing; common-scenarios row split
  into single- vs multi-provider.
- `docs/user-guide.md` — new "Provider configuration",
  "Per-call routing", and "Model + endpoint overrides" subsections.
- `docs/installation.md` — common-scenarios row updated.
- `docs/tour.md` — `translate_nl_to_sql` signature line updated.
- `CHANGELOG.md` — `[Unreleased]` entry.

## Deployment shape this enables

```bash
# All three keys on the host
export ANTHROPIC_API_KEY=sk-ant-…
export OPENAI_API_KEY=sk-…
export GEMINI_API_KEY=sk-…

# Run one MCPg as HTTP
export MCPG_DATABASE_URL=postgresql://…
export MCPG_TRANSPORT=streamable-http
export MCPG_HTTP_AUTH_TOKEN=…
mcpg
```

Now every connected MCP client can call
`translate_nl_to_sql(question, schema, provider="…")` with whichever
provider is appropriate for that agent. Default (no `provider=`
arg) → anthropic. No per-tenant restarts.

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Add multi-provider NL→SQL routing with auto-discovery and per-call provider selection, and expose configured providers via server introspection.

New Features:
- Allow translate_nl_to_sql to route requests per call to anthropic, openai, or gemini based on a new optional provider argument.
- Auto-discover all available NL→SQL providers from vendor API key environment variables and use a defined preference order when no default is pinned.
- Expose NL→SQL default and available providers through get_server_info for client-side introspection.

Enhancements:
- Replace single nl2sql_api_key configuration with a multi-key nl2sql_api_keys mapping to support multiple providers simultaneously.
- Tighten configuration validation so MCPG_NL2SQL_API_KEY must be paired with MCPG_NL2SQL_PROVIDER and fail fast when a provider lacks an API key.
- Update configuration representation and docs to describe multi-provider setup, default resolution, and model/base-URL override semantics.

Tests:
- Extend configuration tests for the new nl2sql_api_keys shape and add coverage for auto-discovery, default preference order, and explicit provider pinning.
- Add tool-level tests to cover translate_nl_to_sql provider selection, error messaging for misconfigured or unknown providers, and server info reporting of providers.