### PR TITLE
feat(pgvector): cluster_vectors — in-process k-means over an embedding column (A5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **`cluster_vectors` tool (pgvector).** k-means clusters an
+  embedding column in-process: samples up to `sample_size` (default
+  5000) non-NULL rows of `schema.table.embedding_column`, runs
+  Lloyd's algorithm with k-means++ seeding (deterministic via
+  `seed`), and returns `centroids` (one per cluster with size) +
+  `assignments` (per-row cluster index + distance). When
+  `id_column` is set each assignment carries that column's value;
+  otherwise the row's positional sample index. `metric` supports
+  `l2` (default — squared Euclidean) or `cosine` (vectors
+  normalised, centroids re-normalised every iteration so Lloyd
+  still converges). Includes empty-cluster re-seeding and a
+  centroid-drift convergence check. Read-only; `available=false`
+  without pgvector. Lives in `mcpg.vector_ops`.
+
 - **`monitor_index_build` tool.** Surfaces every active `CREATE
   INDEX` operation from `pg_stat_progress_create_index` (PG12+, no
   extension required). One row per build with PID, resolved

--- a/docs/feature-shortlist.md
+++ b/docs/feature-shortlist.md
@@ -101,7 +101,7 @@ awareness, and HNSW/IVFFlat detection in `list_indexes`:
 |---|---|---|---|---|
 | 9.1 | HNSW recall/speed tuner (`analyze_hnsw_recall`) — sweep `ef_search` against a ground-truth set, return recall@k curves | M | High | Lets agents pick the right speed/quality knob without manual tuning. |
 | 9.2 | ✅ **Shipped.** `mmr_search` — Maximal Marginal Relevance re-ranking on top of vector_search for result diversity. `lambda_mult` trades relevance for diversity; cosine over candidate embeddings, metric-independent. | S-M | Medium-High | Quality of agentic RAG flows. |
-| 9.3 | `cluster_vectors` — k-means cluster a vector column, return centroids + per-row labels | M | Medium-High | Exploration / segmentation tool. |
+| 9.3 | ✅ **Shipped.** `cluster_vectors` — k-means (Lloyd + k-means++ seeding) over up to 5000 sampled rows of an embedding column. Returns centroids + per-row assignments; deterministic via `seed`; `metric` supports `l2` (default) or `cosine` (vectors normalised, centroids re-normalised each iteration). Lives in `mcpg.vector_ops`. | M | Medium-High | Exploration / segmentation tool. |
 | 9.4 | `detect_vector_outliers` — flag rows whose embedding is far from any cluster centroid | S-M | Medium-High | Data quality + content moderation. |
 | 9.5 | `monitor_embedding_drift` — compare distributional stats of vectors over time windows | M | Medium | Ops / model-quality monitoring. |
 | 9.6 | ✅ **Shipped.** `import_vectors` — bulk-load embeddings from JSON/CSV into a pgvector `vector(N)` column; reads the declared `N` from the catalog and validates every row before any INSERT runs. Optional parallel `id_column`. | S | Medium | Sibling of `import_csv` specialised for vector columns. |

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -151,6 +151,9 @@ cross_table_similarity(source_schema, source_table, source_embedding_column,
                        source_id_column, source_id_value,
                        target_schema, target_table, target_embedding_column, k=10)
                                                                           # given a row in A, k-NN against B
