### PR TITLE
feat(compliance): connection-encryption verify + audit-log retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **`verify_connection_encryption` tool.** Reports whether MCPg's own
+  connection to PostgreSQL is TLS-encrypted — negotiated protocol
+  version, cipher, and key bits from `pg_stat_ssl` — plus a
+  cluster-wide encrypted/unencrypted backend tally. A runtime
+  complement to the startup TLS-enforcement check. Read-only;
+  available in every access mode.
+
+- **`prune_audit_events` retention tool.** Deletes persisted audit
+  events older than `older_than_days` from `mcpg_audit.events`, a
+  cron-friendly cap on the otherwise-unbounded audit table. Returns
+  the number deleted, the cutoff timestamp, and rows remaining.
+  Refuses to run when `MCPG_AUDIT_INTEGRITY` is enabled (pruning
+  would break the HMAC signature chain). Write-gated (unrestricted
+  mode).
+
 - **Subprocess hardening for the shell-gated PG binaries.**
   `run_pg_binary` now (a) validates the resolved `pg_dump` /
   `pg_restore` / `psql` directory against

--- a/README.md
+++ b/README.md
@@ -410,8 +410,10 @@ Compact category list. For the full, current tool reference see
   `find_blocking_chains`, `read_pg_stat_io` (PG16+),
   `generate_test_data`.
 - **Live ops & maintenance** — `list_active_queries`,
-  `run_maintenance` (VACUUM/ANALYZE), `cancel_query`,
-  `terminate_backend`, `run_write`, `run_ddl`, `enable_extension`.
+  `verify_connection_encryption` (TLS status of the live link),
+  `run_maintenance` (VACUUM/ANALYZE), `prune_audit_events`
+  (audit retention), `cancel_query`, `terminate_backend`,
+  `run_write`, `run_ddl`, `enable_extension`.
 - **Data movement** — `export_query` / `export_table` (CSV/JSON),
   `dump_database` / `restore_database`, `import_csv` / `import_json`
   (COPY FROM STDIN), `copy_table_between_databases`.

--- a/docs/feature-shortlist.md
+++ b/docs/feature-shortlist.md
@@ -54,7 +54,7 @@ not covered there:
 
 | # | Item | Effort | Value | Notes |
 |---|---|---|---|---|
-| 4.1 | ✅ **Shipped.** Connection-encryption verification tool (`verify_connection_encryption`) — reports `ssl` + protocol/cipher/bits for MCPg's own link plus a cluster encrypted/unencrypted tally, from `pg_stat_ssl`. | S | Medium | Composes with the existing TLS-enforcement startup check. |
+| 4.1 | ✅ **Shipped.** Connection-encryption verification tool (`verify_connection_encryption`) — reports `ssl` + protocol/cipher/bits for MCPg's own link plus a cluster-wide encrypted/unencrypted backend tally, from `pg_stat_ssl`. | S | Medium | Composes with the existing TLS-enforcement startup check. |
 | 4.2 | ✅ **Shipped.** Audit-log retention via `prune_audit_events(older_than_days)` — deletes old `mcpg_audit.events` rows (cron-friendly). Refuses when `MCPG_AUDIT_INTEGRITY` is on, since pruning would break the HMAC chain. | S | Medium | — |
 | 4.3 | IP allowlist for HTTP transport | S | Low | Tiny middleware. Often handled at the reverse-proxy layer instead. |
 | 4.4 | mTLS for the HTTP transport | S | Medium | Cert wiring; commonly done at the proxy layer. |

--- a/docs/feature-shortlist.md
+++ b/docs/feature-shortlist.md
@@ -54,8 +54,8 @@ not covered there:
 
 | # | Item | Effort | Value | Notes |
 |---|---|---|---|---|
