### PR TITLE
feat: migration history table integration (E1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **`read_migration_history` tool.** Adds a read-only tool to inspect and parse the native migration bookkeeping tables of popular migration frameworks (Alembic, Flyway, Diesel, Django, Prisma, Golang Migrate, Goose, Sequelize). Reports migration history records with full framework-specific metadata fields.
+
 - **`pg_walinspect` integration.** Adds `read_pg_wal_records` and
   `read_pg_wal_stats` tools to analyze Write-Ahead Log (WAL) record details and
   aggregated stats over specified LSN ranges. Degrades gracefully if the extension

--- a/docs/feature-shortlist.md
+++ b/docs/feature-shortlist.md
@@ -79,7 +79,7 @@ not covered there:
 |---|---|---|---|---|
 | 7.1 | Alembic / Flyway / Liquibase migration-script ingestion (parse + apply through `prepare_migration`) | M-L | Medium | Big agentic win for projects with existing migration history. |
 | 7.2 | Pre-deployment migration validation (target schema vs production snapshot) | M | High | Composes `compare_schemas` + shadow workflow. |
-| 7.3 | Migration history table integration (read Alembic / Flyway / Diesel native tables) | S | Medium | Reads existing tooling's bookkeeping. |
+| 7.3 | ✅ **Shipped.** Migration history table integration (read Alembic / Flyway / Diesel native tables) | S | Medium | Reads existing tooling's bookkeeping. |
 | 7.4 | Zero-downtime migration cookbook | S | Medium-High | Pure docs (patterns, not code). |
 
 ## 8. AI / agent-specific

--- a/docs/parallel-roadmap.md
+++ b/docs/parallel-roadmap.md
@@ -84,7 +84,7 @@ mini-sequence (shared centroid code).
 
 | PR | Item | New module? | Effort | Notes |
 |---|---|---|---|---|
-| B1 | Structured JSON logging toggle (1.2) | extends logging setup | S | `MCPG_LOG_FORMAT=text\|json`. Wraps the existing logger. |
+| B1 (✅ PR) | Structured JSON logging toggle (1.2) | extends logging setup | S | `MCPG_LOG_FORMAT=text\|json`. Wraps the existing logger. |
 | B2 (✅ PR) | Slow-call logging from the MCP layer (1.3) | middleware hook | S | Per-tool latency warn over a threshold. |
 | B3 | OpenTelemetry spans per tool call (1.1) | new, optional extra | M | One span per `call_tool` + child spans; behind `mcpg[otel]`. |
 
@@ -116,7 +116,7 @@ All four are independent.
 
 | PR | Item | New module? | Effort | Notes |
 |---|---|---|---|---|
-| E1 | Migration history table read (7.3) | new `migration_history.py` | S | Read Alembic / Flyway / Diesel bookkeeping tables. |
+| E1 (✅ PR) | Migration history table read (7.3) | new `migration_history.py` | S | Read Alembic / Flyway / Diesel bookkeeping tables. |
 | E2 | Zero-downtime migration cookbook (7.4) | docs only | S | Pure `docs/cookbook.md` patterns — zero code, zero conflict. |
 | E3 | Pre-deployment migration validation (7.2) | extends `migrations.py` | M | Composes `compare_schemas` + shadow workflow. |
 | E4 | Alembic/Flyway/Liquibase ingestion (7.1) | extends `migrations.py` | M-L | Large; do after E3. |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -50,6 +50,7 @@ plumbing:
 | **Data movement — subprocess (gated)** | `dump_database`, `restore_database`, `copy_table_between_databases` |
 | **LISTEN/NOTIFY bridge (gated)** | `subscribe_channel`, `poll_notifications`, `unsubscribe_channel`, `list_notification_subscriptions` |
 | **Staged migrations (gated)** | `prepare_migration`, `validate_migration`, `complete_migration`, `cancel_migration`, `list_pending_migrations` |
+| **Migration history** | `read_migration_history` |
 | **Test-data factory** | `generate_test_data` (generates SQL — does not execute) |
 | **TimescaleDB hypertables (gated for writes)** | `list_hypertables`, `list_chunks`, `create_hypertable`, `add_compression_policy`, `add_retention_policy` |
 | **ORM-DSL exporters** | `generate_prisma_schema`, `generate_drizzle_schema`, `generate_sqlalchemy_models`, `generate_sqlc_schema`, `generate_diesel_schema`, `generate_jooq_config`, `generate_ent_schemas`, `generate_ecto_schemas` |
@@ -441,6 +442,9 @@ Drops the shadow without applying. Idempotent — returns
 Lists migrations in `prepared` status, newest first. Sweeps expired
 entries (drops their shadows, flips status to `expired`) before
 listing.
+
+### `read_migration_history`
+Query and summarize historical migrations applied to the database by popular migration frameworks (Alembic, Flyway, Diesel, Django, Prisma, Golang Migrate, Goose, Sequelize). Since it is read-only, it does not require DDL privileges or unrestricted mode. Optional `schema` filter.
 
 ## Audit trail
 

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -190,6 +190,7 @@ validate_migration(target_schema, candidate_sql, sample_rows_per_table=100)
 complete_migration(migration_id)                     # applies to target
 cancel_migration(migration_id)                       # drops shadow
 list_pending_migrations()
+read_migration_history(schema=None)                      # read applied migrations (Alembic/Flyway/etc.); read-only
 generate_test_data(schema, table, rows=10, seed=42)  # synthetic INSERT statements; does NOT execute
 ```
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -402,6 +402,12 @@ All staged-migration tools require `unrestricted` +
 
 ---
 
+## Migration history
+
+`read_migration_history(schema=None)` queries and summarizes applied migrations for popular frameworks (Alembic, Flyway, Diesel, Django, Prisma, Golang Migrate, Goose, Sequelize). Since it is read-only, it does not require DDL privileges or unrestricted mode.
+
+---
+
 ## ORM bridges
 
 Eight read-only exporters generate a starting schema/model file

--- a/src/mcpg/migration_history.py
+++ b/src/mcpg/migration_history.py
@@ -1,0 +1,315 @@
+"""PostgreSQL migration history table reader."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from mcpg._vendor.sql import SqlDriver
+
+
+@dataclass(frozen=True, slots=True)
+class AlembicMigration:
+    """A row from ``alembic_version``."""
+
+    version_num: str
+
+
+@dataclass(frozen=True, slots=True)
+class FlywayMigration:
+    """A row from ``flyway_schema_history``."""
+
+    installed_rank: int
+    version: str | None
+    description: str | None
+    type: str
+    script: str
+    checksum: int | None
+    installed_by: str
+    installed_on: str
+    execution_time: int
+    success: bool
+
+
+@dataclass(frozen=True, slots=True)
+class DieselMigration:
+    """A row from ``__diesel_schema_migrations``."""
+
+    version: str
+    run_on: str
+
+
+@dataclass(frozen=True, slots=True)
+class DjangoMigration:
+    """A row from ``django_migrations``."""
+
+    id: int
+    app: str
+    name: str
+    applied: str
+
+
+@dataclass(frozen=True, slots=True)
+class PrismaMigration:
+    """A row from ``_prisma_migrations``."""
+
+    id: str
+    checksum: str
+    finished_at: str | None
+    migration_name: str
+    logs: str | None
+    rolled_back_at: str | None
+    started_at: str
+    applied_steps_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class GolangMigrateMigration:
+    """A row from ``schema_migrations``."""
+
+    version: int
+    dirty: bool
+
+
+@dataclass(frozen=True, slots=True)
+class GooseMigration:
+    """A row from ``goose_db_version``."""
+
+    id: int
+    version_id: int
+    is_applied: bool
+    tstamp: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class SequelizeMigration:
+    """A row from ``SequelizeMeta``."""
+
+    name: str
+
+
+@dataclass(frozen=True, slots=True)
+class MigrationHistoryReport:
+    """Report summarizing discovered migration histories."""
+
+    alembic: list[AlembicMigration] | None = None
+    flyway: list[FlywayMigration] | None = None
+    diesel: list[DieselMigration] | None = None
+    django: list[DjangoMigration] | None = None
+    prisma: list[PrismaMigration] | None = None
+    golang_migrate: list[GolangMigrateMigration] | None = None
+    goose: list[GooseMigration] | None = None
+    sequelize: list[SequelizeMigration] | None = None
+
+
+def _maybe_int(value: object) -> int | None:
+    if value is None:
+        return None
+    return int(value)  # type: ignore[call-overload,no-any-return]
+
+
+def _maybe_str(value: object) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+async def read_migration_history(
+    driver: SqlDriver,
+    schema: str | None = None,
+) -> MigrationHistoryReport:
+    """Read migration bookkeeping history tables in the database.
+
+    Scans the database (filtered optionally by ``schema``) for standard table names used by
+    common migration frameworks (Alembic, Flyway, Diesel, Django, Prisma, Golang Migrate,
+    Goose, Sequelize) and returns records found in them.
+    """
+    # 1. Discover which tables exist.
+    query = (
+        "SELECT table_schema, table_name "
+        "FROM information_schema.tables "
+        "WHERE table_name IN ("
+        "  'alembic_version', "
+        "  'flyway_schema_history', "
+        "  '__diesel_schema_migrations', "
+        "  'django_migrations', "
+        "  '_prisma_migrations', "
+        "  'schema_migrations', "
+        "  'goose_db_version', "
+        "  'SequelizeMeta'"
+        ") AND table_schema NOT IN ('pg_catalog', 'information_schema')"
+    )
+    params: list[Any] = []
+    if schema:
+        query += " AND table_schema = %s"
+        params.append(schema)
+
+    rows = await driver.execute_query(query, params=params, force_readonly=True)
+    if not rows:
+        return MigrationHistoryReport()
+
+    # Map discovered tables: (table_schema, table_name)
+    discovered = [(str(row.cells["table_schema"]), str(row.cells["table_name"])) for row in rows]
+
+    alembic: list[AlembicMigration] | None = None
+    flyway: list[FlywayMigration] | None = None
+    diesel: list[DieselMigration] | None = None
+    django: list[DjangoMigration] | None = None
+    prisma: list[PrismaMigration] | None = None
+    golang_migrate: list[GolangMigrateMigration] | None = None
+    goose: list[GooseMigration] | None = None
+    sequelize: list[SequelizeMigration] | None = None
+
+    for s, t in discovered:
+        if t == "alembic_version":
+            try:
+                # Alembic has just a single version_num column (typically 1 row)
+                alembic_rows = await driver.execute_query(
+                    f'SELECT version_num::text AS version_num FROM "{s}"."{t}"',
+                    force_readonly=True,
+                )
+                alembic = [AlembicMigration(version_num=str(row.cells["version_num"])) for row in alembic_rows or []]
+            except Exception:
+                pass
+
+        elif t == "flyway_schema_history":
+            try:
+                flyway_rows = await driver.execute_query(
+                    f"SELECT installed_rank, version, description, type, script, "
+                    f"       checksum, installed_by, installed_on::text AS installed_on, "
+                    f"       execution_time, success "
+                    f'FROM "{s}"."{t}" ORDER BY installed_rank',
+                    force_readonly=True,
+                )
+                flyway = [
+                    FlywayMigration(
+                        installed_rank=int(row.cells["installed_rank"]),
+                        version=_maybe_str(row.cells.get("version")),
+                        description=_maybe_str(row.cells.get("description")),
+                        type=str(row.cells["type"]),
+                        script=str(row.cells["script"]),
+                        checksum=_maybe_int(row.cells.get("checksum")),
+                        installed_by=str(row.cells["installed_by"]),
+                        installed_on=str(row.cells["installed_on"]),
+                        execution_time=int(row.cells["execution_time"]),
+                        success=bool(row.cells["success"]),
+                    )
+                    for row in flyway_rows or []
+                ]
+            except Exception:
+                pass
+
+        elif t == "__diesel_schema_migrations":
+            try:
+                diesel_rows = await driver.execute_query(
+                    f'SELECT version, run_on::text AS run_on FROM "{s}"."{t}" ORDER BY version',
+                    force_readonly=True,
+                )
+                diesel = [
+                    DieselMigration(
+                        version=str(row.cells["version"]),
+                        run_on=str(row.cells["run_on"]),
+                    )
+                    for row in diesel_rows or []
+                ]
+            except Exception:
+                pass
+
+        elif t == "django_migrations":
+            try:
+                django_rows = await driver.execute_query(
+                    f'SELECT id, app, name, applied::text AS applied FROM "{s}"."{t}" ORDER BY id',
+                    force_readonly=True,
+                )
+                django = [
+                    DjangoMigration(
+                        id=int(row.cells["id"]),
+                        app=str(row.cells["app"]),
+                        name=str(row.cells["name"]),
+                        applied=str(row.cells["applied"]),
+                    )
+                    for row in django_rows or []
+                ]
+            except Exception:
+                pass
+
+        elif t == "_prisma_migrations":
+            try:
+                prisma_rows = await driver.execute_query(
+                    f"SELECT id, checksum, finished_at::text AS finished_at, migration_name, "
+                    f"       logs, rolled_back_at::text AS rolled_back_at, started_at::text AS started_at, "
+                    f"       applied_steps_count "
+                    f'FROM "{s}"."{t}" ORDER BY started_at',
+                    force_readonly=True,
+                )
+                prisma = [
+                    PrismaMigration(
+                        id=str(row.cells["id"]),
+                        checksum=str(row.cells["checksum"]),
+                        finished_at=_maybe_str(row.cells.get("finished_at")),
+                        migration_name=str(row.cells["migration_name"]),
+                        logs=_maybe_str(row.cells.get("logs")),
+                        rolled_back_at=_maybe_str(row.cells.get("rolled_back_at")),
+                        started_at=str(row.cells["started_at"]),
+                        applied_steps_count=int(row.cells["applied_steps_count"]),
+                    )
+                    for row in prisma_rows or []
+                ]
+            except Exception:
+                pass
+
+        elif t == "schema_migrations":
+            try:
+                # golang-migrate
+                gm_rows = await driver.execute_query(
+                    f'SELECT version, dirty FROM "{s}"."{t}" ORDER BY version',
+                    force_readonly=True,
+                )
+                golang_migrate = [
+                    GolangMigrateMigration(
+                        version=int(row.cells["version"]),
+                        dirty=bool(row.cells["dirty"]),
+                    )
+                    for row in gm_rows or []
+                ]
+            except Exception:
+                pass
+
+        elif t == "goose_db_version":
+            try:
+                goose_rows = await driver.execute_query(
+                    f'SELECT id, version_id, is_applied, tstamp::text AS tstamp FROM "{s}"."{t}" ORDER BY id',
+                    force_readonly=True,
+                )
+                goose = [
+                    GooseMigration(
+                        id=int(row.cells["id"]),
+                        version_id=int(row.cells["version_id"]),
+                        is_applied=bool(row.cells["is_applied"]),
+                        tstamp=_maybe_str(row.cells.get("tstamp")),
+                    )
+                    for row in goose_rows or []
+                ]
+            except Exception:
+                pass
+
+        elif t == "SequelizeMeta":
+            try:
+                seq_rows = await driver.execute_query(
+                    f'SELECT name FROM "{s}"."{t}" ORDER BY name',
+                    force_readonly=True,
+                )
+                sequelize = [SequelizeMigration(name=str(row.cells["name"])) for row in seq_rows or []]
+            except Exception:
+                pass
+
+    return MigrationHistoryReport(
+        alembic=alembic,
+        flyway=flyway,
+        diesel=diesel,
+        django=django,
+        prisma=prisma,
+        golang_migrate=golang_migrate,
+        goose=goose,
+        sequelize=sequelize,
+    )

--- a/src/mcpg/migration_history.py
+++ b/src/mcpg/migration_history.py
@@ -114,6 +114,10 @@ def _maybe_str(value: object) -> str | None:
     return str(value)
 
 
+def _quote_ident(name: str) -> str:
+    return f'"{name.replace(chr(34), chr(34) * 2)}"'
+
+
 async def read_migration_history(
     driver: SqlDriver,
     schema: str | None = None,
@@ -161,14 +165,21 @@ async def read_migration_history(
     sequelize: list[SequelizeMigration] | None = None
 
     for s, t in discovered:
+        quoted_s = _quote_ident(s)
+        quoted_t = _quote_ident(t)
+
         if t == "alembic_version":
             try:
                 # Alembic has just a single version_num column (typically 1 row)
                 alembic_rows = await driver.execute_query(
-                    f'SELECT version_num::text AS version_num FROM "{s}"."{t}"',
+                    f"SELECT version_num::text AS version_num FROM {quoted_s}.{quoted_t}",
                     force_readonly=True,
                 )
-                alembic = [AlembicMigration(version_num=str(row.cells["version_num"])) for row in alembic_rows or []]
+                if alembic is None:
+                    alembic = []
+                alembic.extend(
+                    [AlembicMigration(version_num=str(row.cells["version_num"])) for row in alembic_rows or []]
+                )
             except Exception:
                 pass
 
@@ -178,58 +189,70 @@ async def read_migration_history(
                     f"SELECT installed_rank, version, description, type, script, "
                     f"       checksum, installed_by, installed_on::text AS installed_on, "
                     f"       execution_time, success "
-                    f'FROM "{s}"."{t}" ORDER BY installed_rank',
+                    f"FROM {quoted_s}.{quoted_t} ORDER BY installed_rank",
                     force_readonly=True,
                 )
-                flyway = [
-                    FlywayMigration(
-                        installed_rank=int(row.cells["installed_rank"]),
-                        version=_maybe_str(row.cells.get("version")),
-                        description=_maybe_str(row.cells.get("description")),
-                        type=str(row.cells["type"]),
-                        script=str(row.cells["script"]),
-                        checksum=_maybe_int(row.cells.get("checksum")),
-                        installed_by=str(row.cells["installed_by"]),
-                        installed_on=str(row.cells["installed_on"]),
-                        execution_time=int(row.cells["execution_time"]),
-                        success=bool(row.cells["success"]),
-                    )
-                    for row in flyway_rows or []
-                ]
+                if flyway is None:
+                    flyway = []
+                flyway.extend(
+                    [
+                        FlywayMigration(
+                            installed_rank=int(row.cells["installed_rank"]),
+                            version=_maybe_str(row.cells.get("version")),
+                            description=_maybe_str(row.cells.get("description")),
+                            type=str(row.cells["type"]),
+                            script=str(row.cells["script"]),
+                            checksum=_maybe_int(row.cells.get("checksum")),
+                            installed_by=str(row.cells["installed_by"]),
+                            installed_on=str(row.cells["installed_on"]),
+                            execution_time=int(row.cells["execution_time"]),
+                            success=bool(row.cells["success"]),
+                        )
+                        for row in flyway_rows or []
+                    ]
+                )
             except Exception:
                 pass
 
         elif t == "__diesel_schema_migrations":
             try:
                 diesel_rows = await driver.execute_query(
-                    f'SELECT version, run_on::text AS run_on FROM "{s}"."{t}" ORDER BY version',
+                    f"SELECT version, run_on::text AS run_on FROM {quoted_s}.{quoted_t} ORDER BY version",
                     force_readonly=True,
                 )
-                diesel = [
-                    DieselMigration(
-                        version=str(row.cells["version"]),
-                        run_on=str(row.cells["run_on"]),
-                    )
-                    for row in diesel_rows or []
-                ]
+                if diesel is None:
+                    diesel = []
+                diesel.extend(
+                    [
+                        DieselMigration(
+                            version=str(row.cells["version"]),
+                            run_on=str(row.cells["run_on"]),
+                        )
+                        for row in diesel_rows or []
+                    ]
+                )
             except Exception:
                 pass
 
         elif t == "django_migrations":
             try:
                 django_rows = await driver.execute_query(
-                    f'SELECT id, app, name, applied::text AS applied FROM "{s}"."{t}" ORDER BY id',
+                    f"SELECT id, app, name, applied::text AS applied FROM {quoted_s}.{quoted_t} ORDER BY id",
                     force_readonly=True,
                 )
-                django = [
-                    DjangoMigration(
-                        id=int(row.cells["id"]),
-                        app=str(row.cells["app"]),
-                        name=str(row.cells["name"]),
-                        applied=str(row.cells["applied"]),
-                    )
-                    for row in django_rows or []
-                ]
+                if django is None:
+                    django = []
+                django.extend(
+                    [
+                        DjangoMigration(
+                            id=int(row.cells["id"]),
+                            app=str(row.cells["app"]),
+                            name=str(row.cells["name"]),
+                            applied=str(row.cells["applied"]),
+                        )
+                        for row in django_rows or []
+                    ]
+                )
             except Exception:
                 pass
 
@@ -239,22 +262,26 @@ async def read_migration_history(
                     f"SELECT id, checksum, finished_at::text AS finished_at, migration_name, "
                     f"       logs, rolled_back_at::text AS rolled_back_at, started_at::text AS started_at, "
                     f"       applied_steps_count "
-                    f'FROM "{s}"."{t}" ORDER BY started_at',
+                    f"FROM {quoted_s}.{quoted_t} ORDER BY started_at",
                     force_readonly=True,
                 )
-                prisma = [
-                    PrismaMigration(
-                        id=str(row.cells["id"]),
-                        checksum=str(row.cells["checksum"]),
-                        finished_at=_maybe_str(row.cells.get("finished_at")),
-                        migration_name=str(row.cells["migration_name"]),
-                        logs=_maybe_str(row.cells.get("logs")),
-                        rolled_back_at=_maybe_str(row.cells.get("rolled_back_at")),
-                        started_at=str(row.cells["started_at"]),
-                        applied_steps_count=int(row.cells["applied_steps_count"]),
-                    )
-                    for row in prisma_rows or []
-                ]
+                if prisma is None:
+                    prisma = []
+                prisma.extend(
+                    [
+                        PrismaMigration(
+                            id=str(row.cells["id"]),
+                            checksum=str(row.cells["checksum"]),
+                            finished_at=_maybe_str(row.cells.get("finished_at")),
+                            migration_name=str(row.cells["migration_name"]),
+                            logs=_maybe_str(row.cells.get("logs")),
+                            rolled_back_at=_maybe_str(row.cells.get("rolled_back_at")),
+                            started_at=str(row.cells["started_at"]),
+                            applied_steps_count=int(row.cells["applied_steps_count"]),
+                        )
+                        for row in prisma_rows or []
+                    ]
+                )
             except Exception:
                 pass
 
@@ -262,44 +289,54 @@ async def read_migration_history(
             try:
                 # golang-migrate
                 gm_rows = await driver.execute_query(
-                    f'SELECT version, dirty FROM "{s}"."{t}" ORDER BY version',
+                    f"SELECT version, dirty FROM {quoted_s}.{quoted_t} ORDER BY version",
                     force_readonly=True,
                 )
-                golang_migrate = [
-                    GolangMigrateMigration(
-                        version=int(row.cells["version"]),
-                        dirty=bool(row.cells["dirty"]),
-                    )
-                    for row in gm_rows or []
-                ]
+                if golang_migrate is None:
+                    golang_migrate = []
+                golang_migrate.extend(
+                    [
+                        GolangMigrateMigration(
+                            version=int(row.cells["version"]),
+                            dirty=bool(row.cells["dirty"]),
+                        )
+                        for row in gm_rows or []
+                    ]
+                )
             except Exception:
                 pass
 
         elif t == "goose_db_version":
             try:
                 goose_rows = await driver.execute_query(
-                    f'SELECT id, version_id, is_applied, tstamp::text AS tstamp FROM "{s}"."{t}" ORDER BY id',
+                    f"SELECT id, version_id, is_applied, tstamp::text AS tstamp FROM {quoted_s}.{quoted_t} ORDER BY id",
                     force_readonly=True,
                 )
-                goose = [
-                    GooseMigration(
-                        id=int(row.cells["id"]),
-                        version_id=int(row.cells["version_id"]),
-                        is_applied=bool(row.cells["is_applied"]),
-                        tstamp=_maybe_str(row.cells.get("tstamp")),
-                    )
-                    for row in goose_rows or []
-                ]
+                if goose is None:
+                    goose = []
+                goose.extend(
+                    [
+                        GooseMigration(
+                            id=int(row.cells["id"]),
+                            version_id=int(row.cells["version_id"]),
+                            is_applied=bool(row.cells["is_applied"]),
+                            tstamp=_maybe_str(row.cells.get("tstamp")),
+                        )
+                        for row in goose_rows or []
+                    ]
+                )
             except Exception:
                 pass
 
         elif t == "SequelizeMeta":
             try:
                 seq_rows = await driver.execute_query(
-                    f'SELECT name FROM "{s}"."{t}" ORDER BY name',
+                    f"SELECT name FROM {quoted_s}.{quoted_t} ORDER BY name",
                     force_readonly=True,
                 )
-                sequelize = [SequelizeMigration(name=str(row.cells["name"])) for row in seq_rows or []]
+                if sequelize is None:
+                    sequelize = []
+                sequelize.extend([SequelizeMigration(name=str(row.cells["name"])) for row in seq_rows or []])
             except Exception:
                 pass
 

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -41,6 +41,7 @@ from mcpg import (
     liveops,
     locks,
     maintenance,
+    migration_history,
     migrations,
     naming,
     nl2sql,
@@ -596,6 +597,18 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
             return await introspection.get_compact_schema(_driver(ctx), schema)
 
         return await _cached_call(ctx, "get_compact_schema", _run, schema)
+
+    @server.tool(
+        name="read_migration_history",
+        description=(
+            "Query and summarize historical migrations applied to the database by popular migration "
+            "frameworks (Alembic, Flyway, Diesel, Django, Prisma, Golang Migrate, Goose, Sequelize). "
+            "Allows filtering by schema."
+        ),
+    )
+    async def read_migration_history(ctx: _Ctx, schema: str | None = None) -> dict[str, Any]:
+        report = await migration_history.read_migration_history(_driver(ctx), schema=schema)
+        return asdict(report)
 
 
 def _register_diagrams(server: FastMCP[AppContext]) -> None:

--- a/tests/unit/test_migration_history.py
+++ b/tests/unit/test_migration_history.py
@@ -257,3 +257,38 @@ async def test_read_migration_history_tool() -> None:
         data = json.loads(res.content[0].text)
         assert data["alembic"] == [{"version_num": "ae12d34199f"}]
         assert data["flyway"] is None
+
+
+async def test_read_migration_history_multi_schema_accumulation() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "information_schema.tables": [
+                {"table_schema": "public", "table_name": "alembic_version"},
+                {"table_schema": "tenant1", "table_name": "alembic_version"},
+            ],
+            '"public"."alembic_version"': [{"version_num": "public_version"}],
+            '"tenant1"."alembic_version"': [{"version_num": "tenant1_version"}],
+        }
+    )
+
+    report = await read_migration_history(driver)  # type: ignore[arg-type]
+
+    assert report.alembic == [
+        AlembicMigration(version_num="public_version"),
+        AlembicMigration(version_num="tenant1_version"),
+    ]
+
+
+async def test_read_migration_history_escaped_identifiers() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "information_schema.tables": [{"table_schema": 'tenant"1', "table_name": "alembic_version"}],
+            'tenant""1': [{"version_num": "escaped_version"}],
+        }
+    )
+
+    report = await read_migration_history(driver)  # type: ignore[arg-type]
+
+    assert len(driver.calls) == 2
+    assert '"tenant""1"."alembic_version"' in driver.calls[1][0]
+    assert report.alembic == [AlembicMigration(version_num="escaped_version")]

--- a/tests/unit/test_migration_history.py
+++ b/tests/unit/test_migration_history.py
@@ -1,0 +1,259 @@
+"""Tests for the migration history integration."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from _fakes import FakeDatabase, FakeRoutingDriver
+from mcp.shared.memory import create_connected_server_and_client_session
+
+from mcpg._vendor.sql import SqlDriver
+from mcpg.config import load_settings
+from mcpg.migration_history import (
+    AlembicMigration,
+    DieselMigration,
+    DjangoMigration,
+    FlywayMigration,
+    GolangMigrateMigration,
+    GooseMigration,
+    MigrationHistoryReport,
+    PrismaMigration,
+    SequelizeMigration,
+    read_migration_history,
+)
+from mcpg.server import create_server
+
+_SETTINGS = load_settings({"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db"})
+
+
+async def test_read_migration_history_empty() -> None:
+    # No tables found in information_schema.tables
+    driver = FakeRoutingDriver({"information_schema.tables": []})
+
+    report = await read_migration_history(driver)  # type: ignore[arg-type]
+
+    assert isinstance(report, MigrationHistoryReport)
+    assert report.alembic is None
+    assert report.flyway is None
+    assert report.diesel is None
+    assert report.django is None
+    assert report.prisma is None
+    assert report.golang_migrate is None
+    assert report.goose is None
+    assert report.sequelize is None
+
+
+async def test_read_migration_history_alembic() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "information_schema.tables": [{"table_schema": "public", "table_name": "alembic_version"}],
+            "alembic_version": [{"version_num": "ae12d34199f"}],
+        }
+    )
+
+    report = await read_migration_history(driver)  # type: ignore[arg-type]
+
+    assert report.alembic == [AlembicMigration(version_num="ae12d34199f")]
+    assert report.flyway is None
+
+
+async def test_read_migration_history_flyway() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "information_schema.tables": [{"table_schema": "public", "table_name": "flyway_schema_history"}],
+            "flyway_schema_history": [
+                {
+                    "installed_rank": 1,
+                    "version": "1.0.0",
+                    "description": "Initial Setup",
+                    "type": "SQL",
+                    "script": "V1__setup.sql",
+                    "checksum": 123456,
+                    "installed_by": "db_user",
+                    "installed_on": "2026-06-03 10:00:00",
+                    "execution_time": 45,
+                    "success": True,
+                }
+            ],
+        }
+    )
+
+    report = await read_migration_history(driver)  # type: ignore[arg-type]
+
+    assert len(report.flyway or []) == 1
+    f = (report.flyway or [])[0]
+    assert isinstance(f, FlywayMigration)
+    assert f.installed_rank == 1
+    assert f.version == "1.0.0"
+    assert f.description == "Initial Setup"
+    assert f.type == "SQL"
+    assert f.script == "V1__setup.sql"
+    assert f.checksum == 123456
+    assert f.installed_by == "db_user"
+    assert f.installed_on == "2026-06-03 10:00:00"
+    assert f.execution_time == 45
+    assert f.success is True
+
+
+async def test_read_migration_history_diesel() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "information_schema.tables": [{"table_schema": "public", "table_name": "__diesel_schema_migrations"}],
+            "__diesel_schema_migrations": [{"version": "20260603120000", "run_on": "2026-06-03 12:00:05"}],
+        }
+    )
+
+    report = await read_migration_history(driver)  # type: ignore[arg-type]
+
+    assert report.diesel == [DieselMigration(version="20260603120000", run_on="2026-06-03 12:00:05")]
+
+
+async def test_read_migration_history_django() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "information_schema.tables": [{"table_schema": "public", "table_name": "django_migrations"}],
+            "django_migrations": [{"id": 42, "app": "auth", "name": "0001_initial", "applied": "2026-06-03 10:15:00"}],
+        }
+    )
+
+    report = await read_migration_history(driver)  # type: ignore[arg-type]
+
+    assert report.django == [DjangoMigration(id=42, app="auth", name="0001_initial", applied="2026-06-03 10:15:00")]
+
+
+async def test_read_migration_history_prisma() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "information_schema.tables": [{"table_schema": "public", "table_name": "_prisma_migrations"}],
+            "_prisma_migrations": [
+                {
+                    "id": "e8e1919e-e81a-4ea9-b226-f7f1a3a3112a",
+                    "checksum": "abc123checksum",
+                    "finished_at": "2026-06-03 11:00:00",
+                    "migration_name": "20260603110000_init",
+                    "logs": "No logs",
+                    "rolled_back_at": None,
+                    "started_at": "2026-06-03 10:59:59",
+                    "applied_steps_count": 1,
+                }
+            ],
+        }
+    )
+
+    report = await read_migration_history(driver)  # type: ignore[arg-type]
+
+    assert len(report.prisma or []) == 1
+    p = (report.prisma or [])[0]
+    assert isinstance(p, PrismaMigration)
+    assert p.id == "e8e1919e-e81a-4ea9-b226-f7f1a3a3112a"
+    assert p.checksum == "abc123checksum"
+    assert p.finished_at == "2026-06-03 11:00:00"
+    assert p.migration_name == "20260603110000_init"
+    assert p.logs == "No logs"
+    assert p.rolled_back_at is None
+    assert p.started_at == "2026-06-03 10:59:59"
+    assert p.applied_steps_count == 1
+
+
+async def test_read_migration_history_golang_migrate() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "information_schema.tables": [{"table_schema": "public", "table_name": "schema_migrations"}],
+            "schema_migrations": [{"version": 3, "dirty": False}],
+        }
+    )
+
+    report = await read_migration_history(driver)  # type: ignore[arg-type]
+
+    assert report.golang_migrate == [GolangMigrateMigration(version=3, dirty=False)]
+
+
+async def test_read_migration_history_goose() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "information_schema.tables": [{"table_schema": "public", "table_name": "goose_db_version"}],
+            "goose_db_version": [
+                {"id": 1, "version_id": 2026060300, "is_applied": True, "tstamp": "2026-06-03 12:30:00"}
+            ],
+        }
+    )
+
+    report = await read_migration_history(driver)  # type: ignore[arg-type]
+
+    assert report.goose == [GooseMigration(id=1, version_id=2026060300, is_applied=True, tstamp="2026-06-03 12:30:00")]
+
+
+async def test_read_migration_history_sequelize() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "information_schema.tables": [{"table_schema": "public", "table_name": "SequelizeMeta"}],
+            "SequelizeMeta": [{"name": "20260603120000-init.js"}],
+        }
+    )
+
+    report = await read_migration_history(driver)  # type: ignore[arg-type]
+
+    assert report.sequelize == [SequelizeMigration(name="20260603120000-init.js")]
+
+
+async def test_read_migration_history_schema_filter() -> None:
+    driver = FakeRoutingDriver({"information_schema.tables": []})
+
+    await read_migration_history(driver, schema="my_custom_schema")  # type: ignore[arg-type]
+
+    # Verify that the schema name was passed as parameter in the information_schema query
+    assert len(driver.calls) == 1
+    assert "AND table_schema = %s" in driver.calls[0][0]
+    assert driver.calls[0][1] == ["my_custom_schema"]
+
+
+async def test_read_migration_history_resilient_to_errors() -> None:
+    class FailingRoutingDriver(FakeRoutingDriver):
+        async def execute_query(
+            self, query: str, params: list[Any] | None = None, force_readonly: bool = False
+        ) -> list[SqlDriver.RowResult]:
+            if "alembic_version" in query and "version_num" in query:
+                raise RuntimeError("database error")
+            return await super().execute_query(query, params, force_readonly)
+
+    driver = FailingRoutingDriver(
+        {
+            "information_schema.tables": [
+                {"table_schema": "public", "table_name": "alembic_version"},
+                {"table_schema": "public", "table_name": "SequelizeMeta"},
+            ],
+            "SequelizeMeta": [{"name": "20260603120000-init.js"}],
+        }
+    )
+
+    report = await read_migration_history(driver)  # type: ignore[arg-type]
+
+    # alembic fails query and falls back to None, but sequelize succeeds
+    assert report.alembic is None
+    assert report.sequelize == [SequelizeMigration(name="20260603120000-init.js")]
+
+
+# --- MCP tool registration & execution test ---
+
+
+async def test_read_migration_history_tool() -> None:
+    fake_driver = FakeRoutingDriver(
+        {
+            "information_schema.tables": [{"table_schema": "public", "table_name": "alembic_version"}],
+            "alembic_version": [{"version_num": "ae12d34199f"}],
+        }
+    )
+    server = create_server(_SETTINGS, database=FakeDatabase(fake_driver))  # type: ignore[arg-type]
+
+    async with create_connected_server_and_client_session(server) as client:
+        tools = (await client.list_tools()).tools
+        names = {tool.name for tool in tools}
+        assert "read_migration_history" in names
+
+        res = await client.call_tool("read_migration_history", {"schema": "public"})
+        assert res.isError is False
+        assert res.content[0].text is not None
+        data = json.loads(res.content[0].text)
+        assert data["alembic"] == [{"version_num": "ae12d34199f"}]
+        assert data["flyway"] is None


### PR DESCRIPTION
Implements ead_migration_history tool to query and parse the native migration bookkeeping tables of popular frameworks (Alembic, Flyway, Diesel, Django, Prisma, Golang Migrate, Goose, Sequelize). Since it is read-only, it does not require DDL privileges or unrestricted mode.