### PR TITLE
feat(pgvector): analyze_distance_metric — cosine / l2 / inner_product picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **`analyze_distance_metric` tool (pgvector).** Samples up to
+  `sample_size` (default 1000) non-NULL embeddings from
+  `schema.table.column`, computes each one's L2 norm, and recommends
+  a distance metric from the magnitude distribution: pre-normalised
+  vectors (CV < 5%, mean ≈ 1.0) → `inner_product`; nearly-constant
+  but off-unit magnitudes → `cosine` (same ranking as L2, safer
+  default); variable magnitudes → `cosine` (normalises out
+  heterogeneous sources). Returns the metric + a rationale + the
+  underlying distribution stats. New `mcpg.vector_ops` module — first
+  resident of a vector-analytics namespace separate from search
+  (`textsearch`) and storage tuning (`vector_tuning`,
+  `vector_tuner_advanced`). Read-only; `available=false` without the
+  pgvector extension.
+
 - **`import_vectors` tool (pgvector).** Bulk-load embeddings into a
   pgvector `vector(N)` column from JSON (array of objects) or CSV.
   Reads the column's declared `N` from the catalog up-front and

--- a/docs/feature-shortlist.md
+++ b/docs/feature-shortlist.md
@@ -106,7 +106,7 @@ awareness, and HNSW/IVFFlat detection in `list_indexes`:
 | 9.5 | `monitor_embedding_drift` — compare distributional stats of vectors over time windows | M | Medium | Ops / model-quality monitoring. |
 | 9.6 | ✅ **Shipped.** `import_vectors` — bulk-load embeddings from JSON/CSV into a pgvector `vector(N)` column; reads the declared `N` from the catalog and validates every row before any INSERT runs. Optional parallel `id_column`. | S | Medium | Sibling of `import_csv` specialised for vector columns. |
 | 9.7 | `cross_table_similarity` — given a row in table A, find the k most similar rows in table B (different embedding source, same dim) | S | Medium | Useful for entity resolution / linking across tables. |
-| 9.8 | `analyze_distance_metric` — recommend cosine vs L2 vs inner-product based on vector-magnitude distribution | S | Medium | Concrete advice when the user hasn't decided yet. |
+| 9.8 | ✅ **Shipped.** `analyze_distance_metric` — samples up to 1000 rows of an embedding column, computes the L2-norm distribution, and recommends cosine / l2 / inner_product (pre-normalised → inner_product; constant magnitude → cosine; variable magnitude → cosine). Lives in `mcpg.vector_ops`. | S | Medium | Concrete advice when the user hasn't decided yet. |
 | 9.9 | `monitor_index_build` — surface HNSW / IVFFlat build progress for long-running index creations | S | Medium | Lives next to `list_active_queries`; useful for big-table index work. |
 | 9.10 | `migrate_vector_to_halfvec` — DDL generator to convert a `vector(N)` column to `halfvec(N)` (or `bit`) safely | S-M | Medium | Pairs with `recommend_vector_quantization`. Uses the existing shadow workflow. |
 

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -140,6 +140,8 @@ recommend_vector_index(schema, table, column)                             # HNSW
 recommend_vector_quantization(schema)                                     # vector → halfvec / bit storage advisor
 analyze_vector_search(schema, table, column, query_vector)
 analyze_vector_table(schema, table)
