### PR TITLE
B1: Implement structured JSON logging toggle via MCPG_LOG_FORMAT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Structured JSON logging toggle (`MCPG_LOG_FORMAT`).** Adds an opt-in structured
+  JSON logging format. When `MCPG_LOG_FORMAT=json` is set, all logging output from the
+  `mcpg` server is formatted as a structured JSON object. Standard log messages carry
+  `timestamp`, `level`, `logger`, and `message` keys, while `mcpg.audit` tool calls merge
+  the audit payload (`tool`, `status`, `arguments`, `error`) directly into the top level.
+
 - **`walk_blocking_chains` tool (deadlock cycle walker).** Walks and reconstructs
   the active lock-wait graph of the database using `pg_blocking_pids`. Identifies
   all simple deadlock cycles, linear blocking paths leading to root blockers or

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -423,6 +423,16 @@ Every tool call — success or failure — is logged to the
 arguments (see below), and outcome. Configure where that logger's
 records are shipped via your deployment's logging stack.
 
+### Log Format
+
+By default, the server writes human-readable log messages. You can toggle structured JSON logging using the `MCPG_LOG_FORMAT` environment variable:
+
+```bash
+export MCPG_LOG_FORMAT=json  # text (default) or json
+```
+
+When set to `json`, all logging events from `mcpg` (including tool execution audit events) are serialized as a single-line JSON object containing standard keys (`timestamp`, `level`, `logger`, `message`). For audit events, the fields (`tool`, `status`, `arguments`, and optionally `error`) are merged directly into the top level of the JSON log record.
+
 ### Persistence
 
 With `MCPG_AUDIT_PERSIST=true`, every `run_write` and `run_ddl` is

--- a/src/mcpg/__main__.py
+++ b/src/mcpg/__main__.py
@@ -29,6 +29,9 @@ def main() -> int:
     except ConfigError as exc:
         print(f"mcpg: configuration error: {exc}", file=sys.stderr)
         return 1
+    from mcpg.obs_logging import setup_logging
+
+    setup_logging(settings)
     run(settings)
     return 0
 

--- a/src/mcpg/audit.py
+++ b/src/mcpg/audit.py
@@ -10,6 +10,7 @@ query workloads, and server logs, producing a comprehensive diagnostic JSON repo
 from __future__ import annotations
 
 import datetime
+import json
 import logging
 import os
 import re
@@ -22,6 +23,19 @@ from mcpg._vendor.sql import SqlDriver, obfuscate_password
 # --- Tool invocation logger (Original Audit Logic) ------------------------
 
 audit_logger = logging.getLogger("mcpg.audit")
+
+_log_format: str = "text"
+
+
+def configure_log_format(format_name: str) -> None:
+    """Configure the active log format for tool invocation logs.
+
+    Idempotent.
+    """
+    global _log_format
+    if format_name in {"text", "json"}:
+        _log_format = format_name
+
 
 # Names whose VALUES are credentials and must be masked before the
 # arguments dict is logged or persisted. Each entry is a regex matched
@@ -126,16 +140,30 @@ def redact_arguments(arguments: dict[str, Any]) -> dict[str, Any]:
 def record(event: AuditEvent) -> None:
     """Emit an audit event to the ``mcpg.audit`` logger."""
     safe_arguments = redact_arguments(event.arguments)
-    if event.error is None:
-        audit_logger.info("tool=%s status=%s arguments=%s", event.tool, event.status, safe_arguments)
+    if _log_format == "json":
+        payload = {
+            "tool": event.tool,
+            "status": event.status,
+            "arguments": safe_arguments,
+        }
+        if event.error is not None:
+            payload["error"] = event.error
+        msg = json.dumps(payload)
+        if event.error is None:
+            audit_logger.info(msg)
+        else:
+            audit_logger.warning(msg)
     else:
-        audit_logger.warning(
-            "tool=%s status=%s arguments=%s error=%s",
-            event.tool,
-            event.status,
-            safe_arguments,
-            event.error,
-        )
+        if event.error is None:
+            audit_logger.info("tool=%s status=%s arguments=%s", event.tool, event.status, safe_arguments)
+        else:
+            audit_logger.warning(
+                "tool=%s status=%s arguments=%s error=%s",
+                event.tool,
+                event.status,
+                safe_arguments,
+                event.error,
+            )
 
 
 # --- DBA Database Performance Auditor (New Tier-A Feature) ----------------

