### PR TITLE
Implement walk_blocking_chains deadlock-cycle walker (D4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **`walk_blocking_chains` tool (deadlock cycle walker).** Walks and reconstructs
+  the active lock-wait graph of the database using `pg_blocking_pids`. Identifies
+  all simple deadlock cycles, linear blocking paths leading to root blockers or
+  cycles, list of root blocker PIDs, and renders a styling-annotated Mermaid
+  flowchart representing the lock dependency graph. Read-only.
+
 - **`generate_schema_docs` tool (schema documentation).** Generates a
   comprehensive Markdown catalog reference for a database schema's
   tables, views, foreign tables, custom enums, constraints, indexes,

--- a/docs/feature-shortlist.md
+++ b/docs/feature-shortlist.md
@@ -35,7 +35,7 @@ Effort scale (rough, single-session yardstick):
 | 2.1 | Logical replication management writes (`create_publication`, `drop_publication`, `create_subscription`, `drop_subscription`) | M | Medium-High | Read tools already exist. Closes the loop on logical-replication ops; gated under `MCPG_ALLOW_DDL`. |
 | 2.2 | `pg_buffercache` integration (cache hit analysis at the buffer level) | S | Low-Medium | Niche. |
 | 2.3 | WAL inspection (`pg_walinspect`) | S | Low | Niche but useful for replication debugging. |
-| 2.4 | Deeper `pg_locks` walker — deadlock-cycle reconstruction beyond the current `find_blocking_chains` pair list | S-M | Medium | Live-ops complement. |
+| 2.4 | ✅ **Shipped.** Deeper `pg_locks` walker — deadlock-cycle reconstruction beyond the current `find_blocking_chains` pair list | S-M | Medium | Live-ops complement. |
 
 ## 3. Developer experience
 

--- a/docs/parallel-roadmap.md
+++ b/docs/parallel-roadmap.md
@@ -108,7 +108,7 @@ them** (or coordinate) to avoid colliding on `build_http_app`.
 | D1 | Logical replication writes (2.1) | new `replication.py` | M | `create/drop_publication`, `create/drop_subscription`; DDL-gated. |
 | D2 | `pg_buffercache` integration (2.2) | extends `io_stats.py` | S | Buffer-level cache analysis (needs the extension). |
 | D3 | WAL inspection `pg_walinspect` (2.3) | new small module | S | Niche; replication debugging. |
-| D4 | Deadlock-cycle walker (2.4) | extends `locks.py` | S-M | Reconstruct cycles beyond `find_blocking_chains` pairs. |
+| D4 (✅) | Deadlock-cycle walker (2.4) | extends `locks.py` | S-M | Reconstruct cycles beyond `find_blocking_chains` pairs. |
 
 All four are independent.
 

--- a/docs/parallel-roadmap.md
+++ b/docs/parallel-roadmap.md
@@ -108,7 +108,7 @@ them** (or coordinate) to avoid colliding on `build_http_app`.
 | D1 | Logical replication writes (2.1) | new `replication.py` | M | `create/drop_publication`, `create/drop_subscription`; DDL-gated. |
 | D2 | `pg_buffercache` integration (2.2) | extends `io_stats.py` | S | Buffer-level cache analysis (needs the extension). |
 | D3 | WAL inspection `pg_walinspect` (2.3) | new small module | S | Niche; replication debugging. |
-| D4 (✅) | Deadlock-cycle walker (2.4) | extends `locks.py` | S-M | Reconstruct cycles beyond `find_blocking_chains` pairs. |
+| D4 (✅ PR #45) | Deadlock-cycle walker (2.4) | extends `locks.py` | S-M | Reconstruct cycles beyond `find_blocking_chains` pairs. |
 
 All four are independent.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -29,7 +29,7 @@ plumbing:
 | `MCPG_REPLICA_URLS` | Comma-separated read-replica DSNs. When set, `force_readonly` queries round-robin across healthy replicas; writes always go to the primary. |
 | `MCPG_NL2SQL_PROVIDER` / `MCPG_NL2SQL_API_KEY` / `MCPG_NL2SQL_MODEL` / `MCPG_NL2SQL_BASE_URL` / `MCPG_NL2SQL_MAX_TOKENS` | `translate_nl_to_sql` provider config (Anthropic / OpenAI / Gemini). |
 
-## Tool index (123 tools)
+## Tool index (124 tools)
 
 | Category | Tools |
 |---|---|
@@ -38,7 +38,7 @@ plumbing:
 | **Visualisation & structural diff** | `generate_schema_diagram`, `generate_schema_docs`, `generate_fk_cascade_graph`, `generate_graph_diagram`, `compare_schemas` |
 | **Query intelligence** | `run_select`, `run_select_parallel`, `explain_query`, `analyze_query_plan`, `translate_nl_to_sql` |
 | **Server-side cursors** | `open_cursor`, `fetch_cursor`, `close_cursor`, `list_cursors` |
-| **Composite + diagnostic** | `summarize_table`, `why_is_this_slow`, `find_unused_objects`, `find_sensitive_columns`, `detect_n_plus_one`, `lint_naming_conventions`, `test_rls_for_role`, `list_locks`, `find_blocking_chains`, `read_pg_stat_io` |
+| **Composite + diagnostic** | `summarize_table`, `why_is_this_slow`, `find_unused_objects`, `find_sensitive_columns`, `detect_n_plus_one`, `lint_naming_conventions`, `test_rls_for_role`, `list_locks`, `find_blocking_chains`, `walk_blocking_chains`, `read_pg_stat_io` |
 | **Health & tuning** | `check_database_health`, `audit_database`, `analyze_workload`, `recommend_indexes`, `run_advisors` |
 | **Search** | `fuzzy_search`, `full_text_search`, `vector_search`, `vector_range_search`, `hybrid_search`, `geo_search` |
 | **Vector tuning advisors** | `recommend_vector_index`, `analyze_vector_search`, `analyze_vector_table`, `recommend_vector_quantization` |

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -5,7 +5,7 @@ A compact one-page tour of every tool MCPg exposes, organised by
 surface; the full reference is in [`tools.md`](tools.md), and
 task-oriented recipes live in [`cookbook.md`](cookbook.md).
 
-**123 tools** as of trunk. Each line shows the tool name + how its
+**124 tools** as of trunk. Each line shows the tool name + how its
 parameters land (required first, common defaults after). Capability
 gates are noted in section titles where they apply.
 
@@ -104,6 +104,7 @@ list_active_queries()                                # who's running what right 
 verify_connection_encryption()                       # is MCPg's own link TLS-encrypted? protocol + cipher + cluster tally
 list_locks(limit=100)                                # pg_locks joined with pg_stat_activity (waiters first)
 find_blocking_chains(limit=50)                       # (blocked, blocking) pairs via pg_blocking_pids
+walk_blocking_chains(limit=50)                       # walks the lock graph, detects cycles, and renders a Mermaid flowchart
 read_pg_stat_io()                                    # PG16+ I/O stats; available=false on PG 14/15
 detect_n_plus_one(min_calls=100)                     # pg_stat_statements walker for ORM lazy-load loops
 list_replicas()                                      # health of every read-replica (when MCPG_REPLICA_URLS set)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -35,7 +35,7 @@ first time, skim it as a reference after.
 ## What MCPg is
 
 MCPg is an MCP server that exposes a PostgreSQL database to an AI
-agent through a fixed, audited set of **123 tools**. The agent never
+agent through a fixed, audited set of **124 tools**. The agent never
 gets a raw database connection — it can only call the tools MCPg
 registers, every call is validated, and every call is logged. MCPg
 runs as a single async process and ships as both a PyPI package

--- a/src/mcpg/locks.py
+++ b/src/mcpg/locks.py
@@ -253,12 +253,20 @@ def _build_blocking_graph(rows: Sequence[Any]) -> _BlockingGraph:
 
 
 def _find_roots(all_pids: set[int], in_degrees: dict[int, int], out_degrees: dict[int, int]) -> list[int]:
-    """Find root blockers (block others, but are not blocked themselves)."""
+    """Find root blockers.
+
+    These are "sink" nodes in the dependency graph (edges are directed from blocked to blocking).
+    A root blocker blocks others (in_degree > 0) but is not blocked themselves (out_degree == 0).
+    """
     return sorted(pid for pid in all_pids if in_degrees.get(pid, 0) > 0 and out_degrees.get(pid, 0) == 0)
 
 
-def _find_leaves(all_pids: set[int], in_degrees: dict[int, int], out_degrees: dict[int, int]) -> list[int]:
-    """Find leaf nodes (blocked, but do not block anyone else)."""
+def _find_sources(all_pids: set[int], in_degrees: dict[int, int], out_degrees: dict[int, int]) -> list[int]:
+    """Find source nodes in the dependency graph.
+
+    These represent "blocked" PIDs that do not block any other PID themselves (in_degree == 0, out_degree > 0).
+    They represent the starting points of linear blocking paths.
+    """
     return sorted(pid for pid in all_pids if in_degrees.get(pid, 0) == 0 and out_degrees.get(pid, 0) > 0)
 
 
@@ -305,8 +313,8 @@ def _find_cycles(adj: dict[int, list[int]], all_pids: set[int]) -> list[list[int
     return cycles
 
 
-def _trace_paths(adj: dict[int, list[int]], leaves: list[int]) -> list[list[int]]:
-    """Trace linear blocking paths from leaf nodes down to root blockers or cycle points."""
+def _trace_paths(adj: dict[int, list[int]], sources: list[int]) -> list[list[int]]:
+    """Trace linear blocking paths starting from source nodes (blocked PIDs) to root blockers or cycle points."""
     paths: list[list[int]] = []
     current: list[int] = []
 
@@ -323,8 +331,8 @@ def _trace_paths(adj: dict[int, list[int]], leaves: list[int]) -> list[list[int]
                     dfs(neighbor)
         current.pop()
 
-    for leaf in leaves:
-        dfs(leaf)
+    for source in sources:
+        dfs(source)
 
     return paths
 
@@ -346,7 +354,7 @@ def _to_mermaid(
         detail = nodes[pid]
         query_snippet = ""
         if detail.query:
-            q = detail.query.strip().replace("\n", " ").replace('"', "'")
+            q = detail.query.strip().replace("\n", " ").replace('"', "'").replace("`", "'")
             if len(q) > 60:
                 q = q[:57] + "..."
             query_snippet = f"<br/>`{q}`"
@@ -407,10 +415,10 @@ async def walk_blocking_chains(driver: SqlDriver, *, limit: int = DEFAULT_BLOCKI
 
     graph = _build_blocking_graph(rows or [])
     roots = _find_roots(graph.all_pids, graph.in_degrees, graph.out_degrees)
-    leaves = _find_leaves(graph.all_pids, graph.in_degrees, graph.out_degrees)
+    sources = _find_sources(graph.all_pids, graph.in_degrees, graph.out_degrees)
     cycles = _find_cycles(graph.adj, graph.all_pids)
     cycle_pids = {pid for cyc in cycles for pid in cyc}
-    paths = _trace_paths(graph.adj, leaves)
+    paths = _trace_paths(graph.adj, sources)
     mermaid_str = _to_mermaid(rows or [], graph.nodes, graph.all_pids, roots, cycle_pids)
 
     return BlockingGraphReport(

--- a/src/mcpg/locks.py
+++ b/src/mcpg/locks.py
@@ -161,3 +161,213 @@ async def find_blocking_chains(driver: SqlDriver, *, limit: int = DEFAULT_BLOCKI
         )
         for row in rows or []
     ]
+
+
+@dataclass(frozen=True, slots=True)
+class BlockingChainDetail:
+    """Detailed state information for a backend in a blocking chain."""
+
+    pid: int
+    query: str | None
+    application_name: str | None
+    wait_event: str | None
+    state: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class BlockingGraphReport:
+    """The reconstructed lock-wait graph report.
+
+    Contains all detected simple deadlock cycles, linear blocking paths
+    running to root blockers or cycle points, identified root blocking PIDs,
+    and a pre-rendered Mermaid flowchart representing the dependency graph.
+    """
+
+    cycles: list[list[int]]
+    paths: list[list[int]]
+    roots: list[int]
+    nodes: dict[int, BlockingChainDetail]
+    mermaid: str
+
+
+async def walk_blocking_chains(driver: SqlDriver, *, limit: int = DEFAULT_BLOCKING_LIMIT) -> BlockingGraphReport:
+    """Analyze the PostgreSQL lock-wait graph.
+
+    Detects deadlock cycles, traces blocking paths to their root blockers,
+    and renders a Mermaid flowchart representing the lock dependency graph.
+    """
+    if limit < 1:
+        raise ValueError("limit must be >= 1")
+
+    rows = await driver.execute_query(
+        "SELECT blocked.pid AS blocked_pid, "
+        "       LEFT(blocked.query, 100) AS blocked_query, "
+        "       blocked.application_name AS blocked_application_name, "
+        "       blocked.wait_event AS blocked_wait_event, "
+        "       blocked.state AS blocked_state, "
+        "       blocker.pid AS blocking_pid, "
+        "       LEFT(blocker.query, 100) AS blocking_query, "
+        "       blocker.application_name AS blocking_application_name, "
+        "       blocker.wait_event AS blocking_wait_event, "
+        "       blocker.state AS blocking_state "
+        "FROM pg_stat_activity blocked "
+        "JOIN LATERAL unnest(pg_blocking_pids(blocked.pid)) AS bp(pid) ON TRUE "
+        "JOIN pg_stat_activity blocker ON blocker.pid = bp.pid "
+        "WHERE blocked.wait_event_type = 'Lock' "
+        "ORDER BY blocked.pid "
+        "LIMIT %s",
+        params=[limit],
+        force_readonly=True,
+    )
+
+    nodes: dict[int, BlockingChainDetail] = {}
+    adj: dict[int, list[int]] = {}
+    in_degrees: dict[int, int] = {}
+    out_degrees: dict[int, int] = {}
+    all_pids: set[int] = set()
+
+    for row in rows or []:
+        b_pid = int(row.cells["blocked_pid"])
+        blk_pid = int(row.cells["blocking_pid"])
+
+        all_pids.add(b_pid)
+        all_pids.add(blk_pid)
+
+        adj.setdefault(b_pid, []).append(blk_pid)
+
+        out_degrees[b_pid] = out_degrees.get(b_pid, 0) + 1
+        in_degrees[blk_pid] = in_degrees.get(blk_pid, 0) + 1
+
+        if b_pid not in nodes:
+            nodes[b_pid] = BlockingChainDetail(
+                pid=b_pid,
+                query=str(row.cells["blocked_query"]) if row.cells["blocked_query"] is not None else None,
+                application_name=(
+                    str(row.cells["blocked_application_name"])
+                    if row.cells["blocked_application_name"] is not None
+                    else None
+                ),
+                wait_event=(
+                    str(row.cells["blocked_wait_event"]) if row.cells["blocked_wait_event"] is not None else None
+                ),
+                state=str(row.cells["blocked_state"]) if row.cells["blocked_state"] is not None else None,
+            )
+
+        if blk_pid not in nodes:
+            nodes[blk_pid] = BlockingChainDetail(
+                pid=blk_pid,
+                query=str(row.cells["blocking_query"]) if row.cells["blocking_query"] is not None else None,
+                application_name=(
+                    str(row.cells["blocking_application_name"])
+                    if row.cells["blocking_application_name"] is not None
+                    else None
+                ),
+                wait_event=(
+                    str(row.cells["blocking_wait_event"]) if row.cells["blocking_wait_event"] is not None else None
+                ),
+                state=str(row.cells["blocking_state"]) if row.cells["blocking_state"] is not None else None,
+            )
+
+    # 1. Root blockers are PIDs that block others (in_degree > 0) but are not blocked themselves (out_degree == 0)
+    roots = sorted([pid for pid in all_pids if in_degrees.get(pid, 0) > 0 and out_degrees.get(pid, 0) == 0])
+
+    # 2. DFS simple cycle detection
+    cycles: list[list[int]] = []
+    visited_cycles: set[int] = set()
+    path: list[int] = []
+    path_set: set[int] = set()
+
+    def dfs_cycles(node: int) -> None:
+        if node in path_set:
+            idx = path.index(node)
+            cycle = path[idx:]
+            min_val = min(cycle)
+            min_idx = cycle.index(min_val)
+            normalized = cycle[min_idx:] + cycle[:min_idx]
+            full_cycle = [*normalized, min_val]
+            if full_cycle not in cycles:
+                cycles.append(full_cycle)
+            return
+
+        if node in visited_cycles:
+            return
+
+        path.append(node)
+        path_set.add(node)
+
+        for neighbor in adj.get(node, []):
+            dfs_cycles(neighbor)
+
+        path.pop()
+        path_set.remove(node)
+        visited_cycles.add(node)
+
+    for pid in sorted(all_pids):
+        dfs_cycles(pid)
+
+    # 3. Path tracing starting from leaf nodes (in-degree == 0, out-degree > 0)
+    leaves = [pid for pid in all_pids if in_degrees.get(pid, 0) == 0 and out_degrees.get(pid, 0) > 0]
+    paths: list[list[int]] = []
+
+    def trace_path(node: int, current_path: list[int]) -> None:
+        neighbors = adj.get(node, [])
+        if not neighbors:
+            paths.append(current_path)
+            return
+
+        for neighbor in neighbors:
+            if neighbor in current_path:
+                paths.append([*current_path, neighbor])
+                continue
+            trace_path(neighbor, [*current_path, neighbor])
+
+    for leaf in sorted(leaves):
+        trace_path(leaf, [leaf])
+
+    # 4. Mermaid Flowchart construction
+    mermaid_lines = ["graph TD"]
+    mermaid_lines.append("  classDef root fill:#ff9999,stroke:#333,stroke-width:2px;")
+    mermaid_lines.append("  classDef cycle fill:#ffff99,stroke:#333,stroke-width:2px;")
+
+    cycle_pids = {pid for cyc in cycles for pid in cyc}
+
+    # Define nodes
+    for pid in sorted(all_pids):
+        detail = nodes[pid]
+        query_snippet = ""
+        if detail.query:
+            q = detail.query.strip().replace("\n", " ").replace('"', "'")
+            if len(q) > 60:
+                q = q[:57] + "..."
+            query_snippet = f"<br/>`{q}`"
+
+        app_str = f" ({detail.application_name})" if detail.application_name else ""
+        state_str = f" [{detail.state or 'unknown'}]"
+        label = f"PID {pid}{app_str}{state_str}{query_snippet}"
+        label_escaped = label.replace('"', '\\"')
+
+        mermaid_lines.append(f'  {pid}["{label_escaped}"]')
+
+    # Define edges
+    for row in rows or []:
+        b_pid = int(row.cells["blocked_pid"])
+        blk_pid = int(row.cells["blocking_pid"])
+        wait_evt = str(row.cells["blocked_wait_event"]) if row.cells["blocked_wait_event"] is not None else "Lock"
+        mermaid_lines.append(f'  {b_pid} -->|"{wait_evt}"| {blk_pid}')
+
+    # Apply style classes
+    for r in roots:
+        mermaid_lines.append(f"  class {r} root;")
+    for c_pid in sorted(cycle_pids):
+        if c_pid not in roots:
+            mermaid_lines.append(f"  class {c_pid} cycle;")
+
+    mermaid_str = "\n".join(mermaid_lines)
+
+    return BlockingGraphReport(
+        cycles=cycles,
+        paths=paths,
+        roots=roots,
+        nodes=nodes,
+        mermaid=mermaid_str,
+    )

--- a/src/mcpg/locks.py
+++ b/src/mcpg/locks.py
@@ -13,7 +13,9 @@ slow / stuck query.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
+from typing import Any
 
 from mcpg._vendor.sql import SqlDriver
 
@@ -190,6 +192,189 @@ class BlockingGraphReport:
     mermaid: str
 
 
+@dataclass(frozen=True, slots=True)
+class _BlockingGraph:
+    """Internal graph structure."""
+
+    nodes: dict[int, BlockingChainDetail]
+    adj: dict[int, list[int]]
+    in_degrees: dict[int, int]
+    out_degrees: dict[int, int]
+    all_pids: set[int]
+
+
+def _make_detail(row: Any, pid: int, prefix: str) -> BlockingChainDetail:
+    """Create a BlockingChainDetail for a blocked or blocking PID from a row."""
+    return BlockingChainDetail(
+        pid=pid,
+        query=str(row.cells[f"{prefix}_query"]) if row.cells[f"{prefix}_query"] is not None else None,
+        application_name=(
+            str(row.cells[f"{prefix}_application_name"])
+            if row.cells[f"{prefix}_application_name"] is not None
+            else None
+        ),
+        wait_event=(str(row.cells[f"{prefix}_wait_event"]) if row.cells[f"{prefix}_wait_event"] is not None else None),
+        state=str(row.cells[f"{prefix}_state"]) if row.cells[f"{prefix}_state"] is not None else None,
+    )
+
+
+def _build_blocking_graph(rows: Sequence[Any]) -> _BlockingGraph:
+    """Reconstruct graph nodes, adjacency lists, and degree counts from database rows."""
+    nodes: dict[int, BlockingChainDetail] = {}
+    adj: dict[int, list[int]] = {}
+    in_degrees: dict[int, int] = {}
+    out_degrees: dict[int, int] = {}
+    all_pids: set[int] = set()
+
+    for row in rows or []:
+        b_pid = int(row.cells["blocked_pid"])
+        blk_pid = int(row.cells["blocking_pid"])
+
+        all_pids.add(b_pid)
+        all_pids.add(blk_pid)
+
+        adj.setdefault(b_pid, []).append(blk_pid)
+
+        out_degrees[b_pid] = out_degrees.get(b_pid, 0) + 1
+        in_degrees[blk_pid] = in_degrees.get(blk_pid, 0) + 1
+
+        if b_pid not in nodes:
+            nodes[b_pid] = _make_detail(row, b_pid, "blocked")
+        if blk_pid not in nodes:
+            nodes[blk_pid] = _make_detail(row, blk_pid, "blocking")
+
+    return _BlockingGraph(
+        nodes=nodes,
+        adj=adj,
+        in_degrees=in_degrees,
+        out_degrees=out_degrees,
+        all_pids=all_pids,
+    )
+
+
+def _find_roots(all_pids: set[int], in_degrees: dict[int, int], out_degrees: dict[int, int]) -> list[int]:
+    """Find root blockers (block others, but are not blocked themselves)."""
+    return sorted(pid for pid in all_pids if in_degrees.get(pid, 0) > 0 and out_degrees.get(pid, 0) == 0)
+
+
+def _find_leaves(all_pids: set[int], in_degrees: dict[int, int], out_degrees: dict[int, int]) -> list[int]:
+    """Find leaf nodes (blocked, but do not block anyone else)."""
+    return sorted(pid for pid in all_pids if in_degrees.get(pid, 0) == 0 and out_degrees.get(pid, 0) > 0)
+
+
+def _normalize_cycle(cycle: list[int]) -> tuple[int, ...]:
+    """Normalize cycle representation to be rotation-invariant and closed."""
+    min_val = min(cycle)
+    min_idx = cycle.index(min_val)
+    normalized = cycle[min_idx:] + cycle[:min_idx]
+    return tuple([*normalized, min_val])
+
+
+def _find_cycles(adj: dict[int, list[int]], all_pids: set[int]) -> list[list[int]]:
+    """DFS simple cycle detection returning deduplicated simple cycles."""
+    cycles: list[list[int]] = []
+    seen: set[tuple[int, ...]] = set()
+    visited_cycles: set[int] = set()
+    path: list[int] = []
+    path_set: set[int] = set()
+
+    def dfs(node: int) -> None:
+        if node in path_set:
+            idx = path.index(node)
+            raw_cycle = path[idx:]
+            key = _normalize_cycle(raw_cycle)
+            if key not in seen:
+                seen.add(key)
+                cycles.append(list(key))
+            return
+
+        if node in visited_cycles:
+            return
+
+        path.append(node)
+        path_set.add(node)
+        for neighbor in adj.get(node, []):
+            dfs(neighbor)
+        path.pop()
+        path_set.remove(node)
+        visited_cycles.add(node)
+
+    for pid in sorted(all_pids):
+        dfs(pid)
+
+    return cycles
+
+
+def _trace_paths(adj: dict[int, list[int]], leaves: list[int]) -> list[list[int]]:
+    """Trace linear blocking paths from leaf nodes down to root blockers or cycle points."""
+    paths: list[list[int]] = []
+    current: list[int] = []
+
+    def dfs(node: int) -> None:
+        current.append(node)
+        neighbors = adj.get(node, [])
+        if not neighbors:
+            paths.append(current.copy())
+        else:
+            for neighbor in neighbors:
+                if neighbor in current:
+                    paths.append([*current, neighbor])
+                else:
+                    dfs(neighbor)
+        current.pop()
+
+    for leaf in leaves:
+        dfs(leaf)
+
+    return paths
+
+
+def _to_mermaid(
+    rows: Sequence[Any],
+    nodes: dict[int, BlockingChainDetail],
+    all_pids: set[int],
+    roots: list[int],
+    cycle_pids: set[int],
+) -> str:
+    """Generate a Mermaid flowchart representing the lock dependency graph."""
+    lines = ["graph TD"]
+    lines.append("  classDef root fill:#ff9999,stroke:#333,stroke-width:2px;")
+    lines.append("  classDef cycle fill:#ffff99,stroke:#333,stroke-width:2px;")
+
+    # Define nodes
+    for pid in sorted(all_pids):
+        detail = nodes[pid]
+        query_snippet = ""
+        if detail.query:
+            q = detail.query.strip().replace("\n", " ").replace('"', "'")
+            if len(q) > 60:
+                q = q[:57] + "..."
+            query_snippet = f"<br/>`{q}`"
+
+        app_str = f" ({detail.application_name})" if detail.application_name else ""
+        state_str = f" [{detail.state or 'unknown'}]"
+        label = f"PID {pid}{app_str}{state_str}{query_snippet}"
+        label_escaped = label.replace('"', '\\"')
+
+        lines.append(f'  {pid}["{label_escaped}"]')
+
+    # Define edges
+    for row in rows or []:
+        b_pid = int(row.cells["blocked_pid"])
+        blk_pid = int(row.cells["blocking_pid"])
+        wait_evt = str(row.cells["blocked_wait_event"]) if row.cells["blocked_wait_event"] is not None else "Lock"
+        lines.append(f'  {b_pid} -->|"{wait_evt}"| {blk_pid}')
+
+    # Apply style classes
+    for r in roots:
+        lines.append(f"  class {r} root;")
+    for c_pid in sorted(cycle_pids):
+        if c_pid not in roots:
+            lines.append(f"  class {c_pid} cycle;")
+
+    return "\n".join(lines)
+
+
 async def walk_blocking_chains(driver: SqlDriver, *, limit: int = DEFAULT_BLOCKING_LIMIT) -> BlockingGraphReport:
     """Analyze the PostgreSQL lock-wait graph.
 
@@ -220,154 +405,18 @@ async def walk_blocking_chains(driver: SqlDriver, *, limit: int = DEFAULT_BLOCKI
         force_readonly=True,
     )
 
-    nodes: dict[int, BlockingChainDetail] = {}
-    adj: dict[int, list[int]] = {}
-    in_degrees: dict[int, int] = {}
-    out_degrees: dict[int, int] = {}
-    all_pids: set[int] = set()
-
-    for row in rows or []:
-        b_pid = int(row.cells["blocked_pid"])
-        blk_pid = int(row.cells["blocking_pid"])
-
-        all_pids.add(b_pid)
-        all_pids.add(blk_pid)
-
-        adj.setdefault(b_pid, []).append(blk_pid)
-
-        out_degrees[b_pid] = out_degrees.get(b_pid, 0) + 1
-        in_degrees[blk_pid] = in_degrees.get(blk_pid, 0) + 1
-
-        if b_pid not in nodes:
-            nodes[b_pid] = BlockingChainDetail(
-                pid=b_pid,
-                query=str(row.cells["blocked_query"]) if row.cells["blocked_query"] is not None else None,
-                application_name=(
-                    str(row.cells["blocked_application_name"])
-                    if row.cells["blocked_application_name"] is not None
-                    else None
-                ),
-                wait_event=(
-                    str(row.cells["blocked_wait_event"]) if row.cells["blocked_wait_event"] is not None else None
-                ),
-                state=str(row.cells["blocked_state"]) if row.cells["blocked_state"] is not None else None,
-            )
-
-        if blk_pid not in nodes:
-            nodes[blk_pid] = BlockingChainDetail(
-                pid=blk_pid,
-                query=str(row.cells["blocking_query"]) if row.cells["blocking_query"] is not None else None,
-                application_name=(
-                    str(row.cells["blocking_application_name"])
-                    if row.cells["blocking_application_name"] is not None
-                    else None
-                ),
-                wait_event=(
-                    str(row.cells["blocking_wait_event"]) if row.cells["blocking_wait_event"] is not None else None
-                ),
-                state=str(row.cells["blocking_state"]) if row.cells["blocking_state"] is not None else None,
-            )
-
-    # 1. Root blockers are PIDs that block others (in_degree > 0) but are not blocked themselves (out_degree == 0)
-    roots = sorted([pid for pid in all_pids if in_degrees.get(pid, 0) > 0 and out_degrees.get(pid, 0) == 0])
-
-    # 2. DFS simple cycle detection
-    cycles: list[list[int]] = []
-    visited_cycles: set[int] = set()
-    path: list[int] = []
-    path_set: set[int] = set()
-
-    def dfs_cycles(node: int) -> None:
-        if node in path_set:
-            idx = path.index(node)
-            cycle = path[idx:]
-            min_val = min(cycle)
-            min_idx = cycle.index(min_val)
-            normalized = cycle[min_idx:] + cycle[:min_idx]
-            full_cycle = [*normalized, min_val]
-            if full_cycle not in cycles:
-                cycles.append(full_cycle)
-            return
-
-        if node in visited_cycles:
-            return
-
-        path.append(node)
-        path_set.add(node)
-
-        for neighbor in adj.get(node, []):
-            dfs_cycles(neighbor)
-
-        path.pop()
-        path_set.remove(node)
-        visited_cycles.add(node)
-
-    for pid in sorted(all_pids):
-        dfs_cycles(pid)
-
-    # 3. Path tracing starting from leaf nodes (in-degree == 0, out-degree > 0)
-    leaves = [pid for pid in all_pids if in_degrees.get(pid, 0) == 0 and out_degrees.get(pid, 0) > 0]
-    paths: list[list[int]] = []
-
-    def trace_path(node: int, current_path: list[int]) -> None:
-        neighbors = adj.get(node, [])
-        if not neighbors:
-            paths.append(current_path)
-            return
-
-        for neighbor in neighbors:
-            if neighbor in current_path:
-                paths.append([*current_path, neighbor])
-                continue
-            trace_path(neighbor, [*current_path, neighbor])
-
-    for leaf in sorted(leaves):
-        trace_path(leaf, [leaf])
-
-    # 4. Mermaid Flowchart construction
-    mermaid_lines = ["graph TD"]
-    mermaid_lines.append("  classDef root fill:#ff9999,stroke:#333,stroke-width:2px;")
-    mermaid_lines.append("  classDef cycle fill:#ffff99,stroke:#333,stroke-width:2px;")
-
+    graph = _build_blocking_graph(rows or [])
+    roots = _find_roots(graph.all_pids, graph.in_degrees, graph.out_degrees)
+    leaves = _find_leaves(graph.all_pids, graph.in_degrees, graph.out_degrees)
+    cycles = _find_cycles(graph.adj, graph.all_pids)
     cycle_pids = {pid for cyc in cycles for pid in cyc}
-
-    # Define nodes
-    for pid in sorted(all_pids):
-        detail = nodes[pid]
-        query_snippet = ""
-        if detail.query:
-            q = detail.query.strip().replace("\n", " ").replace('"', "'")
-            if len(q) > 60:
-                q = q[:57] + "..."
-            query_snippet = f"<br/>`{q}`"
-
-        app_str = f" ({detail.application_name})" if detail.application_name else ""
-        state_str = f" [{detail.state or 'unknown'}]"
-        label = f"PID {pid}{app_str}{state_str}{query_snippet}"
-        label_escaped = label.replace('"', '\\"')
-
-        mermaid_lines.append(f'  {pid}["{label_escaped}"]')
-
-    # Define edges
-    for row in rows or []:
-        b_pid = int(row.cells["blocked_pid"])
-        blk_pid = int(row.cells["blocking_pid"])
-        wait_evt = str(row.cells["blocked_wait_event"]) if row.cells["blocked_wait_event"] is not None else "Lock"
-        mermaid_lines.append(f'  {b_pid} -->|"{wait_evt}"| {blk_pid}')
-
-    # Apply style classes
-    for r in roots:
-        mermaid_lines.append(f"  class {r} root;")
-    for c_pid in sorted(cycle_pids):
-        if c_pid not in roots:
-            mermaid_lines.append(f"  class {c_pid} cycle;")
-
-    mermaid_str = "\n".join(mermaid_lines)
+    paths = _trace_paths(graph.adj, leaves)
+    mermaid_str = _to_mermaid(rows or [], graph.nodes, graph.all_pids, roots, cycle_pids)
 
     return BlockingGraphReport(
         cycles=cycles,
         paths=paths,
         roots=roots,
-        nodes=nodes,
+        nodes=graph.nodes,
         mermaid=mermaid_str,
     )

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -494,6 +494,18 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
         return [asdict(row) for row in rows]
 
     @server.tool(
+        name="walk_blocking_chains",
+        description=(
+            "Walk and reconstruct the lock-wait graph of the database. Detects deadlock cycles, "
+            "traces linear blocking paths to their root blockers, and renders a Mermaid flowchart "
+            "representing the lock dependency graph. Read-only."
+        ),
+    )
+    async def walk_blocking_chains(ctx: _Ctx, limit: int = locks.DEFAULT_BLOCKING_LIMIT) -> dict[str, Any]:
+        report = await locks.walk_blocking_chains(_driver(ctx), limit=limit)
+        return asdict(report)
+
+    @server.tool(
         name="read_pg_stat_io",
         description=(
             "Read the pg_stat_io view (PostgreSQL 16+). Reports per "

--- a/tests/unit/test_locks.py
+++ b/tests/unit/test_locks.py
@@ -6,10 +6,13 @@ import pytest
 from _fakes import FakeRoutingDriver
 
 from mcpg.locks import (
+    BlockingChainDetail,
+    BlockingGraphReport,
     BlockingPair,
     LockInfo,
     find_blocking_chains,
     list_locks,
+    walk_blocking_chains,
 )
 
 
@@ -107,3 +110,117 @@ async def test_find_blocking_chains_returns_empty_list_when_nothing_blocked() ->
 async def test_find_blocking_chains_rejects_zero_limit() -> None:
     with pytest.raises(ValueError, match="limit"):
         await find_blocking_chains(FakeRoutingDriver({}), limit=0)  # type: ignore[arg-type]
+
+
+async def test_walk_blocking_chains_returns_empty_when_no_blocks() -> None:
+    driver = FakeRoutingDriver({"unnest(pg_blocking_pids": []})
+    report = await walk_blocking_chains(driver)  # type: ignore[arg-type]
+
+    assert isinstance(report, BlockingGraphReport)
+    assert report.cycles == []
+    assert report.paths == []
+    assert report.roots == []
+    assert report.nodes == {}
+    assert report.mermaid == (
+        "graph TD\n"
+        "  classDef root fill:#ff9999,stroke:#333,stroke-width:2px;\n"
+        "  classDef cycle fill:#ffff99,stroke:#333,stroke-width:2px;"
+    )
+
+
+async def test_walk_blocking_chains_linear_chain() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "unnest(pg_blocking_pids": [
+                {
+                    "blocked_pid": 200,
+                    "blocked_query": "UPDATE widget SET x = 1",
+                    "blocked_application_name": "appA",
+                    "blocked_wait_event": "transactionid",
+                    "blocked_state": "active",
+                    "blocking_pid": 201,
+                    "blocking_query": "UPDATE widget SET x = 2",
+                    "blocking_application_name": "appB",
+                    "blocking_wait_event": "transactionid",
+                    "blocking_state": "active",
+                },
+                {
+                    "blocked_pid": 201,
+                    "blocked_query": "UPDATE widget SET x = 2",
+                    "blocked_application_name": "appB",
+                    "blocked_wait_event": "transactionid",
+                    "blocked_state": "active",
+                    "blocking_pid": 202,
+                    "blocking_query": "UPDATE widget SET x = 3",
+                    "blocking_application_name": "appC",
+                    "blocking_wait_event": None,
+                    "blocking_state": "idle in transaction",
+                },
+            ]
+        }
+    )
+
+    report = await walk_blocking_chains(driver)  # type: ignore[arg-type]
+
+    assert report.cycles == []
+    assert report.roots == [202]
+    assert report.paths == [[200, 201, 202]]
+    assert len(report.nodes) == 3
+
+    assert isinstance(report.nodes[200], BlockingChainDetail)
+    assert report.nodes[200].pid == 200
+    assert report.nodes[200].application_name == "appA"
+
+    assert '200 -->|"transactionid"| 201' in report.mermaid
+    assert '201 -->|"transactionid"| 202' in report.mermaid
+    assert "class 202 root;" in report.mermaid
+
+
+async def test_walk_blocking_chains_deadlock_cycle() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "unnest(pg_blocking_pids": [
+                {
+                    "blocked_pid": 200,
+                    "blocked_query": "UPDATE widget SET x = 1",
+                    "blocked_application_name": "appA",
+                    "blocked_wait_event": "transactionid",
+                    "blocked_state": "active",
+                    "blocking_pid": 201,
+                    "blocking_query": "UPDATE widget SET x = 2",
+                    "blocking_application_name": "appB",
+                    "blocking_wait_event": "transactionid",
+                    "blocking_state": "active",
+                },
+                {
+                    "blocked_pid": 201,
+                    "blocked_query": "UPDATE widget SET x = 2",
+                    "blocked_application_name": "appB",
+                    "blocked_wait_event": "transactionid",
+                    "blocked_state": "active",
+                    "blocking_pid": 200,
+                    "blocking_query": "UPDATE widget SET x = 1",
+                    "blocking_application_name": "appA",
+                    "blocking_wait_event": "transactionid",
+                    "blocking_state": "active",
+                },
+            ]
+        }
+    )
+
+    report = await walk_blocking_chains(driver)  # type: ignore[arg-type]
+
+    assert report.cycles == [[200, 201, 200]]
+    assert report.roots == []
+    assert report.paths == []
+    assert len(report.nodes) == 2
+
+    assert '200 -->|"transactionid"| 201' in report.mermaid
+    assert '201 -->|"transactionid"| 200' in report.mermaid
+    assert "class 200 cycle;" in report.mermaid
+    assert "class 201 cycle;" in report.mermaid
+
+
+async def test_walk_blocking_chains_rejects_zero_limit() -> None:
+    with pytest.raises(ValueError, match="limit"):
+        await walk_blocking_chains(FakeRoutingDriver({}), limit=0)  # type: ignore[arg-type]

--- a/tests/unit/test_locks.py
+++ b/tests/unit/test_locks.py
@@ -134,7 +134,7 @@ async def test_walk_blocking_chains_linear_chain() -> None:
             "unnest(pg_blocking_pids": [
                 {
                     "blocked_pid": 200,
-                    "blocked_query": "UPDATE widget SET x = 1",
+                    "blocked_query": "UPDATE `widget` SET x = 1",
                     "blocked_application_name": "appA",
                     "blocked_wait_event": "transactionid",
                     "blocked_state": "active",
@@ -171,6 +171,7 @@ async def test_walk_blocking_chains_linear_chain() -> None:
     assert report.nodes[200].pid == 200
     assert report.nodes[200].application_name == "appA"
 
+    assert "200[\"PID 200 (appA) [active]<br/>`UPDATE 'widget' SET x = 1`\"]" in report.mermaid
     assert '200 -->|"transactionid"| 201' in report.mermaid
     assert '201 -->|"transactionid"| 202' in report.mermaid
     assert "class 202 root;" in report.mermaid


### PR DESCRIPTION
This PR implements the \walk_blocking_chains\ tool (D4/2.4 in the shortlist) to walk the lock graph, reconstruct deadlock cycles, locate root blockers, trace linear blocking paths, and render a Mermaid flowchart of the blocking chains.

## Summary by Sourcery

Add a new diagnostic tool to walk PostgreSQL lock-wait graphs, reconstruct deadlock cycles and blocking paths, and expose the results via the MCPg tool interface and documentation.

New Features:
- Introduce BlockingChainDetail and BlockingGraphReport data structures to represent detailed lock-wait graph state and analysis results.
- Add walk_blocking_chains function to analyze pg_blocking_pids output, identify root blockers, cycles, and paths, and generate a Mermaid flowchart of the lock dependency graph.
- Expose walk_blocking_chains as an MCPg server tool returning a structured report for clients.

Documentation:
- Document the new walk_blocking_chains tool in the tools index, tour, and changelog, and update tool counts and feature-shortlist/roadmap to reflect its addition.

Tests:
- Add unit tests covering empty graphs, linear blocking chains, deadlock cycles, and validation of the limit parameter for walk_blocking_chains.