-| 4.1 | Connection-encryption verification tool — reports `ssl=on/off` + cipher per connection | S | Medium | Composes with the existing TLS-enforcement startup check. |
-| 4.2 | Audit-log retention / rotation policy in `mcpg_audit.events` | S | Medium | Grows unbounded today; a `prune_audit_events(older_than)` tool + a cron-friendly retention helper. |
+| 4.1 | ✅ **Shipped.** Connection-encryption verification tool (`verify_connection_encryption`) — reports `ssl` + protocol/cipher/bits for MCPg's own link plus a cluster encrypted/unencrypted tally, from `pg_stat_ssl`. | S | Medium | Composes with the existing TLS-enforcement startup check. |
+| 4.2 | ✅ **Shipped.** Audit-log retention via `prune_audit_events(older_than_days)` — deletes old `mcpg_audit.events` rows (cron-friendly). Refuses when `MCPG_AUDIT_INTEGRITY` is on, since pruning would break the HMAC chain. | S | Medium | — |
 | 4.3 | IP allowlist for HTTP transport | S | Low | Tiny middleware. Often handled at the reverse-proxy layer instead. |
 | 4.4 | mTLS for the HTTP transport | S | Medium | Cert wiring; commonly done at the proxy layer. |
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -29,7 +29,7 @@ plumbing:
 | `MCPG_REPLICA_URLS` | Comma-separated read-replica DSNs. When set, `force_readonly` queries round-robin across healthy replicas; writes always go to the primary. |
 | `MCPG_NL2SQL_PROVIDER` / `MCPG_NL2SQL_API_KEY` / `MCPG_NL2SQL_MODEL` / `MCPG_NL2SQL_BASE_URL` / `MCPG_NL2SQL_MAX_TOKENS` | `translate_nl_to_sql` provider config (Anthropic / OpenAI / Gemini). |
 
-## Tool index (117 tools)
+## Tool index (121 tools)
 
 | Category | Tools |
 |---|---|

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -5,7 +5,7 @@ A compact one-page tour of every tool MCPg exposes, organised by
 surface; the full reference is in [`tools.md`](tools.md), and
 task-oriented recipes live in [`cookbook.md`](cookbook.md).
 
-**117 tools** as of trunk. Each line shows the tool name + how its
+**121 tools** as of trunk. Each line shows the tool name + how its
 parameters land (required first, common defaults after). Capability
 gates are noted in section titles where they apply.
 
@@ -100,6 +100,7 @@ audit_database(schema, log_table=null)               # comprehensive 5-category 
 analyze_workload(top_n=10)                           # slow queries from pg_stat_statements
 recommend_indexes()                                  # missing-index heuristics
 list_active_queries()                                # who's running what right now
+verify_connection_encryption()                       # is MCPg's own link TLS-encrypted? protocol + cipher + cluster tally
 list_locks(limit=100)                                # pg_locks joined with pg_stat_activity (waiters first)
 find_blocking_chains(limit=50)                       # (blocked, blocking) pairs via pg_blocking_pids
 read_pg_stat_io()                                    # PG16+ I/O stats; available=false on PG 14/15
@@ -205,6 +206,7 @@ documented gaps.
 ```
 run_write(sql)                                       # one INSERT/UPDATE/DELETE; add RETURNING
 run_maintenance(operation, schema, table)            # VACUUM / ANALYZE / REINDEX
+prune_audit_events(older_than_days)                  # retention: delete old mcpg_audit.events rows (refused if integrity on)
 cancel_query(pid)
 terminate_backend(pid)
 ```
@@ -266,6 +268,7 @@ list_replicas()                                             # per-replica health
 
 ```
 list_audit_events(limit=100, tool=null)              # MCPG_AUDIT_PERSIST=true required
+verify_audit_chain()                                 # validate the HMAC integrity chain
 get_server_info()                                    # version, mode, transport, DB state
 ```
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -35,7 +35,7 @@ first time, skim it as a reference after.
 ## What MCPg is
 
 MCPg is an MCP server that exposes a PostgreSQL database to an AI
-agent through a fixed, audited set of **117 tools**. The agent never
+agent through a fixed, audited set of **121 tools**. The agent never
 gets a raw database connection — it can only call the tools MCPg
 registers, every call is validated, and every call is logged. MCPg
 runs as a single async process and ships as both a PyPI package

