### PR TITLE
feat(security): finish hardening queue — subprocess hardening + HTTP request timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Subprocess hardening for the shell-gated PG binaries.**
+  `run_pg_binary` now (a) validates the resolved `pg_dump` /
+  `pg_restore` / `psql` directory against
+  `MCPG_SUBPROCESS_BIN_ALLOWLIST` (empty = trust `PATH`), rejecting a
+  PATH shim in an untrusted directory while still allowing distro
+  `pg_dump -> pg_wrapper` symlinks; (b) applies `RLIMIT_CPU` /
+  `RLIMIT_AS` via a `preexec_fn` when `MCPG_SUBPROCESS_CPU_SECONDS` /
+  `MCPG_SUBPROCESS_MEMORY_MB` are set (POSIX only); and (c) spawns in
+  a throwaway temp working directory. All opt-in; defaults preserve
+  prior behaviour.
+
+- **Opt-in per-request HTTP timeout.**
+  `MCPG_HTTP_REQUEST_TIMEOUT_SECONDS` (default `0` = disabled) caps
+  wall-clock time per request on the HTTP transports, returning `504`
+  on expiry. Disabled by default so long-lived SSE / streamable-http
+  streams keep working; intended for plain request/response
+  deployments wanting a DoS backstop. Completes the HTTP-hardening
+  set started in the security-diagnostics release.
+
+- **Advanced security hardening, lifecycles & diagnostics (#37).**
+  HTTP hardening middleware (security headers, request-size limit,
+  CORS allowlist); graceful-shutdown draining of in-flight tool calls
+  (`MCPG_SHUTDOWN_DRAIN_SECONDS`); audit-log HMAC integrity chain with
+  the `verify_audit_chain` tool (`MCPG_AUDIT_INTEGRITY` +
+  `MCPG_AUDIT_HMAC_KEY`); a redundant-index advisor; and an
+  `analyze_hnsw_recall` pgvector tuner.
+
+- **Adaptive caching, feature flags & related (#36).** See the PR for
+  detail.
+
 - **Multi-provider routing for `translate_nl_to_sql`.** MCPg now
   auto-discovers every configured NL→SQL provider from the
   environment at startup (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`,

--- a/README.md
+++ b/README.md
@@ -187,6 +187,15 @@ everything else has a safe default.
 | `MCPG_OIDC_JWKS_URL` | discovered | Override JWKS endpoint (auto-discovered from issuer's `.well-known` otherwise). |
 | `MCPG_OIDC_ROLE_CLAIM` | — | JWT claim whose value becomes the per-request PG role (`SET LOCAL ROLE`). Composes with the tenancy driver. |
 
+#### HTTP hardening (HTTP transports only)
+
+| Variable | Default | Description |
+|---|---|---|
+| `MCPG_HTTP_MAX_BODY_BYTES` | `1048576` | (1 MiB) Request bodies above this get a `413`. Counts streamed bytes, so a missing/lying `Content-Length` can't bypass it. |
+| `MCPG_HTTP_ALLOWED_ORIGINS` | — | Comma-separated CORS allowlist. Unset = no CORS middleware (no cross-origin headers emitted). |
+| `MCPG_HTTP_HSTS_MAX_AGE` | `31536000` | `Strict-Transport-Security` max-age. `0` disables the HSTS header. Security headers (CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy) are always added unless the app already set them. |
+| `MCPG_HTTP_REQUEST_TIMEOUT_SECONDS` | `0` | Per-request wall-clock cap (`504` on expiry). `0` = disabled. Leave off if you rely on long-lived SSE / streamable-http streams — a hard cap also severs those. |
+
 #### Multi-tenancy (`SET ROLE`)
 
 | Variable | Default | Description |
@@ -209,6 +218,7 @@ everything else has a safe default.
 | `MCPG_STATEMENT_TIMEOUT_MS` | `30000` | Per-session `statement_timeout` set on connection checkout. Runaway queries self-terminate. |
 | `MCPG_LOCK_TIMEOUT_MS` | `5000` | Per-session `lock_timeout`. Hanging lock waits self-terminate. |
 | `MCPG_ALLOW_INSECURE_TLS` | `false` | Bypass the startup TLS check that refuses remote DSNs without `sslmode=require` (or stronger). Loopback hosts are always exempt. |
+| `MCPG_SHUTDOWN_DRAIN_SECONDS` | `30` | On SIGTERM, wait up to this long for in-flight tool calls to finish before closing the pool and cursors. |
 
 #### Subprocess tools (`MCPG_ALLOW_SHELL=true` only)
 
@@ -216,6 +226,9 @@ everything else has a safe default.
 |---|---|---|
 | `MCPG_SHELL_TIMEOUT_SEC` | `60` | Max wall-clock for `pg_dump` / `pg_restore` / `psql` invocations. |
 | `MCPG_SHELL_MAX_OUTPUT_BYTES` | `67108864` | (64 MiB) Cap on captured stdout per subprocess call. |
+| `MCPG_SUBPROCESS_BIN_ALLOWLIST` | — | Comma-separated absolute dirs the resolved `pg_dump` / `pg_restore` / `psql` must live under. Empty = trust `PATH`. Defeats a PATH-shim of these binaries. |
+| `MCPG_SUBPROCESS_CPU_SECONDS` | — | Per-child `RLIMIT_CPU` (seconds). POSIX only; unset = inherit. |
+| `MCPG_SUBPROCESS_MEMORY_MB` | — | Per-child `RLIMIT_AS` (MiB). POSIX only; unset = inherit. |
 
 #### LISTEN/NOTIFY (`MCPG_ALLOW_LISTEN=true` only)
 
@@ -229,6 +242,8 @@ everything else has a safe default.
 |---|---|---|
 | `MCPG_AUDIT_PERSIST` | `false` | When true, every `run_write` / `run_ddl` call persists to a `mcpg_audit.events` table (auto-created idempotently). |
 | `MCPG_AUDIT_REDACT_KEYS` | — | Comma-separated regex fragments added to the secret-name pattern (defaults already cover `password`, `passwd`, `secret`, `token`, `api[_-]?key`, `bearer`, `authorization`, `database_url`, `dsn`, `conninfo`). |
+| `MCPG_AUDIT_INTEGRITY` | `false` | When true, each persisted event is signed with an HMAC chained over the previous event; the `verify_audit_chain` tool walks the chain and reports the first break. Requires `MCPG_AUDIT_HMAC_KEY`. |
+| `MCPG_AUDIT_HMAC_KEY` | — | Secret key for the audit HMAC chain. Required when `MCPG_AUDIT_INTEGRITY=true`. Never appears in `repr`/logs. |
 
 #### Rate limiting
 

--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -122,7 +122,17 @@ left in place.
 
 ## Queued (next focused PRs)
 
-### ⬜ HTTP hardening (request limits + security headers + CORS)
+> Most of this section has now shipped. Only **Pluggable secrets
+> backend** remains queued; the rest are marked ✅ with the landing
+> note inline.
+
+### ✅ HTTP hardening (request limits + security headers + CORS + timeout)
+**Shipped.** Security headers + request-size limit + CORS allowlist
+landed in the security-diagnostics PR; the opt-in per-request
+timeout (`MCPG_HTTP_REQUEST_TIMEOUT_SECONDS`, default `0` = disabled
+so long-lived SSE / streamable-http streams keep working) landed in
+the security-hardening-queue PR.
+
 **Problem.** The streamable-http / sse transports today have no
 request body size limit, no per-request timeout, no
 `Content-Security-Policy` / `X-Frame-Options` /
@@ -142,7 +152,10 @@ unconditionally (operators can disable per header via env). New
 
 **Effort:** medium (one new middleware module + 6-8 tests).
 
-### [x] Audit log integrity (HMAC chain + verifier tool)
+### ✅ Audit log integrity (HMAC chain + verifier tool)
+**Shipped** in the security-diagnostics PR (columns + tool + a
+process-wide write lock so the chain stays linear under concurrency).
+
 **Problem.** An attacker with write access to `mcpg.audit_events`
 can truncate, alter, or insert events undetected.
 
@@ -180,27 +193,26 @@ plus backend-specific (e.g. `VAULT_ADDR`, `VAULT_TOKEN`,
 `mcpg[vault]`, `mcpg[aws-secrets]`; ~150 LOC core + per-backend
 integrations + 12+ tests).
 
-### ⬜ Subprocess hardening
-**Problem.** `pg_dump` / `pg_restore` / `psql` subprocesses
-inherit the parent's full environment + PATH. A malicious entry
-on PATH could shim one of these binaries.
+### ✅ Subprocess hardening
+**Shipped** in the security-hardening-queue PR. On top of the
+existing minimal-env spawn (only allowlisted `PG*` / `LANG` /
+`LC_ALL` / `PATH` reach the child) and `shutil.which` resolution,
+`run_pg_binary` now:
+- validates the resolved binary's directory against
+  `MCPG_SUBPROCESS_BIN_ALLOWLIST` (empty = trust PATH); a PATH shim
+  in an untrusted dir is rejected. The check compares the resolved
+  *directory* so distro `pg_dump -> pg_wrapper` symlinks still work.
+- applies `RLIMIT_CPU` / `RLIMIT_AS` via a `preexec_fn` when
+  `MCPG_SUBPROCESS_CPU_SECONDS` / `MCPG_SUBPROCESS_MEMORY_MB` are set
+  (POSIX only; a no-op on platforms without the `resource` module).
+- spawns in a throwaway temp working directory, cleaned up after.
 
-**Solution.** Compose subprocess env explicitly:
-- Resolve the binary's absolute path at startup; refuse if outside
-  `MCPG_SUBPROCESS_BIN_ALLOWLIST`.
-- Spawn with a minimal env: `PGHOST` / `PGPORT` / `PGUSER` /
-  `PGPASSWORD` / `PGSSLMODE` / `LANG` / `TZ` only.
-- Drop into a temp working directory.
-- Apply CPU + memory ulimits where the platform supports them
-  (`resource.setrlimit` on Linux/macOS).
+**Env vars:** `MCPG_SUBPROCESS_BIN_ALLOWLIST` (comma-separated
+absolute paths), `MCPG_SUBPROCESS_CPU_SECONDS`,
+`MCPG_SUBPROCESS_MEMORY_MB`. All opt-in; defaults preserve today's
+behaviour.
 
-**Env vars to add:** `MCPG_SUBPROCESS_BIN_ALLOWLIST` (paths),
-`MCPG_SUBPROCESS_CPU_SECONDS`, `MCPG_SUBPROCESS_MEMORY_MB`.
-
-**Effort:** medium (~100 LOC + cross-platform conditionals + 6-8
-tests).
-
-### [x] Graceful shutdown
+### ✅ Graceful shutdown
 **Problem.** On SIGTERM today the server exits immediately,
 abandoning in-flight tool calls and any open cursors.
 
@@ -217,12 +229,13 @@ audit trail, then exits. Configurable max-drain window
 
 ## Posture summary
 
-| Area | Today | After this PR | After roadmap |
-|---|---|---|---|
-| Authn | Static + OIDC | Same | + secrets backend for keys |
-| Authz | Capability gates + tenancy | Same | Same |
-| Transport security | bearer token | + PG TLS enforcement | + HTTP hardening |
-| Audit | Recorded | + arg redaction | + integrity chain |
-| Supply chain | Manual deps | + CI bandit + pip-audit | Same |
-| Lifecycle | Hard exit | Same | Graceful shutdown |
-| Subprocess | Default env | Same | Hardened spawn |
+| Area | Today (on `main`) | Remaining roadmap |
+|---|---|---|
+| Authn | Static + OIDC | + secrets backend for keys |
+| Authz | Capability gates + tenancy | Same |
+| Transport security | bearer token + PG TLS enforcement + HTTP hardening (headers, body limit, CORS, opt-in request timeout) | Same |
+| Audit | Recorded + arg redaction + HMAC integrity chain | Same |
+| Supply chain | CI bandit + pip-audit | Same |
+| Lifecycle | Graceful shutdown draining | Same |
+| Subprocess | Minimal env + bin allowlist + rlimits + temp cwd | Same |
+| Secrets | Env vars | Pluggable backend (Vault / AWS / GCP / file) |

--- a/src/mcpg/config.py
+++ b/src/mcpg/config.py
@@ -12,6 +12,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import StrEnum
 from os import environ
+from os.path import isabs
 
 from mcpg._vendor.sql import obfuscate_password
 from mcpg.nl2sql import VENDOR_ENV_VAR_HINT
@@ -61,6 +62,14 @@ class Settings:
     allow_listen: bool = False
     shell_timeout_sec: int = 60
     shell_max_output_bytes: int = 64 * 1024 * 1024
+    # Subprocess hardening for the shell-gated PG binaries. All opt-in.
+    # ``subprocess_bin_allowlist`` is a tuple of absolute directories the
+    # resolved pg_dump / pg_restore / psql binary must live under (empty
+    # = trust PATH). ``subprocess_cpu_seconds`` / ``subprocess_memory_mb``
+    # apply RLIMIT_CPU / RLIMIT_AS to each child on POSIX (None = inherit).
+    subprocess_bin_allowlist: tuple[str, ...] = ()
+    subprocess_cpu_seconds: int | None = None
+    subprocess_memory_mb: int | None = None
     listen_queue_max: int = 1000
     audit_persist: bool = False
     pool_min_size: int = 1
@@ -135,6 +144,11 @@ class Settings:
     http_max_body_bytes: int = 1048576
     http_allowed_origins: tuple[str, ...] = ()
     http_hsts_max_age: int = 31536000
+    # Per-request wall-clock cap for the HTTP transports. 0 = disabled
+    # (default), because a hard cap also severs long-lived SSE /
+    # streamable-http streams. Set a positive value for plain
+    # request/response deployments that want a DoS backstop.
+    http_request_timeout_seconds: int = 0
     shutdown_drain_seconds: int = 30
     audit_hmac_key: str | None = None
     audit_integrity: bool = False
@@ -153,6 +167,9 @@ class Settings:
             f"allow_listen={self.allow_listen}, "
             f"shell_timeout_sec={self.shell_timeout_sec}, "
             f"shell_max_output_bytes={self.shell_max_output_bytes}, "
+            f"subprocess_bin_allowlist={self.subprocess_bin_allowlist!r}, "
+            f"subprocess_cpu_seconds={self.subprocess_cpu_seconds}, "
+            f"subprocess_memory_mb={self.subprocess_memory_mb}, "
             f"listen_queue_max={self.listen_queue_max}, "
             f"audit_persist={self.audit_persist}, "
             f"pool_min_size={self.pool_min_size}, pool_max_size={self.pool_max_size}, "
@@ -186,6 +203,7 @@ class Settings:
             f"http_max_body_bytes={self.http_max_body_bytes}, "
             f"http_allowed_origins={self.http_allowed_origins!r}, "
             f"http_hsts_max_age={self.http_hsts_max_age}, "
+            f"http_request_timeout_seconds={self.http_request_timeout_seconds}, "
             f"shutdown_drain_seconds={self.shutdown_drain_seconds}, "
             f"audit_hmac_key={audit_hmac_key_repr!r}, "
             f"audit_integrity={self.audit_integrity})"
@@ -337,6 +355,22 @@ def load_settings(env: Mapping[str, str] | None = None) -> Settings:
     shell_max_output_bytes = 64 * 1024 * 1024
     if (raw := env.get("MCPG_SHELL_MAX_OUTPUT_BYTES")) is not None:
         shell_max_output_bytes = _parse_positive_int("MCPG_SHELL_MAX_OUTPUT_BYTES", raw)
+
+    subprocess_bin_allowlist: tuple[str, ...] = ()
+    if (raw := env.get("MCPG_SUBPROCESS_BIN_ALLOWLIST")) is not None:
+        dirs = tuple(d.strip() for d in raw.split(",") if d.strip())
+        for d in dirs:
+            if not isabs(d):
+                raise ConfigError(f"MCPG_SUBPROCESS_BIN_ALLOWLIST entries must be absolute paths (got {d!r})")
+        subprocess_bin_allowlist = dirs
+
+    subprocess_cpu_seconds: int | None = None
+    if (raw := env.get("MCPG_SUBPROCESS_CPU_SECONDS")) is not None:
+        subprocess_cpu_seconds = _parse_positive_int("MCPG_SUBPROCESS_CPU_SECONDS", raw)
+
+    subprocess_memory_mb: int | None = None
+    if (raw := env.get("MCPG_SUBPROCESS_MEMORY_MB")) is not None:
+        subprocess_memory_mb = _parse_positive_int("MCPG_SUBPROCESS_MEMORY_MB", raw)
 
     allow_listen = False
     if (raw := env.get("MCPG_ALLOW_LISTEN")) is not None:
@@ -608,6 +642,18 @@ def load_settings(env: Mapping[str, str] | None = None) -> Settings:
         except ValueError:
             raise ConfigError(f"MCPG_HTTP_HSTS_MAX_AGE must be a non-negative integer (got {raw!r})") from None
 
+    http_request_timeout_seconds = 0
+    if (raw := env.get("MCPG_HTTP_REQUEST_TIMEOUT_SECONDS")) is not None:
+        try:
+            val = int(raw)
+            if val < 0:
+                raise ValueError()
+            http_request_timeout_seconds = val
+        except ValueError:
+            raise ConfigError(
+                f"MCPG_HTTP_REQUEST_TIMEOUT_SECONDS must be a non-negative integer (got {raw!r})"
+            ) from None
+
     shutdown_drain_seconds = 30
     if (raw := env.get("MCPG_SHUTDOWN_DRAIN_SECONDS")) is not None:
         shutdown_drain_seconds = _parse_positive_int("MCPG_SHUTDOWN_DRAIN_SECONDS", raw)
@@ -638,6 +684,9 @@ def load_settings(env: Mapping[str, str] | None = None) -> Settings:
         allow_listen=allow_listen,
         shell_timeout_sec=shell_timeout_sec,
         shell_max_output_bytes=shell_max_output_bytes,
+        subprocess_bin_allowlist=subprocess_bin_allowlist,
+        subprocess_cpu_seconds=subprocess_cpu_seconds,
+        subprocess_memory_mb=subprocess_memory_mb,
         listen_queue_max=listen_queue_max,
         audit_persist=audit_persist,
         pool_min_size=pool_min_size,
@@ -672,6 +721,7 @@ def load_settings(env: Mapping[str, str] | None = None) -> Settings:
         http_max_body_bytes=http_max_body_bytes,
         http_allowed_origins=http_allowed_origins,
         http_hsts_max_age=http_hsts_max_age,
+        http_request_timeout_seconds=http_request_timeout_seconds,
         shutdown_drain_seconds=shutdown_drain_seconds,
         audit_hmac_key=audit_hmac_key,
         audit_integrity=audit_integrity,

--- a/src/mcpg/data_movement.py
+++ b/src/mcpg/data_movement.py
@@ -31,7 +31,7 @@ from urllib.parse import unquote, urlparse
 from mcpg._vendor.sql import SqlDriver
 from mcpg.database import Database
 from mcpg.query import QueryError, run_select
-from mcpg.shell import ShellError, run_pg_binary
+from mcpg.shell import ShellError, SubprocessLimits, run_pg_binary
 
 # Same identifier allowlist as mcpg.textsearch / mcpg.prisma / mcpg.vector_tuning —
 # refuse names that need delimited-identifier quoting, accept plain ones.
@@ -217,6 +217,7 @@ async def dump_database(
     max_output_bytes: int,
     format: str = "plain",
     schema_only: bool = False,
+    limits: SubprocessLimits | None = None,
 ) -> DumpResult:
     """Run ``pg_dump`` against the database in ``database_url`` and capture stdout.
 
@@ -252,6 +253,7 @@ async def dump_database(
         env=env,
         timeout_sec=timeout_sec,
         max_output_bytes=max_output_bytes,
+        limits=limits,
     )
 
     # For plain format the stdout is SQL text; decode as UTF-8. For
@@ -303,6 +305,7 @@ async def restore_database(
     timeout_sec: int,
     max_output_bytes: int,
     format: str = "plain",
+    limits: SubprocessLimits | None = None,
 ) -> RestoreResult:
     """Restore a dump into the database in ``database_url``.
 
@@ -361,6 +364,7 @@ async def restore_database(
         timeout_sec=timeout_sec,
         max_output_bytes=max_output_bytes,
         stdin=stdin,
+        limits=limits,
     )
 
     stderr_tail = result.stderr.decode("utf-8", errors="replace")
@@ -416,6 +420,7 @@ async def copy_table_between_databases(
     include_data: bool,
     timeout_sec: int,
     max_output_bytes: int,
+    limits: SubprocessLimits | None = None,
 ) -> CopyTableResult:
     """Copy ``schema.table`` from ``source_url`` into ``dest_url``.
 
@@ -480,6 +485,7 @@ async def copy_table_between_databases(
         env=source_env,
         timeout_sec=timeout_sec,
         max_output_bytes=max_output_bytes,
+        limits=limits,
     )
     if dump.output_truncated:
         raise ShellError(
@@ -529,6 +535,7 @@ async def copy_table_between_databases(
         timeout_sec=timeout_sec,
         max_output_bytes=max_output_bytes,
         stdin=dump.stdout,
+        limits=limits,
     )
 
     return CopyTableResult(

--- a/src/mcpg/http_runtime.py
+++ b/src/mcpg/http_runtime.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import asyncio
 import hmac
+import json
 import logging
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, cast
@@ -306,7 +307,7 @@ async def _send_413(send: object, reason: str) -> None:
 
 async def _send_504(send: object, reason: str) -> None:
     """Emit a minimal 504 response."""
-    body = f'{{"error": "gateway_timeout", "reason": "{reason}"}}\n'.encode()
+    body = json.dumps({"error": "gateway_timeout", "reason": reason}).encode() + b"\n"
     await send(  # type: ignore[operator]
         {
             "type": "http.response.start",
@@ -443,6 +444,14 @@ class _RequestTimeoutMiddleware:
             async with asyncio.timeout(self._timeout):
                 await self._app(scope, receive, send_wrapper)  # type: ignore[operator]
         except TimeoutError:
+            # On Python 3.11+ ``asyncio.TimeoutError`` IS the builtin
+            # ``TimeoutError`` (the asyncio name is a deprecated alias —
+            # ruff UP041 rejects it), so they can't be distinguished
+            # at catch time. If an inner app ever raises a bare
+            # ``TimeoutError`` we'd mis-attribute it to our cap; this
+            # is preferable to leaking an exception out of the
+            # middleware. Inner apps that want to surface their own
+            # timeout should raise a domain-specific subclass.
             # Only safe to write a status line if the app hasn't already.
             if not started:
                 await _send_504(send, f"request exceeded {self._timeout}s")

--- a/src/mcpg/http_runtime.py
+++ b/src/mcpg/http_runtime.py
@@ -21,6 +21,7 @@ guard. ``run_http`` builds the wrapped app and serves it via uvicorn.
 
 from __future__ import annotations
 
+import asyncio
 import hmac
 import logging
 from collections.abc import Iterable
@@ -303,6 +304,22 @@ async def _send_413(send: object, reason: str) -> None:
     await send({"type": "http.response.body", "body": body})  # type: ignore[operator]
 
 
+async def _send_504(send: object, reason: str) -> None:
+    """Emit a minimal 504 response."""
+    body = f'{{"error": "gateway_timeout", "reason": "{reason}"}}\n'.encode()
+    await send(  # type: ignore[operator]
+        {
+            "type": "http.response.start",
+            "status": 504,
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"content-length", str(len(body)).encode()),
+            ],
+        }
+    )
+    await send({"type": "http.response.body", "body": body})  # type: ignore[operator]
+
+
 class _SecurityHeadersMiddleware:
     """ASGI middleware that enforces standard security headers."""
 
@@ -391,6 +408,46 @@ class _RequestSizeLimitMiddleware:
             await _send_413(send, "request body too large")
 
 
+class _RequestTimeoutMiddleware:
+    """ASGI middleware that caps wall-clock time for a single request.
+
+    Off by default (``MCPG_HTTP_REQUEST_TIMEOUT_SECONDS=0``); only
+    installed when a positive timeout is configured. Intended for
+    request/response deployments — note that a hard cap will also cut
+    off long-lived streaming responses, so leave it disabled if you
+    rely on long SSE / streamable-http streams.
+
+    On expiry, if the downstream app has not started the response yet,
+    a 504 is emitted; if bytes were already sent we can only abort the
+    stream (the status line is long gone).
+    """
+
+    def __init__(self, app: object, *, timeout_seconds: int) -> None:
+        self._app = app
+        self._timeout = timeout_seconds
+
+    async def __call__(self, scope: dict[str, object], receive: object, send: object) -> None:
+        if scope["type"] != "http":
+            await self._app(scope, receive, send)  # type: ignore[operator]
+            return
+
+        started = False
+
+        async def send_wrapper(message: dict[str, object]) -> None:
+            nonlocal started
+            if message["type"] == "http.response.start":
+                started = True
+            await send(message)  # type: ignore[operator]
+
+        try:
+            async with asyncio.timeout(self._timeout):
+                await self._app(scope, receive, send_wrapper)  # type: ignore[operator]
+        except TimeoutError:
+            # Only safe to write a status line if the app hasn't already.
+            if not started:
+                await _send_504(send, f"request exceeded {self._timeout}s")
+
+
 def build_http_app(server: object, settings: Settings, *, kind: str) -> Starlette:
     """Wrap a FastMCP HTTP app with metrics + optional auth.
 
@@ -456,6 +513,10 @@ def build_http_app(server: object, settings: Settings, *, kind: str) -> Starlett
     # Outer middlewares (processed first on request)
     app.add_middleware(_SecurityHeadersMiddleware, hsts_max_age=settings.http_hsts_max_age)
     app.add_middleware(_RequestSizeLimitMiddleware, max_bytes=settings.http_max_body_bytes)
+    # Opt-in per-request wall-clock cap. Disabled (0) by default so the
+    # streamable-http / sse long-lived streams keep working untouched.
+    if settings.http_request_timeout_seconds > 0:
+        app.add_middleware(_RequestTimeoutMiddleware, timeout_seconds=settings.http_request_timeout_seconds)
     if settings.http_allowed_origins:
         from starlette.middleware.cors import CORSMiddleware
 

--- a/src/mcpg/shell.py
+++ b/src/mcpg/shell.py
@@ -29,8 +29,15 @@ from __future__ import annotations
 import asyncio
 import os
 import shutil
+import tempfile
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Final
+
+try:  # POSIX-only; absent on Windows. Guarded so the import never breaks startup.
+    import resource
+except ImportError:  # pragma: no cover - exercised only on non-POSIX platforms
+    resource = None  # type: ignore[assignment]
 
 _ALLOWED_BINARIES: Final[frozenset[str]] = frozenset({"pg_dump", "pg_restore", "psql"})
 
@@ -65,6 +72,31 @@ class ShellError(Exception):
 
 
 @dataclass(frozen=True, slots=True)
+class SubprocessLimits:
+    """Deployment-wide hardening policy for spawned PG binaries.
+
+    All fields default to "no extra restriction" so the policy is
+    opt-in. Populated from ``MCPG_SUBPROCESS_*`` settings and threaded
+    into :func:`run_pg_binary`.
+
+    Attributes:
+        bin_allowlist: Absolute directory paths the resolved binary
+            MUST live under. Empty means "trust PATH resolution" (the
+            historical behaviour). When set, a binary resolved to a
+            directory outside the allowlist is rejected — this defeats
+            a malicious PATH shim of ``pg_dump`` / ``psql``.
+        cpu_seconds: Per-process CPU-time rlimit (``RLIMIT_CPU``).
+            ``None`` leaves the inherited limit untouched.
+        memory_mb: Per-process address-space rlimit (``RLIMIT_AS``),
+            in mebibytes. ``None`` leaves it untouched.
+    """
+
+    bin_allowlist: tuple[str, ...] = ()
+    cpu_seconds: int | None = None
+    memory_mb: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
 class SubprocessResult:
     """The outcome of a single subprocess invocation.
 
@@ -89,14 +121,56 @@ class SubprocessResult:
     env_redacted: dict[str, str] = field(default_factory=dict)
 
 
-def _resolve_binary(name: str) -> str:
-    """Look up ``name`` on PATH and return the absolute path, or raise."""
+def _resolve_binary(name: str, bin_allowlist: tuple[str, ...] = ()) -> str:
+    """Look up ``name`` on PATH and return the absolute path, or raise.
+
+    When ``bin_allowlist`` is non-empty, the resolved absolute path must
+    live directly under one of the allowlisted directories; otherwise a
+    PATH shim of ``pg_dump`` / ``psql`` is rejected before it can run.
+    """
     if name not in _ALLOWED_BINARIES:
         raise ShellError(f"binary {name!r} is not on the allowlist (expected one of {sorted(_ALLOWED_BINARIES)})")
     resolved = shutil.which(name)
     if resolved is None:
         raise ShellError(f"binary {name!r} not found on PATH; install it on the server")
+    if bin_allowlist:
+        # Compare the *directory* PATH resolved the binary into — not the
+        # realpath of the file, since distro packages legitimately symlink
+        # e.g. /usr/bin/pg_dump -> pg_wrapper outside the bin dir. We only
+        # normalise the directory for symlinks so a PATH shim in an
+        # untrusted dir is still rejected.
+        resolved_dir = os.path.realpath(os.path.dirname(resolved))
+        allowed = {os.path.realpath(d) for d in bin_allowlist}
+        if resolved_dir not in allowed:
+            raise ShellError(
+                f"binary {name!r} resolved to {resolved!r}, which is outside "
+                f"MCPG_SUBPROCESS_BIN_ALLOWLIST ({sorted(bin_allowlist)})"
+            )
     return resolved
+
+
+def _make_preexec_fn(limits: SubprocessLimits) -> Callable[[], None] | None:
+    """Build a child-side ``preexec_fn`` applying CPU / memory rlimits.
+
+    Returns ``None`` when no rlimit is requested or the platform lacks
+    the ``resource`` module (Windows), so the spawn path stays unchanged
+    in those cases.
+    """
+    if resource is None:
+        return None
+    if limits.cpu_seconds is None and limits.memory_mb is None:
+        return None
+
+    cpu_seconds = limits.cpu_seconds
+    memory_bytes = limits.memory_mb * 1024 * 1024 if limits.memory_mb is not None else None
+
+    def _apply_limits() -> None:  # pragma: no cover - runs in the forked child
+        if cpu_seconds is not None:
+            resource.setrlimit(resource.RLIMIT_CPU, (cpu_seconds, cpu_seconds))
+        if memory_bytes is not None:
+            resource.setrlimit(resource.RLIMIT_AS, (memory_bytes, memory_bytes))
+
+    return _apply_limits
 
 
 def _redact_env(env: dict[str, str]) -> dict[str, str]:
@@ -128,6 +202,7 @@ async def run_pg_binary(
     timeout_sec: int,
     max_output_bytes: int,
     stdin: bytes | None = None,
+    limits: SubprocessLimits | None = None,
 ) -> SubprocessResult:
     """Execute an allowlisted PostgreSQL binary with the agreed policy.
 
@@ -153,9 +228,14 @@ async def run_pg_binary(
         ShellError: When ``binary`` is not allowlisted, can't be found
             on PATH, or asyncio can't spawn it.
     """
-    resolved = _resolve_binary(binary)
+    limits = limits or SubprocessLimits()
+    resolved = _resolve_binary(binary, limits.bin_allowlist)
     safe_env = _filter_env(env)
     redacted = _redact_env(safe_env)
+    # Spawn in a throwaway working directory so a binary that writes
+    # relative-path files (none of ours do today, but defence in depth)
+    # can't litter the server's CWD. Cleaned up after the call.
+    workdir = tempfile.mkdtemp(prefix="mcpg-pg-")
     try:
         process = await asyncio.create_subprocess_exec(
             resolved,
@@ -164,8 +244,11 @@ async def run_pg_binary(
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             env=safe_env,
+            cwd=workdir,
+            preexec_fn=_make_preexec_fn(limits),
         )
     except (OSError, FileNotFoundError) as exc:
+        shutil.rmtree(workdir, ignore_errors=True)
         raise ShellError(f"failed to spawn {binary!r}: {exc}") from exc
 
     timed_out = False
@@ -248,6 +331,7 @@ async def run_pg_binary(
         except Exception:
             stderr_bytes = b""
 
+    shutil.rmtree(workdir, ignore_errors=True)
     stdout_bytes = b"".join(stdout_chunks)
     return SubprocessResult(
         binary=binary,

--- a/src/mcpg/shell.py
+++ b/src/mcpg/shell.py
@@ -30,7 +30,8 @@ import asyncio
 import os
 import shutil
 import tempfile
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Final
 
@@ -149,6 +150,20 @@ def _resolve_binary(name: str, bin_allowlist: tuple[str, ...] = ()) -> str:
     return resolved
 
 
+@contextmanager
+def _subprocess_workdir() -> Iterator[str]:
+    """Create + always remove a throwaway cwd for one subprocess call.
+
+    Localised in a ``try/finally`` so an asyncio cancellation in the
+    middle of ``run_pg_binary`` can't leave the temp directory behind.
+    """
+    workdir = tempfile.mkdtemp(prefix="mcpg-pg-")
+    try:
+        yield workdir
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)
+
+
 def _make_preexec_fn(limits: SubprocessLimits) -> Callable[[], None] | None:
     """Build a child-side ``preexec_fn`` applying CPU / memory rlimits.
 
@@ -234,104 +249,103 @@ async def run_pg_binary(
     redacted = _redact_env(safe_env)
     # Spawn in a throwaway working directory so a binary that writes
     # relative-path files (none of ours do today, but defence in depth)
-    # can't litter the server's CWD. Cleaned up after the call.
-    workdir = tempfile.mkdtemp(prefix="mcpg-pg-")
-    try:
-        process = await asyncio.create_subprocess_exec(
-            resolved,
-            *argv,
-            stdin=asyncio.subprocess.PIPE if stdin is not None else asyncio.subprocess.DEVNULL,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            env=safe_env,
-            cwd=workdir,
-            preexec_fn=_make_preexec_fn(limits),
-        )
-    except (OSError, FileNotFoundError) as exc:
-        shutil.rmtree(workdir, ignore_errors=True)
-        raise ShellError(f"failed to spawn {binary!r}: {exc}") from exc
+    # can't litter the server's CWD. The context manager removes it on
+    # every exit path, including asyncio cancellation.
+    with _subprocess_workdir() as workdir:
+        try:
+            process = await asyncio.create_subprocess_exec(
+                resolved,
+                *argv,
+                stdin=asyncio.subprocess.PIPE if stdin is not None else asyncio.subprocess.DEVNULL,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=safe_env,
+                cwd=workdir,
+                preexec_fn=_make_preexec_fn(limits),
+            )
+        except (OSError, FileNotFoundError) as exc:
+            raise ShellError(f"failed to spawn {binary!r}: {exc}") from exc
 
-    timed_out = False
-    truncated = False
-    output_bytes_seen = 0
-    stdout_chunks: list[bytes] = []
-    # Initialise so an unexpected exception path doesn't leave this
-    # name unbound when we build the SubprocessResult.
-    stderr_bytes: bytes = b""
+        timed_out = False
+        truncated = False
+        output_bytes_seen = 0
+        stdout_chunks: list[bytes] = []
+        # Initialise so an unexpected exception path doesn't leave this
+        # name unbound when we build the SubprocessResult.
+        stderr_bytes: bytes = b""
 
-    async def _read_capped() -> None:
-        nonlocal output_bytes_seen, truncated
-        # Drain stdout into a bytes buffer, but stop appending once
-        # we've hit the cap. We must keep reading so the child doesn't
-        # block on a full pipe, even if we discard the bytes.
-        assert process.stdout is not None
-        while True:
-            chunk = await process.stdout.read(64 * 1024)
-            if not chunk:
+        async def _read_capped() -> None:
+            nonlocal output_bytes_seen, truncated
+            # Drain stdout into a bytes buffer, but stop appending once
+            # we've hit the cap. We must keep reading so the child doesn't
+            # block on a full pipe, even if we discard the bytes.
+            assert process.stdout is not None
+            while True:
+                chunk = await process.stdout.read(64 * 1024)
+                if not chunk:
+                    return
+                output_bytes_seen += len(chunk)
+                if not truncated:
+                    if output_bytes_seen <= max_output_bytes:
+                        stdout_chunks.append(chunk)
+                    else:
+                        overshoot = output_bytes_seen - max_output_bytes
+                        keep = len(chunk) - overshoot
+                        if keep > 0:
+                            stdout_chunks.append(chunk[:keep])
+                        truncated = True
+
+        async def _write_stdin() -> None:
+            # The child may exit early on a SQL error (psql) or invalid
+            # archive (pg_restore) while we're still writing. That closes
+            # the pipe and raises BrokenPipeError / ConnectionResetError
+            # here — if those propagate through asyncio.gather, we never
+            # return the real exit code or stderr, and the agent loses
+            # the diagnostic. Swallow them and let process.wait() +
+            # stderr_task surface the actual failure cause.
+            if stdin is None or process.stdin is None:
                 return
-            output_bytes_seen += len(chunk)
-            if not truncated:
-                if output_bytes_seen <= max_output_bytes:
-                    stdout_chunks.append(chunk)
-                else:
-                    overshoot = output_bytes_seen - max_output_bytes
-                    keep = len(chunk) - overshoot
-                    if keep > 0:
-                        stdout_chunks.append(chunk[:keep])
-                    truncated = True
-
-    async def _write_stdin() -> None:
-        # The child may exit early on a SQL error (psql) or invalid
-        # archive (pg_restore) while we're still writing. That closes
-        # the pipe and raises BrokenPipeError / ConnectionResetError
-        # here — if those propagate through asyncio.gather, we never
-        # return the real exit code or stderr, and the agent loses
-        # the diagnostic. Swallow them and let process.wait() +
-        # stderr_task surface the actual failure cause.
-        if stdin is None or process.stdin is None:
-            return
-        try:
             try:
-                process.stdin.write(stdin)
-                await process.stdin.drain()
-            except (BrokenPipeError, ConnectionResetError):
-                pass
-        finally:
-            # Close UNCONDITIONALLY so the child always sees EOF even
-            # when write/drain raised something other than a pipe error
-            # (OSError on saturated pipe, RuntimeError from a closed
-            # loop in tests). Without this, a non-pipe exception would
-            # leave the child blocked reading stdin until the timeout.
-            try:
-                process.stdin.close()
-                await process.stdin.wait_closed()
-            except (BrokenPipeError, ConnectionResetError):
-                pass
+                try:
+                    process.stdin.write(stdin)
+                    await process.stdin.drain()
+                except (BrokenPipeError, ConnectionResetError):
+                    pass
+            finally:
+                # Close UNCONDITIONALLY so the child always sees EOF even
+                # when write/drain raised something other than a pipe error
+                # (OSError on saturated pipe, RuntimeError from a closed
+                # loop in tests). Without this, a non-pipe exception would
+                # leave the child blocked reading stdin until the timeout.
+                try:
+                    process.stdin.close()
+                    await process.stdin.wait_closed()
+                except (BrokenPipeError, ConnectionResetError):
+                    pass
 
-    try:
-        async with asyncio.timeout(timeout_sec):
-            stderr_task = asyncio.create_task(process.stderr.read())  # type: ignore[union-attr]
-            # stdin is written concurrently with stdout/stderr draining
-            # — pg_restore (and any consumer) only starts producing
-            # stdout/stderr after it begins reading stdin, so the
-            # earlier "write stdin after wait" ordering would deadlock.
-            await asyncio.gather(_write_stdin(), _read_capped(), stderr_task, process.wait())
-            stderr_bytes = stderr_task.result()
-    except TimeoutError:
-        timed_out = True
-        process.kill()
         try:
-            async with asyncio.timeout(5):
-                await process.wait()
+            async with asyncio.timeout(timeout_sec):
+                stderr_task = asyncio.create_task(process.stderr.read())  # type: ignore[union-attr]
+                # stdin is written concurrently with stdout/stderr draining
+                # — pg_restore (and any consumer) only starts producing
+                # stdout/stderr after it begins reading stdin, so the
+                # earlier "write stdin after wait" ordering would deadlock.
+                await asyncio.gather(_write_stdin(), _read_capped(), stderr_task, process.wait())
+                stderr_bytes = stderr_task.result()
         except TimeoutError:
-            # Best-effort reap; the OS will collect it.
-            pass
-        try:
-            stderr_bytes = await process.stderr.read() if process.stderr else b""
-        except Exception:
-            stderr_bytes = b""
+            timed_out = True
+            process.kill()
+            try:
+                async with asyncio.timeout(5):
+                    await process.wait()
+            except TimeoutError:
+                # Best-effort reap; the OS will collect it.
+                pass
+            try:
+                stderr_bytes = await process.stderr.read() if process.stderr else b""
+            except Exception:
+                stderr_bytes = b""
 
-    shutil.rmtree(workdir, ignore_errors=True)
     stdout_bytes = b"".join(stdout_chunks)
     return SubprocessResult(
         binary=binary,

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -49,6 +49,7 @@ from mcpg import (
     query,
     rls,
     schema_diff,
+    shell,
     sqlalchemy_export,
     sqlc,
     test_data,
@@ -93,6 +94,15 @@ def build_server_info(app: AppContext) -> ServerInfo:
 
 
 T = TypeVar("T")
+
+
+def _subprocess_limits(settings: Settings) -> shell.SubprocessLimits:
+    """Build the subprocess hardening policy from active settings."""
+    return shell.SubprocessLimits(
+        bin_allowlist=settings.subprocess_bin_allowlist,
+        cpu_seconds=settings.subprocess_cpu_seconds,
+        memory_mb=settings.subprocess_memory_mb,
+    )
 
 
 async def _cached_call(  # noqa: UP047
@@ -1337,6 +1347,7 @@ def _register_data_movement_shell(server: FastMCP[AppContext]) -> None:
             max_output_bytes=app.settings.shell_max_output_bytes,
             format=format,
             schema_only=schema_only,
+            limits=_subprocess_limits(app.settings),
         )
         return asdict(result)
 
@@ -1359,6 +1370,7 @@ def _register_data_movement_shell(server: FastMCP[AppContext]) -> None:
             timeout_sec=app.settings.shell_timeout_sec,
             max_output_bytes=app.settings.shell_max_output_bytes,
             format=format,
+            limits=_subprocess_limits(app.settings),
         )
         await app.cache.clear()
         return asdict(result)
@@ -1396,6 +1408,7 @@ def _register_data_movement_shell(server: FastMCP[AppContext]) -> None:
             include_data=include_data,
             timeout_sec=app.settings.shell_timeout_sec,
             max_output_bytes=app.settings.shell_max_output_bytes,
+            limits=_subprocess_limits(app.settings),
         )
         await app.cache.clear()
         return asdict(result)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -642,3 +642,69 @@ def test_new_config_parameters_loads_and_validates() -> None:
     # Test obfuscated audit HMAC key in repr
     assert "my-secret-key" not in repr(settings)
     assert "audit_hmac_key='set'" in repr(settings)
+
+
+# --- subprocess hardening + HTTP request timeout -------------------------
+
+
+def test_subprocess_hardening_defaults_to_open() -> None:
+    settings = load_settings({"MCPG_DATABASE_URL": _DB_URL})
+    assert settings.subprocess_bin_allowlist == ()
+    assert settings.subprocess_cpu_seconds is None
+    assert settings.subprocess_memory_mb is None
+
+
+def test_subprocess_hardening_parses_allowlist_and_limits() -> None:
+    settings = load_settings(
+        {
+            "MCPG_DATABASE_URL": _DB_URL,
+            "MCPG_SUBPROCESS_BIN_ALLOWLIST": "/usr/bin, /usr/local/bin",
+            "MCPG_SUBPROCESS_CPU_SECONDS": "30",
+            "MCPG_SUBPROCESS_MEMORY_MB": "512",
+        }
+    )
+    assert settings.subprocess_bin_allowlist == ("/usr/bin", "/usr/local/bin")
+    assert settings.subprocess_cpu_seconds == 30
+    assert settings.subprocess_memory_mb == 512
+
+
+def test_subprocess_bin_allowlist_rejects_relative_paths() -> None:
+    with pytest.raises(ConfigError, match="MCPG_SUBPROCESS_BIN_ALLOWLIST"):
+        load_settings(
+            {
+                "MCPG_DATABASE_URL": _DB_URL,
+                "MCPG_SUBPROCESS_BIN_ALLOWLIST": "/usr/bin, relative/dir",
+            }
+        )
+
+
+def test_subprocess_cpu_seconds_rejects_non_positive() -> None:
+    with pytest.raises(ConfigError, match="MCPG_SUBPROCESS_CPU_SECONDS"):
+        load_settings(
+            {
+                "MCPG_DATABASE_URL": _DB_URL,
+                "MCPG_SUBPROCESS_CPU_SECONDS": "0",
+            }
+        )
+
+
+def test_http_request_timeout_defaults_to_zero_and_parses() -> None:
+    assert load_settings({"MCPG_DATABASE_URL": _DB_URL}).http_request_timeout_seconds == 0
+
+    settings = load_settings(
+        {
+            "MCPG_DATABASE_URL": _DB_URL,
+            "MCPG_HTTP_REQUEST_TIMEOUT_SECONDS": "20",
+        }
+    )
+    assert settings.http_request_timeout_seconds == 20
+
+
+def test_http_request_timeout_rejects_negative() -> None:
+    with pytest.raises(ConfigError, match="MCPG_HTTP_REQUEST_TIMEOUT_SECONDS"):
+        load_settings(
+            {
+                "MCPG_DATABASE_URL": _DB_URL,
+                "MCPG_HTTP_REQUEST_TIMEOUT_SECONDS": "-5",
+            }
+        )

--- a/tests/unit/test_http_runtime.py
+++ b/tests/unit/test_http_runtime.py
@@ -833,3 +833,112 @@ def test_run_http_builds_app_and_serves_via_uvicorn(monkeypatch: pytest.MonkeyPa
     assert captured["host"] == "0.0.0.0"
     assert captured["port"] == 9999
     assert captured["app"] is not None
+
+
+# --- request timeout middleware -------------------------------------------
+
+
+async def test_request_timeout_middleware_returns_504_when_app_is_too_slow() -> None:
+    import asyncio
+
+    from mcpg.http_runtime import _RequestTimeoutMiddleware
+
+    async def _slow_app(scope: dict[str, object], receive: object, send: object) -> None:
+        await asyncio.sleep(10)  # far longer than the 0s cap
+
+    sent: list[dict[str, object]] = []
+
+    async def send(message: dict[str, object]) -> None:
+        sent.append(message)
+
+    async def receive() -> dict[str, object]:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    mw = _RequestTimeoutMiddleware(_slow_app, timeout_seconds=0)
+    await mw({"type": "http", "path": "/mcp", "headers": []}, receive, send)
+
+    starts = [m for m in sent if m["type"] == "http.response.start"]
+    assert starts and starts[0]["status"] == 504
+
+
+async def test_request_timeout_middleware_passes_through_a_fast_app() -> None:
+    from mcpg.http_runtime import _RequestTimeoutMiddleware
+
+    async def _fast_app(scope: dict[str, object], receive: object, send: object) -> None:
+        await send({"type": "http.response.start", "status": 200, "headers": []})  # type: ignore[operator]
+        await send({"type": "http.response.body", "body": b"ok"})  # type: ignore[operator]
+
+    sent: list[dict[str, object]] = []
+
+    async def send(message: dict[str, object]) -> None:
+        sent.append(message)
+
+    async def receive() -> dict[str, object]:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    mw = _RequestTimeoutMiddleware(_fast_app, timeout_seconds=5)
+    await mw({"type": "http", "path": "/mcp", "headers": []}, receive, send)
+
+    starts = [m for m in sent if m["type"] == "http.response.start"]
+    assert starts and starts[0]["status"] == 200
+
+
+async def test_request_timeout_middleware_passes_through_non_http_scope() -> None:
+    from mcpg.http_runtime import _RequestTimeoutMiddleware
+
+    called = False
+
+    async def _inner(scope: dict[str, object], receive: object, send: object) -> None:
+        nonlocal called
+        called = True
+
+    mw = _RequestTimeoutMiddleware(_inner, timeout_seconds=1)
+    await mw({"type": "lifespan"}, None, None)
+    assert called is True
+
+
+async def test_request_timeout_middleware_does_not_double_send_after_stream_started() -> None:
+    # If the app already sent the response start before timing out, the
+    # middleware must NOT try to write a 504 on top of it.
+    import asyncio
+
+    from mcpg.http_runtime import _RequestTimeoutMiddleware
+
+    async def _streamer(scope: dict[str, object], receive: object, send: object) -> None:
+        await send({"type": "http.response.start", "status": 200, "headers": []})  # type: ignore[operator]
+        await asyncio.sleep(10)  # times out mid-stream
+
+    sent: list[dict[str, object]] = []
+
+    async def send(message: dict[str, object]) -> None:
+        sent.append(message)
+
+    async def receive() -> dict[str, object]:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    mw = _RequestTimeoutMiddleware(_streamer, timeout_seconds=0)
+    await mw({"type": "http", "path": "/mcp", "headers": []}, receive, send)
+
+    statuses = [m["status"] for m in sent if m["type"] == "http.response.start"]
+    # Exactly one start, the app's 200 — no 504 stacked on top.
+    assert statuses == [200]
+
+
+def test_build_http_app_installs_request_timeout_only_when_positive() -> None:
+    base = {"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db"}
+
+    class _Stub:
+        def streamable_http_app(self) -> Starlette:
+            return _bare_app()
+
+    # Disabled (default 0): no timeout middleware in the stack.
+    off = build_http_app(_Stub(), load_settings(base), kind="streamable-http")
+    assert not any(m.cls.__name__ == "_RequestTimeoutMiddleware" for m in off.user_middleware)
+
+    # Enabled: middleware present.
+    on = build_http_app(
+        _Stub(),
+        load_settings({**base, "MCPG_HTTP_REQUEST_TIMEOUT_SECONDS": "5"}),
+        kind="streamable-http",
+    )
+    assert any(m.cls.__name__ == "_RequestTimeoutMiddleware" for m in on.user_middleware)

--- a/tests/unit/test_shell.py
+++ b/tests/unit/test_shell.py
@@ -1,5 +1,6 @@
 """Tests for the subprocess execution policy (ADR-0004)."""
 
+import os
 from typing import Any
 
 import pytest
@@ -311,8 +312,11 @@ async def test_run_pg_binary_spawns_in_a_temp_cwd_with_no_preexec_by_default(
 
     # A throwaway working directory is always passed; no rlimit preexec
     # unless limits are configured.
-    assert record["kwargs"]["cwd"].startswith("/")
+    cwd = record["kwargs"]["cwd"]
+    assert cwd.startswith("/")
     assert record["kwargs"]["preexec_fn"] is None
+    # The temp cwd must be cleaned up by the time run_pg_binary returns.
+    assert not os.path.isdir(cwd)
 
 
 async def test_run_pg_binary_passes_a_preexec_fn_when_limits_are_set(
@@ -335,6 +339,28 @@ async def test_run_pg_binary_passes_a_preexec_fn_when_limits_are_set(
     )
 
     assert callable(record["kwargs"]["preexec_fn"])
+
+
+async def test_run_pg_binary_cleans_up_temp_cwd_when_cancelled(monkeypatch: pytest.MonkeyPatch) -> None:
+    # If the asyncio task is cancelled mid-call (the inner await raises
+    # CancelledError), the workdir context manager's finally block must
+    # still remove the temp directory.
+    import asyncio
+
+    captured: dict[str, str] = {}
+
+    async def fake_exec(*args: Any, **kwargs: Any) -> _FakeProcess:
+        captured["cwd"] = kwargs["cwd"]
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr("mcpg.shell.shutil.which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr("mcpg.shell.asyncio.create_subprocess_exec", fake_exec)
+
+    with pytest.raises(asyncio.CancelledError):
+        await run_pg_binary("pg_dump", "--version", timeout_sec=10, max_output_bytes=1024)
+
+    assert captured["cwd"]  # spawn got far enough to record it
+    assert not os.path.isdir(captured["cwd"])
 
 
 async def test_run_pg_binary_enforces_the_bin_allowlist(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_shell.py
+++ b/tests/unit/test_shell.py
@@ -6,8 +6,10 @@ import pytest
 
 from mcpg.shell import (
     ShellError,
+    SubprocessLimits,
     SubprocessResult,
     _filter_env,
+    _make_preexec_fn,
     _redact_env,
     _resolve_binary,
     run_pg_binary,
@@ -249,3 +251,99 @@ async def test_run_pg_binary_surfaces_exit_code_when_child_closes_stdin_early(
     assert result.exit_code == 3
     assert result.stderr == b"ERROR: syntax"
     assert result.timed_out is False
+
+
+# --- subprocess hardening: binary-path allowlist --------------------------
+
+
+def test_resolve_binary_accepts_a_path_inside_the_allowlisted_dir(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("mcpg.shell.shutil.which", lambda name: f"/usr/bin/{name}")
+    resolved = _resolve_binary("pg_dump", bin_allowlist=("/usr/bin",))
+    assert resolved == "/usr/bin/pg_dump"
+
+
+def test_resolve_binary_rejects_a_path_outside_the_allowlisted_dir(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A PATH shim resolving to /tmp/evil must be rejected when the
+    # operator pins the binary directory.
+    monkeypatch.setattr("mcpg.shell.shutil.which", lambda name: f"/tmp/evil/{name}")
+    with pytest.raises(ShellError, match="outside MCPG_SUBPROCESS_BIN_ALLOWLIST"):
+        _resolve_binary("pg_dump", bin_allowlist=("/usr/bin", "/usr/local/bin"))
+
+
+# --- subprocess hardening: rlimit preexec_fn ------------------------------
+
+
+def test_make_preexec_fn_is_none_when_no_limits_requested() -> None:
+    assert _make_preexec_fn(SubprocessLimits()) is None
+
+
+def test_make_preexec_fn_applies_cpu_and_memory_rlimits(monkeypatch: pytest.MonkeyPatch) -> None:
+    import mcpg.shell as shell_mod
+
+    if shell_mod.resource is None:  # pragma: no cover - non-POSIX
+        pytest.skip("resource module not available on this platform")
+
+    calls: list[tuple[int, tuple[int, int]]] = []
+    monkeypatch.setattr(shell_mod.resource, "setrlimit", lambda which, limit: calls.append((which, limit)))
+
+    fn = _make_preexec_fn(SubprocessLimits(cpu_seconds=5, memory_mb=128))
+    assert fn is not None
+    fn()  # would run in the forked child; here it just records
+
+    whichs = {which for which, _ in calls}
+    assert shell_mod.resource.RLIMIT_CPU in whichs
+    assert shell_mod.resource.RLIMIT_AS in whichs
+    # Memory limit is converted to bytes.
+    as_limit = next(limit for which, limit in calls if which == shell_mod.resource.RLIMIT_AS)
+    assert as_limit == (128 * 1024 * 1024, 128 * 1024 * 1024)
+
+
+# --- subprocess hardening: run_pg_binary spawn wiring ---------------------
+
+
+async def test_run_pg_binary_spawns_in_a_temp_cwd_with_no_preexec_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = _FakeProcess(stdout=[b"ok\n"], stderr=b"", returncode=0)
+    record = _patch_exec(monkeypatch, process)
+
+    await run_pg_binary("pg_dump", "--version", timeout_sec=10, max_output_bytes=1024)
+
+    # A throwaway working directory is always passed; no rlimit preexec
+    # unless limits are configured.
+    assert record["kwargs"]["cwd"].startswith("/")
+    assert record["kwargs"]["preexec_fn"] is None
+
+
+async def test_run_pg_binary_passes_a_preexec_fn_when_limits_are_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import mcpg.shell as shell_mod
+
+    if shell_mod.resource is None:  # pragma: no cover - non-POSIX
+        pytest.skip("resource module not available on this platform")
+
+    process = _FakeProcess(stdout=[b"ok\n"], stderr=b"", returncode=0)
+    record = _patch_exec(monkeypatch, process)
+
+    await run_pg_binary(
+        "pg_dump",
+        "--version",
+        timeout_sec=10,
+        max_output_bytes=1024,
+        limits=SubprocessLimits(cpu_seconds=5, memory_mb=64),
+    )
+
+    assert callable(record["kwargs"]["preexec_fn"])
+
+
+async def test_run_pg_binary_enforces_the_bin_allowlist(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("mcpg.shell.shutil.which", lambda name: f"/opt/sneaky/{name}")
+    with pytest.raises(ShellError, match="outside MCPG_SUBPROCESS_BIN_ALLOWLIST"):
+        await run_pg_binary(
+            "pg_dump",
+            "--version",
+            timeout_sec=10,
+            max_output_bytes=1024,
+            limits=SubprocessLimits(bin_allowlist=("/usr/bin",)),
+        )


### PR DESCRIPTION
## Why

This is **item 1 of the 4-item feature plan** we agreed to work through in order. It closes the two remaining *queued* items in `docs/security-hardening.md` (everything except the large pluggable-secrets-backend lift): **subprocess hardening** and the **opt-in HTTP request timeout**.

PR #37 shipped the rest of the HTTP-hardening set (headers, body limit, CORS) plus the audit HMAC chain and graceful shutdown — but the docs still listed those as pending, so this PR also folds the doc updates in (per the agreed approach).

## What

### Subprocess hardening (`mcpg.shell`)
On top of the existing minimal-env spawn + `shutil.which` resolution, `run_pg_binary` now:
- **Binary-path allowlist** — validates the resolved binary's *directory* against `MCPG_SUBPROCESS_BIN_ALLOWLIST` (empty = trust `PATH`). A PATH shim in an untrusted dir is rejected. Comparing the directory (not the file's `realpath`) means distro `pg_dump → pg_wrapper` symlinks still resolve.
- **ulimits** — `RLIMIT_CPU` / `RLIMIT_AS` via a `preexec_fn` when `MCPG_SUBPROCESS_CPU_SECONDS` / `MCPG_SUBPROCESS_MEMORY_MB` are set (POSIX only; no-op where `resource` is absent).
- **Temp cwd** — each spawn runs in a throwaway working directory, cleaned up after.

Threaded via a new `SubprocessLimits` dataclass through `data_movement`'s dump/restore/copy. All opt-in; defaults preserve today's behaviour.

### HTTP request timeout (`mcpg.http_runtime`)
- New `_RequestTimeoutMiddleware` + `MCPG_HTTP_REQUEST_TIMEOUT_SECONDS` (default `0` = disabled). Returns `504` on expiry, but only if the app hasn't already started the response — no double-send into a live stream.
- **Disabled by default** so long-lived SSE / streamable-http streams are untouched; installed only when a positive value is configured. Intended for plain request/response deployments wanting a DoS backstop.

### Config
Three new `MCPG_SUBPROCESS_*` settings (absolute-path validation on the allowlist; positive-int CPU/memory) + `http_request_timeout_seconds` (non-negative). All surfaced in `repr`.

## Test plan
- [x] **+18 unit tests**: bin-allowlist accept/reject, `setrlimit` preexec wiring, temp-cwd/preexec spawn assertions, request-timeout `504` / passthrough / non-http / no-double-send-after-stream-start, `build_http_app` install-only-when-positive, and the new config parsing/validation.
- [x] **979 unit tests pass.** ruff / ruff-format / mypy(`src/mcpg`) / bandit all clean.
- [x] Coverage on changed files: `http_runtime` 100%, `data_movement` 98%, `config` 91%, `shell` 94% — keeps the 90% gate comfortable.

## Docs (folded in)
- `security-hardening.md`: flipped HTTP hardening / audit HMAC / graceful shutdown / subprocess hardening to ✅ with landing notes; only the secrets backend remains queued; posture table refreshed.
- `README.md`: new **HTTP hardening** env table (#37 + this PR), plus audit-integrity, shutdown-drain, and subprocess rows.
- `CHANGELOG.md`: entries for #36, #37, and this work.

## Note on the remaining plan
After this merges I'll move on to **item 2 — compliance quick-wins** (`4.1` connection-encryption verify + `4.2` `prune_audit_events` retention), then **3 — pluggable secrets backend**, then **4 — pgvector expansion**.

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Harden subprocess execution for PostgreSQL utilities and add an opt-in HTTP request timeout to complete the security-hardening queue.

New Features:
- Introduce configurable per-request HTTP timeout middleware for the HTTP runtime, controlled via MCPG_HTTP_REQUEST_TIMEOUT_SECONDS.
- Add configurable subprocess hardening policy for pg_dump/pg_restore/psql, including binary directory allowlisting and per-process CPU/memory limits.

Enhancements:
- Run PostgreSQL subprocesses in temporary working directories that are cleaned up after execution to reduce filesystem exposure.
- Thread subprocess hardening limits through data-movement operations and tools so all shell-based PG operations inherit the central policy.

Documentation:
- Update security-hardening guide, README, and posture summary to document the new HTTP timeout and subprocess hardening settings and to mark previously shipped security features as delivered.

Tests:
- Add unit tests covering HTTP timeout behavior, middleware installation conditions, subprocess binary allowlisting, rlimit preexec configuration, temp working directory usage, and config parsing/validation for the new settings.