### PR TITLE
feat(pgvector): mmr_search — diversity-aware re-ranking (MMR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **`mmr_search` tool (pgvector).** Diversity-aware vector search:
+  fetches `fetch_k` nearest candidates by pgvector distance, then
+  re-ranks with Maximal Marginal Relevance to return `k` rows that
+  are relevant but not near-duplicates — better LLM context than raw
+  top-k. `lambda_mult` (0–1) trades relevance for diversity; both the
+  relevance and diversity terms are cosine similarities computed
+  in-process over candidate embeddings, so the result is independent
+  of the recall-pass `metric`. Each hit carries its `relevance`,
+  `mmr_score`, and selection `rank`. Read-only; `available=false`
+  without the pgvector extension.
+
 - **Pluggable secrets backend (`MCPG_SECRETS_BACKEND`).** A
   `SecretsProvider` abstraction (`mcpg.secrets`) that the secrets read
   in `load_settings` route through — the NL→SQL provider API

--- a/docs/feature-shortlist.md
+++ b/docs/feature-shortlist.md
@@ -100,7 +100,7 @@ awareness, and HNSW/IVFFlat detection in `list_indexes`:
 | # | Item | Effort | Value | Notes |
 |---|---|---|---|---|
 | 9.1 | HNSW recall/speed tuner (`analyze_hnsw_recall`) — sweep `ef_search` against a ground-truth set, return recall@k curves | M | High | Lets agents pick the right speed/quality knob without manual tuning. |
-| 9.2 | `mmr_search` — Maximal Marginal Relevance re-ranking on top of vector_search for result diversity | S-M | Medium-High | Quality of agentic RAG flows. |
+| 9.2 | ✅ **Shipped.** `mmr_search` — Maximal Marginal Relevance re-ranking on top of vector_search for result diversity. `lambda_mult` trades relevance for diversity; cosine over candidate embeddings, metric-independent. | S-M | Medium-High | Quality of agentic RAG flows. |
 | 9.3 | `cluster_vectors` — k-means cluster a vector column, return centroids + per-row labels | M | Medium-High | Exploration / segmentation tool. |
 | 9.4 | `detect_vector_outliers` — flag rows whose embedding is far from any cluster centroid | S-M | Medium-High | Data quality + content moderation. |
 | 9.5 | `monitor_embedding_drift` — compare distributional stats of vectors over time windows | M | Medium | Ops / model-quality monitoring. |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -29,7 +29,7 @@ plumbing:
 | `MCPG_REPLICA_URLS` | Comma-separated read-replica DSNs. When set, `force_readonly` queries round-robin across healthy replicas; writes always go to the primary. |
 | `MCPG_NL2SQL_PROVIDER` / `MCPG_NL2SQL_API_KEY` / `MCPG_NL2SQL_MODEL` / `MCPG_NL2SQL_BASE_URL` / `MCPG_NL2SQL_MAX_TOKENS` | `translate_nl_to_sql` provider config (Anthropic / OpenAI / Gemini). |
 
-## Tool index (121 tools)
+## Tool index (122 tools)
 
 | Category | Tools |
 |---|---|

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -5,7 +5,7 @@ A compact one-page tour of every tool MCPg exposes, organised by
 surface; the full reference is in [`tools.md`](tools.md), and
 task-oriented recipes live in [`cookbook.md`](cookbook.md).
 
-**121 tools** as of trunk. Each line shows the tool name + how its
+**122 tools** as of trunk. Each line shows the tool name + how its
 parameters land (required first, common defaults after). Capability
 gates are noted in section titles where they apply.
 
@@ -124,6 +124,8 @@ fuzzy_search(schema, table, column, query)                                # pg_t
 full_text_search(schema, table, column, query)                            # tsvector / tsquery, web-search syntax
 vector_search(schema, table, column, query_vector, k=10, operator="<->")  # pgvector k-NN
 vector_range_search(schema, table, column, query_vector, max_distance)    # pgvector threshold
+mmr_search(schema, table, column, query_vector, k=10, fetch_k=null, lambda_mult=0.5)
+                                                                          # diversity re-rank (Maximal Marginal Relevance)
 hybrid_search(schema, table, vector_col, text_col, query_vector, text_query)
                                                                           # vector + FTS fused via RRF
 geo_search(schema, table, column, lon, lat, k=10)                         # PostGIS k-NN

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -35,7 +35,7 @@ first time, skim it as a reference after.
 ## What MCPg is
 
 MCPg is an MCP server that exposes a PostgreSQL database to an AI
-agent through a fixed, audited set of **121 tools**. The agent never
+agent through a fixed, audited set of **122 tools**. The agent never
 gets a raw database connection — it can only call the tools MCPg
 registers, every call is validated, and every call is logged. MCPg
 runs as a single async process and ships as both a PyPI package

--- a/src/mcpg/textsearch.py
+++ b/src/mcpg/textsearch.py
@@ -93,6 +93,34 @@ class VectorSearchResult:
 
 
 @dataclass(frozen=True, slots=True)
+class MmrMatch:
+    """One MMR-reranked hit.
+
+    ``relevance`` is the cosine similarity to the query (higher = closer).
+    ``mmr_score`` is the Maximal Marginal Relevance score at the moment
+    the row was selected — ``λ·relevance - (1-λ)·max_sim_to_selected``.
+    ``rank`` is the 0-based selection order.
+    """
+
+    row: dict[str, Any]
+    relevance: float
+    mmr_score: float
+    rank: int
+
+
+@dataclass(frozen=True, slots=True)
+class MmrSearchResult:
+    """The outcome of an MMR search.
+
+    ``available`` is false when the ``vector`` (pgvector) extension is not
+    installed.
+    """
+
+    available: bool
+    matches: list[MmrMatch]
+
+
+@dataclass(frozen=True, slots=True)
 class GeoMatch:
     """One geo-search hit: the row (minus the geometry column) and distance."""
 
@@ -309,6 +337,137 @@ async def vector_range_search(
         cells.pop(column, None)
         matches.append(VectorMatch(distance=distance, row=cells))
     return VectorSearchResult(available=True, matches=matches)
+
+
+# --- MMR re-ranking (pgvector) -------------------------------------------
+
+
+DEFAULT_MMR_LAMBDA = 0.5
+
+
+def _parse_embedding(value: Any) -> list[float]:
+    """Coerce a pgvector cell into a list of floats.
+
+    pgvector hands its column back either as a Python sequence (when the
+    psycopg adapter is registered) or as a bracketed text literal like
+    ``"[0.1,0.2,0.3]"`` otherwise — accept both.
+    """
+    if isinstance(value, (list, tuple)):
+        return [float(v) for v in value]
+    if isinstance(value, str):
+        inner = value.strip().lstrip("[").rstrip("]").strip()
+        if not inner:
+            return []
+        return [float(part) for part in inner.split(",")]
+    raise SearchError(f"could not parse embedding value of type {type(value).__name__}")
+
+
+def _cosine_similarity(a: list[float], b: list[float]) -> float:
+    """Cosine similarity of two equal-length vectors; 0.0 if either is zero."""
+    dot = 0.0
+    norm_a = 0.0
+    norm_b = 0.0
+    for x, y in zip(a, b, strict=False):
+        dot += x * y
+        norm_a += x * x
+        norm_b += y * y
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 0.0
+    return dot / math.sqrt(norm_a * norm_b)
+
+
+async def mmr_search(
+    driver: SqlDriver,
+    schema: str,
+    table: str,
+    column: str,
+    query_vector: list[float],
+    *,
+    k: int = DEFAULT_LIMIT,
+    fetch_k: int | None = None,
+    lambda_mult: float = DEFAULT_MMR_LAMBDA,
+    metric: str = DEFAULT_VECTOR_METRIC,
+) -> MmrSearchResult:
+    """Re-rank a vector search for diversity via Maximal Marginal Relevance.
+
+    Plain k-NN tends to return near-duplicates; MMR trades a little
+    relevance for variety, which usually improves the context an agent
+    feeds to an LLM. The algorithm fetches ``fetch_k`` nearest candidates
+    by ``metric`` (the recall pass), then greedily picks ``k`` of them
+    maximising ``λ·sim(query, doc) - (1-λ)·max sim(doc, picked)``.
+    ``lambda_mult=1`` is pure relevance (≈ vector_search); ``0`` is pure
+    diversity. Relevance and the diversity penalty are both cosine
+    similarities computed in-process over the candidate embeddings, so
+    the result is independent of which ``metric`` drove the recall pass.
+
+    Args:
+        k: How many rows to return.
+        fetch_k: Candidate pool size for the recall pass; defaults to
+            ``max(4·k, 20)``. Larger gives MMR more to choose from at the
+            cost of a wider initial scan.
+        lambda_mult: Relevance/diversity trade-off in ``[0, 1]``.
+        metric: ``l2``, ``cosine``, or ``inner_product`` for the recall pass.
+
+    Raises:
+        SearchError: On an invalid identifier / metric, a non-finite query
+            value, or out-of-range ``k`` / ``fetch_k`` / ``lambda_mult``.
+    """
+    if not await extension_installed(driver, "vector"):
+        return MmrSearchResult(available=False, matches=[])
+    if metric not in _VECTOR_METRICS:
+        raise SearchError(f"unknown vector metric: {metric!r}")
+    if not all(math.isfinite(value) for value in query_vector):
+        raise SearchError("query_vector must contain only finite numbers")
+    if k < 1:
+        raise SearchError("k must be at least 1")
+    if not 0.0 <= lambda_mult <= 1.0:
+        raise SearchError("lambda_mult must be between 0 and 1")
+    pool = fetch_k if fetch_k is not None else max(4 * k, 20)
+    if pool < k:
+        raise SearchError("fetch_k must be >= k")
+
+    operator = _VECTOR_METRICS[metric]
+    relation = f"{_quoted(schema, 'schema')}.{_quoted(table, 'table')}"
+    col = _quoted(column, "column")
+    literal = "[" + ",".join(str(float(value)) for value in query_vector) + "]"
+    # Keep the embedding column this time — MMR needs candidate vectors to
+    # measure their similarity to one another.
+    rows = await driver.execute_query(
+        f"SELECT *, {col} {operator} %s::vector AS mcpg_distance "
+        f"FROM {relation} ORDER BY {col} {operator} %s::vector LIMIT %s",
+        params=[literal, literal, pool],
+        force_readonly=True,
+    )
+
+    candidates: list[tuple[dict[str, Any], list[float], float]] = []
+    for row in rows or []:
+        cells = dict(row.cells)
+        cells.pop("mcpg_distance", None)
+        embedding = _parse_embedding(cells.get(column))
+        cells.pop(column, None)  # drop the embedding from the returned row
+        relevance = _cosine_similarity(query_vector, embedding)
+        candidates.append((cells, embedding, relevance))
+
+    matches: list[MmrMatch] = []
+    selected: list[list[float]] = []
+    remaining = list(range(len(candidates)))
+    target = min(k, len(candidates))
+    while len(matches) < target:
+        best_idx = -1
+        best_score = -math.inf
+        for idx in remaining:
+            _, embedding, relevance = candidates[idx]
+            diversity = max((_cosine_similarity(embedding, s) for s in selected), default=0.0)
+            score = lambda_mult * relevance - (1.0 - lambda_mult) * diversity
+            if score > best_score:
+                best_score = score
+                best_idx = idx
+        cells, embedding, relevance = candidates[best_idx]
+        matches.append(MmrMatch(row=cells, relevance=relevance, mmr_score=best_score, rank=len(matches)))
+        selected.append(embedding)
+        remaining.remove(best_idx)
+
+    return MmrSearchResult(available=True, matches=matches)
 
 
 # --- hybrid search (Phase 11.1) ------------------------------------------

--- a/src/mcpg/textsearch.py
+++ b/src/mcpg/textsearch.py
@@ -363,11 +363,17 @@ def _parse_embedding(value: Any) -> list[float]:
 
 
 def _cosine_similarity(a: list[float], b: list[float]) -> float:
-    """Cosine similarity of two equal-length vectors; 0.0 if either is zero."""
+    """Cosine similarity of two equal-length vectors; 0.0 if either is zero.
+
+    ``zip(..., strict=True)`` is a defence-in-depth check: callers are
+    expected to enforce equal dimensions before calling (mmr_search
+    does); a length mismatch here means an internal invariant broke and
+    should fail loudly rather than silently truncating.
+    """
     dot = 0.0
     norm_a = 0.0
     norm_b = 0.0
-    for x, y in zip(a, b, strict=False):
+    for x, y in zip(a, b, strict=True):
         dot += x * y
         norm_a += x * x
         norm_b += y * y
@@ -440,11 +446,24 @@ async def mmr_search(
     )
 
     candidates: list[tuple[dict[str, Any], list[float], float]] = []
+    expected_dim = len(query_vector)
     for row in rows or []:
         cells = dict(row.cells)
         cells.pop("mcpg_distance", None)
-        embedding = _parse_embedding(cells.get(column))
+        raw_embedding = cells.get(column)
         cells.pop(column, None)  # drop the embedding from the returned row
+        # Rows whose embedding is NULL (the column wasn't populated yet)
+        # are silently skipped — failing the whole search because one row
+        # is missing an embedding would be hostile to data-quality issues
+        # the caller is probably already aware of.
+        if raw_embedding is None:
+            continue
+        embedding = _parse_embedding(raw_embedding)
+        if len(embedding) != expected_dim:
+            raise SearchError(
+                f"row's {column!r} embedding has dimension {len(embedding)}, "
+                f"expected {expected_dim} (matches query_vector length)"
+            )
         relevance = _cosine_similarity(query_vector, embedding)
         candidates.append((cells, embedding, relevance))
 

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -1843,6 +1843,46 @@ def _register_health(server: FastMCP[AppContext]) -> None:
         return asdict(result)
 
     @server.tool(
+        name="mmr_search",
+        description=(
+            "Diversity-aware vector search: fetch `fetch_k` nearest "
+            "candidates by pgvector distance, then re-rank with Maximal "
+            "Marginal Relevance to return `k` rows that are relevant but "
+            "not near-duplicates — better LLM context than raw top-k. "
+            "`lambda_mult` in [0,1] trades relevance (1.0) for diversity "
+            "(0.0); default 0.5. Relevance + diversity are cosine "
+            "similarities computed over candidate embeddings, so the "
+            "result is independent of the recall-pass `metric`. Each hit "
+            "carries its relevance, mmr_score, and selection rank. "
+            "Reports available=false if the pgvector extension is not "
+            "installed."
+        ),
+    )
+    async def mmr_search(
+        ctx: _Ctx,
+        schema: str,
+        table: str,
+        column: str,
+        query_vector: list[float],
+        k: int = textsearch.DEFAULT_LIMIT,
+        fetch_k: int | None = None,
+        lambda_mult: float = textsearch.DEFAULT_MMR_LAMBDA,
+        metric: str = textsearch.DEFAULT_VECTOR_METRIC,
+    ) -> dict[str, Any]:
+        result = await textsearch.mmr_search(
+            _driver(ctx),
+            schema,
+            table,
+            column,
+            query_vector,
+            k=k,
+            fetch_k=fetch_k,
+            lambda_mult=lambda_mult,
+            metric=metric,
+        )
+        return asdict(result)
+
+    @server.tool(
         name="hybrid_search",
         description=(
             "Combine vector and full-text ranking via reciprocal-rank fusion "

--- a/tests/unit/test_textsearch.py
+++ b/tests/unit/test_textsearch.py
@@ -296,6 +296,36 @@ async def test_mmr_search_parses_bracketed_text_embeddings() -> None:
     assert [m.row["id"] for m in result.matches] == [1, 2]
 
 
+async def test_mmr_search_skips_rows_with_null_embeddings() -> None:
+    # A NULL in the embedding column must not crash the whole search;
+    # the row is dropped and the rest are reranked normally.
+    routes = {
+        "pg_extension": [{"present": 1}],
+        "::vector": [
+            {"id": 1, "embedding": [1.0, 0.0], "mcpg_distance": 0.0},
+            {"id": 2, "embedding": None, "mcpg_distance": 0.5},
+            {"id": 3, "embedding": [0.0, 1.0], "mcpg_distance": 1.0},
+        ],
+    }
+    result = await mmr_search(FakeRoutingDriver(routes), "app", "docs", "embedding", [1.0, 0.0], k=3)  # type: ignore[arg-type]
+
+    assert [m.row["id"] for m in result.matches] == [1, 3]
+
+
+async def test_mmr_search_raises_when_an_embedding_dim_does_not_match_query() -> None:
+    # A 3-dim row when the query is 2-dim is almost always a schema bug;
+    # surface it clearly instead of silently scoring it via truncation.
+    routes = {
+        "pg_extension": [{"present": 1}],
+        "::vector": [
+            {"id": 1, "embedding": [1.0, 0.0], "mcpg_distance": 0.0},
+            {"id": 2, "embedding": [0.1, 0.2, 0.3], "mcpg_distance": 0.5},
+        ],
+    }
+    with pytest.raises(SearchError, match="dimension 3, expected 2"):
+        await mmr_search(FakeRoutingDriver(routes), "app", "docs", "embedding", [1.0, 0.0], k=2)  # type: ignore[arg-type]
+
+
 async def test_mmr_search_fetch_k_defaults_to_a_wider_pool() -> None:
     driver = FakeRoutingDriver(_mmr_candidates())
 
@@ -369,6 +399,15 @@ def test_cosine_similarity_is_zero_for_a_zero_vector() -> None:
 
     assert _cosine_similarity([0.0, 0.0], [1.0, 1.0]) == 0.0
     assert _cosine_similarity([1.0, 0.0], [1.0, 0.0]) == pytest.approx(1.0)
+
+
+def test_cosine_similarity_raises_on_dim_mismatch() -> None:
+    # strict=True guards against silently truncating one vector. Callers
+    # are expected to validate dimensions first; this is defence in depth.
+    from mcpg.textsearch import _cosine_similarity
+
+    with pytest.raises(ValueError):
+        _cosine_similarity([1.0, 0.0], [1.0, 0.0, 0.0])
 
 
 # --- geo search ------------------------------------------------------------

--- a/tests/unit/test_textsearch.py
+++ b/tests/unit/test_textsearch.py
@@ -12,6 +12,7 @@ from mcpg.textsearch import (
     GeoMatch,
     HybridMatch,
     HybridSearchResult,
+    MmrSearchResult,
     QuantizationRecommendation,
     SearchError,
     VectorMatch,
@@ -22,6 +23,7 @@ from mcpg.textsearch import (
     fuzzy_search,
     geo_search,
     hybrid_search,
+    mmr_search,
     recommend_vector_quantization,
     vector_range_search,
     vector_search,
@@ -224,6 +226,149 @@ async def test_vector_search_tool_is_callable_from_a_client() -> None:
     assert result.isError is False
     assert result.structuredContent is not None
     assert result.structuredContent["available"] is False
+
+
+# --- MMR search ------------------------------------------------------------
+
+
+def _mmr_candidates() -> dict[str, list[dict[str, object]]]:
+    # query is [1,0]; A is identical, B is near-duplicate of A, C is diverse.
+    return {
+        "pg_extension": [{"present": 1}],
+        "::vector": [
+            {"id": 1, "embedding": [1.0, 0.0], "mcpg_distance": 0.0},
+            {"id": 2, "embedding": [0.99, 0.141], "mcpg_distance": 0.01},
+            {"id": 3, "embedding": [0.0, 1.0], "mcpg_distance": 1.0},
+        ],
+    }
+
+
+async def test_mmr_search_reports_unavailable_without_pgvector() -> None:
+    driver = FakeRoutingDriver({"pg_extension": []})
+
+    result = await mmr_search(driver, "app", "docs", "embedding", [1.0, 0.0])  # type: ignore[arg-type]
+
+    assert result == MmrSearchResult(available=False, matches=[])
+
+
+async def test_mmr_search_pure_relevance_keeps_the_near_duplicate() -> None:
+    # lambda=1 ignores diversity -> top-2 by relevance: A then B.
+    driver = FakeRoutingDriver(_mmr_candidates())
+
+    result = await mmr_search(driver, "app", "docs", "embedding", [1.0, 0.0], k=2, lambda_mult=1.0)  # type: ignore[arg-type]
+
+    assert result.available is True
+    assert [m.row["id"] for m in result.matches] == [1, 2]
+    assert [m.rank for m in result.matches] == [0, 1]
+
+
+async def test_mmr_search_pure_diversity_swaps_in_the_distinct_row() -> None:
+    # lambda=0 maximises diversity -> A first, then C (not the near-dup B).
+    driver = FakeRoutingDriver(_mmr_candidates())
+
+    result = await mmr_search(driver, "app", "docs", "embedding", [1.0, 0.0], k=2, lambda_mult=0.0)  # type: ignore[arg-type]
+
+    assert [m.row["id"] for m in result.matches] == [1, 3]
+
+
+async def test_mmr_search_drops_the_embedding_column_from_rows() -> None:
+    driver = FakeRoutingDriver(_mmr_candidates())
+
+    result = await mmr_search(driver, "app", "docs", "embedding", [1.0, 0.0], k=1)  # type: ignore[arg-type]
+
+    assert "embedding" not in result.matches[0].row
+    assert result.matches[0].row == {"id": 1}
+    # First pick's relevance is cosine to an identical vector -> 1.0.
+    assert result.matches[0].relevance == pytest.approx(1.0)
+
+
+async def test_mmr_search_parses_bracketed_text_embeddings() -> None:
+    # pgvector hands the column back as "[..]" text when no adapter is registered.
+    routes = {
+        "pg_extension": [{"present": 1}],
+        "::vector": [
+            {"id": 1, "embedding": "[1.0,0.0]", "mcpg_distance": 0.0},
+            {"id": 2, "embedding": "[0.0,1.0]", "mcpg_distance": 1.0},
+        ],
+    }
+    result = await mmr_search(FakeRoutingDriver(routes), "app", "docs", "embedding", [1.0, 0.0], k=2)  # type: ignore[arg-type]
+
+    assert [m.row["id"] for m in result.matches] == [1, 2]
+
+
+async def test_mmr_search_fetch_k_defaults_to_a_wider_pool() -> None:
+    driver = FakeRoutingDriver(_mmr_candidates())
+
+    await mmr_search(driver, "app", "docs", "embedding", [1.0, 0.0], k=3)  # type: ignore[arg-type]
+
+    search_call = next(call for call in driver.calls if "::vector" in call[0])
+    # default fetch_k = max(4*k, 20) = 20 for k=3; bound as the LIMIT param.
+    assert search_call[1][-1] == 20
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"metric": "manhattan"}, "metric"),
+        ({"k": 0}, "k must be"),
+        ({"lambda_mult": 1.5}, "lambda_mult"),
+        ({"k": 5, "fetch_k": 2}, "fetch_k"),
+    ],
+)
+async def test_mmr_search_validates_arguments(kwargs: dict[str, object], match: str) -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(SearchError, match=match):
+        await mmr_search(driver, "app", "docs", "embedding", [1.0, 0.0], **kwargs)  # type: ignore[arg-type]
+
+
+async def test_mmr_search_rejects_non_finite_query_vector() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(SearchError, match="finite"):
+        await mmr_search(driver, "app", "docs", "embedding", [1.0, float("inf")])  # type: ignore[arg-type]
+
+
+async def test_mmr_search_tool_is_callable_from_a_client() -> None:
+    database = FakeDatabase(FakeRoutingDriver(_mmr_candidates()))
+    server = create_server(_SETTINGS, database=database)  # type: ignore[arg-type]
+
+    async with create_connected_server_and_client_session(server) as client:
+        listed = {tool.name for tool in (await client.list_tools()).tools}
+        assert "mmr_search" in listed
+        result = await client.call_tool(
+            "mmr_search",
+            {"schema": "app", "table": "docs", "column": "embedding", "query_vector": [1.0, 0.0], "k": 2},
+        )
+
+    assert result.isError is False
+    assert result.structuredContent is not None
+    assert result.structuredContent["available"] is True
+    assert len(result.structuredContent["matches"]) == 2
+
+
+def test_parse_embedding_handles_sequences_strings_and_empties() -> None:
+    from mcpg.textsearch import _parse_embedding
+
+    assert _parse_embedding([1, 2, 3]) == [1.0, 2.0, 3.0]
+    assert _parse_embedding((0.5, 1.5)) == [0.5, 1.5]
+    assert _parse_embedding("[1.0, 2.0]") == [1.0, 2.0]
+    assert _parse_embedding("[]") == []
+    assert _parse_embedding("   ") == []
+
+
+def test_parse_embedding_rejects_unparseable_types() -> None:
+    from mcpg.textsearch import _parse_embedding
+
+    with pytest.raises(SearchError, match="could not parse embedding"):
+        _parse_embedding(object())
+
+
+def test_cosine_similarity_is_zero_for_a_zero_vector() -> None:
+    from mcpg.textsearch import _cosine_similarity
+
+    assert _cosine_similarity([0.0, 0.0], [1.0, 1.0]) == 0.0
+    assert _cosine_similarity([1.0, 0.0], [1.0, 0.0]) == pytest.approx(1.0)
 
 
 # --- geo search ------------------------------------------------------------


### PR DESCRIPTION
## Why

**Item 4 of the feature plan, first slice** (shortlist **9.2**), following the agreed one-tool-per-PR cadence for the pgvector expansion.

## What

**`mmr_search`** — diversity-aware vector search. Plain k-NN tends to return near-duplicates; MMR trades a little relevance for variety, which usually improves the context an agent feeds to an LLM.

The algorithm fetches `fetch_k` nearest candidates by pgvector distance (the recall pass), then greedily picks `k` maximising:

```
lambda·sim(query, doc) - (1-lambda)·max sim(doc, already_picked)
```

- `lambda_mult=1` → pure relevance (≈ `vector_search`); `0` → pure diversity; default `0.5`.
- Relevance **and** the diversity penalty are both cosine similarities computed **in-process over the candidate embeddings**, so the ranking is independent of which `metric` drove the recall pass.
- `fetch_k` defaults to `max(4·k, 20)`.
- Each hit carries `relevance`, `mmr_score`, and selection `rank`. Read-only; `available=false` without pgvector.

Implementation: new `MmrMatch` / `MmrSearchResult` dataclasses + `mmr_search()` in `mcpg.textsearch`, two small pure helpers (`_parse_embedding` — accepts pgvector's list form *or* its `"[..]"` text literal; `_cosine_similarity` — zero-vector safe), and the tool registration in `tools.py`.

## Test plan
- [x] **+15 tests** in `test_textsearch.py`: unavailable-without-pgvector; **pure-relevance keeps the near-duplicate**; **pure-diversity swaps in the distinct row** (the core MMR behaviour, asserted on a hand-built query/A/B/C set); embedding column dropped from result rows; bracketed-text embedding parsing; default `fetch_k` pool sizing; argument validation (`metric` / `k` / `lambda_mult` / `fetch_k>=k` / non-finite); tool callable from a client; plus direct coverage of both helpers.
- [x] **1024 unit tests pass**; ruff / format / mypy(`src/mcpg`) / bandit clean.

## Docs (folded in)
- `tour.md` Search section; `feature-shortlist.md` 9.2 → ✅; CHANGELOG.
- Tool count **121 → 122** across `tour` / `user-guide` / `tools`.

## Remaining pgvector slices
`import_vectors` (9.6, next), then `detect_vector_outliers` (9.4) + `cluster_vectors` (9.3), as separate focused PRs.

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Add a diversity-aware pgvector MMR search tool and expose it via the MCPg tool interface.

New Features:
- Introduce MmrMatch and MmrSearchResult result types for Maximal Marginal Relevance vector searches.
- Add an mmr_search function that re-ranks pgvector k-NN results for diversity using a lambda-controlled relevance/diversity trade-off and returns per-hit relevance, MMR score, and rank.
- Expose mmr_search as a new MCPg server tool, returning structured results and reporting availability based on the pgvector extension.

Documentation:
- Document the new mmr_search tool in the changelog, tool tour, and tools reference, and update the advertised tool count to 122.
- Mark the mmr_search feature as shipped in the feature shortlist, noting its relevance/diversity trade-off and metric-independent behaviour.

Tests:
- Add unit tests covering MMR behaviour across relevance-only and diversity-only settings, result shaping, default fetch_k sizing, argument validation, and non-finite query vectors.
- Add tests for the embedding parsing and cosine similarity helpers, including multiple input formats and zero-vector handling.
- Add an integration-style test ensuring the mmr_search tool is discoverable and callable from a client session.