### PR TITLE
B2: Implement slow-call logging from the MCP layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Slow-call logging from the MCP layer (`MCPG_SLOW_CALL_THRESHOLD_MS`).** Logs a warning
+  to the `mcpg.server` logger when any tool execution duration exceeds the configured threshold.
+  Defaults to `1000` ms. A value of `0` or less disables this logging.
+
 - **Structured JSON logging toggle (`MCPG_LOG_FORMAT`).** Adds an opt-in structured
   JSON logging format. When `MCPG_LOG_FORMAT=json` is set, all logging output from the
   `mcpg` server is formatted as a structured JSON object. Standard log messages carry

--- a/docs/feature-shortlist.md
+++ b/docs/feature-shortlist.md
@@ -26,7 +26,7 @@ Effort scale (rough, single-session yardstick):
 |---|---|---|---|---|
 | 1.1 | OpenTelemetry spans per tool call | M | Medium-High | One span per `call_tool` + child spans for the actual query / subprocess. |
 | 1.2 | Structured JSON logging output toggle | S | Medium | Wraps the existing `mcpg.audit` logger. |
-| 1.3 | Slow-call logging from the MCP layer | S | Low | Per-tool latency log to flag slow MCPg-side calls (the existing `analyze_workload` covers PG-side timings). |
+| 1.3 | ✅ **Shipped.** Slow-call logging from the MCP layer | S | Low | Per-tool latency log to flag slow MCPg-side calls (the existing `analyze_workload` covers PG-side timings). |
 
 ## 2. PostgreSQL feature coverage
 

--- a/docs/parallel-roadmap.md
+++ b/docs/parallel-roadmap.md
@@ -85,7 +85,7 @@ mini-sequence (shared centroid code).
 | PR | Item | New module? | Effort | Notes |
 |---|---|---|---|---|
 | B1 | Structured JSON logging toggle (1.2) | extends logging setup | S | `MCPG_LOG_FORMAT=text\|json`. Wraps the existing logger. |
-| B2 | Slow-call logging from the MCP layer (1.3) | middleware hook | S | Per-tool latency warn over a threshold. |
+| B2 (✅ PR) | Slow-call logging from the MCP layer (1.3) | middleware hook | S | Per-tool latency warn over a threshold. |
 | B3 | OpenTelemetry spans per tool call (1.1) | new, optional extra | M | One span per `call_tool` + child spans; behind `mcpg[otel]`. |
 
 B1/B2 are independent; B3 is larger and best alone.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -488,6 +488,17 @@ For stdio deployments, the `get_metrics_exposition()` MCP tool
 returns the same Prometheus payload as a string the agent can hand
 to a scrape target.
 
+### Slow-call latency logging
+
+To flag slow MCP-side tool calls, MCPg supports a latency threshold warning log:
+
+```bash
+export MCPG_SLOW_CALL_THRESHOLD_MS=1000  # Threshold in milliseconds (default: 1000)
+```
+
+* When configured (defaults to `1000` ms), tool calls that exceed this threshold are logged as a warning to `mcpg.server`.
+* Set this to `0` or a negative value to disable slow-call logging.
+
 ---
 
 ## Rate limiting

--- a/src/mcpg/config.py
+++ b/src/mcpg/config.py
@@ -138,6 +138,7 @@ class Settings:
     allow_insecure_tls: bool = False
     statement_timeout_ms: int = 30000
     lock_timeout_ms: int = 5000
+    slow_call_threshold_ms: int = 1000
     cache_enabled: bool = True
     cache_ttl_seconds: int = 300
     cache_maxsize: int = 1024
@@ -202,6 +203,7 @@ class Settings:
             f"allow_insecure_tls={self.allow_insecure_tls}, "
             f"statement_timeout_ms={self.statement_timeout_ms}, "
             f"lock_timeout_ms={self.lock_timeout_ms}, "
+            f"slow_call_threshold_ms={self.slow_call_threshold_ms}, "
             f"cache_enabled={self.cache_enabled}, "
             f"cache_ttl_seconds={self.cache_ttl_seconds}, "
             f"cache_maxsize={self.cache_maxsize}, "
@@ -625,6 +627,13 @@ def load_settings(env: Mapping[str, str] | None = None) -> Settings:
         except ValueError:
             raise ConfigError(f"MCPG_LOCK_TIMEOUT_MS must be a non-negative integer (got {raw!r})") from None
 
+    slow_call_threshold_ms = 1000
+    if (raw := env.get("MCPG_SLOW_CALL_THRESHOLD_MS")) is not None:
+        try:
+            slow_call_threshold_ms = int(raw)
+        except ValueError:
+            raise ConfigError(f"MCPG_SLOW_CALL_THRESHOLD_MS must be an integer (got {raw!r})") from None
+
     # Re-arm the audit-trail redaction pattern with the operator's
     # MCPG_AUDIT_REDACT_KEYS extension (if any) so the very first audit
     # event the server records honours the configured list.