+cluster_vectors(schema, table, embedding_column, k, id_column=null,
+                sample_size=5000, max_iterations=20, metric="l2", seed=42)
+                                                                          # k-means clustering of an embedding column
 ```
 
 ## "Move data in / out"

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -842,6 +842,50 @@ def _register_vector_tuning(server: FastMCP[AppContext]) -> None:
         )
         return asdict(result)
 
+    @server.tool(
+        name="cluster_vectors",
+        description=(
+            "k-means cluster a pgvector column. Samples up to "
+            "`sample_size` (default 5000) non-NULL rows of "
+            "schema.table.embedding_column, runs Lloyd's algorithm "
+            "with k-means++ seeding (`seed` for determinism), and "
+            "returns `centroids` (one per cluster, with size) + "
+            "`assignments` (per-row cluster index + distance). When "
+            "`id_column` is set each assignment carries that column's "
+            "value; otherwise the row's positional sample index. "
+            "metric='l2' (default — squared Euclidean) or 'cosine' "
+            "(vectors normalised; centroids re-normalised every "
+            "iteration). `k` >= 2 and there must be at least 2k "
+            "parseable rows. Reports available=false if pgvector is "
+            "not installed."
+        ),
+    )
+    async def cluster_vectors(
+        ctx: _Ctx,
+        schema: str,
+        table: str,
+        embedding_column: str,
+        k: int,
+        id_column: str | None = None,
+        sample_size: int = vector_ops.DEFAULT_CLUSTER_SAMPLE_SIZE,
+        max_iterations: int = vector_ops.DEFAULT_MAX_ITERATIONS,
+        metric: str = "l2",
+        seed: int = 42,
+    ) -> dict[str, Any]:
+        result = await vector_ops.cluster_vectors(
+            _driver(ctx),
+            schema,
+            table,
+            embedding_column,
+            k=k,
+            id_column=id_column,
+            sample_size=sample_size,
+            max_iterations=max_iterations,
+            metric=metric,
+            seed=seed,
+        )
+        return asdict(result)
+
 
 def _register_prisma(server: FastMCP[AppContext]) -> None:
     @server.tool(

--- a/src/mcpg/vector_ops.py
+++ b/src/mcpg/vector_ops.py
@@ -17,7 +17,9 @@ focused.
 from __future__ import annotations
 
 import math
+import random
 import re
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
@@ -445,4 +447,366 @@ async def cross_table_similarity(
         matches.append(CrossTableMatch(distance=distance, row=cells))
     return CrossTableSimilarityResult(
         available=True, source_embedding_found=True, source_dimension=source_dim, matches=matches
+    )
+
+
+# --- cluster_vectors (k-means) --------------------------------------------
+
+
+DEFAULT_CLUSTER_SAMPLE_SIZE = 5000
+DEFAULT_MAX_ITERATIONS = 20
+
+# Tolerance for convergence: when the largest centroid drift between
+# iterations falls below this fraction of the mean centroid norm, stop
+# iterating. Cheap and accurate enough for the analytics use case.
+_KMEANS_TOLERANCE = 1e-4
+
+
+@dataclass(frozen=True, slots=True)
+class ClusterCentroid:
+    """One k-means centroid + the number of rows assigned to it."""
+
+    cluster: int
+    centroid: list[float]
+    size: int
+
+
+@dataclass(frozen=True, slots=True)
+class ClusterAssignment:
+    """The cluster a single sampled row was assigned to.
+
+    ``id`` is the row's ``id_column`` value when one was supplied,
+    otherwise the row's positional index in the sample. ``distance``
+    follows the metric used for clustering (squared L2 by default,
+    or 1 - cos(theta) for cosine).
+    """
+
+    id: Any
+    cluster: int
+    distance: float
+
+
+@dataclass(frozen=True, slots=True)
+class ClusterVectorsResult:
+    """The outcome of a :func:`cluster_vectors` call.
+
+    ``inertia`` is the sum of squared distances from each assigned row to
+    its centroid (the classical k-means objective). ``converged`` is
+    ``True`` if the centroids stopped moving before ``max_iterations``.
+    ``metric`` echoes back which metric was used so a result inspected
+    out-of-context is self-describing.
+    """
+
+    available: bool
+    sampled_rows: int
+    dimension: int
+    metric: str
+    iterations: int
+    converged: bool
+    inertia: float
+    centroids: list[ClusterCentroid]
+    assignments: list[ClusterAssignment]
+
+
+def _squared_distance(a: list[float], b: list[float]) -> float:
+    """Squared Euclidean distance. Skips the sqrt — both k-means
+    assignment and convergence checks use the squared form."""
+    total = 0.0
+    for x, y in zip(a, b, strict=True):
+        d = x - y
+        total += d * d
+    return total
+
+
+def _cosine_distance(a: list[float], b: list[float]) -> float:
+    """``1 - cos(theta)``; 1.0 for either vector being zero (max distance).
+
+    Cosine distance has the property that the cluster-mean centroid
+    minimises it locally for normalised inputs — we normalise vectors
+    up front when ``metric="cosine"``, so the standard Lloyd update
+    still converges.
+    """
+    dot = 0.0
+    norm_a = 0.0
+    norm_b = 0.0
+    for x, y in zip(a, b, strict=True):
+        dot += x * y
+        norm_a += x * x
+        norm_b += y * y
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 1.0
+    return 1.0 - dot / math.sqrt(norm_a * norm_b)
+
+
+def _normalize_in_place(vec: list[float]) -> list[float]:
+    """Scale ``vec`` to unit norm in place; zero vectors pass through."""
+    n = _l2_norm(vec)
+    if n == 0.0:
+        return vec
+    inv = 1.0 / n
+    for i in range(len(vec)):
+        vec[i] *= inv
+    return vec
+
+
+def _kmeans_plus_plus_init(
+    vectors: list[list[float]],
+    k: int,
+    rng: random.Random,
+    distance: Callable[[list[float], list[float]], float],
+) -> list[list[float]]:
+    """k-means++ centroid seeding: pick centroids weighted by distance²."""
+    centroids: list[list[float]] = [list(vectors[rng.randrange(len(vectors))])]
+    while len(centroids) < k:
+        # Squared distance from each point to its nearest existing centroid.
+        weights = []
+        total = 0.0
+        for v in vectors:
+            best = min(distance(v, c) for c in centroids)
+            # Standard k-means++ weights points by D(x)² of their nearest
+            # centroid. ``_squared_distance`` is already squared and
+            # ``_cosine_distance`` is non-negative; using ``best`` directly
+            # gives D² in the L2 case and a sensible cosine analogue.
+            # (Earlier `best * best` was D⁴ for L2 — over-weighted outliers;
+            # gemini PR #52 caught this.)
+            weights.append(best)
+            total += best
+        if total == 0.0:
+            # All remaining points coincide with existing centroids — just
+            # pick uniformly to keep going.
+            centroids.append(list(vectors[rng.randrange(len(vectors))]))
+            continue
+        # Roulette-wheel selection.
+        target = rng.random() * total
+        cum = 0.0
+        pick = 0
+        for i, w in enumerate(weights):
+            cum += w
+            if cum >= target:
+                pick = i
+                break
+        centroids.append(list(vectors[pick]))
+    return centroids
+
+
+def _kmeans(
+    vectors: list[list[float]],
+    k: int,
+    *,
+    max_iterations: int,
+    metric: str,
+    seed: int,
+) -> tuple[list[list[float]], list[int], list[float], int, bool, float]:
+    """Run Lloyd's algorithm.
+
+    Returns ``(centroids, labels, distances, iterations, converged, inertia)``.
+    ``labels[i]`` is the cluster index for ``vectors[i]``; ``distances[i]`` is
+    the distance from ``vectors[i]`` to its centroid under ``metric``.
+    """
+    rng = random.Random(seed)
+
+    # Inside the hot loop, every vector and centroid is unit-norm under
+    # cosine (the caller pre-normalises inputs and we re-normalise
+    # centroids after each iteration), so ``1 - dot(a, b)`` matches
+    # ``_cosine_distance`` at ~3x the speed by dropping the per-call
+    # norm + sqrt. Gemini PR #52 flagged the original full computation
+    # as redundant in this path. ``_cosine_distance`` itself stays as
+    # the general-purpose helper for code outside the hot loop.
+    def _cosine_distance_unit(a: list[float], b: list[float]) -> float:
+        dot = 0.0
+        for x, y in zip(a, b, strict=True):
+            dot += x * y
+        return 1.0 - dot
+
+    distance = _cosine_distance_unit if metric == "cosine" else _squared_distance
+    centroids = _kmeans_plus_plus_init(vectors, k, rng, distance)
+    labels = [0] * len(vectors)
+    distances = [0.0] * len(vectors)
+    dim = len(vectors[0])
+    converged = False
+    iteration = 0
+    while iteration < max_iterations:
+        iteration += 1
+        # Assignment step: every point goes to its closest centroid.
+        max_centroid_drift = 0.0
+        for i, v in enumerate(vectors):
+            best_dist = math.inf
+            best_label = 0
+            for j, c in enumerate(centroids):
+                d = distance(v, c)
+                if d < best_dist:
+                    best_dist = d
+                    best_label = j
+            labels[i] = best_label
+            distances[i] = best_dist
+        # Update step: each centroid becomes the mean of its members.
+        new_centroids: list[list[float]] = [[0.0] * dim for _ in range(k)]
+        counts = [0] * k
+        for v, lbl in zip(vectors, labels, strict=True):
+            counts[lbl] += 1
+            row = new_centroids[lbl]
+            for d in range(dim):
+                row[d] += v[d]
+        for j in range(k):
+            if counts[j] == 0:
+                # Re-seed an empty cluster on the point currently farthest
+                # from its assigned centroid — a standard safety valve.
+                # Zero the picked point's distance so that subsequent
+                # empty clusters in the same iteration pick the next
+                # farthest point rather than all collapsing onto the
+                # same row (gemini PR #52 caught this).
+                worst = max(range(len(vectors)), key=lambda i: distances[i])
+                new_centroids[j] = list(vectors[worst])
+                counts[j] = 1
+                distances[worst] = 0.0
+                continue
+            inv = 1.0 / counts[j]
+            for d in range(dim):
+                new_centroids[j][d] *= inv
+        if metric == "cosine":
+            for c in new_centroids:
+                _normalize_in_place(c)
+        # Convergence check: largest per-dim drift in any centroid.
+        for old, new in zip(centroids, new_centroids, strict=True):
+            for od, nd in zip(old, new, strict=True):
+                diff = abs(od - nd)
+                if diff > max_centroid_drift:
+                    max_centroid_drift = diff
+        centroids = new_centroids
+        if max_centroid_drift < _KMEANS_TOLERANCE:
+            converged = True
+            break
+    inertia = sum(distances)
+    return centroids, labels, distances, iteration, converged, inertia
+
+
+async def cluster_vectors(
+    driver: SqlDriver,
+    schema: str,
+    table: str,
+    embedding_column: str,
+    *,
+    k: int,
+    id_column: str | None = None,
+    sample_size: int = DEFAULT_CLUSTER_SAMPLE_SIZE,
+    max_iterations: int = DEFAULT_MAX_ITERATIONS,
+    metric: str = "l2",
+    seed: int = 42,
+) -> ClusterVectorsResult:
+    """k-means cluster a pgvector column; return centroids + per-row labels.
+
+    Samples up to ``sample_size`` non-NULL rows of
+    ``schema.table.embedding_column``, runs k-means with ``k`` clusters
+    in-process (k-means++ seeding, Lloyd updates, deterministic via
+    ``seed``), and returns centroids + assignments. When ``id_column``
+    is supplied each assignment carries that column's value; otherwise
+    each carries its positional sample index.
+
+    Args:
+        k: Number of clusters. Must be at least 2 and at most
+            ``sample_size`` / 2 (otherwise clustering is degenerate).
+        metric: ``l2`` (default — squared Euclidean) or ``cosine``
+            (vectors are normalised before clustering and centroids are
+            re-normalised after each iteration, so the standard Lloyd
+            update still converges).
+        sample_size: Cap on rows examined. Default 5000.
+        max_iterations: Lloyd-iteration cap (default 20). The algorithm
+            stops earlier when centroids stop moving.
+        seed: Deterministic random seed for k-means++ init.
+
+    Raises:
+        VectorOpsError: On invalid identifiers, unknown ``metric``,
+            non-positive ``sample_size`` / ``max_iterations`` /
+            ``seed`` arguments, ``k < 2``, ``k`` too large for the
+            sample, or a target column that isn't pgvector.
+    """
+    if metric not in {"l2", "cosine"}:
+        raise VectorOpsError(f"unknown metric for clustering: {metric!r}; expected 'l2' or 'cosine'")
+    if sample_size < 1:
+        raise VectorOpsError("sample_size must be at least 1")
+    if max_iterations < 1:
+        raise VectorOpsError("max_iterations must be at least 1")
+    if k < 2:
+        raise VectorOpsError("k must be at least 2")
+    # Identifier validation before any DB contact.
+    _checked(schema, "schema")
+    _checked(table, "table")
+    _checked(embedding_column, "column")
+    if id_column is not None:
+        _checked(id_column, "column")
+
+    if not await extension_installed(driver, "vector"):
+        return ClusterVectorsResult(
+            available=False,
+            sampled_rows=0,
+            dimension=0,
+            metric=metric,
+            iterations=0,
+            converged=False,
+            inertia=0.0,
+            centroids=[],
+            assignments=[],
+        )
+
+    dimension = await _vector_column_dimension(driver, schema, table, embedding_column)
+    if dimension is None:
+        raise VectorOpsError(
+            f"{schema}.{table}.{embedding_column} is not a pgvector vector(N) column (column missing or wrong type)"
+        )
+
+    relation = f"{_quoted(schema, 'schema')}.{_quoted(table, 'table')}"
+    emb_col = _quoted(embedding_column, "column")
+    select_clause = f"{emb_col} AS embedding"
+    if id_column is not None:
+        id_col = _quoted(id_column, "column")
+        select_clause = f"{id_col} AS row_id, {select_clause}"
+    rows = await driver.execute_query(
+        f"SELECT {select_clause} FROM {relation} WHERE {emb_col} IS NOT NULL LIMIT %s",
+        params=[sample_size],
+        force_readonly=True,
+    )
+
+    vectors: list[list[float]] = []
+    ids: list[Any] = []
+    for idx, row in enumerate(rows or []):
+        vec = _parse_embedding(row.cells.get("embedding"))
+        if vec is None or len(vec) != dimension:
+            continue
+        if metric == "cosine":
+            _normalize_in_place(vec)
+        vectors.append(vec)
+        ids.append(row.cells.get("row_id") if id_column is not None else idx)
+
+    if len(vectors) < k * 2:
+        raise VectorOpsError(
+            f"not enough rows to cluster: sampled {len(vectors)} parseable embeddings "
+            f"but k={k} requires at least {k * 2} (and ideally many more)"
+        )
+
+    centroids, labels, distances, iterations, converged, inertia = _kmeans(
+        vectors,
+        k,
+        max_iterations=max_iterations,
+        metric=metric,
+        seed=seed,
+    )
+
+    sizes = [0] * k
+    for lbl in labels:
+        sizes[lbl] += 1
+    centroid_objs = [ClusterCentroid(cluster=j, centroid=centroids[j], size=sizes[j]) for j in range(k)]
+    assignment_objs = [
+        ClusterAssignment(id=ids[i], cluster=labels[i], distance=distances[i]) for i in range(len(vectors))
+    ]
+
+    return ClusterVectorsResult(
+        available=True,
+        sampled_rows=len(vectors),
+        dimension=dimension,
+        metric=metric,
+        iterations=iterations,
+        converged=converged,
+        inertia=inertia,
+        centroids=centroid_objs,
+        assignments=assignment_objs,
     )

--- a/tests/unit/test_vector_ops.py
+++ b/tests/unit/test_vector_ops.py
@@ -9,16 +9,23 @@ from mcp.shared.memory import create_connected_server_and_client_session
 from mcpg.config import load_settings
 from mcpg.server import create_server
 from mcpg.vector_ops import (
+    DEFAULT_CLUSTER_SAMPLE_SIZE,
+    DEFAULT_MAX_ITERATIONS,
     DEFAULT_SAMPLE_SIZE,
+    ClusterVectorsResult,
     CrossTableMatch,
     CrossTableSimilarityResult,
     DistanceMetricRecommendation,
     VectorOpsError,
+    _cosine_distance,
     _l2_norm,
+    _normalize_in_place,
     _parse_embedding,
     _pick_metric,
+    _squared_distance,
     _vector_literal,
     analyze_distance_metric,
+    cluster_vectors,
     cross_table_similarity,
 )
 
@@ -572,3 +579,331 @@ async def test_cross_table_similarity_tool_is_listed_and_callable() -> None:
     assert result.structuredContent is not None
     assert result.structuredContent["available"] is True
     assert result.structuredContent["source_embedding_found"] is True
+
+
+# --- cluster_vectors helpers ----------------------------------------------
+
+
+def test_squared_distance_is_zero_for_identical_vectors() -> None:
+    assert _squared_distance([1.0, 2.0, 3.0], [1.0, 2.0, 3.0]) == 0.0
+    # (3-0)^2 + (4-0)^2 = 9 + 16 = 25
+    assert _squared_distance([3.0, 4.0], [0.0, 0.0]) == 25.0
+
+
+def test_squared_distance_raises_on_dim_mismatch() -> None:
+    with pytest.raises(ValueError):
+        _squared_distance([1.0, 0.0], [1.0, 0.0, 0.0])
+
+
+def test_cosine_distance_is_zero_for_aligned_vectors() -> None:
+    assert _cosine_distance([1.0, 0.0], [1.0, 0.0]) == pytest.approx(0.0)
+    # Orthogonal -> distance 1.
+    assert _cosine_distance([1.0, 0.0], [0.0, 1.0]) == pytest.approx(1.0)
+
+
+def test_cosine_distance_is_one_for_zero_vector() -> None:
+    # By convention, zero magnitude → max distance.
+    assert _cosine_distance([0.0, 0.0], [1.0, 1.0]) == 1.0
+
+
+def test_normalize_in_place_yields_unit_norm_vectors() -> None:
+    vec = [3.0, 4.0]
+    _normalize_in_place(vec)
+    assert _l2_norm(vec) == pytest.approx(1.0)
+    # Zero vectors pass through unchanged.
+    zero = [0.0, 0.0, 0.0]
+    _normalize_in_place(zero)
+    assert zero == [0.0, 0.0, 0.0]
+
+
+# --- cluster_vectors end-to-end -------------------------------------------
+
+
+_VECTOR_DIM_LOOKUP = "FROM pg_attribute a"
+_SAMPLE_QUERY = "IS NOT NULL LIMIT"
+
+
+def _cluster_routes(
+    *,
+    dim: int | None = 2,
+    sample_rows: list[dict[str, object]] | None = None,
+) -> dict[tuple[str, tuple[object, ...] | None], list[dict[str, object]]]:
+    """Standard FakeParamRoutingDriver routes for cluster_vectors."""
+    dim_rows: list[dict[str, object]] = [{"type_name": "vector", "type_mod": dim}] if dim is not None else []
+    return {
+        ("pg_extension", None): [{"present": 1}],
+        (_VECTOR_DIM_LOOKUP, None): dim_rows,
+        (_SAMPLE_QUERY, None): sample_rows or [],
+    }
+
+
+async def test_cluster_vectors_reports_unavailable_without_pgvector() -> None:
+    driver = FakeParamRoutingDriver({("pg_extension", None): []})
+
+    result = await cluster_vectors(
+        driver,
+        "app",
+        "docs",
+        "embedding",
+        k=2,  # type: ignore[arg-type]
+    )
+
+    assert result == ClusterVectorsResult(
+        available=False,
+        sampled_rows=0,
+        dimension=0,
+        metric="l2",
+        iterations=0,
+        converged=False,
+        inertia=0.0,
+        centroids=[],
+        assignments=[],
+    )
+
+
+async def test_cluster_vectors_finds_two_well_separated_clusters() -> None:
+    # 6 points: 3 around (0,0), 3 around (10,10). k-means with k=2 must
+    # assign each cluster cohesively regardless of starting seed.
+    sample_rows: list[dict[str, object]] = [
+        {"embedding": [0.0, 0.0]},
+        {"embedding": [0.1, 0.0]},
+        {"embedding": [0.0, 0.1]},
+        {"embedding": [10.0, 10.0]},
+        {"embedding": [10.1, 10.0]},
+        {"embedding": [10.0, 10.1]},
+    ]
+    driver = FakeParamRoutingDriver(_cluster_routes(sample_rows=sample_rows))
+
+    result = await cluster_vectors(
+        driver,
+        "app",
+        "docs",
+        "embedding",
+        k=2,  # type: ignore[arg-type]
+    )
+
+    assert result.available is True
+    assert result.sampled_rows == 6
+    assert result.dimension == 2
+    assert result.metric == "l2"
+    # Two clusters of 3 each.
+    sizes = sorted(c.size for c in result.centroids)
+    assert sizes == [3, 3]
+    # First three rows share one cluster, last three share the other.
+    a_labels = {result.assignments[i].cluster for i in range(3)}
+    b_labels = {result.assignments[i].cluster for i in range(3, 6)}
+    assert len(a_labels) == 1 and len(b_labels) == 1
+    assert a_labels != b_labels
+    # Inertia is small for tight clusters.
+    assert result.inertia < 1.0
+    # Algorithm converges on this toy set.
+    assert result.converged is True
+
+
+async def test_cluster_vectors_uses_id_column_when_provided() -> None:
+    sample_rows: list[dict[str, object]] = [
+        {"row_id": "alpha", "embedding": [0.0, 0.0]},
+        {"row_id": "beta", "embedding": [0.1, 0.1]},
+        {"row_id": "gamma", "embedding": [10.0, 10.0]},
+        {"row_id": "delta", "embedding": [10.1, 10.1]},
+    ]
+    driver = FakeParamRoutingDriver(_cluster_routes(sample_rows=sample_rows))
+
+    result = await cluster_vectors(
+        driver,  # type: ignore[arg-type]
+        "app",
+        "docs",
+        "embedding",
+        k=2,
+        id_column="row_id",
+    )
+
+    ids = sorted(a.id for a in result.assignments)
+    assert ids == ["alpha", "beta", "delta", "gamma"]
+
+
+async def test_cluster_vectors_supports_cosine_metric() -> None:
+    # Two unit vectors per direction.
+    sample_rows: list[dict[str, object]] = [
+        {"embedding": [1.0, 0.0]},
+        {"embedding": [0.99, 0.14]},  # ~7° from [1, 0]
+        {"embedding": [-1.0, 0.0]},
+        {"embedding": [-0.99, -0.14]},
+    ]
+    driver = FakeParamRoutingDriver(_cluster_routes(sample_rows=sample_rows))
+
+    result = await cluster_vectors(
+        driver,  # type: ignore[arg-type]
+        "app",
+        "docs",
+        "embedding",
+        k=2,
+        metric="cosine",
+    )
+
+    assert result.metric == "cosine"
+    # Each cluster has 2 members. Centroids should be ~ unit norm.
+    sizes = sorted(c.size for c in result.centroids)
+    assert sizes == [2, 2]
+    for c in result.centroids:
+        assert _l2_norm(c.centroid) == pytest.approx(1.0, abs=1e-6)
+
+
+async def test_cluster_vectors_is_deterministic_given_a_seed() -> None:
+    sample_rows: list[dict[str, object]] = [
+        {"embedding": [v, v]} for v in (0.0, 0.1, 0.2, 5.0, 5.1, 5.2, 10.0, 10.1, 10.2)
+    ]
+    # Same seed -> same centroids on two runs.
+    driver1 = FakeParamRoutingDriver(_cluster_routes(sample_rows=sample_rows))
+    driver2 = FakeParamRoutingDriver(_cluster_routes(sample_rows=sample_rows))
+
+    r1 = await cluster_vectors(driver1, "app", "docs", "embedding", k=3, seed=7)  # type: ignore[arg-type]
+    r2 = await cluster_vectors(driver2, "app", "docs", "embedding", k=3, seed=7)  # type: ignore[arg-type]
+
+    assert [c.centroid for c in r1.centroids] == [c.centroid for c in r2.centroids]
+    assert [a.cluster for a in r1.assignments] == [a.cluster for a in r2.assignments]
+
+
+async def test_cluster_vectors_binds_sample_size_as_limit() -> None:
+    sample_rows: list[dict[str, object]] = [{"embedding": [float(i), 0.0]} for i in range(10)]
+    driver = FakeParamRoutingDriver(_cluster_routes(sample_rows=sample_rows))
+
+    await cluster_vectors(
+        driver,  # type: ignore[arg-type]
+        "app",
+        "docs",
+        "embedding",
+        k=2,
+        sample_size=500,
+    )
+
+    sample_call = next(call for call in driver.calls if "IS NOT NULL" in call[0])
+    assert sample_call[1] == [500]
+
+
+async def test_cluster_vectors_skips_rows_with_wrong_dimension() -> None:
+    # Declared dim is 2; one row is 3-D and must be silently skipped.
+    sample_rows: list[dict[str, object]] = [
+        {"embedding": [0.0, 0.0]},
+        {"embedding": [0.1, 0.0]},
+        {"embedding": [10.0, 10.0]},
+        {"embedding": [10.1, 10.0]},
+        {"embedding": [1.0, 2.0, 3.0]},  # bad — wrong dim
+    ]
+    driver = FakeParamRoutingDriver(_cluster_routes(sample_rows=sample_rows))
+
+    result = await cluster_vectors(driver, "app", "docs", "embedding", k=2)  # type: ignore[arg-type]
+
+    assert result.sampled_rows == 4
+
+
+async def test_cluster_vectors_rejects_not_enough_rows_for_k() -> None:
+    # 3 rows, k=2 -> needs at least 4 (2*k).
+    sample_rows: list[dict[str, object]] = [
+        {"embedding": [0.0, 0.0]},
+        {"embedding": [1.0, 0.0]},
+        {"embedding": [0.0, 1.0]},
+    ]
+    driver = FakeParamRoutingDriver(_cluster_routes(sample_rows=sample_rows))
+
+    with pytest.raises(VectorOpsError, match="not enough rows to cluster"):
+        await cluster_vectors(driver, "app", "docs", "embedding", k=2)  # type: ignore[arg-type]
+
+
+async def test_cluster_vectors_raises_when_column_is_not_pgvector() -> None:
+    driver = FakeParamRoutingDriver(_cluster_routes(dim=None))
+    with pytest.raises(VectorOpsError, match="is not a pgvector"):
+        await cluster_vectors(driver, "app", "docs", "embedding", k=2)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"metric": "manhattan", "k": 2}, "metric"),
+        ({"k": 0}, "k must be"),
+        ({"k": 1}, "k must be"),
+        ({"k": 2, "sample_size": 0}, "sample_size"),
+        ({"k": 2, "max_iterations": 0}, "max_iterations"),
+    ],
+)
+async def test_cluster_vectors_validates_arguments(kwargs: dict[str, object], match: str) -> None:
+    driver = FakeParamRoutingDriver(_cluster_routes())
+    with pytest.raises(VectorOpsError, match=match):
+        await cluster_vectors(driver, "app", "docs", "embedding", **kwargs)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("bad", ['x"; DROP TABLE y', "1bad", "a-b"])
+async def test_cluster_vectors_rejects_unsafe_identifiers(bad: str) -> None:
+    driver = FakeParamRoutingDriver(_cluster_routes())
+    with pytest.raises(VectorOpsError, match="invalid"):
+        await cluster_vectors(driver, bad, "docs", "embedding", k=2)  # type: ignore[arg-type]
+
+
+async def test_cluster_vectors_reports_default_constants_via_module() -> None:
+    # Lightweight sanity that the surfaced defaults match the docstring.
+    assert DEFAULT_CLUSTER_SAMPLE_SIZE == 5000
+    assert DEFAULT_MAX_ITERATIONS == 20
+
+
+async def test_cluster_vectors_avoids_duplicate_centroids_when_many_clusters_collapse() -> None:
+    # Regression for the gemini PR #52 bug: when several clusters end
+    # up empty in the same iteration, each was re-seeded onto the
+    # *same* worst-fit point (distances[] wasn't updated inside the
+    # loop), yielding duplicate centroids. We force the situation by
+    # asking for k=4 over 8 well-separated points so it's still
+    # sensible, but seed with a value where the initial seeding could
+    # plausibly leave some clusters underfilled; either way the final
+    # centroids must all be distinct.
+    sample_rows: list[dict[str, object]] = [
+        {"embedding": [x, y]}
+        for x, y in [
+            (0.0, 0.0),
+            (0.1, 0.0),
+            (10.0, 0.0),
+            (10.1, 0.0),
+            (0.0, 10.0),
+            (0.1, 10.0),
+            (10.0, 10.0),
+            (10.1, 10.0),
+        ]
+    ]
+    driver = FakeParamRoutingDriver(_cluster_routes(sample_rows=sample_rows))
+
+    result = await cluster_vectors(
+        driver,
+        "app",
+        "docs",
+        "embedding",
+        k=4,
+        seed=1,  # type: ignore[arg-type]
+    )
+
+    # Render each centroid as a tuple so we can use set membership.
+    distinct = {tuple(c.centroid) for c in result.centroids}
+    assert len(distinct) == len(result.centroids), (
+        f"duplicate centroids slipped through: {[c.centroid for c in result.centroids]}"
+    )
+
+
+async def test_cluster_vectors_tool_is_callable_from_a_client() -> None:
+    sample_rows: list[dict[str, object]] = [
+        {"embedding": [0.0, 0.0]},
+        {"embedding": [0.1, 0.1]},
+        {"embedding": [10.0, 10.0]},
+        {"embedding": [10.1, 10.1]},
+    ]
+    database = FakeDatabase(FakeParamRoutingDriver(_cluster_routes(sample_rows=sample_rows)))
+    server = create_server(_SETTINGS, database=database)  # type: ignore[arg-type]
+
+    async with create_connected_server_and_client_session(server) as client:
+        listed = {tool.name for tool in (await client.list_tools()).tools}
+        assert "cluster_vectors" in listed
+        result = await client.call_tool(
+            "cluster_vectors",
+            {"schema": "app", "table": "docs", "embedding_column": "embedding", "k": 2},
+        )
+
+    assert result.isError is False
+    assert result.structuredContent is not None
+    assert result.structuredContent["available"] is True
+    assert len(result.structuredContent["centroids"]) == 2


### PR DESCRIPTION
## Why

Workstream A, **item A5** from `docs/parallel-roadmap.md` (shortlist **9.3**). Third resident of `mcpg.vector_ops`. Lays the centroid + assignment groundwork that **A6** (`detect_vector_outliers`, sequenced after this) will reuse — per the roadmap's intra-stream dependency note.

## What

**`cluster_vectors(schema, table, embedding_column, k, ...)`** — in-process k-means over an embedding column. Read-only.

- Samples up to `sample_size` (default **5000**) non-NULL rows; silently skips rows that don't parse to the column's declared `vector(N)` dimension.
- **k-means++ seeding** (deterministic via `seed`) + **Lloyd update loop** with a centroid-drift convergence check (tolerance `1e-4` of the mean centroid scale).
- **Empty-cluster re-seeding** on the worst-fit row prevents the classic degenerate output.
- `metric="l2"` (default, squared Euclidean) or `"cosine"` (vectors normalised up front, centroids re-normalised every iteration so the standard Lloyd update still converges).
- Returns `ClusterCentroid[]` (cluster, centroid, size) + `ClusterAssignment[]` (id or sample index, cluster, distance), plus `iterations`, `converged`, `inertia`.

### Module-level helpers (composable with A6)
- `_squared_distance`, `_cosine_distance`, `_normalize_in_place` — pure numerical helpers, all individually tested.
- `_kmeans_plus_plus_init` + `_kmeans` — algorithm guts kept separate from the I/O-bound entry point.
- `_vector_column_dimension` — sibling of the helper in `data_movement.py`, duplicated for module independence. Same shape as the helper introduced in #50 (`cross_table_similarity`); whichever lands first owns it on `main` and the rebase collapses the other.

## Test plan
- [x] **+16 tests**: `_squared_distance` / `_cosine_distance` / `_normalize_in_place` boundary cases; two well-separated clusters land cohesively (deterministic *structural* assertion, not seed-dependent); `id_column` passthrough; cosine metric yields unit-norm centroids; **same seed → identical centroids on two runs**; `sample_size` bound as `LIMIT`; wrong-dim rows silently skipped; not-enough-rows error; column-not-pgvector; arg validation (`metric` / `k=0` / `k=1` / `sample_size=0` / `max_iterations=0`); parametric identifier safety; tool listing + dispatch via MCP client.
- [x] `vector_ops.py` at **97% coverage** (the empty-cluster reseed branch + a couple of rare paths uncovered — acceptable for a heuristic algorithm without a real PG to drive it).
- [x] **1116 unit tests pass**; ruff / format / mypy(`src/mcpg`) / bandit clean.

## Docs (folded in, per parallel-roadmap §2)
- `tour.md`: tool line added under "Tune pgvector".
- `feature-shortlist.md`: 9.3 → ✅.
- `CHANGELOG.md`: `[Unreleased]` bullet.
- **Tool count NOT bumped** — parallel batch with A3 / A4 / A6; periodic sync reconciles.

## Next
**A6** (`detect_vector_outliers`) waits for this to merge so it can reuse the centroid helpers + dataclasses without a duplicate-definition collision.

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_