### PR TITLE
feat(secrets): pluggable secrets backend — env (default) + file overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 - **Pluggable secrets backend (`MCPG_SECRETS_BACKEND`).** A
-  `SecretsProvider` abstraction (`mcpg.secrets`) that the secret
-  reads in `load_settings` route through — the NL→SQL provider API
+  `SecretsProvider` abstraction (`mcpg.secrets`) that the secrets read
+  in `load_settings` route through — the NL→SQL provider API
   keys, `MCPG_HTTP_AUTH_TOKEN`, and `MCPG_AUDIT_HMAC_KEY`. Two
   backends ship: `env` (default — unchanged behaviour, zero new
   deps) and `file`, which overlays a JSON (or YAML, when PyYAML is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Pluggable secrets backend (`MCPG_SECRETS_BACKEND`).** A
+  `SecretsProvider` abstraction (`mcpg.secrets`) that the secret
+  reads in `load_settings` route through — the NL→SQL provider API
+  keys, `MCPG_HTTP_AUTH_TOKEN`, and `MCPG_AUDIT_HMAC_KEY`. Two
+  backends ship: `env` (default — unchanged behaviour, zero new
+  deps) and `file`, which overlays a JSON (or YAML, when PyYAML is
+  importable) `name → value` map from `MCPG_SECRETS_FILE_PATH` on
+  top of the environment (a name in the file wins; anything absent
+  falls back to its env var). Cloud backends (Vault / AWS / GCP)
+  will follow behind optional extras using the same switch.
+  `Settings.secrets_backend` records the active choice (values never
+  appear in `repr`).
+
 - **`verify_connection_encryption` tool.** Reports whether MCPg's own
   connection to PostgreSQL is TLS-encrypted — negotiated protocol
   version, cipher, and key bits from `pg_stat_ssl` — plus a

--- a/README.md
+++ b/README.md
@@ -245,6 +245,18 @@ everything else has a safe default.
 | `MCPG_AUDIT_INTEGRITY` | `false` | When true, each persisted event is signed with an HMAC chained over the previous event; the `verify_audit_chain` tool walks the chain and reports the first break. Requires `MCPG_AUDIT_HMAC_KEY`. |
 | `MCPG_AUDIT_HMAC_KEY` | — | Secret key for the audit HMAC chain. Required when `MCPG_AUDIT_INTEGRITY=true`. Never appears in `repr`/logs. |
 
+#### Secrets backend
+
+By default every secret is read straight from the environment. Set
+`MCPG_SECRETS_BACKEND=file` to instead load API keys / bearer token /
+HMAC key from a mounted file — a name in the file wins; anything absent
+falls back to the env var, so partial files work.
+
+| Variable | Default | Description |
+|---|---|---|
+| `MCPG_SECRETS_BACKEND` | `env` | `env` (read every secret from the environment) \| `file` (overlay a secrets file on top of the environment). |
+| `MCPG_SECRETS_FILE_PATH` | — | Required when `MCPG_SECRETS_BACKEND=file`. Path to a flat `name → value` map: JSON always, or YAML (`.yaml`/`.yml`) when PyYAML is installed. Covers `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY` / `GOOGLE_API_KEY` / `MCPG_NL2SQL_API_KEY`, `MCPG_HTTP_AUTH_TOKEN`, and `MCPG_AUDIT_HMAC_KEY`. |
+
 #### Rate limiting
 
 | Variable | Default | Description |

--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -179,7 +179,7 @@ Secret Manager have to inject them through their orchestrator
 sidecar rather than letting MCPg fetch them directly.
 
 **Solution.** A `SecretsProvider` protocol (`mcpg.secrets`) picked by
-`MCPG_SECRETS_BACKEND`; the secret reads in `load_settings`
+`MCPG_SECRETS_BACKEND`; the secrets read in `load_settings`
 (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY` /
 `GOOGLE_API_KEY` / `MCPG_NL2SQL_API_KEY`, `MCPG_HTTP_AUTH_TOKEN`,
 `MCPG_AUDIT_HMAC_KEY`) route through `provider.get(name)`.

--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -171,27 +171,29 @@ break. Persistence schema gains `prev_hmac` + `event_hmac` columns.
 **Effort:** medium (schema migration + HMAC computation +
 verifier tool + 5-7 tests).
 
-### ⬜ Pluggable secrets backend
+### 🟡 Pluggable secrets backend
 **Problem.** API keys for the NL→SQL providers, OIDC client
 secrets (future), and the static bearer token all live in env vars.
 Deployments that use HashiCorp Vault / AWS Secrets Manager / GCP
 Secret Manager have to inject them through their orchestrator
 sidecar rather than letting MCPg fetch them directly.
 
-**Solution.** Define a `SecretsProvider` protocol; ship four
-implementations: `env` (today), `file` (mount a JSON / YAML file
-of name→value), `vault` (HashiCorp), `aws` (Secrets Manager),
-`gcp` (Secret Manager). The active provider is picked by
-`MCPG_SECRETS_BACKEND`. Settings that today read env vars route
-through `provider.get(name)`.
+**Solution.** A `SecretsProvider` protocol (`mcpg.secrets`) picked by
+`MCPG_SECRETS_BACKEND`; the secret reads in `load_settings`
+(`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY` /
+`GOOGLE_API_KEY` / `MCPG_NL2SQL_API_KEY`, `MCPG_HTTP_AUTH_TOKEN`,
+`MCPG_AUDIT_HMAC_KEY`) route through `provider.get(name)`.
 
-**Env vars to add:** `MCPG_SECRETS_BACKEND=env|file|vault|aws|gcp`,
-plus backend-specific (e.g. `VAULT_ADDR`, `VAULT_TOKEN`,
-`MCPG_SECRETS_FILE_PATH`, `AWS_SECRETS_MANAGER_REGION`).
+**✅ Shipped:** `env` (default, unchanged) and `file` (overlay a
+JSON / YAML `name → value` map via `MCPG_SECRETS_FILE_PATH`, env
+fallback for unlisted names). Zero new required dependencies — YAML
+is read only when PyYAML happens to be importable.
 
-**Effort:** large (4 new optional dep families behind extras like
-`mcpg[vault]`, `mcpg[aws-secrets]`; ~150 LOC core + per-backend
-integrations + 12+ tests).
+**⬜ Remaining:** the cloud backends — `vault` (HashiCorp), `aws`
+(Secrets Manager), `gcp` (Secret Manager) — each behind an optional
+extra (`mcpg[vault]`, `mcpg[aws-secrets]`, `mcpg[gcp-secrets]`),
+selected by the same `MCPG_SECRETS_BACKEND` switch. The DSN itself
+is not yet routed through the provider.
 
 ### ✅ Subprocess hardening
 **Shipped** in the security-hardening-queue PR. On top of the
@@ -238,4 +240,4 @@ audit trail, then exits. Configurable max-drain window
 | Supply chain | CI bandit + pip-audit | Same |
 | Lifecycle | Graceful shutdown draining | Same |
 | Subprocess | Minimal env + bin allowlist + rlimits + temp cwd | Same |
-| Secrets | Env vars | Pluggable backend (Vault / AWS / GCP / file) |
+| Secrets | Env vars + file overlay (`MCPG_SECRETS_BACKEND`) | + cloud backends (Vault / AWS / GCP) |

--- a/src/mcpg/config.py
+++ b/src/mcpg/config.py
@@ -328,12 +328,13 @@ def load_settings(env: Mapping[str, str] | None = None) -> Settings:
     # Secret *values* (API keys, bearer token, audit HMAC key) resolve
     # through the configured secrets backend; non-secret config still
     # comes straight from ``env``. A SecretsError is surfaced as a
-    # ConfigError so startup fails with one consistent error type.
+    # ConfigError so startup fails with one consistent error type. The
+    # builder returns the normalised backend name so we don't re-parse
+    # MCPG_SECRETS_BACKEND ourselves.
     try:
-        secrets = build_secrets_provider(env)
+        secrets, secrets_backend = build_secrets_provider(env)
     except SecretsError as exc:
         raise ConfigError(str(exc)) from exc
-    secrets_backend = (env.get("MCPG_SECRETS_BACKEND") or "env").strip().lower()
 
     database_url = env.get("MCPG_DATABASE_URL", "").strip()
     if not database_url:

--- a/src/mcpg/config.py
+++ b/src/mcpg/config.py
@@ -16,6 +16,7 @@ from os.path import isabs
 
 from mcpg._vendor.sql import obfuscate_password
 from mcpg.nl2sql import VENDOR_ENV_VAR_HINT
+from mcpg.secrets import SecretsError, build_secrets_provider
 
 # PG role names must be safe identifiers — we inline them into
 # ``SET ROLE "<name>"`` so anything outside ``[A-Za-z_][A-Za-z0-9_]*``
@@ -152,6 +153,10 @@ class Settings:
     shutdown_drain_seconds: int = 30
     audit_hmac_key: str | None = None
     audit_integrity: bool = False
+    # Which secrets backend resolved API keys / bearer token / HMAC key
+    # at startup: "env" (default) or "file". Recorded for observability;
+    # the actual values never appear here.
+    secrets_backend: str = "env"
 
     def __repr__(self) -> str:
         # Never let credentials reach logs or tracebacks.
@@ -206,7 +211,8 @@ class Settings:
             f"http_request_timeout_seconds={self.http_request_timeout_seconds}, "
             f"shutdown_drain_seconds={self.shutdown_drain_seconds}, "
             f"audit_hmac_key={audit_hmac_key_repr!r}, "
-            f"audit_integrity={self.audit_integrity})"
+            f"audit_integrity={self.audit_integrity}, "
+            f"secrets_backend={self.secrets_backend!r})"
         )
 
 
@@ -319,6 +325,16 @@ def load_settings(env: Mapping[str, str] | None = None) -> Settings:
     """
     env = environ if env is None else env
 
+    # Secret *values* (API keys, bearer token, audit HMAC key) resolve
+    # through the configured secrets backend; non-secret config still
+    # comes straight from ``env``. A SecretsError is surfaced as a
+    # ConfigError so startup fails with one consistent error type.
+    try:
+        secrets = build_secrets_provider(env)
+    except SecretsError as exc:
+        raise ConfigError(str(exc)) from exc
+    secrets_backend = (env.get("MCPG_SECRETS_BACKEND") or "env").strip().lower()
+
     database_url = env.get("MCPG_DATABASE_URL", "").strip()
     if not database_url:
         raise ConfigError("MCPG_DATABASE_URL is required")
@@ -396,7 +412,7 @@ def load_settings(env: Mapping[str, str] | None = None) -> Settings:
         raise ConfigError(f"MCPG_POOL_MAX_SIZE ({pool_max_size}) must be >= MCPG_POOL_MIN_SIZE ({pool_min_size})")
 
     http_auth_token: str | None = None
-    if (raw := env.get("MCPG_HTTP_AUTH_TOKEN")) is not None:
+    if (raw := secrets.get("MCPG_HTTP_AUTH_TOKEN")) is not None:
         stripped = raw.strip()
         if not stripped:
             raise ConfigError("MCPG_HTTP_AUTH_TOKEN must not be blank when set")
@@ -481,15 +497,15 @@ def load_settings(env: Mapping[str, str] | None = None) -> Settings:
     # provider at an explicit key via ``MCPG_NL2SQL_API_KEY`` —
     # which always wins over the vendor-conventional fallback.
     api_keys: dict[str, str] = {}
-    if anthropic_key := (env.get("ANTHROPIC_API_KEY") or "").strip():
+    if anthropic_key := (secrets.get("ANTHROPIC_API_KEY") or "").strip():
         api_keys["anthropic"] = anthropic_key
-    if openai_key := (env.get("OPENAI_API_KEY") or "").strip():
+    if openai_key := (secrets.get("OPENAI_API_KEY") or "").strip():
         api_keys["openai"] = openai_key
-    gemini_key = (env.get("GEMINI_API_KEY") or "").strip() or (env.get("GOOGLE_API_KEY") or "").strip()
+    gemini_key = (secrets.get("GEMINI_API_KEY") or "").strip() or (secrets.get("GOOGLE_API_KEY") or "").strip()
     if gemini_key:
         api_keys["gemini"] = gemini_key
 
-    if (raw := env.get("MCPG_NL2SQL_API_KEY")) is not None:
+    if (raw := secrets.get("MCPG_NL2SQL_API_KEY")) is not None:
         stripped = raw.strip()
         if not stripped:
             raise ConfigError("MCPG_NL2SQL_API_KEY must not be blank when set")
@@ -659,7 +675,7 @@ def load_settings(env: Mapping[str, str] | None = None) -> Settings:
         shutdown_drain_seconds = _parse_positive_int("MCPG_SHUTDOWN_DRAIN_SECONDS", raw)
 
     audit_hmac_key: str | None = None
-    if (raw := env.get("MCPG_AUDIT_HMAC_KEY")) is not None:
+    if (raw := secrets.get("MCPG_AUDIT_HMAC_KEY")) is not None:
         stripped = raw.strip()
         if not stripped:
             raise ConfigError("MCPG_AUDIT_HMAC_KEY must not be blank when set")
@@ -725,4 +741,5 @@ def load_settings(env: Mapping[str, str] | None = None) -> Settings:
         shutdown_drain_seconds=shutdown_drain_seconds,
         audit_hmac_key=audit_hmac_key,
         audit_integrity=audit_integrity,
+        secrets_backend=secrets_backend,
     )

--- a/src/mcpg/secrets.py
+++ b/src/mcpg/secrets.py
@@ -94,12 +94,24 @@ def _load_overlay(path: str) -> dict[str, str]:
         try:
             data = yaml.safe_load(raw_text)
         except yaml.YAMLError as exc:
-            raise SecretsError(f"MCPG_SECRETS_FILE_PATH ({path!r}) is not valid YAML: {exc}") from exc
+            # Deliberately surface only the file path + structural position
+            # (line/column when available) — the parser's full message can
+            # echo source text and would leak secret values into logs.
+            location = ""
+            problem_mark = getattr(exc, "problem_mark", None)
+            if problem_mark is not None:
+                location = f" at line {problem_mark.line + 1}, column {problem_mark.column + 1}"
+            raise SecretsError(f"MCPG_SECRETS_FILE_PATH ({path!r}) is not valid YAML{location}") from exc
     else:
         try:
             data = json.loads(raw_text)
         except json.JSONDecodeError as exc:
-            raise SecretsError(f"MCPG_SECRETS_FILE_PATH ({path!r}) is not valid JSON: {exc}") from exc
+            # Same as YAML above: include line/column only, never the
+            # exception message — JSONDecodeError.msg can include the
+            # offending character which may be inside a secret value.
+            raise SecretsError(
+                f"MCPG_SECRETS_FILE_PATH ({path!r}) is not valid JSON at line {exc.lineno}, column {exc.colno}"
+            ) from exc
 
     if not isinstance(data, dict):
         raise SecretsError(f"MCPG_SECRETS_FILE_PATH ({path!r}) must contain a top-level object of name -> value pairs")
@@ -120,11 +132,16 @@ def _load_overlay(path: str) -> dict[str, str]:
     return overlay
 
 
-def build_secrets_provider(env: Mapping[str, str]) -> SecretsProvider:
+def build_secrets_provider(env: Mapping[str, str]) -> tuple[SecretsProvider, str]:
     """Construct the secrets provider selected by ``MCPG_SECRETS_BACKEND``.
 
     Defaults to the ``env`` backend (current behaviour). ``file`` loads
     ``MCPG_SECRETS_FILE_PATH`` once at startup.
+
+    Returns:
+        ``(provider, backend_name)`` — the normalised, validated backend
+        name comes back alongside the provider so ``load_settings``
+        doesn't have to re-parse ``MCPG_SECRETS_BACKEND``.
 
     Raises:
         SecretsError: For an unknown backend, a missing file path, or an
@@ -138,6 +155,6 @@ def build_secrets_provider(env: Mapping[str, str]) -> SecretsProvider:
         path = (env.get("MCPG_SECRETS_FILE_PATH") or "").strip()
         if not path:
             raise SecretsError("MCPG_SECRETS_BACKEND=file requires MCPG_SECRETS_FILE_PATH")
-        return FileSecretsProvider(overlay=_load_overlay(path), env=env)
+        return FileSecretsProvider(overlay=_load_overlay(path), env=env), backend
 
-    return EnvSecretsProvider(env=env)
+    return EnvSecretsProvider(env=env), backend

--- a/src/mcpg/secrets.py
+++ b/src/mcpg/secrets.py
@@ -1,0 +1,143 @@
+"""Pluggable secrets backend.
+
+By default MCPg reads every secret straight from the process
+environment (``MCPG_SECRETS_BACKEND=env``) — the historical behaviour,
+zero new dependencies. Deployments that keep credentials in a mounted
+file can set ``MCPG_SECRETS_BACKEND=file`` + ``MCPG_SECRETS_FILE_PATH``
+to load a flat ``name -> value`` map of JSON (always) or YAML (when
+PyYAML is importable).
+
+A provider only supplies *secret values*; non-secret configuration
+still comes from the environment. The ``file`` provider overlays the
+file on top of the environment — a name present in the file wins, and
+anything absent falls back to the env var — so partial files and the
+vendor-conventional API-key env vars keep working.
+
+Cloud backends (Vault / AWS Secrets Manager / GCP Secret Manager) are
+designed for but not yet implemented; they will register here behind
+optional extras and be selected by the same ``MCPG_SECRETS_BACKEND``
+switch.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+_SUPPORTED_BACKENDS = frozenset({"env", "file"})
+
+
+class SecretsError(Exception):
+    """Raised when the secrets backend is misconfigured or unreadable."""
+
+
+@runtime_checkable
+class SecretsProvider(Protocol):
+    """Resolves a secret by name, returning the raw value or ``None``.
+
+    Callers keep their own stripping / blank-rejection — ``get`` simply
+    returns whatever the backend holds (or ``None`` when absent), so it
+    is a drop-in replacement for ``env.get(name)``.
+    """
+
+    def get(self, name: str) -> str | None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class EnvSecretsProvider:
+    """Reads secrets from a mapping (the process environment by default)."""
+
+    env: Mapping[str, str]
+
+    def get(self, name: str) -> str | None:
+        return self.env.get(name)
+
+
+@dataclass(frozen=True, slots=True)
+class FileSecretsProvider:
+    """Reads secrets from a file overlay, falling back to the environment.
+
+    ``overlay`` is the flat ``name -> value`` map loaded from the
+    configured file; a name present there wins, everything else defers
+    to ``env`` so non-secret config and unlisted vendor keys still work.
+    """
+
+    overlay: Mapping[str, str]
+    env: Mapping[str, str]
+
+    def get(self, name: str) -> str | None:
+        if name in self.overlay:
+            return self.overlay[name]
+        return self.env.get(name)
+
+
+def _load_overlay(path: str) -> dict[str, str]:
+    """Load + validate a flat ``name -> value`` secrets file (JSON / YAML)."""
+    try:
+        with open(path, encoding="utf-8") as handle:
+            raw_text = handle.read()
+    except OSError as exc:
+        raise SecretsError(f"could not read MCPG_SECRETS_FILE_PATH ({path!r}): {exc}") from exc
+
+    is_yaml = path.lower().endswith((".yaml", ".yml"))
+    data: object
+    if is_yaml:
+        try:
+            import yaml  # type: ignore[import-untyped]
+        except ImportError as exc:  # pragma: no cover - PyYAML is present in CI
+            raise SecretsError(
+                f"MCPG_SECRETS_FILE_PATH ({path!r}) is YAML but PyYAML is not installed; "
+                "install it (pip install pyyaml) or use a .json secrets file"
+            ) from exc
+        try:
+            data = yaml.safe_load(raw_text)
+        except yaml.YAMLError as exc:
+            raise SecretsError(f"MCPG_SECRETS_FILE_PATH ({path!r}) is not valid YAML: {exc}") from exc
+    else:
+        try:
+            data = json.loads(raw_text)
+        except json.JSONDecodeError as exc:
+            raise SecretsError(f"MCPG_SECRETS_FILE_PATH ({path!r}) is not valid JSON: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise SecretsError(f"MCPG_SECRETS_FILE_PATH ({path!r}) must contain a top-level object of name -> value pairs")
+
+    overlay: dict[str, str] = {}
+    for key, value in data.items():
+        if not isinstance(key, str):
+            raise SecretsError(f"MCPG_SECRETS_FILE_PATH ({path!r}) has a non-string key {key!r}")
+        if value is None:
+            continue
+        # Coerce scalars (a YAML int/bool, or a JSON number) to str so
+        # downstream code that expects string secrets is unaffected.
+        if isinstance(value, (dict, list)):
+            raise SecretsError(
+                f"MCPG_SECRETS_FILE_PATH ({path!r}) value for {key!r} must be a scalar, not {type(value).__name__}"
+            )
+        overlay[key] = value if isinstance(value, str) else str(value)
+    return overlay
+
+
+def build_secrets_provider(env: Mapping[str, str]) -> SecretsProvider:
+    """Construct the secrets provider selected by ``MCPG_SECRETS_BACKEND``.
+
+    Defaults to the ``env`` backend (current behaviour). ``file`` loads
+    ``MCPG_SECRETS_FILE_PATH`` once at startup.
+
+    Raises:
+        SecretsError: For an unknown backend, a missing file path, or an
+            unreadable / malformed secrets file.
+    """
+    backend = (env.get("MCPG_SECRETS_BACKEND") or "env").strip().lower()
+    if backend not in _SUPPORTED_BACKENDS:
+        raise SecretsError(f"MCPG_SECRETS_BACKEND must be one of {sorted(_SUPPORTED_BACKENDS)} (got {backend!r})")
+
+    if backend == "file":
+        path = (env.get("MCPG_SECRETS_FILE_PATH") or "").strip()
+        if not path:
+            raise SecretsError("MCPG_SECRETS_BACKEND=file requires MCPG_SECRETS_FILE_PATH")
+        return FileSecretsProvider(overlay=_load_overlay(path), env=env)
+
+    return EnvSecretsProvider(env=env)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -137,9 +137,11 @@ def test_pool_max_below_min_raises() -> None:
 
 
 def test_repr_does_not_leak_the_password() -> None:
-    settings = load_settings({"MCPG_DATABASE_URL": _DB_URL})
+    # Use a distinctive password — "secret" would collide with the
+    # legitimate ``secrets_backend`` repr field.
+    settings = load_settings({"MCPG_DATABASE_URL": "postgresql://user:hunter2pw@localhost:5432/app"})
     rendered = repr(settings)
-    assert "secret" not in rendered
+    assert "hunter2pw" not in rendered
     assert "****" in rendered
 
 

--- a/tests/unit/test_secrets.py
+++ b/tests/unit/test_secrets.py
@@ -1,0 +1,183 @@
+"""Tests for the pluggable secrets backend (mcpg.secrets) + its config wiring."""
+
+import json
+
+import pytest
+
+from mcpg.config import ConfigError, load_settings
+from mcpg.secrets import (
+    EnvSecretsProvider,
+    FileSecretsProvider,
+    SecretsError,
+    build_secrets_provider,
+)
+
+_DB_URL = "postgresql://user:secret@localhost:5432/app"
+
+
+# --- provider selection ----------------------------------------------------
+
+
+def test_default_backend_is_env() -> None:
+    provider = build_secrets_provider({"FOO": "bar"})
+    assert isinstance(provider, EnvSecretsProvider)
+    assert provider.get("FOO") == "bar"
+    assert provider.get("MISSING") is None
+
+
+def test_unknown_backend_raises() -> None:
+    with pytest.raises(SecretsError, match="MCPG_SECRETS_BACKEND"):
+        build_secrets_provider({"MCPG_SECRETS_BACKEND": "vault"})
+
+
+def test_file_backend_requires_a_path() -> None:
+    with pytest.raises(SecretsError, match="MCPG_SECRETS_FILE_PATH"):
+        build_secrets_provider({"MCPG_SECRETS_BACKEND": "file"})
+
+
+# --- file backend ----------------------------------------------------------
+
+
+def test_file_backend_loads_json_and_overlays_env(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    path = tmp_path / "secrets.json"
+    path.write_text(json.dumps({"ANTHROPIC_API_KEY": "from-file", "MCPG_AUDIT_HMAC_KEY": "hmac-from-file"}))
+
+    env = {
+        "MCPG_SECRETS_BACKEND": "file",
+        "MCPG_SECRETS_FILE_PATH": str(path),
+        # Present in env but overridden by the file:
+        "ANTHROPIC_API_KEY": "from-env",
+        # Not in the file — must fall through to env:
+        "OPENAI_API_KEY": "openai-from-env",
+    }
+    provider = build_secrets_provider(env)
+    assert isinstance(provider, FileSecretsProvider)
+    assert provider.get("ANTHROPIC_API_KEY") == "from-file"  # file wins
+    assert provider.get("MCPG_AUDIT_HMAC_KEY") == "hmac-from-file"
+    assert provider.get("OPENAI_API_KEY") == "openai-from-env"  # env fallback
+    assert provider.get("NOPE") is None
+
+
+def test_file_backend_coerces_scalar_values_to_str(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    path = tmp_path / "secrets.json"
+    path.write_text(json.dumps({"PORT_SECRET": 5432, "FLAG": True}))
+    provider = build_secrets_provider({"MCPG_SECRETS_BACKEND": "file", "MCPG_SECRETS_FILE_PATH": str(path)})
+    assert provider.get("PORT_SECRET") == "5432"
+    assert provider.get("FLAG") == "True"
+
+
+def test_file_backend_rejects_non_object_top_level(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    path = tmp_path / "secrets.json"
+    path.write_text(json.dumps(["not", "a", "map"]))
+    with pytest.raises(SecretsError, match="name -> value"):
+        build_secrets_provider({"MCPG_SECRETS_BACKEND": "file", "MCPG_SECRETS_FILE_PATH": str(path)})
+
+
+def test_file_backend_rejects_nested_values(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    path = tmp_path / "secrets.json"
+    path.write_text(json.dumps({"KEY": {"nested": "object"}}))
+    with pytest.raises(SecretsError, match="must be a scalar"):
+        build_secrets_provider({"MCPG_SECRETS_BACKEND": "file", "MCPG_SECRETS_FILE_PATH": str(path)})
+
+
+def test_file_backend_rejects_malformed_json(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    path = tmp_path / "secrets.json"
+    path.write_text("{not valid json")
+    with pytest.raises(SecretsError, match="not valid JSON"):
+        build_secrets_provider({"MCPG_SECRETS_BACKEND": "file", "MCPG_SECRETS_FILE_PATH": str(path)})
+
+
+def test_file_backend_missing_file_raises() -> None:
+    with pytest.raises(SecretsError, match="could not read"):
+        build_secrets_provider({"MCPG_SECRETS_BACKEND": "file", "MCPG_SECRETS_FILE_PATH": "/nonexistent/secrets.json"})
+
+
+def test_file_backend_loads_yaml_when_pyyaml_available(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    pytest.importorskip("yaml")
+    path = tmp_path / "secrets.yaml"
+    path.write_text("ANTHROPIC_API_KEY: sk-ant-yaml\nMCPG_HTTP_AUTH_TOKEN: tok-yaml\n")
+    provider = build_secrets_provider({"MCPG_SECRETS_BACKEND": "file", "MCPG_SECRETS_FILE_PATH": str(path)})
+    assert provider.get("ANTHROPIC_API_KEY") == "sk-ant-yaml"
+    assert provider.get("MCPG_HTTP_AUTH_TOKEN") == "tok-yaml"
+
+
+def test_file_backend_rejects_malformed_yaml(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    pytest.importorskip("yaml")
+    path = tmp_path / "secrets.yaml"
+    path.write_text("key: : : broken\n  bad indent")
+    with pytest.raises(SecretsError, match="not valid YAML"):
+        build_secrets_provider({"MCPG_SECRETS_BACKEND": "file", "MCPG_SECRETS_FILE_PATH": str(path)})
+
+
+def test_file_backend_rejects_non_string_key(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    pytest.importorskip("yaml")
+    # YAML permits non-string mapping keys (JSON does not).
+    path = tmp_path / "secrets.yaml"
+    path.write_text("1: oops\n")
+    with pytest.raises(SecretsError, match="non-string key"):
+        build_secrets_provider({"MCPG_SECRETS_BACKEND": "file", "MCPG_SECRETS_FILE_PATH": str(path)})
+
+
+def test_file_backend_skips_null_values(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    path = tmp_path / "secrets.json"
+    path.write_text(json.dumps({"PRESENT": "yes", "ABSENT": None}))
+    provider = build_secrets_provider({"MCPG_SECRETS_BACKEND": "file", "MCPG_SECRETS_FILE_PATH": str(path)})
+    assert provider.get("PRESENT") == "yes"
+    # A null value is skipped entirely, so lookup falls through to env (None here).
+    assert provider.get("ABSENT") is None
+
+
+# --- config integration ----------------------------------------------------
+
+
+def test_load_settings_defaults_to_env_backend() -> None:
+    settings = load_settings({"MCPG_DATABASE_URL": _DB_URL})
+    assert settings.secrets_backend == "env"
+
+
+def test_load_settings_resolves_secrets_from_a_file(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    path = tmp_path / "secrets.json"
+    path.write_text(
+        json.dumps(
+            {
+                "MCPG_HTTP_AUTH_TOKEN": "tok-from-file",
+                "ANTHROPIC_API_KEY": "sk-ant-from-file",
+                "MCPG_AUDIT_HMAC_KEY": "hmac-from-file",
+            }
+        )
+    )
+    settings = load_settings(
+        {
+            "MCPG_DATABASE_URL": _DB_URL,
+            "MCPG_SECRETS_BACKEND": "file",
+            "MCPG_SECRETS_FILE_PATH": str(path),
+            "MCPG_AUDIT_INTEGRITY": "true",
+        }
+    )
+
+    assert settings.secrets_backend == "file"
+    assert settings.http_auth_token == "tok-from-file"
+    assert dict(settings.nl2sql_api_keys)["anthropic"] == "sk-ant-from-file"
+    assert settings.audit_hmac_key == "hmac-from-file"
+    # The default provider is auto-picked from the file-supplied key.
+    assert settings.nl2sql_provider == "anthropic"
+
+
+def test_load_settings_surfaces_secrets_errors_as_config_errors() -> None:
+    with pytest.raises(ConfigError, match="MCPG_SECRETS_BACKEND"):
+        load_settings({"MCPG_DATABASE_URL": _DB_URL, "MCPG_SECRETS_BACKEND": "bogus"})
+
+
+def test_secrets_backend_does_not_leak_secret_values_in_repr(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    path = tmp_path / "secrets.json"
+    path.write_text(json.dumps({"MCPG_HTTP_AUTH_TOKEN": "super-secret-token"}))
+    settings = load_settings(
+        {
+            "MCPG_DATABASE_URL": _DB_URL,
+            "MCPG_SECRETS_BACKEND": "file",
+            "MCPG_SECRETS_FILE_PATH": str(path),
+        }
+    )
+    rendered = repr(settings)
+    assert "super-secret-token" not in rendered
+    assert "secrets_backend='file'" in rendered

--- a/tests/unit/test_secrets.py
+++ b/tests/unit/test_secrets.py
@@ -19,7 +19,7 @@ _DB_URL = "postgresql://user:secret@localhost:5432/app"
 
 
 def test_default_backend_is_env() -> None:
-    provider = build_secrets_provider({"FOO": "bar"})
+    provider, _backend = build_secrets_provider({"FOO": "bar"})
     assert isinstance(provider, EnvSecretsProvider)
     assert provider.get("FOO") == "bar"
     assert provider.get("MISSING") is None
@@ -50,7 +50,7 @@ def test_file_backend_loads_json_and_overlays_env(tmp_path) -> None:  # type: ig
         # Not in the file — must fall through to env:
         "OPENAI_API_KEY": "openai-from-env",
     }
-    provider = build_secrets_provider(env)
+    provider, _backend = build_secrets_provider(env)
     assert isinstance(provider, FileSecretsProvider)
     assert provider.get("ANTHROPIC_API_KEY") == "from-file"  # file wins
     assert provider.get("MCPG_AUDIT_HMAC_KEY") == "hmac-from-file"
@@ -61,7 +61,7 @@ def test_file_backend_loads_json_and_overlays_env(tmp_path) -> None:  # type: ig
 def test_file_backend_coerces_scalar_values_to_str(tmp_path) -> None:  # type: ignore[no-untyped-def]
     path = tmp_path / "secrets.json"
     path.write_text(json.dumps({"PORT_SECRET": 5432, "FLAG": True}))
-    provider = build_secrets_provider({"MCPG_SECRETS_BACKEND": "file", "MCPG_SECRETS_FILE_PATH": str(path)})
+    provider, _backend = build_secrets_provider({"MCPG_SECRETS_BACKEND": "file", "MCPG_SECRETS_FILE_PATH": str(path)})
     assert provider.get("PORT_SECRET") == "5432"
     assert provider.get("FLAG") == "True"
 
@@ -83,8 +83,36 @@ def test_file_backend_rejects_nested_values(tmp_path) -> None:  # type: ignore[n
 def test_file_backend_rejects_malformed_json(tmp_path) -> None:  # type: ignore[no-untyped-def]
     path = tmp_path / "secrets.json"
     path.write_text("{not valid json")
-    with pytest.raises(SecretsError, match="not valid JSON"):
+    with pytest.raises(SecretsError, match="not valid JSON") as excinfo:
         build_secrets_provider({"MCPG_SECRETS_BACKEND": "file", "MCPG_SECRETS_FILE_PATH": str(path)})
+    # The parse-error message must NOT echo source text — only the file
+    # path + line/column. (Sourcery security note on PR #41.)
+    assert "not valid json" not in str(excinfo.value)
+
+
+def test_file_backend_parse_error_does_not_leak_source_text(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    # A malformed JSON file whose error point lies inside what could be a
+    # secret value: a stock JSONDecodeError message would include the
+    # offending character. Our wrapper must keep it out of the message.
+    path = tmp_path / "secrets.json"
+    path.write_text('{"PASSWORD": "hunter2-with-stray-quote " extra"}')
+    with pytest.raises(SecretsError, match="not valid JSON") as excinfo:
+        build_secrets_provider({"MCPG_SECRETS_BACKEND": "file", "MCPG_SECRETS_FILE_PATH": str(path)})
+    message = str(excinfo.value)
+    assert "hunter2" not in message
+    assert "PASSWORD" not in message
+
+
+def test_file_backend_yaml_parse_error_does_not_leak_source_text(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    pytest.importorskip("yaml")
+    path = tmp_path / "secrets.yaml"
+    # Unbalanced quote inside what could be a secret value.
+    path.write_text('PASSWORD: "hunter2-unclosed\nOTHER: ok\n')
+    with pytest.raises(SecretsError, match="not valid YAML") as excinfo:
+        build_secrets_provider({"MCPG_SECRETS_BACKEND": "file", "MCPG_SECRETS_FILE_PATH": str(path)})
+    message = str(excinfo.value)
+    assert "hunter2" not in message
+    assert "PASSWORD" not in message
 
 
 def test_file_backend_missing_file_raises() -> None:
@@ -96,7 +124,7 @@ def test_file_backend_loads_yaml_when_pyyaml_available(tmp_path) -> None:  # typ
     pytest.importorskip("yaml")
     path = tmp_path / "secrets.yaml"
     path.write_text("ANTHROPIC_API_KEY: sk-ant-yaml\nMCPG_HTTP_AUTH_TOKEN: tok-yaml\n")
-    provider = build_secrets_provider({"MCPG_SECRETS_BACKEND": "file", "MCPG_SECRETS_FILE_PATH": str(path)})
+    provider, _backend = build_secrets_provider({"MCPG_SECRETS_BACKEND": "file", "MCPG_SECRETS_FILE_PATH": str(path)})
     assert provider.get("ANTHROPIC_API_KEY") == "sk-ant-yaml"
     assert provider.get("MCPG_HTTP_AUTH_TOKEN") == "tok-yaml"
 
@@ -121,7 +149,7 @@ def test_file_backend_rejects_non_string_key(tmp_path) -> None:  # type: ignore[
 def test_file_backend_skips_null_values(tmp_path) -> None:  # type: ignore[no-untyped-def]
     path = tmp_path / "secrets.json"
     path.write_text(json.dumps({"PRESENT": "yes", "ABSENT": None}))
-    provider = build_secrets_provider({"MCPG_SECRETS_BACKEND": "file", "MCPG_SECRETS_FILE_PATH": str(path)})
+    provider, _backend = build_secrets_provider({"MCPG_SECRETS_BACKEND": "file", "MCPG_SECRETS_FILE_PATH": str(path)})
     assert provider.get("PRESENT") == "yes"
     # A null value is skipped entirely, so lookup falls through to env (None here).
     assert provider.get("ABSENT") is None


### PR DESCRIPTION
## Why

**Item 3 of the 4-item feature plan**, first slice. The pluggable-secrets-backend item from `docs/security-hardening.md`. Credentials no longer have to come exclusively from the process environment.

Per our exchange, this PR ships the **core abstraction + `env`/`file` backends**; the cloud backends (Vault / AWS / GCP) follow in a later PR behind optional extras, using the same switch.

## What

### New module `mcpg.secrets`
- **`SecretsProvider`** protocol — `get(name) -> str | None`, a drop-in for `env.get(name)`.
- **`EnvSecretsProvider`** — the default; reads from the env mapping. Behaviour-preserving, zero new deps.
- **`FileSecretsProvider`** — overlays a flat `name → value` map from `MCPG_SECRETS_FILE_PATH` on top of the environment: **a name in the file wins; anything absent falls back to its env var**, so partial files and the vendor-conventional API-key env vars keep working. JSON always; YAML when PyYAML is importable (clear error otherwise).
- **`build_secrets_provider(env)`** selects via `MCPG_SECRETS_BACKEND` (`env` | `file`); `SecretsError` on misconfig.

### `config.py` wiring
- `load_settings` builds the provider once and routes the **secret** reads through it — the NL→SQL API keys (`ANTHROPIC`/`OPENAI`/`GEMINI`/`GOOGLE` + `MCPG_NL2SQL_API_KEY`), `MCPG_HTTP_AUTH_TOKEN`, and `MCPG_AUDIT_HMAC_KEY`. Non-secret config still reads straight from `env`. `SecretsError` → `ConfigError` so startup fails with one error type.
- New `Settings.secrets_backend` field (recorded for observability; values never appear in `repr`). The `env` backend is a **verified no-op** — the existing config tests pass unchanged.

Scope notes: cloud backends + routing the DSN through the provider are explicitly deferred.

## Test plan
- [x] **New `test_secrets.py`** — provider selection, file overlay + env fallback, scalar coercion, null-skip, non-string-key (YAML), malformed JSON/YAML, missing file, full `load_settings` integration, and repr non-leak.
- [x] `secrets.py` at **97%** (only the PyYAML-absent branch — marked `# pragma: no cover` — is unexercised, since PyYAML is present in CI).
- [x] Adjusted the existing repr-leak test to use a distinctive password (`"secret"` now collides with the legitimate `secrets_backend` field).
- [x] **1007 unit tests pass**; ruff / format / mypy(`src/mcpg`) / bandit clean.

## Docs (folded in)
- README: new **Secrets backend** env table.
- `security-hardening.md`: item marked 🟡 (env + file shipped, cloud remaining) + posture table updated.
- CHANGELOG entry.

## Remaining plan
After this: **item 4 — pgvector expansion** (`mmr_search`, `cluster_vectors`, `detect_vector_outliers`, `import_vectors`). The secrets cloud backends can also be a follow-up whenever you want them.

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Introduce a pluggable secrets backend with env-based defaults and optional file overlay, and route all secret configuration through it while recording the active backend in settings.

New Features:
- Add a pluggable secrets backend module with a SecretsProvider abstraction and env/file implementations for resolving secrets.
- Allow secrets to be loaded from a JSON or YAML file overlay selected via MCPG_SECRETS_BACKEND and MCPG_SECRETS_FILE_PATH, with environment fallback for missing entries.
- Record the active secrets backend on the Settings object for observability without exposing secret values.

Enhancements:
- Route API keys, HTTP auth token, and audit HMAC key reads in config through the selected secrets backend while preserving existing non-secret env-based configuration.
- Extend Settings.__repr__ to include the secrets backend field without leaking any secret values.

Documentation:
- Document the new secrets backend configuration in the README and security-hardening guide, including current env/file support and planned cloud backends.
- Add a changelog entry describing the pluggable secrets backend and its initial env/file implementations.

Tests:
- Add comprehensive unit tests for the secrets backend module and its integration with load_settings, including file overlay behavior, error handling, and repr non-leakage.