@@ -741,6 +750,7 @@ def load_settings(env: Mapping[str, str] | None = None) -> Settings:
         allow_insecure_tls=allow_insecure_tls,
         statement_timeout_ms=statement_timeout_ms,
         lock_timeout_ms=lock_timeout_ms,
+        slow_call_threshold_ms=slow_call_threshold_ms,
         cache_enabled=cache_enabled,
         cache_ttl_seconds=cache_ttl_seconds,
         cache_maxsize=cache_maxsize,

--- a/src/mcpg/server.py
+++ b/src/mcpg/server.py
@@ -38,7 +38,26 @@ class AuditedFastMCP(FastMCP[AppContext]):
     """A FastMCP server that records an audit event for every tool call."""
 
     rate_limiter: RateLimiter
+    mcpg_settings: Settings
     in_flight_calls: int = 0
+
+    def _log_if_slow(self, name: str, duration: float) -> None:
+        if not hasattr(self, "mcpg_settings"):
+            return
+        threshold_ms = self.mcpg_settings.slow_call_threshold_ms
+        if threshold_ms <= 0:
+            return
+        threshold_sec = threshold_ms / 1000.0
+        if duration > threshold_sec:
+            import logging
+
+            logger = logging.getLogger("mcpg.server")
+            logger.warning(
+                "Slow tool call: %s took %.3fs (threshold: %.3fs)",
+                name,
+                duration,
+                threshold_sec,
+            )
 
     async def call_tool(self, name: str, arguments: dict[str, Any]) -> Sequence[ContentBlock] | dict[str, Any]:
         self.in_flight_calls += 1
@@ -55,10 +74,12 @@ class AuditedFastMCP(FastMCP[AppContext]):
                 result = await super().call_tool(name, arguments)
             except Exception as exc:
                 duration = time.monotonic() - start
+                self._log_if_slow(name, duration)
                 audit.record(audit.AuditEvent(tool=name, arguments=arguments, status="error", error=str(exc)))
                 metrics.record_call(name, "error", duration)
                 raise
             duration = time.monotonic() - start
+            self._log_if_slow(name, duration)
             audit.record(audit.AuditEvent(tool=name, arguments=arguments, status="ok"))
             metrics.record_call(name, "ok", duration)
             return result
@@ -163,6 +184,7 @@ def create_server(
         host=settings.http_host,
         port=settings.http_port,
     )