--- a/src/mcpg/audit_trail.py
+++ b/src/mcpg/audit_trail.py
@@ -48,6 +48,24 @@ _QUALIFIED = f"{AUDIT_SCHEMA}.{AUDIT_TABLE}"
 _MASK = "****"
 
 
+class AuditTrailError(Exception):
+    """Raised when an audit-trail maintenance operation is rejected."""
+
+
+@dataclass(frozen=True, slots=True)
+class PruneResult:
+    """The outcome of a :func:`prune_audit_events` call.
+
+    ``deleted`` is the number of rows removed. ``cutoff`` is the
+    ISO-8601 timestamp before which events were pruned. ``remaining``
+    is the row count left in the table afterwards.
+    """
+
+    deleted: int
+    cutoff: str
+    remaining: int
+
+
 @dataclass(frozen=True, slots=True)
 class AuditTrailEntry:
     """A persisted SQL audit row read back from ``mcpg_audit.events``."""
@@ -264,6 +282,64 @@ async def list_audit_events(driver: SqlDriver, *, limit: int = 100, tool: str | 
         )
         for row in rows or []
     ]
+
+
+async def prune_audit_events(
+    driver: SqlDriver,
+    *,
+    older_than_days: int,
+    integrity_enabled: bool = False,
+) -> PruneResult:
+    """Delete persisted audit events older than ``older_than_days``.
+
+    A cron-friendly retention helper for the unbounded
+    ``mcpg_audit.events`` table. The cutoff is ``now() - interval`` in
+    the database's clock.
+
+    Refuses to run when ``integrity_enabled`` is true: the HMAC chain
+    anchors its first row on an empty ``prev_hmac``, so deleting the
+    oldest rows would leave a row whose ``prev_hmac`` references a
+    now-gone event — :func:`mcpg.audit_integrity.verify_audit_chain`
+    would then (correctly) report tampering. Operators who need both
+    retention and integrity should export-then-truncate out of band;
+    re-anchoring the chain in place is deferred.
+
+    Returns a :class:`PruneResult`; pruning a not-yet-created table is a
+    no-op (``deleted=0``).
+    """
+    if older_than_days < 1:
+        raise AuditTrailError("older_than_days must be at least 1")
+    if integrity_enabled:
+        raise AuditTrailError(
+            "refusing to prune mcpg_audit.events while MCPG_AUDIT_INTEGRITY is enabled: "
+            "deleting the oldest rows would break the HMAC signature chain and make "
+            "verify_audit_chain report tampering. Disable integrity to prune, or export "
+            "and truncate out of band."
+        )
+    if not await _audit_table_exists(driver):
+        return PruneResult(deleted=0, cutoff="", remaining=0)
+
+    rows = await driver.execute_query(
+        f"WITH cutoff AS (SELECT now() - make_interval(days => %s) AS ts) "
+        f"DELETE FROM {_QUALIFIED} WHERE occurred_at < (SELECT ts FROM cutoff) "
+        f"RETURNING (SELECT ts FROM cutoff) AS cutoff_ts",
+        params=[older_than_days],
+        force_readonly=False,
+    )
+    deleted = len(rows or [])
+    cutoff = ""
+    if rows:
+        cutoff_val = rows[0].cells.get("cutoff_ts")
+        if cutoff_val is not None:
+            cutoff = cutoff_val.isoformat() if hasattr(cutoff_val, "isoformat") else str(cutoff_val)
+
+    remaining_rows = await driver.execute_query(
+        f"SELECT count(*) AS n FROM {_QUALIFIED}",
+        force_readonly=True,
+    )
+    remaining = int(remaining_rows[0].cells.get("n") or 0) if remaining_rows else 0
+
+    return PruneResult(deleted=deleted, cutoff=cutoff, remaining=remaining)
 
 
 async def _audit_table_exists(driver: SqlDriver) -> bool:

