### PR TITLE
ci: retry pgvector docker build to survive Docker Hub flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,27 @@ jobs:
       # and run as a step because GitHub `services:` cannot build images.
       - name: Start PostgreSQL (pgvector + PostGIS)
         run: |
-          docker build -f .github/ci-postgres.Dockerfile \
-            --build-arg PG_MAJOR=${{ matrix.postgres }} -t mcpg-ci-db .
+          # Docker Hub intermittently times out resolving the
+          # pgvector base-image manifest (observed across the matrix:
+          # "Head https://registry-1.docker.io/...: i/o timeout"). That
+          # is transient infra, not a code failure, so retry the build
+          # with exponential backoff before giving up.
+          build_db() {
+            docker build -f .github/ci-postgres.Dockerfile \
+              --build-arg PG_MAJOR=${{ matrix.postgres }} -t mcpg-ci-db .
+          }
+          attempt=1
+          max_attempts=4
+          until build_db; do
+            if [ "$attempt" -ge "$max_attempts" ]; then
+              echo "docker build failed after $attempt attempts" >&2
+              exit 1
+            fi
+            backoff=$((2 ** attempt))
+            echo "docker build attempt $attempt failed; retrying in ${backoff}s..." >&2
+            sleep "$backoff"
+            attempt=$((attempt + 1))
+          done
           docker run -d --name mcpg-db -p 5432:5432 \
             -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres \
             -e POSTGRES_DB=mcpg_test mcpg-ci-db


### PR DESCRIPTION
## Why

The `Tests (PG NN)` matrix intermittently fails at the **Start PostgreSQL** step when Docker Hub times out resolving the `pgvector/pgvector` base-image manifest:

```
#2 ERROR: failed to do request: Head "https://registry-1.docker.io/v2/pgvector/pgvector/manifests/pgNN": i/o timeout
ERROR: failed to build: ... DeadlineExceeded
```

This is **transient registry infra, not a code failure** — the same commit routinely passes the identical job in the parallel push/PR run. It has now bitten PR #37 (PG 14) and PR #38 (PG 15), each time forcing a manual re-run.

## What

Wrap the `docker build` in a retry loop: up to **4 attempts** with exponential backoff (**2s → 4s → 8s**) before failing the job. The base-image pull happens inside the build, so retrying the build re-attempts the flaky manifest fetch.

No change to *what* is built or *how* the tests run — only resilience around the network-dependent build step.

## Test plan
- [x] `yaml.safe_load` parses the workflow.
- [x] Dry-ran the retry loop locally: 3 retries at 2s/4s/8s, then fails cleanly on the 4th — and returns immediately on first success.
- [x] CI on this PR exercises the (happy-path) build across all five PG versions.

CI-only change; no application code touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

CI:
- Wrap the pgvector PostgreSQL Docker image build step in a retry loop with exponential backoff to tolerate transient Docker Hub manifest resolution failures.