--- a/src/mcpg/config.py
+++ b/src/mcpg/config.py
@@ -58,6 +58,7 @@ class Settings:
     http_host: str = "127.0.0.1"
     http_port: int = 8000
     log_level: str = "INFO"
+    log_format: str = "text"
     allow_ddl: bool = False
     allow_shell: bool = False
     allow_listen: bool = False
@@ -167,7 +168,8 @@ class Settings:
             f"access_mode={self.access_mode.value!r}, "
             f"transport={self.transport.value!r}, "
             f"http_host={self.http_host!r}, http_port={self.http_port}, "
-            f"log_level={self.log_level!r}, allow_ddl={self.allow_ddl}, "
+            f"log_level={self.log_level!r}, log_format={self.log_format!r}, "
+            f"allow_ddl={self.allow_ddl}, "
             f"allow_shell={self.allow_shell}, "
             f"allow_listen={self.allow_listen}, "
             f"shell_timeout_sec={self.shell_timeout_sec}, "
@@ -356,6 +358,13 @@ def load_settings(env: Mapping[str, str] | None = None) -> Settings:
     if log_level not in _LOG_LEVELS:
         valid = ", ".join(sorted(_LOG_LEVELS))
         raise ConfigError(f"MCPG_LOG_LEVEL must be one of: {valid} (got {log_level!r})")
+
+    log_format = "text"
+    if (raw := env.get("MCPG_LOG_FORMAT")) is not None:
+        candidate = raw.strip().lower()
+        if candidate not in {"text", "json"}:
+            raise ConfigError(f"MCPG_LOG_FORMAT must be one of: text, json (got {raw!r})")
+        log_format = candidate
 
     allow_ddl = False
     if (raw := env.get("MCPG_ALLOW_DDL")) is not None:
@@ -619,9 +628,10 @@ def load_settings(env: Mapping[str, str] | None = None) -> Settings:
     # Re-arm the audit-trail redaction pattern with the operator's
     # MCPG_AUDIT_REDACT_KEYS extension (if any) so the very first audit
     # event the server records honours the configured list.
-    from mcpg.audit import configure_redaction
+    from mcpg.audit import configure_log_format, configure_redaction
 
     configure_redaction(env)
+    configure_log_format(log_format)
 
     cache_enabled = True
     if (raw := env.get("MCPG_CACHE_ENABLED")) is not None:
@@ -696,6 +706,7 @@ def load_settings(env: Mapping[str, str] | None = None) -> Settings:
         http_host=env.get("MCPG_HTTP_HOST", "127.0.0.1"),
         http_port=http_port,
         log_level=log_level,
+        log_format=log_format,
         allow_ddl=allow_ddl,
         allow_shell=allow_shell,
         allow_listen=allow_listen,

--- a/src/mcpg/obs_logging.py
+++ b/src/mcpg/obs_logging.py
@@ -53,6 +53,10 @@ def setup_logging(settings: Settings) -> None:
     in re-entrant test environments, sets the configured log level, and sets
     up either standard text or structured JSON formatting on stderr.
     """
+    from mcpg.audit import configure_log_format
+
+    configure_log_format(settings.log_format)
+
     logger = logging.getLogger("mcpg")
     logger.setLevel(settings.log_level)
 

--- a/src/mcpg/obs_logging.py
+++ b/src/mcpg/obs_logging.py
@@ -1,0 +1,75 @@
+"""Observability Logging — Structured JSON logging and setup for MCPg loggers."""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mcpg.config import Settings
+
+
+class JSONFormatter(logging.Formatter):
+    """Formatter that outputs structured JSON for log events.
+
+    For audit events (from the ``mcpg.audit`` logger), it parses the message
+    JSON payload and merges it into the top-level keys of the log dictionary.
+    """
+
+    def format(self, record: logging.LogRecord) -> str:
+        # Standardised RFC 3339 UTC timestamp with millisecond precision
+        dt = datetime.fromtimestamp(record.created, UTC)
+        timestamp = dt.strftime("%Y-%m-%dT%H:%M:%S") + f".{int(record.msecs):03d}Z"
+
+        log_data = {
+            "timestamp": timestamp,
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+
+        if record.exc_info:
+            log_data["exception"] = self.formatException(record.exc_info)
+
+        # Merge fields directly if this is an audit event
+        if record.name == "mcpg.audit":
+            try:
+                audit_payload = json.loads(record.getMessage())
+                if isinstance(audit_payload, dict):
+                    log_data.update(audit_payload)
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+        return json.dumps(log_data)
+
+
+def setup_logging(settings: Settings) -> None:
+    """Configure the level and format for the package-level ``mcpg`` logger.
+
+    Clears any existing handlers on the ``mcpg`` logger to prevent duplicate logs
+    in re-entrant test environments, sets the configured log level, and sets
+    up either standard text or structured JSON formatting on stderr.
+    """
+    logger = logging.getLogger("mcpg")
+    logger.setLevel(settings.log_level)
+
+    # De-duplicate handlers to prevent duplicate output in tests/re-initialisation
+    for handler in list(logger.handlers):
+        logger.removeHandler(handler)
+
+    handler = logging.StreamHandler(sys.stderr)
+
+    formatter: logging.Formatter
+    if settings.log_format == "json":
+        formatter = JSONFormatter()
+    else:
+        formatter = logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+
+    # Disable propagation to prevent double-logging if root has handlers
+    logger.propagate = False

--- a/src/mcpg/server.py
+++ b/src/mcpg/server.py
@@ -145,6 +145,10 @@ def create_server(
             to inject a fake connection factory); otherwise a default
             one is created from ``settings``.
     """
