### PR TITLE
feat(security): TLS / mTLS for the HTTP transport (C2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **TLS / mTLS for the HTTP transports
+  (`MCPG_HTTP_TLS_CERTFILE` / `MCPG_HTTP_TLS_KEYFILE` /
+  `MCPG_HTTP_TLS_CA_CERTS` / `MCPG_HTTP_TLS_CLIENT_CERT_REQUIRED`).**
+  When `certfile` + `keyfile` are set, `run_http` instructs uvicorn
+  to terminate TLS itself. Adding `ca_certs` plus flipping
+  `client_cert_required=true` upgrades the listener to full mutual
+  TLS — connections without a client cert signed by a CA in the
+  bundle are refused at the handshake layer, before any ASGI
+  middleware sees the request. Settings are cross-validated at
+  boot: `certfile` and `keyfile` must both be set (or both be
+  unset), `client_cert_required` requires `ca_certs` (otherwise
+  the listener would either reject everyone or accept any self-
+  signed cert depending on the SSL backend), and every path must
+  exist on disk so a typo fails `load_settings` instead of the
+  first uvicorn startup. Lives in `mcpg.http_runtime`; disabled by
+  default — operators behind a reverse proxy continue to terminate
+  TLS at the proxy as before.
+
 - **IP allowlist for the HTTP transports (`MCPG_HTTP_IP_ALLOWLIST`).**
   When set, every request to the HTTP transports (streamable-http /
   sse) is matched against a comma-separated list of IP addresses

--- a/docs/feature-shortlist.md
+++ b/docs/feature-shortlist.md
@@ -57,7 +57,7 @@ not covered there:
 | 4.1 | ✅ **Shipped.** Connection-encryption verification tool (`verify_connection_encryption`) — reports `ssl` + protocol/cipher/bits for MCPg's own link plus a cluster-wide encrypted/unencrypted backend tally, from `pg_stat_ssl`. | S | Medium | Composes with the existing TLS-enforcement startup check. |
 | 4.2 | ✅ **Shipped.** Audit-log retention via `prune_audit_events(older_than_days)` — deletes old `mcpg_audit.events` rows (cron-friendly). Refuses when `MCPG_AUDIT_INTEGRITY` is on, since pruning would break the HMAC chain. | S | Medium | — |
 | 4.3 | ✅ **Shipped.** IP allowlist for HTTP transport (`MCPG_HTTP_IP_ALLOWLIST`) — comma-separated IP / CIDR list, validated at boot. Tiny ASGI middleware sits at the outermost layer so denied clients never reach the auth / size-limit stack. `X-Forwarded-For` is intentionally not honoured (spoofing); reverse-proxy deployments should enforce there. Lives in `mcpg.http_runtime`. | S | Low | Tiny middleware. Often handled at the reverse-proxy layer instead. |
-| 4.4 | mTLS for the HTTP transport | S | Medium | Cert wiring; commonly done at the proxy layer. |
+| 4.4 | ✅ **Shipped.** TLS / mTLS for the HTTP transport (`MCPG_HTTP_TLS_CERTFILE` / `MCPG_HTTP_TLS_KEYFILE` / `MCPG_HTTP_TLS_CA_CERTS` / `MCPG_HTTP_TLS_CLIENT_CERT_REQUIRED`) — uvicorn terminates TLS itself; with `client_cert_required=true` + a CA bundle it's full mutual TLS. Cross-validated at boot (cert+key both set, mTLS needs CA, paths must exist). Lives in `mcpg.http_runtime`. | S | Medium | Cert wiring; commonly done at the proxy layer. |
 
 ## 5. Backups & DR
 

--- a/docs/parallel-roadmap.md
+++ b/docs/parallel-roadmap.md
@@ -95,7 +95,7 @@ B1/B2 are independent; B3 is larger and best alone.
 | PR | Item | New module? | Effort | Depends on | Notes |
 |---|---|---|---|---|---|
 | C1 (✅ PR) | IP allowlist for HTTP transport (4.3) | `http_runtime.py` middleware | S | — | Tiny ASGI middleware + `MCPG_HTTP_IP_ALLOWLIST`. |
-| C2 | mTLS for the HTTP transport (4.4) | `http_runtime.py` / `run_http` | S | — | Client-cert verification (uvicorn ssl params). |
+| C2 (✅ PR) | mTLS for the HTTP transport (4.4) | `http_runtime.py` / `run_http` | S | — | Client-cert verification (uvicorn ssl params). |
 | C3 | Secrets cloud backends — Vault / AWS / GCP | extends `secrets.py` | L | — | Each behind an extra (`mcpg[vault]` …); same `MCPG_SECRETS_BACKEND` switch. Can split per provider. |
 
 C1 and C2 both edit `http_runtime.py`'s middleware stack — **sequence

--- a/src/mcpg/config.py
+++ b/src/mcpg/config.py
@@ -172,6 +172,19 @@ class Settings:
     # enforce the allowlist at the proxy layer (where the TLS
     # termination already sits).
     http_ip_allowlist: tuple[str, ...] = ()
+    # HTTP transport TLS / mTLS. ``http_tls_certfile`` +
+    # ``http_tls_keyfile`` enable TLS termination at the uvicorn
+    # layer. Add ``http_tls_ca_certs`` + ``http_tls_client_cert_required=true``
+    # for full mutual TLS — the server then refuses connections from
+    # any client whose certificate isn't signed by a CA in the bundle.
+    # When unset (default), the HTTP transports run plain HTTP and
+    # rely on a reverse proxy to terminate TLS. Paths are validated
+    # at boot so a typo fails ``load_settings`` rather than the first
+    # uvicorn startup.
+    http_tls_certfile: str | None = None
+    http_tls_keyfile: str | None = None
+    http_tls_ca_certs: str | None = None
+    http_tls_client_cert_required: bool = False
     # Per-request wall-clock cap for the HTTP transports. 0 = disabled
     # (default), because a hard cap also severs long-lived SSE /
     # streamable-http streams. Set a positive value for plain
@@ -240,6 +253,10 @@ class Settings:
             f"http_allowed_origins={self.http_allowed_origins!r}, "
             f"http_ip_allowlist={self.http_ip_allowlist!r}, "
             f"http_hsts_max_age={self.http_hsts_max_age}, "
+            f"http_tls_certfile={self.http_tls_certfile!r}, "
+            f"http_tls_keyfile={self.http_tls_keyfile!r}, "
+            f"http_tls_ca_certs={self.http_tls_ca_certs!r}, "
+            f"http_tls_client_cert_required={self.http_tls_client_cert_required}, "
             f"http_request_timeout_seconds={self.http_request_timeout_seconds}, "
             f"shutdown_drain_seconds={self.shutdown_drain_seconds}, "
             f"audit_hmac_key={audit_hmac_key_repr!r}, "
@@ -748,6 +765,37 @@ def load_settings(env: Mapping[str, str] | None = None) -> Settings:
         except ValueError:
             raise ConfigError(f"MCPG_HTTP_HSTS_MAX_AGE must be a non-negative integer (got {raw!r})") from None
 
+    # HTTP TLS / mTLS. Parsed together so we can enforce the
+    # invariant "if either cert or key is set, the other must be too"
+    # at boot — uvicorn doesn't validate this until startup, by which
+    # point the operator has already restarted the service.
+    http_tls_certfile = env.get("MCPG_HTTP_TLS_CERTFILE", "").strip() or None
+    http_tls_keyfile = env.get("MCPG_HTTP_TLS_KEYFILE", "").strip() or None
+    http_tls_ca_certs = env.get("MCPG_HTTP_TLS_CA_CERTS", "").strip() or None
+    http_tls_client_cert_required = False
+    if (raw := env.get("MCPG_HTTP_TLS_CLIENT_CERT_REQUIRED")) is not None:
+        http_tls_client_cert_required = _parse_bool("MCPG_HTTP_TLS_CLIENT_CERT_REQUIRED", raw)
+
+    if (http_tls_certfile is None) != (http_tls_keyfile is None):
+        raise ConfigError("MCPG_HTTP_TLS_CERTFILE and MCPG_HTTP_TLS_KEYFILE must both be set or both be unset")
+    if http_tls_client_cert_required and not http_tls_ca_certs:
+        # CERT_REQUIRED without a CA bundle would either reject every
+        # client or accept anyone with a self-signed cert (depending
+        # on the SSL backend). Both are footguns — fail at boot.
+        raise ConfigError("MCPG_HTTP_TLS_CLIENT_CERT_REQUIRED=true needs MCPG_HTTP_TLS_CA_CERTS to verify against")
+    # Verify paths exist on disk so a typo fails at config time
+    # instead of at the first incoming connection.
+    for env_var, path in (
+        ("MCPG_HTTP_TLS_CERTFILE", http_tls_certfile),
+        ("MCPG_HTTP_TLS_KEYFILE", http_tls_keyfile),
+        ("MCPG_HTTP_TLS_CA_CERTS", http_tls_ca_certs),
+    ):
+        if path is not None:
+            from os.path import isfile
+
+            if not isfile(path):
+                raise ConfigError(f"{env_var} points to a non-existent file: {path!r}")
+
     http_request_timeout_seconds = 0
     if (raw := env.get("MCPG_HTTP_REQUEST_TIMEOUT_SECONDS")) is not None:
         try:
@@ -833,6 +881,10 @@ def load_settings(env: Mapping[str, str] | None = None) -> Settings:
         http_allowed_origins=http_allowed_origins,
         http_ip_allowlist=http_ip_allowlist,
         http_hsts_max_age=http_hsts_max_age,
+        http_tls_certfile=http_tls_certfile,
+        http_tls_keyfile=http_tls_keyfile,
+        http_tls_ca_certs=http_tls_ca_certs,
+        http_tls_client_cert_required=http_tls_client_cert_required,
         http_request_timeout_seconds=http_request_timeout_seconds,
         shutdown_drain_seconds=shutdown_drain_seconds,
         audit_hmac_key=audit_hmac_key,

--- a/src/mcpg/http_runtime.py
+++ b/src/mcpg/http_runtime.py
@@ -615,8 +615,51 @@ def build_http_app(server: object, settings: Settings, *, kind: str) -> Starlett
 
 
 def run_http(server: object, settings: Settings, *, kind: str) -> None:
-    """Build the wrapped HTTP app and serve it via uvicorn."""
+    """Build the wrapped HTTP app and serve it via uvicorn.
+
+    Honours the project's TLS / mTLS settings: when
+    ``http_tls_certfile`` + ``http_tls_keyfile`` are set, uvicorn
+    terminates TLS itself. Adding ``http_tls_ca_certs`` and
+    flipping ``http_tls_client_cert_required=true`` upgrades the
+    listener to full mutual TLS — connections without a client cert
+    signed by a CA in the bundle are refused at the handshake
+    layer, before any ASGI middleware sees the request.
+    """
+    import ssl
+
     import uvicorn
 
     app = build_http_app(server, settings, kind=kind)
-    uvicorn.run(app, host=settings.http_host, port=settings.http_port)
+    tls_kwargs = _uvicorn_tls_kwargs(settings, ssl_module=ssl)
+    # mypy can't reason about ``**dict[str, object]`` against the
+    # large, overloaded ``uvicorn.run`` signature; the dict's contents
+    # are already constrained by ``_uvicorn_tls_kwargs``.
+    uvicorn.run(app, host=settings.http_host, port=settings.http_port, **tls_kwargs)  # type: ignore[arg-type]
+
+
+def _uvicorn_tls_kwargs(settings: Settings, *, ssl_module: object) -> dict[str, object]:
+    """Translate the project's TLS settings into the uvicorn keyword arg shape.
+
+    ``ssl_module`` is parameterised so tests can pass a stub without
+    importing the real :mod:`ssl` (avoids creating a real SSL context
+    just to assert the argument routing). At runtime callers pass
+    ``ssl`` directly.
+
+    Returns an empty dict when TLS isn't configured, so the call site
+    can ``uvicorn.run(..., **tls_kwargs)`` unconditionally.
+    """
+    if settings.http_tls_certfile is None or settings.http_tls_keyfile is None:
+        return {}
+    kwargs: dict[str, object] = {
+        "ssl_certfile": settings.http_tls_certfile,
+        "ssl_keyfile": settings.http_tls_keyfile,
+    }
+    if settings.http_tls_ca_certs is not None:
+        kwargs["ssl_ca_certs"] = settings.http_tls_ca_certs
+    if settings.http_tls_client_cert_required:
+        # ``ssl.CERT_REQUIRED`` tells the TLS handshake to refuse a
+        # connection whose client cert isn't signed by a CA in the
+        # configured bundle. config.load_settings already enforces the
+        # ``ca_certs`` invariant so this combination is always valid.
+        kwargs["ssl_cert_reqs"] = ssl_module.CERT_REQUIRED  # type: ignore[attr-defined]
+    return kwargs

--- a/tests/unit/test_http_runtime.py
+++ b/tests/unit/test_http_runtime.py
@@ -924,6 +924,136 @@ async def test_request_timeout_middleware_does_not_double_send_after_stream_star
     assert statuses == [200]
 
 
+# --- TLS / mTLS settings -> uvicorn kwargs ---------------------------------
+
+
+def test_uvicorn_tls_kwargs_empty_when_tls_disabled() -> None:
+    from mcpg.http_runtime import _uvicorn_tls_kwargs
+
+    settings = load_settings({"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db"})
+    assert _uvicorn_tls_kwargs(settings, ssl_module=None) == {}
+
+
+def test_uvicorn_tls_kwargs_emits_cert_and_key_when_set(tmp_path: object) -> None:
+    from mcpg.http_runtime import _uvicorn_tls_kwargs
+
+    cert = tmp_path / "server.crt"  # type: ignore[operator]
+    key = tmp_path / "server.key"  # type: ignore[operator]
+    cert.write_text("-- placeholder; load_settings only checks existence\n")
+    key.write_text("-- placeholder\n")
+
+    settings = load_settings(
+        {
+            "MCPG_DATABASE_URL": "postgresql://u:p@localhost/db",
+            "MCPG_HTTP_TLS_CERTFILE": str(cert),
+            "MCPG_HTTP_TLS_KEYFILE": str(key),
+        }
+    )
+
+    kwargs = _uvicorn_tls_kwargs(settings, ssl_module=None)
+    assert kwargs == {"ssl_certfile": str(cert), "ssl_keyfile": str(key)}
+
+
+def test_uvicorn_tls_kwargs_includes_ca_certs_when_set(tmp_path: object) -> None:
+    from mcpg.http_runtime import _uvicorn_tls_kwargs
+
+    cert = tmp_path / "server.crt"  # type: ignore[operator]
+    key = tmp_path / "server.key"  # type: ignore[operator]
+    ca = tmp_path / "ca.crt"  # type: ignore[operator]
+    for f in (cert, key, ca):
+        f.write_text("-- placeholder\n")
+
+    settings = load_settings(
+        {
+            "MCPG_DATABASE_URL": "postgresql://u:p@localhost/db",
+            "MCPG_HTTP_TLS_CERTFILE": str(cert),
+            "MCPG_HTTP_TLS_KEYFILE": str(key),
+            "MCPG_HTTP_TLS_CA_CERTS": str(ca),
+        }
+    )
+
+    kwargs = _uvicorn_tls_kwargs(settings, ssl_module=None)
+    assert kwargs == {
+        "ssl_certfile": str(cert),
+        "ssl_keyfile": str(key),
+        "ssl_ca_certs": str(ca),
+    }
+
+
+def test_uvicorn_tls_kwargs_sets_cert_required_for_mtls(tmp_path: object) -> None:
+    from mcpg.http_runtime import _uvicorn_tls_kwargs
+
+    cert = tmp_path / "server.crt"  # type: ignore[operator]
+    key = tmp_path / "server.key"  # type: ignore[operator]
+    ca = tmp_path / "ca.crt"  # type: ignore[operator]
+    for f in (cert, key, ca):
+        f.write_text("-- placeholder\n")
+
+    settings = load_settings(
+        {
+            "MCPG_DATABASE_URL": "postgresql://u:p@localhost/db",
+            "MCPG_HTTP_TLS_CERTFILE": str(cert),
+            "MCPG_HTTP_TLS_KEYFILE": str(key),
+            "MCPG_HTTP_TLS_CA_CERTS": str(ca),
+            "MCPG_HTTP_TLS_CLIENT_CERT_REQUIRED": "true",
+        }
+    )
+
+    # Stand-in for the ssl module — the kwarg routing should pull
+    # CERT_REQUIRED off whatever ssl-shaped object we pass through.
+    class _StubSSL:
+        CERT_REQUIRED = "CERT_REQUIRED_SENTINEL"
+
+    kwargs = _uvicorn_tls_kwargs(settings, ssl_module=_StubSSL())
+    assert kwargs["ssl_cert_reqs"] == "CERT_REQUIRED_SENTINEL"
+    assert kwargs["ssl_ca_certs"] == str(ca)
+
+
+def test_settings_rejects_certfile_without_keyfile(tmp_path: object) -> None:
+    from mcpg.config import ConfigError
+
+    cert = tmp_path / "server.crt"  # type: ignore[operator]
+    cert.write_text("-- placeholder\n")
+    with pytest.raises(ConfigError, match="must both be set or both be unset"):
+        load_settings(
+            {
+                "MCPG_DATABASE_URL": "postgresql://u:p@localhost/db",
+                "MCPG_HTTP_TLS_CERTFILE": str(cert),
+            }
+        )
+
+
+def test_settings_rejects_client_cert_required_without_ca_certs(tmp_path: object) -> None:
+    from mcpg.config import ConfigError
+
+    cert = tmp_path / "server.crt"  # type: ignore[operator]
+    key = tmp_path / "server.key"  # type: ignore[operator]
+    for f in (cert, key):
+        f.write_text("-- placeholder\n")
+    with pytest.raises(ConfigError, match="needs MCPG_HTTP_TLS_CA_CERTS"):
+        load_settings(
+            {
+                "MCPG_DATABASE_URL": "postgresql://u:p@localhost/db",
+                "MCPG_HTTP_TLS_CERTFILE": str(cert),
+                "MCPG_HTTP_TLS_KEYFILE": str(key),
+                "MCPG_HTTP_TLS_CLIENT_CERT_REQUIRED": "true",
+            }
+        )
+
+
+def test_settings_rejects_nonexistent_cert_path() -> None:
+    from mcpg.config import ConfigError
+
+    with pytest.raises(ConfigError, match="non-existent file"):
+        load_settings(
+            {
+                "MCPG_DATABASE_URL": "postgresql://u:p@localhost/db",
+                "MCPG_HTTP_TLS_CERTFILE": "/nonexistent/server.crt",
+                "MCPG_HTTP_TLS_KEYFILE": "/nonexistent/server.key",
+            }
+        )
+
+
 def test_build_http_app_installs_request_timeout_only_when_positive() -> None:
     base = {"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db"}
 


### PR DESCRIPTION
## Summary
- Wires uvicorn's SSL kwargs from project settings — `MCPG_HTTP_TLS_CERTFILE` + `MCPG_HTTP_TLS_KEYFILE` enable plain TLS; adding `MCPG_HTTP_TLS_CA_CERTS` + `MCPG_HTTP_TLS_CLIENT_CERT_REQUIRED=true` upgrades to full mTLS (handshake-layer rejection of unauthenticated clients).
- Cross-validated at boot: `certfile`/`keyfile` both set or both unset, mTLS requires `ca_certs`, every configured path must exist on disk.
- `_uvicorn_tls_kwargs(settings, ssl_module=...)` is parameterised on the SSL module so tests can pass a stub without importing the real `ssl`.
- Defaults unchanged: TLS disabled by default; reverse-proxy deployments continue terminating TLS at the proxy.

> Sequenced after #63 (C1) per the parallel-roadmap — both touch `http_runtime.py` and `build_http_app` so they need to land in order to avoid mid-air collisions.

## Test plan
- [x] 7 new unit tests cover the disabled / cert-only / cert+ca / mTLS routings plus the three config-rejection cases (mismatched cert/key, mTLS-without-CA, nonexistent path).
- [x] `uv run ruff check . && uv run ruff format --check . && uv run mypy src/mcpg` clean.
- [x] `uv run pytest tests/unit` — 1324 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_