--- a/src/mcpg/audit_trail.py
+++ b/src/mcpg/audit_trail.py
@@ -57,12 +57,13 @@ class PruneResult:
     """The outcome of a :func:`prune_audit_events` call.
 
     ``deleted`` is the number of rows removed. ``cutoff`` is the
-    ISO-8601 timestamp before which events were pruned. ``remaining``
-    is the row count left in the table afterwards.
+    ISO-8601 timestamp before which events were pruned, or ``None`` when
+    no prune ran (the audit table doesn't exist yet). ``remaining`` is
+    the row count left in the table afterwards.
     """
 
     deleted: int
-    cutoff: str
+    cutoff: str | None
     remaining: int
 
 
@@ -317,22 +318,31 @@ async def prune_audit_events(
             "and truncate out of band."
         )
     if not await _audit_table_exists(driver):
-        return PruneResult(deleted=0, cutoff="", remaining=0)
+        return PruneResult(deleted=0, cutoff=None, remaining=0)
 
+    # Aggregate the delete count inside the CTE rather than RETURNING one
+    # row per deleted event — pruning millions of rows must not
+    # materialise millions of result rows in memory. The query always
+    # returns exactly one row (count over the empty set is 0), so the
+    # cutoff timestamp comes back even when nothing matched.
     rows = await driver.execute_query(
-        f"WITH cutoff AS (SELECT now() - make_interval(days => %s) AS ts) "
-        f"DELETE FROM {_QUALIFIED} WHERE occurred_at < (SELECT ts FROM cutoff) "
-        f"RETURNING (SELECT ts FROM cutoff) AS cutoff_ts",
+        f"WITH cutoff AS (SELECT now() - make_interval(days => %s) AS ts), "
+        f"deleted AS (DELETE FROM {_QUALIFIED} WHERE occurred_at < (SELECT ts FROM cutoff) RETURNING 1) "
+        f"SELECT count(*) AS deleted_count, (SELECT ts FROM cutoff) AS cutoff_ts FROM deleted",
         params=[older_than_days],
         force_readonly=False,
     )
-    deleted = len(rows or [])
-    cutoff = ""
+    deleted = 0
+    cutoff: str | None = None
     if rows:
+        deleted = int(rows[0].cells.get("deleted_count") or 0)
         cutoff_val = rows[0].cells.get("cutoff_ts")
         if cutoff_val is not None:
             cutoff = cutoff_val.isoformat() if hasattr(cutoff_val, "isoformat") else str(cutoff_val)
 
