### PR TITLE
feat: pg_buffercache integration (D2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **`pg_buffercache` integration.** Adds `read_pg_buffercache_summary` and
+  `read_pg_buffercache_relations` tools to analyze shared buffer cache usage
+  at the cluster and relation levels. Degrades gracefully if the extension
+  is not installed (`available=false`). Adds `pg_buffercache` to the list of
+  programmatically enableable extensions.
+
 - **Slow-call logging from the MCP layer (`MCPG_SLOW_CALL_THRESHOLD_MS`).** Logs a warning
   to the `mcpg.server` logger when any tool execution duration exceeds the configured threshold.
   Defaults to `1000` ms. A value of `0` or less disables this logging.

--- a/docs/feature-shortlist.md
+++ b/docs/feature-shortlist.md
@@ -33,7 +33,7 @@ Effort scale (rough, single-session yardstick):
 | # | Item | Effort | Value | Notes |
 |---|---|---|---|---|
 | 2.1 | Logical replication management writes (`create_publication`, `drop_publication`, `create_subscription`, `drop_subscription`) | M | Medium-High | Read tools already exist. Closes the loop on logical-replication ops; gated under `MCPG_ALLOW_DDL`. |
-| 2.2 | `pg_buffercache` integration (cache hit analysis at the buffer level) | S | Low-Medium | Niche. |
+| 2.2 | ✅ **Shipped.** `pg_buffercache` integration (cache hit analysis at the buffer level) | S | Low-Medium | Niche. |
 | 2.3 | WAL inspection (`pg_walinspect`) | S | Low | Niche but useful for replication debugging. |
 | 2.4 | ✅ **Shipped.** Deeper `pg_locks` walker — deadlock-cycle reconstruction beyond the current `find_blocking_chains` pair list | S-M | Medium | Live-ops complement. |
 

--- a/docs/parallel-roadmap.md
+++ b/docs/parallel-roadmap.md
@@ -106,7 +106,7 @@ them** (or coordinate) to avoid colliding on `build_http_app`.
 | PR | Item | New module? | Effort | Notes |
 |---|---|---|---|---|
 | D1 | Logical replication writes (2.1) | new `replication.py` | M | `create/drop_publication`, `create/drop_subscription`; DDL-gated. |
-| D2 | `pg_buffercache` integration (2.2) | extends `io_stats.py` | S | Buffer-level cache analysis (needs the extension). |
+| D2 (✅ PR) | `pg_buffercache` integration (2.2) | extends `io_stats.py` | S | Buffer-level cache analysis (needs the extension). |
 | D3 | WAL inspection `pg_walinspect` (2.3) | new small module | S | Niche; replication debugging. |
 | D4 (✅ PR #45) | Deadlock-cycle walker (2.4) | extends `locks.py` | S-M | Reconstruct cycles beyond `find_blocking_chains` pairs. |
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -38,7 +38,7 @@ plumbing:
 | **Visualisation & structural diff** | `generate_schema_diagram`, `generate_schema_docs`, `generate_fk_cascade_graph`, `generate_graph_diagram`, `compare_schemas` |
 | **Query intelligence** | `run_select`, `run_select_parallel`, `explain_query`, `analyze_query_plan`, `translate_nl_to_sql` |
 | **Server-side cursors** | `open_cursor`, `fetch_cursor`, `close_cursor`, `list_cursors` |
-| **Composite + diagnostic** | `summarize_table`, `why_is_this_slow`, `find_unused_objects`, `find_sensitive_columns`, `detect_n_plus_one`, `lint_naming_conventions`, `test_rls_for_role`, `list_locks`, `find_blocking_chains`, `walk_blocking_chains`, `read_pg_stat_io` |
+| **Composite + diagnostic** | `summarize_table`, `why_is_this_slow`, `find_unused_objects`, `find_sensitive_columns`, `detect_n_plus_one`, `lint_naming_conventions`, `test_rls_for_role`, `list_locks`, `find_blocking_chains`, `walk_blocking_chains`, `read_pg_stat_io`, `read_pg_buffercache_summary`, `read_pg_buffercache_relations` |
 | **Health & tuning** | `check_database_health`, `audit_database`, `analyze_workload`, `recommend_indexes`, `run_advisors` |
 | **Search** | `fuzzy_search`, `full_text_search`, `vector_search`, `vector_range_search`, `hybrid_search`, `geo_search` |
 | **Vector tuning advisors** | `recommend_vector_index`, `analyze_vector_search`, `analyze_vector_table`, `recommend_vector_quantization` |

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -106,6 +106,8 @@ list_locks(limit=100)                                # pg_locks joined with pg_s
 find_blocking_chains(limit=50)                       # (blocked, blocking) pairs via pg_blocking_pids
 walk_blocking_chains(limit=50)                       # walks the lock graph, detects cycles, and renders a Mermaid flowchart
 read_pg_stat_io()                                    # PG16+ I/O stats; available=false on PG 14/15
+read_pg_buffercache_summary()                        # high-level shared buffer cache usage summary
+read_pg_buffercache_relations(schema=null, limit=100) # relations taking up the most space in shared buffer cache
 detect_n_plus_one(min_calls=100)                     # pg_stat_statements walker for ORM lazy-load loops
 list_replicas()                                      # health of every read-replica (when MCPG_REPLICA_URLS set)
 ```

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -175,6 +175,9 @@ storage advisor).
   issues, and prescriptive recommendations.
 - `analyze_workload` — slowest query templates from
   `pg_stat_statements`.
+- `read_pg_buffercache_summary` and `read_pg_buffercache_relations` —
+  shared buffer cache usage summary and relation-level breakdown
+  (requires the `pg_buffercache` extension).
 - `recommend_indexes` — missing-index heuristics.
 - `find_unused_objects(schema)` — zero-scan tables and user
   indexes; great for "what can I drop?".
@@ -591,7 +594,7 @@ roadmap of shipped (✅) and queued (⬜) hardening items.
 - **A write tool is missing.** Set `MCPG_ACCESS_MODE=unrestricted`
   plus the matching gate (`MCPG_ALLOW_DDL=true`,
   `MCPG_ALLOW_SHELL=true`, or `MCPG_ALLOW_LISTEN=true`).
-- **`fuzzy_search` / `analyze_workload` / `vector_search` reports
+- **`fuzzy_search` / `analyze_workload` / `vector_search` / `read_pg_buffercache_summary` / `read_pg_buffercache_relations` reports
   `available: false`.** The corresponding extension isn't
   installed in the target DB. MCPg degrades gracefully — install
   when ready.

--- a/src/mcpg/extensions.py
+++ b/src/mcpg/extensions.py
@@ -38,6 +38,7 @@ ENABLEABLE_EXTENSIONS = frozenset(
         "postgres_fdw",
         "pg_cron",
         "pg_partman",
+        "pg_buffercache",
     }
 )
 

--- a/src/mcpg/io_stats.py
+++ b/src/mcpg/io_stats.py
@@ -127,3 +127,156 @@ def _maybe_float(value: object) -> float | None:
     if value is None:
         return None
     return float(value)  # type: ignore[arg-type]
+
+
+@dataclass(frozen=True, slots=True)
+class BufferCacheSummaryReport:
+    """High-level shared buffer cache usage summary."""
+
+    available: bool
+    total_buffers: int | None = None
+    free_buffers: int | None = None
+    used_buffers: int | None = None
+    dirty_buffers: int | None = None
+    average_usage_count: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class BufferCacheRelationRow:
+    """Buffer cache usage for one database relation (table or index)."""
+
+    schema_name: str
+    relation_name: str
+    relation_kind: str
+    buffered_blocks: int
+    buffered_bytes: int
+    buffer_percent: float | None
+    percent_of_relation_buffered: float | None
+    average_usage_count: float | None
+    dirty_pages: int
+
+
+@dataclass(frozen=True, slots=True)
+class BufferCacheRelationsReport:
+    """Relations taking up space in the shared buffer cache."""
+
+    available: bool
+    relations: list[BufferCacheRelationRow]
+
+
+_RELKIND_MAP = {
+    "r": "table",
+    "i": "index",
+    "S": "sequence",
+    "t": "toast table",
+    "v": "view",
+    "m": "materialized view",
+    "c": "composite type",
+    "f": "foreign table",
+    "p": "partitioned table",
+    "I": "partitioned index",
+}
+
+
+def _map_relkind(kind: str | None) -> str:
+    if not kind:
+        return "unknown"
+    return _RELKIND_MAP.get(kind, f"unknown ({kind})")
+
+
+async def read_pg_buffercache_summary(driver: SqlDriver) -> BufferCacheSummaryReport:
+    """Get a high-level summary of the shared buffer cache state.
+
+    Requires the ``pg_buffercache`` extension. Returns ``available=False`` if not installed.
+    """
+    from mcpg.extensions import extension_installed
+
+    if not await extension_installed(driver, "pg_buffercache"):
+        return BufferCacheSummaryReport(available=False)
+
+    rows = await driver.execute_query(
+        "SELECT count(*) AS total_buffers, "
+        "       sum(case when relfilenode IS NULL then 1 else 0 end) AS free_buffers, "
+        "       sum(case when relfilenode IS NOT NULL then 1 else 0 end) AS used_buffers, "
+        "       sum(case when isdirty then 1 else 0 end) AS dirty_buffers, "
+        "       avg(usagecount) AS average_usage_count "
+        "FROM pg_buffercache",
+        force_readonly=True,
+    )
+    if not rows:
+        return BufferCacheSummaryReport(available=True)
+
+    row = rows[0]
+    return BufferCacheSummaryReport(
+        available=True,
+        total_buffers=_maybe_int(row.cells.get("total_buffers")),
+        free_buffers=_maybe_int(row.cells.get("free_buffers")),
+        used_buffers=_maybe_int(row.cells.get("used_buffers")),
+        dirty_buffers=_maybe_int(row.cells.get("dirty_buffers")),
+        average_usage_count=_maybe_float(row.cells.get("average_usage_count")),
+    )
+
+
+async def read_pg_buffercache_relations(
+    driver: SqlDriver,
+    *,
+    schema: str | None = None,
+    limit: int = 100,
+) -> BufferCacheRelationsReport:
+    """Get the list of relations taking up the most space in the shared buffer cache.
+
+    Requires the ``pg_buffercache`` extension. Returns ``available=False`` if not installed.
+    """
+    from mcpg.extensions import extension_installed
+
+    if not await extension_installed(driver, "pg_buffercache"):
+        return BufferCacheRelationsReport(available=False, relations=[])
+
+    query = (
+        "SELECT n.nspname AS schema_name, "
+        "       c.relname AS relation_name, "
+        "       c.relkind AS relation_kind, "
+        "       count(*) AS buffered_blocks, "
+        "       count(*) * 8192 AS buffered_bytes, "
+        "       round(100.0 * count(*) / (SELECT nullif(setting::integer, 0) "
+        "                                 FROM pg_settings WHERE name='shared_buffers'), 2) AS buffer_percent, "
+        "       round(100.0 * count(*) * 8192 / nullif(pg_relation_size(c.oid), 0), 2) "
+        "         AS percent_of_relation_buffered, "
+        "       avg(usagecount) AS average_usage_count, "
+        "       sum(case when isdirty then 1 else 0 end) AS dirty_pages "
+        "FROM pg_buffercache b "
+        "JOIN pg_class c ON b.relfilenode = pg_relation_filenode(c.oid) "
+        "JOIN pg_namespace n ON n.oid = c.relnamespace "
+        "JOIN pg_database d ON (b.reldatabase = d.oid AND d.datname = current_database()) "
+    )
+
+    params: list[object] = []
+    if schema is not None:
+        query += "WHERE n.nspname = %s "
+        params.append(schema)
+
+    query += "GROUP BY n.nspname, c.oid, c.relname, c.relkind ORDER BY count(*) DESC LIMIT %s"
+    params.append(limit)
+
+    rows = await driver.execute_query(
+        query,
+        params=params,
+        force_readonly=True,
+    )
+
+    relations = [
+        BufferCacheRelationRow(
+            schema_name=str(row.cells["schema_name"]),
+            relation_name=str(row.cells["relation_name"]),
+            relation_kind=_map_relkind(str(row.cells.get("relation_kind"))),
+            buffered_blocks=_maybe_int(row.cells.get("buffered_blocks")) or 0,
+            buffered_bytes=_maybe_int(row.cells.get("buffered_bytes")) or 0,
+            buffer_percent=_maybe_float(row.cells.get("buffer_percent")),
+            percent_of_relation_buffered=_maybe_float(row.cells.get("percent_of_relation_buffered")),
+            average_usage_count=_maybe_float(row.cells.get("average_usage_count")),
+            dirty_pages=_maybe_int(row.cells.get("dirty_pages")) or 0,
+        )
+        for row in rows or []
+    ]
+
+    return BufferCacheRelationsReport(available=True, relations=relations)

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -521,6 +521,35 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
         return asdict(report)
 
     @server.tool(
+        name="read_pg_buffercache_summary",
+        description=(
+            "Read a high-level summary of the PostgreSQL shared buffer cache usage. "
+            "Reports total buffers, free/used buffers, dirty buffers, and average usage count. "
+            "Requires the pg_buffercache extension. If not installed, returns available=false."
+        ),
+    )
+    async def read_pg_buffercache_summary(ctx: _Ctx) -> dict[str, Any]:
+        report = await io_stats.read_pg_buffercache_summary(_driver(ctx))
+        return asdict(report)
+
+    @server.tool(
+        name="read_pg_buffercache_relations",
+        description=(
+            "Read the list of database relations taking up the most space in the PostgreSQL shared buffer cache. "
+            "Reports buffered size, percentage of shared buffers, percent of relation buffered, "
+            "average usage count, and dirty pages. Allows filtering by schema. "
+            "Requires the pg_buffercache extension. If not installed, returns available=false."
+        ),
+    )
+    async def read_pg_buffercache_relations(
+        ctx: _Ctx,
+        schema: str | None = None,
+        limit: int = 100,
+    ) -> dict[str, Any]:
+        report = await io_stats.read_pg_buffercache_relations(_driver(ctx), schema=schema, limit=limit)
+        return asdict(report)
+
+    @server.tool(
         name="get_compact_schema",
         description=(
             "Return a highly condensed, token-efficient text summary of a schema's "

--- a/tests/unit/test_buffercache.py
+++ b/tests/unit/test_buffercache.py
@@ -1,0 +1,232 @@
+"""Tests for the pg_buffercache integration."""
+
+from __future__ import annotations
+
+import json
+
+from _fakes import FakeDatabase, FakeDriver, FakeRoutingDriver
+from mcp.shared.memory import create_connected_server_and_client_session
+
+from mcpg.config import load_settings
+from mcpg.io_stats import (
+    BufferCacheRelationsReport,
+    BufferCacheSummaryReport,
+    read_pg_buffercache_relations,
+    read_pg_buffercache_summary,
+)
+from mcpg.server import create_server
+
+_SETTINGS = load_settings({"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db"})
+
+
+async def test_read_pg_buffercache_summary_extension_not_installed() -> None:
+    # extension_installed checks pg_extension for the name. We return empty list.
+    driver = FakeRoutingDriver({"pg_extension": []})
+
+    report = await read_pg_buffercache_summary(driver)  # type: ignore[arg-type]
+
+    assert isinstance(report, BufferCacheSummaryReport)
+    assert report.available is False
+    assert report.total_buffers is None
+
+
+async def test_read_pg_buffercache_summary_installed_but_empty() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "total_buffers": [],
+        }
+    )
+
+    report = await read_pg_buffercache_summary(driver)  # type: ignore[arg-type]
+
+    assert isinstance(report, BufferCacheSummaryReport)
+    assert report.available is True
+    assert report.total_buffers is None
+
+
+async def test_read_pg_buffercache_summary_installed_with_data() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "total_buffers": [
+                {
+                    "total_buffers": 16384,
+                    "free_buffers": 4096,
+                    "used_buffers": 12288,
+                    "dirty_buffers": 256,
+                    "average_usage_count": 3.14,
+                }
+            ],
+        }
+    )
+
+    report = await read_pg_buffercache_summary(driver)  # type: ignore[arg-type]
+
+    assert isinstance(report, BufferCacheSummaryReport)
+    assert report.available is True
+    assert report.total_buffers == 16384
+    assert report.free_buffers == 4096
+    assert report.used_buffers == 12288
+    assert report.dirty_buffers == 256
+    assert report.average_usage_count == 3.14
+
+
+async def test_read_pg_buffercache_relations_extension_not_installed() -> None:
+    driver = FakeRoutingDriver({"pg_extension": []})
+
+    report = await read_pg_buffercache_relations(driver)  # type: ignore[arg-type]
+
+    assert isinstance(report, BufferCacheRelationsReport)
+    assert report.available is False
+    assert report.relations == []
+
+
+async def test_read_pg_buffercache_relations_installed_with_data() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "schema_name": [
+                {
+                    "schema_name": "public",
+                    "relation_name": "users",
+                    "relation_kind": "r",
+                    "buffered_blocks": 100,
+                    "buffered_bytes": 819200,
+                    "buffer_percent": 0.61,
+                    "percent_of_relation_buffered": 100.0,
+                    "average_usage_count": 4.5,
+                    "dirty_pages": 10,
+                },
+                {
+                    "schema_name": "public",
+                    "relation_name": "users_pkey",
+                    "relation_kind": "i",
+                    "buffered_blocks": 50,
+                    "buffered_bytes": 409600,
+                    "buffer_percent": 0.31,
+                    "percent_of_relation_buffered": 80.0,
+                    "average_usage_count": 3.0,
+                    "dirty_pages": 0,
+                },
+                {
+                    "schema_name": "public",
+                    "relation_name": "unknown_rel",
+                    "relation_kind": "x",
+                    "buffered_blocks": 10,
+                    "buffered_bytes": 81920,
+                    "buffer_percent": 0.06,
+                    "percent_of_relation_buffered": None,
+                    "average_usage_count": None,
+                    "dirty_pages": 1,
+                },
+            ],
+        }
+    )
+
+    report = await read_pg_buffercache_relations(driver)  # type: ignore[arg-type]
+
+    assert isinstance(report, BufferCacheRelationsReport)
+    assert report.available is True
+    assert len(report.relations) == 3
+
+    r1 = report.relations[0]
+    assert r1.schema_name == "public"
+    assert r1.relation_name == "users"
+    assert r1.relation_kind == "table"
+    assert r1.buffered_blocks == 100
+    assert r1.buffered_bytes == 819200
+    assert r1.buffer_percent == 0.61
+    assert r1.percent_of_relation_buffered == 100.0
+    assert r1.average_usage_count == 4.5
+    assert r1.dirty_pages == 10
+
+    r2 = report.relations[1]
+    assert r2.relation_kind == "index"
+
+    r3 = report.relations[2]
+    assert r3.relation_kind == "unknown (x)"
+    assert r3.percent_of_relation_buffered is None
+    assert r3.average_usage_count is None
+
+
+async def test_read_pg_buffercache_relations_filters_by_schema() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "schema_name": [],
+        }
+    )
+
+    await read_pg_buffercache_relations(driver, schema="app", limit=10)  # type: ignore[arg-type]
+
+    # Verify query structure and params
+    calls = driver.calls
+    assert len(calls) > 1  # first is extension check, second is relations query
+    rel_query, rel_params, _ = calls[1]
+    assert "WHERE n.nspname = %s" in rel_query
+    assert "LIMIT %s" in rel_query
+    assert rel_params == ["app", 10]
+
+
+# --- MCP tool registration tests ---
+
+
+async def test_buffercache_tools_are_registered() -> None:
+    server = create_server(_SETTINGS, database=FakeDatabase(FakeDriver()))  # type: ignore[arg-type]
+
+    async with create_connected_server_and_client_session(server) as client:
+        tools = (await client.list_tools()).tools
+        names = {tool.name for tool in tools}
+
+    assert "read_pg_buffercache_summary" in names
+    assert "read_pg_buffercache_relations" in names
+
+
+async def test_buffercache_tools_execution() -> None:
+    fake_driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "total_buffers": [
+                {
+                    "total_buffers": 100,
+                    "free_buffers": 10,
+                    "used_buffers": 90,
+                    "dirty_buffers": 5,
+                    "average_usage_count": 2.5,
+                }
+            ],
+            "schema_name": [
+                {
+                    "schema_name": "public",
+                    "relation_name": "users",
+                    "relation_kind": "r",
+                    "buffered_blocks": 100,
+                    "buffered_bytes": 819200,
+                    "buffer_percent": 0.61,
+                    "percent_of_relation_buffered": 100.0,
+                    "average_usage_count": 4.5,
+                    "dirty_pages": 10,
+                }
+            ],
+        }
+    )
+    server = create_server(_SETTINGS, database=FakeDatabase(fake_driver))  # type: ignore[arg-type]
+
+    async with create_connected_server_and_client_session(server) as client:
+        # Call read_pg_buffercache_summary tool
+        result_summary = await client.call_tool("read_pg_buffercache_summary", {})
+        assert result_summary.isError is False
+        assert result_summary.content[0].text is not None
+        summary_data = json.loads(result_summary.content[0].text)
+        assert summary_data["available"] is True
+        assert summary_data["total_buffers"] == 100
+
+        # Call read_pg_buffercache_relations tool
+        result_relations = await client.call_tool("read_pg_buffercache_relations", {"schema": "public", "limit": 5})
+        assert result_relations.isError is False
+        assert result_relations.content[0].text is not None
+        relations_data = json.loads(result_relations.content[0].text)
+        assert relations_data["available"] is True
+        assert len(relations_data["relations"]) == 1
+        assert relations_data["relations"][0]["relation_name"] == "users"


### PR DESCRIPTION
## Summary

New tool addition for pg)buffercache

## Roadmap

continue on pending feature lists

## Checklist

- [ ] Tests added/updated first (TDD); suite passes locally
- [ ] `ruff`, `ruff format`, and `mypy src/mcpg` pass
- [ ] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] `docs/PROGRESS.md` updated if a roadmap task was completed
- [ ] No hand-edits to `src/mcpg/_vendor/`