+    from mcpg.obs_logging import setup_logging
+
+    setup_logging(settings)
+
     db = database if database is not None else Database(settings)
     lm = (
         listen_manager

--- a/tests/unit/test_audit.py
+++ b/tests/unit/test_audit.py
@@ -262,3 +262,32 @@ async def test_audit_database_with_pg17_checkpointer_compatibility() -> None:
     assert any("pg_views" in c[0] for c in driver.calls)
     # Verify that it queried the combined pg_stat_checkpointer query
     assert any("pg_stat_checkpointer" in c[0] for c in driver.calls)
+
+
+def test_audit_record_json_format(caplog) -> None:
+    import json
+    import logging
+
+    from mcpg.audit import AuditEvent, configure_log_format, record
+
+    configure_log_format("json")
+    try:
+        event = AuditEvent(tool="my_test_tool", arguments={"foo": "bar"}, status="ok")
+        logger = logging.getLogger("mcpg")
+        old_propagate = logger.propagate
+        logger.propagate = True
+        try:
+            caplog.set_level(logging.INFO)
+            record(event)
+            audit_records = [r for r in caplog.records if r.name == "mcpg.audit"]
+            assert len(audit_records) == 1
+            log_record = audit_records[0]
+            payload = json.loads(log_record.message)
+            assert payload["tool"] == "my_test_tool"
+            assert payload["status"] == "ok"
+            assert payload["arguments"] == {"foo": "bar"}
+            assert "error" not in payload
+        finally:
+            logger.propagate = old_propagate
+    finally:
+        configure_log_format("text")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -75,6 +75,21 @@ def test_log_level_is_normalised_to_upper_case() -> None:
     assert settings.log_level == "DEBUG"
 
 
+def test_log_format_defaults_to_text() -> None:
+    settings = load_settings({"MCPG_DATABASE_URL": _DB_URL})
+    assert settings.log_format == "text"
+
+
+def test_log_format_parses_json_case_insensitively() -> None:
+    settings = load_settings({"MCPG_DATABASE_URL": _DB_URL, "MCPG_LOG_FORMAT": "JSON"})
+    assert settings.log_format == "json"
+
+
+def test_invalid_log_format_raises() -> None:
+    with pytest.raises(ConfigError, match="MCPG_LOG_FORMAT"):
+        load_settings({"MCPG_DATABASE_URL": _DB_URL, "MCPG_LOG_FORMAT": "yaml"})
+
+
 def test_settings_is_immutable() -> None:
     settings = load_settings({"MCPG_DATABASE_URL": _DB_URL})
     with pytest.raises(AttributeError):

--- a/tests/unit/test_obs_logging.py
+++ b/tests/unit/test_obs_logging.py
@@ -1,0 +1,128 @@
+"""Unit tests for the structured logging module (obs_logging.py)."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from mcpg.config import load_settings
+from mcpg.obs_logging import JSONFormatter, setup_logging
+
+
+def test_json_formatter_formats_standard_record() -> None:
+    formatter = JSONFormatter()
+    record = logging.LogRecord(
+        name="mcpg.server",
+        level=logging.INFO,
+        pathname="server.py",
+        lineno=42,
+        msg="Starting server on port %d",
+        args=(8000,),
+        exc_info=None,
+    )
+    formatted = formatter.format(record)
+    data = json.loads(formatted)
+
+    assert "timestamp" in data
+    assert data["timestamp"].endswith("Z")
+    assert data["level"] == "INFO"
+    assert data["logger"] == "mcpg.server"
+    assert data["message"] == "Starting server on port 8000"
+    assert "exception" not in data
+
+
+def test_json_formatter_includes_exceptions() -> None:
+    formatter = JSONFormatter()
+    try:
+        raise ValueError("Something went wrong")
+    except ValueError:
+        import sys
+
+        exc_info = sys.exc_info()
+
+    record = logging.LogRecord(
+        name="mcpg.server",
+        level=logging.ERROR,
+        pathname="server.py",
+        lineno=42,
+        msg="An error occurred",
+        args=(),
+        exc_info=exc_info,
+    )
+    formatted = formatter.format(record)
+    data = json.loads(formatted)
+
+    assert data["level"] == "ERROR"
+    assert "exception" in data
+    assert "ValueError: Something went wrong" in data["exception"]
+
+
+def test_json_formatter_merges_audit_payload() -> None:
+    formatter = JSONFormatter()
+    audit_msg = json.dumps(
+        {
+            "tool": "list_tables",
+            "status": "ok",
+            "arguments": {"schema": "public"},
+        }
+    )
+    record = logging.LogRecord(
+        name="mcpg.audit",
+        level=logging.INFO,
+        pathname="audit.py",
+        lineno=100,
+        msg=audit_msg,
+        args=(),
+        exc_info=None,
+    )
+    formatted = formatter.format(record)
+    data = json.loads(formatted)
+
+    assert data["level"] == "INFO"
+    assert data["logger"] == "mcpg.audit"
+    # Merged keys
+    assert data["tool"] == "list_tables"
+    assert data["status"] == "ok"
+    assert data["arguments"] == {"schema": "public"}
+
+
+def test_json_formatter_handles_malformed_audit_payload() -> None:
+    formatter = JSONFormatter()
+    # Non-JSON or malformed payload in mcpg.audit should not crash the formatter
+    record = logging.LogRecord(
+        name="mcpg.audit",
+        level=logging.INFO,
+        pathname="audit.py",
+        lineno=100,
+        msg="not-valid-json",
+        args=(),
+        exc_info=None,
+    )
+    formatted = formatter.format(record)
+    data = json.loads(formatted)
+
+    assert data["level"] == "INFO"
+    assert data["logger"] == "mcpg.audit"
+    assert data["message"] == "not-valid-json"
+
+
+def test_setup_logging_configures_logger() -> None:
+    settings = load_settings(
+        {
+            "MCPG_DATABASE_URL": "postgresql://u:p@localhost/db",
+            "MCPG_LOG_LEVEL": "DEBUG",
+            "MCPG_LOG_FORMAT": "json",
+        }
+    )
+
+    logger = logging.getLogger("mcpg")
+    # Reset logger state to mock
+    logger.handlers.clear()
+    logger.propagate = True
+
+    setup_logging(settings)
+
+    assert logger.level == logging.DEBUG
+    assert len(logger.handlers) == 1
+    assert isinstance(logger.handlers[0].formatter, JSONFormatter)
+    assert logger.propagate is False

--- a/tests/unit/test_obs_logging.py
+++ b/tests/unit/test_obs_logging.py
@@ -126,3 +126,21 @@ def test_setup_logging_configures_logger() -> None:
     assert len(logger.handlers) == 1
     assert isinstance(logger.handlers[0].formatter, JSONFormatter)
     assert logger.propagate is False
+
+
+def test_setup_logging_synchronizes_audit_format() -> None:
+    from mcpg.audit import configure_log_format
+
+    configure_log_format("text")
+
+    settings = load_settings(
+        {
+            "MCPG_DATABASE_URL": "postgresql://u:p@localhost/db",
+            "MCPG_LOG_FORMAT": "json",
+        }
+    )
+    setup_logging(settings)
+
+    from mcpg.audit import _log_format as current_format
+
+    assert current_format == "json"


### PR DESCRIPTION
## Summary

ability to provide json format logs, for telemetry automation / integration

## Roadmap

json logging format and audit. 
## Checklist

- [ ] Tests added/updated first (TDD); suite passes locally
- [ ] `ruff`, `ruff format`, and `mypy src/mcpg` pass
- [ ] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] `docs/PROGRESS.md` updated if a roadmap task was completed
- [ ] No hand-edits to `src/mcpg/_vendor/`