+analyze_distance_metric(schema, table, column, sample_size=1000)          # cosine / l2 / inner_product picker
+                                                                          # from the magnitude distribution
 ```
 
 ## "Move data in / out"

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -56,6 +56,7 @@ from mcpg import (
     test_data,
     textsearch,
     timescaledb,
+    vector_ops,
     vector_tuner_advanced,
     vector_tuning,
     workload,
@@ -686,6 +687,38 @@ def _register_vector_tuning(server: FastMCP[AppContext]) -> None:
             k=k,
             metric=metric,
         )
+
+    @server.tool(
+        name="analyze_distance_metric",
+        description=(
+            "Recommend a pgvector distance metric (cosine | l2 | "
+            "inner_product) from the embedding-magnitude distribution. "
+            "Samples up to `sample_size` non-NULL rows of "
+            "schema.table.column, computes each embedding's L2 norm, "
+            "and applies a small heuristic: pre-normalised (CV < 5% "
+            "and mean ≈ 1.0) → inner_product; nearly-constant magnitude "
+            "but not unit-norm → cosine (same ranking as L2, safer "
+            "default); variable magnitude → cosine (normalises out "
+            "heterogeneous sources). Returns the metric + a rationale + "
+            "the underlying distribution stats. Reports available=false "
+            "if the pgvector extension is not installed."
+        ),
+    )
+    async def analyze_distance_metric(
+        ctx: _Ctx,
+        schema: str,
+        table: str,
+        column: str,
+        sample_size: int = vector_ops.DEFAULT_SAMPLE_SIZE,
+    ) -> dict[str, Any]:
+        result = await vector_ops.analyze_distance_metric(
+            _driver(ctx),
+            schema,
+            table,
+            column,
+            sample_size=sample_size,
+        )
+        return asdict(result)
 
 
 def _register_prisma(server: FastMCP[AppContext]) -> None:

--- a/src/mcpg/vector_ops.py
+++ b/src/mcpg/vector_ops.py
@@ -1,0 +1,252 @@
+"""pgvector analytics — heuristics on top of stored embeddings.
+
+This module hosts vector-analytics tools that aren't search and aren't
+storage tuning — they reason about the *distribution* of embeddings
+already in a column:
+
+- :func:`analyze_distance_metric` — sample rows and recommend cosine,
+  L2, or inner-product based on the magnitude distribution.
+
+Future siblings (cluster_vectors, detect_vector_outliers,
+monitor_embedding_drift, cross_table_similarity) land here so the
+search surface (:mod:`mcpg.textsearch`) and the storage advisors
+(:mod:`mcpg.vector_tuning`, :mod:`mcpg.vector_tuner_advanced`) stay
+focused.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from mcpg._vendor.sql import SqlDriver
+from mcpg.extensions import extension_installed
+
+_IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
+
+# Default sample size when the caller doesn't pass one. Chosen so the
+# tool is cheap on big tables (a few MB of vectors) while still giving
+# the magnitude-distribution heuristic a stable signal.
+DEFAULT_SAMPLE_SIZE = 1000
+
+
+# Below this coefficient of variation we treat the magnitudes as
+# "essentially constant" — in that regime cosine / L2 / inner-product
+# give the same ranking, and inner-product is the cheapest to compute.
+# Above it the metric choice matters; we default to cosine because it
+# normalises out magnitude (the usual right answer for embeddings
+# coming from heterogeneous sources or models that don't pre-normalise).
+_CV_FLAT_THRESHOLD = 0.05
+
+# A vector with norm within this band of 1.0 is considered
+# pre-normalised. Combined with a low coefficient of variation, this
+# triggers the "inner-product is equivalent to cosine and cheaper"
+# recommendation. Two non-trivial decimals so a near-1.0 hand-rolled
+# normaliser still trips it.
+_NORM_TOLERANCE = 0.02
+
+
+class VectorOpsError(Exception):
+    """Raised when a vector-analytics request is rejected."""
+
+
+@dataclass(frozen=True, slots=True)
+class DistanceMetricRecommendation:
+    """The outcome of an :func:`analyze_distance_metric` call.
+
+    ``available`` is ``False`` when the pgvector extension isn't
+    installed. ``sampled_rows`` is the number of non-NULL embeddings
+    actually examined (may be less than the requested ``sample_size``).
+    ``mean_magnitude`` / ``magnitude_std`` describe the L2-norm
+    distribution, ``magnitude_cv`` is the scale-free coefficient of
+    variation (``std / mean``). ``pre_normalised`` flags the
+    "everything looks like a unit vector" case where inner-product
+    is preferable.
+    """
+
+    available: bool
+    sampled_rows: int
+    mean_magnitude: float
+    magnitude_std: float
+    magnitude_cv: float
+    pre_normalised: bool
+    recommended_metric: str
+    rationale: str
+
+
+def _checked(name: str, kind: str) -> str:
+    if not _IDENTIFIER.match(name):
+        raise VectorOpsError(f"invalid {kind} name: {name!r}")
+    return name
+
+
+def _quoted(name: str, kind: str) -> str:
+    return f'"{_checked(name, kind)}"'
+
+
+def _parse_embedding(value: Any) -> list[float] | None:
+    """Coerce a pgvector cell into a list of floats, or ``None``.
+
+    Same shape pgvector cells arrive in as :func:`mcpg.textsearch._parse_embedding`,
+    but tolerant: any unparseable / unexpected value returns ``None``
+    so a single bad row doesn't sink the whole analysis (the caller
+    counts only the rows that parsed).
+    """
+    if value is None:
+        return None
+    if isinstance(value, (list, tuple)):
+        try:
+            return [float(v) for v in value]
+        except (TypeError, ValueError):
+            return None
+    if isinstance(value, str):
+        inner = value.strip().lstrip("[").rstrip("]").strip()
+        if not inner:
+            return None
+        try:
+            return [float(part) for part in inner.split(",")]
+        except ValueError:
+            return None
+    return None
+
+
+def _l2_norm(vec: list[float]) -> float:
+    """Plain Euclidean norm; 0.0 for a zero vector."""
+    total = 0.0
+    for v in vec:
+        total += v * v
+    return math.sqrt(total)
+
+
+def _pick_metric(mean_mag: float, cv: float) -> tuple[str, bool, str]:
+    """Translate distribution stats into (metric, pre_normalised, rationale).
+
+    The three branches are documented in the module's threshold comments.
+    """
+    if mean_mag == 0.0:
+        return (
+            "cosine",
+            False,
+            "All sampled embeddings have zero magnitude — column likely uninitialised; defaulting to cosine.",
+        )
+    pre_normalised = cv < _CV_FLAT_THRESHOLD and abs(mean_mag - 1.0) < _NORM_TOLERANCE
+    if pre_normalised:
+        return (
+            "inner_product",
+            True,
+            f"Embeddings look pre-normalised (mean magnitude {mean_mag:.3f}, "
+            f"CV {cv:.4f} < {_CV_FLAT_THRESHOLD}); inner-product is equivalent "
+            "to cosine and cheaper.",
+        )
+    if cv < _CV_FLAT_THRESHOLD:
+        return (
+            "cosine",
+            False,
+            f"Magnitudes are nearly constant (CV {cv:.4f} < {_CV_FLAT_THRESHOLD}) "
+            f"but not unit-norm (mean {mean_mag:.3f}); cosine and L2 give the same "
+            "ranking — cosine is the safe choice.",
+        )
+    return (
+        "cosine",
+        False,
+        f"Magnitudes vary substantially (CV {cv:.4f}); cosine normalises out "
+        "magnitude differences from heterogeneous sources — the safe default "
+        "for mixed embedding pipelines.",
+    )
+
+
+async def analyze_distance_metric(
+    driver: SqlDriver,
+    schema: str,
+    table: str,
+    column: str,
+    *,
+    sample_size: int = DEFAULT_SAMPLE_SIZE,
+) -> DistanceMetricRecommendation:
+    """Recommend a pgvector distance metric from the embedding-magnitude distribution.
+
+    Samples up to ``sample_size`` non-NULL rows of ``schema.table.column``,
+    computes each embedding's L2 norm, and applies a small heuristic:
+
+    - **Pre-normalised** (CV < 5%, mean ≈ 1.0): every vector is
+      effectively a unit vector → inner-product is the cheapest and
+      gives the same ranking as cosine.
+    - **Nearly constant magnitude** but **not unit-norm**: cosine and
+      L2 give the same ranking; cosine is the safer default.
+    - **Variable magnitude** (CV ≥ 5%): cosine normalises out
+      magnitude differences from heterogeneous sources.
+
+    Args:
+        sample_size: Cap on rows examined. Defaults to 1000 — enough
+            to stabilise the CV signal without scanning huge tables.
+
+    Raises:
+        VectorOpsError: On an invalid identifier or a non-positive
+            ``sample_size``.
+    """
+    if sample_size < 1:
+        raise VectorOpsError("sample_size must be at least 1")
+    if not await extension_installed(driver, "vector"):
+        return DistanceMetricRecommendation(
+            available=False,
+            sampled_rows=0,
+            mean_magnitude=0.0,
+            magnitude_std=0.0,
+            magnitude_cv=0.0,
+            pre_normalised=False,
+            recommended_metric="cosine",
+            rationale="pgvector extension is not installed",
+        )
+
+    relation = f"{_quoted(schema, 'schema')}.{_quoted(table, 'table')}"
+    col = _quoted(column, "column")
+    rows = await driver.execute_query(
+        f"SELECT {col} AS embedding FROM {relation} WHERE {col} IS NOT NULL LIMIT %s",
+        params=[sample_size],
+        force_readonly=True,
+    )
+    magnitudes: list[float] = []
+    for row in rows or []:
+        vec = _parse_embedding(row.cells.get("embedding"))
+        if vec is None:
+            continue
+        magnitudes.append(_l2_norm(vec))
+
+    if not magnitudes:
+        return DistanceMetricRecommendation(
+            available=True,
+            sampled_rows=0,
+            mean_magnitude=0.0,
+            magnitude_std=0.0,
+            magnitude_cv=0.0,
+            pre_normalised=False,
+            recommended_metric="cosine",
+            rationale=(
+                f"No non-NULL embeddings found in {schema}.{table}.{column} (within the "
+                f"first {sample_size} rows); defaulting to cosine. Backfill embeddings "
+                "and re-run for a real recommendation."
+            ),
+        )
+
+    n = len(magnitudes)
+    mean_mag = sum(magnitudes) / n
+    # Population variance is sufficient — this is a heuristic, not
+    # statistical inference, so the Bessel correction would just be
+    # noise. Guard against a flat sample (variance == 0 → CV == 0).
+    variance = sum((m - mean_mag) ** 2 for m in magnitudes) / n
+    std = math.sqrt(variance)
+    cv = std / mean_mag if mean_mag > 0 else 0.0
+
+    metric, pre_normalised, rationale = _pick_metric(mean_mag, cv)
+    return DistanceMetricRecommendation(
+        available=True,
+        sampled_rows=n,
+        mean_magnitude=mean_mag,
+        magnitude_std=std,
+        magnitude_cv=cv,
+        pre_normalised=pre_normalised,
+        recommended_metric=metric,
+        rationale=rationale,
+    )

--- a/tests/unit/test_vector_ops.py
+++ b/tests/unit/test_vector_ops.py
@@ -1,0 +1,289 @@
+"""Tests for mcpg.vector_ops (pgvector analytics + the analyze_distance_metric tool)."""
+
+import math
+
+import pytest
+from _fakes import FakeDatabase, FakeRoutingDriver
+from mcp.shared.memory import create_connected_server_and_client_session
+
+from mcpg.config import load_settings
+from mcpg.server import create_server
+from mcpg.vector_ops import (
+    DEFAULT_SAMPLE_SIZE,
+    DistanceMetricRecommendation,
+    VectorOpsError,
+    _l2_norm,
+    _parse_embedding,
+    _pick_metric,
+    analyze_distance_metric,
+)
+
+_SETTINGS = load_settings({"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db"})
+
+
+# --- _parse_embedding ------------------------------------------------------
+
+
+def test_parse_embedding_accepts_lists_tuples_and_strings() -> None:
+    assert _parse_embedding([1, 2, 3]) == [1.0, 2.0, 3.0]
+    assert _parse_embedding((0.5, 1.5)) == [0.5, 1.5]
+    assert _parse_embedding("[0.1, 0.2]") == [0.1, 0.2]
+
+
+def test_parse_embedding_returns_none_for_unparseable_cells() -> None:
+    # Tolerant by design — bad rows are skipped, not fatal.
+    assert _parse_embedding(None) is None
+    assert _parse_embedding("[not a number]") is None
+    assert _parse_embedding("") is None
+    assert _parse_embedding("[]") is None
+    assert _parse_embedding(object()) is None
+    assert _parse_embedding([1, "x"]) is None  # mixed-type list
+
+
+# --- _l2_norm + _pick_metric ----------------------------------------------
+
+
+def test_l2_norm_handles_zero_and_unit_vectors() -> None:
+    assert _l2_norm([0.0, 0.0, 0.0]) == 0.0
+    assert _l2_norm([1.0, 0.0, 0.0]) == pytest.approx(1.0)
+    assert _l2_norm([3.0, 4.0]) == pytest.approx(5.0)
+
+
+def test_pick_metric_recommends_inner_product_for_pre_normalised_vectors() -> None:
+    metric, pre, rationale = _pick_metric(mean_mag=1.0, cv=0.001)
+    assert metric == "inner_product"
+    assert pre is True
+    assert "pre-normalised" in rationale
+
+
+def test_pick_metric_recommends_cosine_for_flat_but_off_unit_magnitudes() -> None:
+    metric, pre, rationale = _pick_metric(mean_mag=10.0, cv=0.001)
+    assert metric == "cosine"
+    assert pre is False
+    assert "nearly constant" in rationale
+
+
+def test_pick_metric_recommends_cosine_for_variable_magnitudes() -> None:
+    metric, pre, rationale = _pick_metric(mean_mag=5.0, cv=0.5)
+    assert metric == "cosine"
+    assert pre is False
+    assert "vary substantially" in rationale
+
+
+def test_pick_metric_handles_zero_mean_magnitude_safely() -> None:
+    metric, pre, rationale = _pick_metric(mean_mag=0.0, cv=0.0)
+    assert metric == "cosine"
+    assert pre is False
+    assert "zero magnitude" in rationale
+
+
+# --- analyze_distance_metric ----------------------------------------------
+
+
+def _routes(rows: list[dict[str, object]]) -> dict[str, list[dict[str, object]]]:
+    """Routes for FakeRoutingDriver: extension-present + the sample query."""
+    return {
+        "pg_extension": [{"present": 1}],
+        # The actual SELECT uses LIMIT %s; we route on a substring that's
+        # unique to this tool's query.
+        'WHERE "embedding" IS NOT NULL': rows,
+    }
+
+
+async def test_analyze_distance_metric_reports_unavailable_without_pgvector() -> None:
+    driver = FakeRoutingDriver({"pg_extension": []})
+
+    result = await analyze_distance_metric(driver, "app", "docs", "embedding")  # type: ignore[arg-type]
+
+    assert result == DistanceMetricRecommendation(
+        available=False,
+        sampled_rows=0,
+        mean_magnitude=0.0,
+        magnitude_std=0.0,
+        magnitude_cv=0.0,
+        pre_normalised=False,
+        recommended_metric="cosine",
+        rationale="pgvector extension is not installed",
+    )
+
+
+async def test_analyze_distance_metric_detects_pre_normalised_embeddings() -> None:
+    # Three unit vectors — magnitudes all exactly 1.0 → CV=0, pre-normalised.
+    rows = [
+        {"embedding": [1.0, 0.0, 0.0]},
+        {"embedding": [0.0, 1.0, 0.0]},
+        {"embedding": [0.0, 0.0, 1.0]},
+    ]
+    driver = FakeRoutingDriver(_routes(rows))
+
+    result = await analyze_distance_metric(driver, "app", "docs", "embedding")  # type: ignore[arg-type]
+
+    assert result.available is True
+    assert result.sampled_rows == 3
+    assert result.mean_magnitude == pytest.approx(1.0)
+    assert result.magnitude_cv == pytest.approx(0.0)
+    assert result.pre_normalised is True
+    assert result.recommended_metric == "inner_product"
+
+
+async def test_analyze_distance_metric_recommends_cosine_for_constant_off_unit_magnitudes() -> None:
+    # All vectors have magnitude exactly 10 -> CV=0 but not unit-norm.
+    rows = [
+        {"embedding": [10.0, 0.0]},
+        {"embedding": [0.0, 10.0]},
+        {"embedding": [6.0, 8.0]},
+    ]
+    driver = FakeRoutingDriver(_routes(rows))
+
+    result = await analyze_distance_metric(driver, "app", "docs", "embedding")  # type: ignore[arg-type]
+
+    assert result.mean_magnitude == pytest.approx(10.0)
+    assert result.magnitude_cv == pytest.approx(0.0)
+    assert result.pre_normalised is False
+    assert result.recommended_metric == "cosine"
+
+
+async def test_analyze_distance_metric_recommends_cosine_for_variable_magnitudes() -> None:
+    rows = [
+        {"embedding": [1.0, 0.0]},
+        {"embedding": [10.0, 0.0]},
+        {"embedding": [100.0, 0.0]},
+    ]
+    driver = FakeRoutingDriver(_routes(rows))
+
+    result = await analyze_distance_metric(driver, "app", "docs", "embedding")  # type: ignore[arg-type]
+
+    assert result.magnitude_cv > 0.5
+    assert result.recommended_metric == "cosine"
+    assert "vary substantially" in result.rationale
+
+
+async def test_analyze_distance_metric_returns_zero_sample_when_table_is_empty() -> None:
+    driver = FakeRoutingDriver(_routes([]))
+
+    result = await analyze_distance_metric(driver, "app", "docs", "embedding")  # type: ignore[arg-type]
+
+    assert result.available is True
+    assert result.sampled_rows == 0
+    assert result.recommended_metric == "cosine"
+    assert "No non-NULL embeddings" in result.rationale
+
+
+async def test_analyze_distance_metric_skips_unparseable_rows_silently() -> None:
+    rows = [
+        {"embedding": [1.0, 0.0]},
+        {"embedding": None},  # NULL — skipped
+        {"embedding": "[bad text]"},  # unparseable — skipped
+        {"embedding": [0.0, 1.0]},
+    ]
+    driver = FakeRoutingDriver(_routes(rows))
+
+    result = await analyze_distance_metric(driver, "app", "docs", "embedding")  # type: ignore[arg-type]
+
+    assert result.sampled_rows == 2
+    assert result.mean_magnitude == pytest.approx(1.0)
+
+
+async def test_analyze_distance_metric_parses_bracketed_text_embeddings() -> None:
+    # pgvector hands the column back as a text literal when the
+    # psycopg adapter isn't registered.
+    rows = [
+        {"embedding": "[3.0, 4.0]"},
+        {"embedding": "[6.0, 8.0]"},
+    ]
+    driver = FakeRoutingDriver(_routes(rows))
+
+    result = await analyze_distance_metric(driver, "app", "docs", "embedding")  # type: ignore[arg-type]
+
+    assert result.sampled_rows == 2
+    # Norms are 5 and 10 -> mean 7.5
+    assert result.mean_magnitude == pytest.approx(7.5)
+
+
+async def test_analyze_distance_metric_binds_sample_size_as_limit() -> None:
+    driver = FakeRoutingDriver(_routes([{"embedding": [1.0, 0.0]}]))
+
+    await analyze_distance_metric(driver, "app", "docs", "embedding", sample_size=42)  # type: ignore[arg-type]
+
+    sample_call = next(call for call in driver.calls if "IS NOT NULL" in call[0])
+    assert sample_call[1] == [42]
+
+
+async def test_analyze_distance_metric_uses_default_sample_size() -> None:
+    driver = FakeRoutingDriver(_routes([{"embedding": [1.0, 0.0]}]))
+
+    await analyze_distance_metric(driver, "app", "docs", "embedding")  # type: ignore[arg-type]
+
+    sample_call = next(call for call in driver.calls if "IS NOT NULL" in call[0])
+    assert sample_call[1] == [DEFAULT_SAMPLE_SIZE]
+
+
+async def test_analyze_distance_metric_rejects_non_positive_sample_size() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(VectorOpsError, match="sample_size"):
+        await analyze_distance_metric(driver, "app", "docs", "embedding", sample_size=0)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("bad", ['docs"; DROP TABLE x', "1bad", "a-b"])
+async def test_analyze_distance_metric_rejects_unsafe_identifiers(bad: str) -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(VectorOpsError, match="invalid"):
+        await analyze_distance_metric(driver, "app", bad, "embedding")  # type: ignore[arg-type]
+
+
+async def test_analyze_distance_metric_reports_realistic_distribution_stats() -> None:
+    # A small sample where the mean and std are easy to verify by hand.
+    rows = [
+        {"embedding": [1.0, 0.0]},  # norm 1
+        {"embedding": [2.0, 0.0]},  # norm 2
+        {"embedding": [3.0, 0.0]},  # norm 3
+    ]
+    driver = FakeRoutingDriver(_routes(rows))
+
+    result = await analyze_distance_metric(driver, "app", "docs", "embedding")  # type: ignore[arg-type]
+
+    # mean = 2, var = ((1-2)^2 + 0 + (3-2)^2)/3 = 2/3, std = sqrt(2/3)
+    assert result.mean_magnitude == pytest.approx(2.0)
+    assert result.magnitude_std == pytest.approx(math.sqrt(2 / 3))
+    assert result.magnitude_cv == pytest.approx(math.sqrt(2 / 3) / 2.0)
+
+
+# --- tool wiring -----------------------------------------------------------
+
+
+async def test_analyze_distance_metric_tool_is_callable_from_a_client() -> None:
+    database = FakeDatabase(
+        FakeRoutingDriver({"pg_extension": [{"present": 1}], 'WHERE "embedding" IS NOT NULL': []}),
+    )
+    server = create_server(_SETTINGS, database=database)  # type: ignore[arg-type]
+
+    async with create_connected_server_and_client_session(server) as client:
+        listed = {tool.name for tool in (await client.list_tools()).tools}
+        assert "analyze_distance_metric" in listed
+        result = await client.call_tool(
+            "analyze_distance_metric",
+            {"schema": "app", "table": "docs", "column": "embedding"},
+        )
+
+    assert result.isError is False
+    assert result.structuredContent is not None
+    assert result.structuredContent["available"] is True
+    assert result.structuredContent["recommended_metric"] in {"cosine", "l2", "inner_product"}
+
+
+async def test_analyze_distance_metric_tool_reports_unavailable_via_client() -> None:
+    database = FakeDatabase(FakeRoutingDriver({"pg_extension": []}))
+    server = create_server(_SETTINGS, database=database)  # type: ignore[arg-type]
+
+    async with create_connected_server_and_client_session(server) as client:
+        result = await client.call_tool(
+            "analyze_distance_metric",
+            {"schema": "app", "table": "docs", "column": "embedding"},
+        )
+
+    assert result.isError is False
+    assert result.structuredContent is not None
+    assert result.structuredContent["available"] is False
+    assert "pgvector extension" in result.structuredContent["rationale"]


### PR DESCRIPTION
## Why

Workstream A, **item A2** from `docs/parallel-roadmap.md` (shortlist **9.8**). Lands the first resident of a new **vector-analytics namespace** — `mcpg.vector_ops` — distinct from search (`mcpg.textsearch`) and storage tuning (`mcpg.vector_tuning`, `mcpg.vector_tuner_advanced`). Future siblings A5–A8 (cluster_vectors, detect_vector_outliers, monitor_embedding_drift, cross_table_similarity) land here too.

This PR is **independent of #48** (`import_vectors`) — different module, different test file. They can be reviewed and merged in any order.

## What

**`analyze_distance_metric(schema, table, column, sample_size=1000)`** — recommends `cosine` / `l2` / `inner_product` from the embedding-magnitude distribution.

Algorithm:
1. Sample up to `sample_size` non-NULL rows of `schema.table.column`.
2. Compute each embedding's L2 norm. Rows that don't parse are tolerated and skipped.
3. Heuristic on the magnitude distribution:
   - **Pre-normalised** (`CV < 5%` AND `|mean − 1.0| < 0.02`) → `inner_product` — same ranking as cosine, cheaper.
   - **Constant magnitude** but off-unit → `cosine` — same ranking as L2, safer default.
   - **Variable magnitude** (`CV ≥ 5%`) → `cosine` — normalises out heterogeneous-source magnitude.

Returns the metric + a rationale string + `sampled_rows`, `mean_magnitude`, `magnitude_std`, `magnitude_cv`, `pre_normalised`. Read-only; `available=false` without pgvector. Registered next to `analyze_hnsw_recall`.

## Test plan
- [x] **+23 tests** in a new `test_vector_ops.py`: `_parse_embedding` tolerance (lists / tuples / text literals / mixed-type lists / empties); `_l2_norm` boundary cases; `_pick_metric` covers each branch; end-to-end `analyze_distance_metric` for each branch; empty-table no-op; unparseable rows skipped silently; bracketed-text embeddings parsed; `sample_size` bound as `LIMIT`; default sample size; non-positive sample-size rejection; identifier safety (parametric); realistic stats verification (norms 1/2/3 → mean 2, std √(2/3)); both client-dispatch shapes (extension present + extension absent).
- [x] `vector_ops.py` at **100% unit coverage**.
- [x] **1050 unit tests pass**; ruff / format / mypy(`src/mcpg`) / bandit clean.

## Docs (folded in, per parallel-roadmap §2)
- `tour.md`: tool line added under "Tune pgvector".
- `feature-shortlist.md`: 9.8 → ✅.
- `CHANGELOG.md`: `[Unreleased]` bullet.
- **Tool count NOT bumped** — A1 (#48) and this PR are simultaneous and would otherwise collide on the three docs that hard-code the count. The periodic sync per the roadmap reconciles after merge.

## Next
Per the roadmap, workstream A continues with A3 (`cross_table_similarity`) and A4 (`monitor_index_build`) — both independent of #48 and this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_