+    server.mcpg_settings = settings
     # Instantiate and register the RateLimiter
     server.rate_limiter = RateLimiter(
         enabled=settings.rate_limit_enabled,

--- a/tests/unit/test_slow_call.py
+++ b/tests/unit/test_slow_call.py
@@ -1,0 +1,158 @@
+"""Tests for slow-call logging in MCPg server."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from mcpg.config import load_settings
+from mcpg.server import create_server
+
+
+def test_slow_call_config_parsing() -> None:
+    # 1. Test default value
+    settings = load_settings({"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db"})
+    assert settings.slow_call_threshold_ms == 1000
+
+    # 2. Test custom positive value
+    settings = load_settings(
+        {
+            "MCPG_DATABASE_URL": "postgresql://u:p@localhost/db",
+            "MCPG_SLOW_CALL_THRESHOLD_MS": "500",
+        }
+    )
+    assert settings.slow_call_threshold_ms == 500
+
+    # 3. Test invalid value raises ConfigError
+    from mcpg.config import ConfigError
+
+    with pytest.raises(ConfigError) as exc_info:
+        load_settings(
+            {
+                "MCPG_DATABASE_URL": "postgresql://u:p@localhost/db",
+                "MCPG_SLOW_CALL_THRESHOLD_MS": "not-an-int",
+            }
+        )
+    assert "MCPG_SLOW_CALL_THRESHOLD_MS must be an integer" in str(exc_info.value)
+
+
+@pytest.mark.anyio
+async def test_slow_call_warning_emitted_when_exceeding_threshold(caplog) -> None:
+    settings = load_settings(
+        {
+            "MCPG_DATABASE_URL": "postgresql://u:p@localhost/db",
+            "MCPG_SLOW_CALL_THRESHOLD_MS": "100",  # 0.1 seconds
+        }
+    )
+
+    server = create_server(settings)
+
+    # We patch super().call_tool to simulate a successful tool run
+    # and time.monotonic to simulate 0.15 seconds duration (exceeds threshold)
+    with (
+        patch("mcp.server.fastmcp.FastMCP.call_tool", return_value="ok_result"),
+        patch("time.monotonic", side_effect=[0.0, 0.15]),
+        caplog.at_level(logging.WARNING, logger="mcpg.server"),
+    ):
+        # Propagate must be enabled for caplog to capture sub-logger logs
+        mcpg_logger = logging.getLogger("mcpg")
+        old_propagate = mcpg_logger.propagate
+        mcpg_logger.propagate = True
+        try:
+            result = await server.call_tool("my_tool", {})
+            assert result == "ok_result"
+
+            # Check warning was logged
+            warnings = [r for r in caplog.records if r.levelname == "WARNING" and r.name == "mcpg.server"]
+            assert len(warnings) == 1
+            assert "Slow tool call: my_tool took 0.150s" in warnings[0].message
+        finally:
+            mcpg_logger.propagate = old_propagate
+
+
+@pytest.mark.anyio
+async def test_slow_call_warning_not_emitted_when_under_threshold(caplog) -> None:
+    settings = load_settings(
+        {
+            "MCPG_DATABASE_URL": "postgresql://u:p@localhost/db",
+            "MCPG_SLOW_CALL_THRESHOLD_MS": "100",  # 0.1 seconds
+        }
+    )
+
+    server = create_server(settings)
+
+    with (
+        patch("mcp.server.fastmcp.FastMCP.call_tool", return_value="ok_result"),
+        patch("time.monotonic", side_effect=[0.0, 0.05]),
+        caplog.at_level(logging.WARNING, logger="mcpg.server"),
+    ):
+        mcpg_logger = logging.getLogger("mcpg")
+        old_propagate = mcpg_logger.propagate
+        mcpg_logger.propagate = True
+        try:
+            await server.call_tool("my_tool", {})
+
+            warnings = [r for r in caplog.records if r.levelname == "WARNING" and r.name == "mcpg.server"]
+            assert len(warnings) == 0
+        finally:
+            mcpg_logger.propagate = old_propagate
+
+
+@pytest.mark.anyio
+async def test_slow_call_warning_not_emitted_when_disabled(caplog) -> None:
+    settings = load_settings(
+        {
+            "MCPG_DATABASE_URL": "postgresql://u:p@localhost/db",
+            "MCPG_SLOW_CALL_THRESHOLD_MS": "0",  # Disabled
+        }
+    )
+
+    server = create_server(settings)
+
+    with (
+        patch("mcp.server.fastmcp.FastMCP.call_tool", return_value="ok_result"),
+        patch("time.monotonic", side_effect=[0.0, 5.0]),
+        caplog.at_level(logging.WARNING, logger="mcpg.server"),
+    ):
+        mcpg_logger = logging.getLogger("mcpg")
+        old_propagate = mcpg_logger.propagate
+        mcpg_logger.propagate = True
+        try:
+            await server.call_tool("my_tool", {})
+
+            warnings = [r for r in caplog.records if r.levelname == "WARNING" and r.name == "mcpg.server"]
+            assert len(warnings) == 0
+        finally:
+            mcpg_logger.propagate = old_propagate
+
+
+@pytest.mark.anyio
+async def test_slow_call_warning_emitted_on_error_path(caplog) -> None:
+    settings = load_settings(
+        {
+            "MCPG_DATABASE_URL": "postgresql://u:p@localhost/db",
+            "MCPG_SLOW_CALL_THRESHOLD_MS": "100",  # 0.1 seconds
+        }
+    )
+
+    server = create_server(settings)
+
+    with (
+        patch("mcp.server.fastmcp.FastMCP.call_tool", side_effect=ValueError("fail")),
+        patch("time.monotonic", side_effect=[0.0, 0.15]),
+        caplog.at_level(logging.WARNING, logger="mcpg.server"),
+    ):
+        mcpg_logger = logging.getLogger("mcpg")
+        old_propagate = mcpg_logger.propagate
+        mcpg_logger.propagate = True
+        try:
+            with pytest.raises(ValueError, match="fail"):
+                await server.call_tool("my_tool", {})
+
+            warnings = [r for r in caplog.records if r.levelname == "WARNING" and r.name == "mcpg.server"]
+            assert len(warnings) == 1
+            assert "Slow tool call: my_tool took 0.150s" in warnings[0].message
+        finally:
+            mcpg_logger.propagate = old_propagate


### PR DESCRIPTION
## Summary
observe the observer ! 

## Roadmap
maintain thresholds ( not dynamic yet ), and compare the call times against them to log 'delays' in MCP layer for tool execution.

## Checklist

- [ ] Tests added/updated first (TDD); suite passes locally
- [ ] `ruff`, `ruff format`, and `mypy src/mcpg` pass
- [ ] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] `docs/PROGRESS.md` updated if a roadmap task was completed
- [ ] No hand-edits to `src/mcpg/_vendor/`