+    # Remaining count is a SEPARATE statement on purpose: a count folded
+    # into the CTE above would read the table at the statement snapshot
+    # (before the DELETE is visible) and report the pre-prune total.
     remaining_rows = await driver.execute_query(
         f"SELECT count(*) AS n FROM {_QUALIFIED}",
         force_readonly=True,

--- a/src/mcpg/liveops.py
+++ b/src/mcpg/liveops.py
@@ -152,11 +152,16 @@ async def verify_connection_encryption(driver: SqlDriver) -> ConnectionEncryptio
     total = int(counts.get("total") or 0)
     encrypted = int(counts.get("encrypted") or 0)
 
+    # Normalise bits to int — keep the dataclass's int | None contract
+    # even if a driver hands back Decimal/str for the key size.
+    bits_value = cell.get("bits")
+    bits = int(bits_value) if ssl_on and bits_value is not None else None
+
     return ConnectionEncryption(
         ssl=ssl_on,
         version=cell.get("version") if ssl_on else None,
         cipher=cell.get("cipher") if ssl_on else None,
-        bits=cell.get("bits") if ssl_on else None,
+        bits=bits,
         total_connections=total,
         encrypted_connections=encrypted,
         unencrypted_connections=total - encrypted,

--- a/src/mcpg/liveops.py
+++ b/src/mcpg/liveops.py
@@ -106,3 +106,58 @@ async def terminate_backend(driver: SqlDriver, pid: int) -> BackendActionResult:
     )
     succeeded = bool((rows or [])[0].cells["ok"])
     return BackendActionResult(pid=pid, action="terminate_backend", succeeded=succeeded)
+
+
+@dataclass(frozen=True, slots=True)
+class ConnectionEncryption:
+    """TLS status of the MCPg→PostgreSQL connection (+ cluster overview).
+
+    The per-connection fields describe *this* backend's link, read from
+    ``pg_stat_ssl`` for ``pg_backend_pid()``. ``cipher`` / ``version`` /
+    ``bits`` are ``None`` when the connection is not encrypted. The
+    ``*_connections`` counts summarise every backend visible in
+    ``pg_stat_ssl`` — a non-superuser may only see its own row, so the
+    counts are a lower bound under restricted privileges.
+    """
+
+    ssl: bool
+    version: str | None
+    cipher: str | None
+    bits: int | None
+    total_connections: int
+    encrypted_connections: int
+    unencrypted_connections: int
+
+
+async def verify_connection_encryption(driver: SqlDriver) -> ConnectionEncryption:
+    """Report whether the active connection is TLS-encrypted, plus a cluster tally.
+
+    Composes with the startup TLS-enforcement check (which refuses
+    insecure DSNs): this confirms, at runtime, that the negotiated
+    connection actually came up encrypted and surfaces the protocol +
+    cipher for an auditor.
+    """
+    own = await driver.execute_query(
+        "SELECT ssl, version, cipher, bits FROM pg_stat_ssl WHERE pid = pg_backend_pid()",
+        force_readonly=True,
+    )
+    cell = own[0].cells if own else {}
+    ssl_on = bool(cell.get("ssl"))
+
+    tally = await driver.execute_query(
+        "SELECT count(*) AS total, count(*) FILTER (WHERE ssl) AS encrypted FROM pg_stat_ssl",
+        force_readonly=True,
+    )
+    counts = tally[0].cells if tally else {}
+    total = int(counts.get("total") or 0)
+    encrypted = int(counts.get("encrypted") or 0)
+
+    return ConnectionEncryption(
+        ssl=ssl_on,
+        version=cell.get("version") if ssl_on else None,
+        cipher=cell.get("cipher") if ssl_on else None,
+        bits=cell.get("bits") if ssl_on else None,
+        total_connections=total,
+        encrypted_connections=encrypted,
+        unencrypted_connections=total - encrypted,
+    )

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -1933,6 +1933,21 @@ def _register_liveops(server: FastMCP[AppContext]) -> None:
         return [asdict(active) for active in queries]
 
     @server.tool(
+        name="verify_connection_encryption",
+        description=(
+            "Report whether MCPg's own connection to PostgreSQL is "
+            "TLS-encrypted, including the negotiated protocol version, "
+            "cipher, and key bits (from pg_stat_ssl). Also returns a "
+            "cluster-wide tally of encrypted vs unencrypted backends "
+            "(a lower bound under non-superuser privileges). Complements "
+            "the startup TLS-enforcement check by confirming the live "
+            "connection actually came up encrypted."
+        ),
+    )
+    async def verify_connection_encryption(ctx: _Ctx) -> dict[str, Any]:
+        return asdict(await liveops.verify_connection_encryption(_driver(ctx)))
+
+    @server.tool(
         name="list_replicas",
         description=(
             "Report the health of every configured read replica. Each "
@@ -2084,6 +2099,26 @@ def _register_maintenance(server: FastMCP[AppContext]) -> None:
         database = ctx.request_context.lifespan_context.database
         result = await maintenance.run_maintenance(database, operation, schema, table)
         await ctx.request_context.lifespan_context.cache.clear()
+        return asdict(result)
+
+    @server.tool(
+        name="prune_audit_events",
+        description=(
+            "Delete persisted audit events older than older_than_days from "
+            "mcpg_audit.events — a cron-friendly retention helper for the "
+            "otherwise-unbounded audit table. Returns the number deleted, the "
+            "cutoff timestamp, and the rows remaining. Refuses to run when "
+            "MCPG_AUDIT_INTEGRITY is enabled (pruning would break the HMAC "
+            "signature chain). Available only in unrestricted mode."
+        ),
+    )
+    async def prune_audit_events(ctx: _Ctx, older_than_days: int) -> dict[str, Any]:
+        settings = ctx.request_context.lifespan_context.settings
+        result = await audit_trail.prune_audit_events(
+            _driver(ctx),
+            older_than_days=older_than_days,
+            integrity_enabled=settings.audit_integrity,
+        )
         return asdict(result)
 
 

--- a/tests/unit/test_audit_trail.py
+++ b/tests/unit/test_audit_trail.py
@@ -13,12 +13,14 @@ from mcpg.audit_trail import (
     AUDIT_SCHEMA,
     AUDIT_TABLE,
     AuditTrailEntry,
+    AuditTrailError,
     SchemaDiffSnapshot,
     _redact,
     _reset_audit_init_cache,
     capture_columns,
     ensure_audit_table,
     list_audit_events,
+    prune_audit_events,
     record_audit,
 )
 from mcpg.config import load_settings
@@ -414,6 +416,76 @@ async def test_list_audit_events_filters_by_tool_when_supplied() -> None:
     assert len(select_calls) == 1
     params = select_calls[0][1]
     assert params == ["run_write", 5]
+
+
+# --- prune_audit_events ----------------------------------------------------
+
+
+async def test_prune_audit_events_deletes_old_rows_and_reports_counts() -> None:
+    import datetime
+
+    cutoff_dt = datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC)
+    driver = FakeRoutingDriver(
+        {
+            "FROM pg_class c": [{"present": 1}],
+            # DELETE ... RETURNING — one row per deleted event.
+            "DELETE FROM mcpg_audit.events": [{"cutoff_ts": cutoff_dt} for _ in range(3)],
+            "count(*) AS n": [{"n": 7}],
+        }
+    )
+
+    result = await prune_audit_events(driver, older_than_days=30)  # type: ignore[arg-type]
+
+    assert result.deleted == 3
+    assert result.remaining == 7
+    assert result.cutoff == cutoff_dt.isoformat()
+    # The DELETE was a write (force_readonly False).
+    delete_call = next(call for call in driver.calls if "DELETE FROM" in call[0])
+    assert delete_call[2] is False
+    assert delete_call[1] == [30]
+
+
+async def test_prune_audit_events_refuses_when_integrity_enabled() -> None:
+    driver = FakeRoutingDriver({"FROM pg_class c": [{"present": 1}]})
+
+    with pytest.raises(AuditTrailError, match="MCPG_AUDIT_INTEGRITY"):
+        await prune_audit_events(driver, older_than_days=30, integrity_enabled=True)  # type: ignore[arg-type]
+
+    # Nothing was deleted — it bailed before touching the table.
+    assert not any("DELETE FROM" in call[0] for call in driver.calls)
+
+
+async def test_prune_audit_events_rejects_non_positive_window() -> None:
+    with pytest.raises(AuditTrailError, match="older_than_days"):
+        await prune_audit_events(FakeDriver(), older_than_days=0)  # type: ignore[arg-type]
+
+
+async def test_prune_audit_events_is_a_noop_when_table_absent() -> None:
+    # Existence check returns no rows -> table not created yet.
+    driver = FakeRoutingDriver({"FROM pg_class c": []})
+
+    result = await prune_audit_events(driver, older_than_days=30)  # type: ignore[arg-type]
+
+    assert result.deleted == 0
+    assert result.remaining == 0
+    assert not any("DELETE FROM" in call[0] for call in driver.calls)
+
+
+async def test_prune_audit_events_tool_is_registered_in_unrestricted_mode() -> None:
+    unrestricted = load_settings(
+        {"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db", "MCPG_ACCESS_MODE": "unrestricted"}
+    )
+    driver = FakeRoutingDriver({"FROM pg_class c": []})
+    server = create_server(unrestricted, database=FakeDatabase(driver))  # type: ignore[arg-type]
+
+    async with create_connected_server_and_client_session(server) as client:
+        listed = {tool.name for tool in (await client.list_tools()).tools}
+        assert "prune_audit_events" in listed
+        result = await client.call_tool("prune_audit_events", {"older_than_days": 90})
+
+    assert result.isError is False
+    assert result.structuredContent is not None
+    assert result.structuredContent["deleted"] == 0
 
 
 # --- capture_columns ------------------------------------------------------

--- a/tests/unit/test_audit_trail.py
+++ b/tests/unit/test_audit_trail.py
@@ -428,8 +428,8 @@ async def test_prune_audit_events_deletes_old_rows_and_reports_counts() -> None:
     driver = FakeRoutingDriver(
         {
             "FROM pg_class c": [{"present": 1}],
-            # DELETE ... RETURNING — one row per deleted event.
-            "DELETE FROM mcpg_audit.events": [{"cutoff_ts": cutoff_dt} for _ in range(3)],
+            # CTE DELETE returns a single aggregated row (count + cutoff).
+            "DELETE FROM mcpg_audit.events": [{"deleted_count": 3, "cutoff_ts": cutoff_dt}],
             "count(*) AS n": [{"n": 7}],
         }
     )
@@ -486,6 +486,18 @@ async def test_prune_audit_events_tool_is_registered_in_unrestricted_mode() -> N
     assert result.isError is False
     assert result.structuredContent is not None
     assert result.structuredContent["deleted"] == 0
+
+
+@pytest.mark.parametrize("mode", ["read-only", "restricted"])
+async def test_prune_audit_events_tool_is_absent_without_write_capability(mode: str) -> None:
+    # prune deletes rows -> it must only appear in unrestricted mode.
+    settings = load_settings({"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db", "MCPG_ACCESS_MODE": mode})
+    server = create_server(settings, database=FakeDatabase(FakeDriver()))  # type: ignore[arg-type]
+
+    async with create_connected_server_and_client_session(server) as client:
+        listed = {tool.name for tool in (await client.list_tools()).tools}
+
+    assert "prune_audit_events" not in listed
 
 
 # --- capture_columns ------------------------------------------------------

--- a/tests/unit/test_liveops.py
+++ b/tests/unit/test_liveops.py
@@ -1,6 +1,6 @@
 """Tests for live-operations introspection and the list_active_queries tool."""
 
-from _fakes import FakeDatabase, FakeDriver
+from _fakes import FakeDatabase, FakeDriver, FakeRoutingDriver
 from mcp.shared.memory import create_connected_server_and_client_session
 
 from mcpg.config import load_settings
@@ -10,6 +10,7 @@ from mcpg.liveops import (
     cancel_query,
     list_active_queries,
     terminate_backend,
+    verify_connection_encryption,
 )
 from mcpg.server import create_server
 
@@ -107,3 +108,59 @@ async def test_backend_control_tools_are_callable_in_unrestricted_mode() -> None
 
     assert cancelled.isError is False
     assert terminated.isError is False
+
+
+# --- verify_connection_encryption -----------------------------------------
+
+
+async def test_verify_connection_encryption_reports_an_encrypted_link() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_backend_pid()": [{"ssl": True, "version": "TLSv1.3", "cipher": "TLS_AES_256_GCM_SHA384", "bits": 256}],
+            "count(*) AS total": [{"total": 5, "encrypted": 4}],
+        }
+    )
+
+    result = await verify_connection_encryption(driver)  # type: ignore[arg-type]
+
+    assert result.ssl is True
+    assert result.version == "TLSv1.3"
+    assert result.cipher == "TLS_AES_256_GCM_SHA384"
+    assert result.bits == 256
+    assert result.total_connections == 5
+    assert result.encrypted_connections == 4
+    assert result.unencrypted_connections == 1
+
+
+async def test_verify_connection_encryption_nulls_cipher_when_plaintext() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_backend_pid()": [{"ssl": False, "version": None, "cipher": None, "bits": None}],
+            "count(*) AS total": [{"total": 2, "encrypted": 0}],
+        }
+    )
+
+    result = await verify_connection_encryption(driver)  # type: ignore[arg-type]
+
+    assert result.ssl is False
+    assert result.version is None and result.cipher is None and result.bits is None
+    assert result.unencrypted_connections == 2
+
+
+async def test_verify_connection_encryption_tool_is_registered_in_read_mode() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_backend_pid()": [{"ssl": True, "version": "TLSv1.3", "cipher": "X", "bits": 256}],
+            "count(*) AS total": [{"total": 1, "encrypted": 1}],
+        }
+    )
+    server = create_server(_SETTINGS, database=FakeDatabase(driver))  # type: ignore[arg-type]
+
+    async with create_connected_server_and_client_session(server) as client:
+        listed = {tool.name for tool in (await client.list_tools()).tools}
+        assert "verify_connection_encryption" in listed
+        result = await client.call_tool("verify_connection_encryption", {})
+
+    assert result.isError is False
+    assert result.structuredContent is not None
+    assert result.structuredContent["ssl"] is True


### PR DESCRIPTION
## Why

**Item 2 of the 4-item feature plan.** Ships the two compliance quick-wins from `docs/feature-shortlist.md` §4 — `4.1` connection-encryption verification and `4.2` audit-log retention.

## What

### `verify_connection_encryption` (read-only, all access modes)
Reports whether MCPg's own connection to PostgreSQL is TLS-encrypted — negotiated **protocol version, cipher, and key bits** from `pg_stat_ssl` for `pg_backend_pid()` — plus a cluster-wide **encrypted/unencrypted backend tally** (a lower bound under non-superuser privileges).

A runtime complement to the startup TLS-enforcement check: that *refuses* insecure DSNs; this *confirms* the negotiated link actually came up encrypted and hands an auditor the cipher details.

### `prune_audit_events(older_than_days)` (write-gated / unrestricted)
Deletes `mcpg_audit.events` rows older than the cutoff — a cron-friendly cap on the otherwise-unbounded audit table. Returns `deleted`, `cutoff`, and `remaining`.

**Refuses when `MCPG_AUDIT_INTEGRITY` is enabled:** the HMAC chain anchors its first row on an empty `prev_hmac`, so deleting the oldest rows would make `verify_audit_chain` report tampering. Operators who need both retention *and* integrity export-then-truncate out of band; in-place chain re-anchoring is deferred (documented in the docstring + error message).

## Test plan
- [x] **+10 unit tests** — SSL probe (encrypted / plaintext / tool-registration); prune (delete-and-count / refuse-on-integrity / reject-non-positive-window / no-table no-op / tool-registration under unrestricted).
- [x] Both new code modules at **100% unit coverage**.
- [x] **988 unit tests pass**; ruff / ruff-format / mypy(`src/mcpg`) / bandit all clean.

## Docs (folded in)
- README catalog + (existing) audit env table; `tour.md` gains both tools.
- `feature-shortlist.md`: 4.1 / 4.2 flipped to ✅.
- **Tool count corrected to 121** across `tour.md` / `user-guide.md` / `tools.md` — the "117" was stale (PR #37's `verify_audit_chain` + `analyze_hnsw_recall` were never counted; this PR adds two more → 121, matching `grep -c '@server.tool'`).

## Remaining plan
After this: **item 3 — pluggable secrets backend** (the large one), then **item 4 — pgvector expansion**.

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Add compliance-focused tooling for verifying database connection encryption and managing audit-log retention, along with tests and docs updates.

New Features:
- Introduce a read-only verify_connection_encryption tool that reports TLS status and cipher details for MCPg's PostgreSQL connection plus a cluster-wide encrypted vs unencrypted tally.
- Add a prune_audit_events retention tool that deletes old mcpg_audit.events rows with safeguards when audit integrity is enabled.

Enhancements:
- Expose the new compliance tools through the server tool registry with appropriate access-mode gating and structured results.

Documentation:
- Document the new verify_connection_encryption and prune_audit_events tools across the README, tour, tools index, and feature shortlist, and update the documented tool count from 117 to 121.

Tests:
- Add unit tests covering prune_audit_events behavior, error conditions, tool registration, and verify_connection_encryption reporting and registration.