### PR TITLE
feat(security): cloud secrets backends — Vault / AWS / GCP (C3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,41 @@ adheres to [Semantic Versioning](https://semver.org/).
   middleware is only added to the stack when an allowlist is
   configured. Lives in `mcpg.http_runtime`.
 
+- **Cloud secrets backends — Vault / AWS / GCP
+  (`MCPG_SECRETS_BACKEND=vault|aws|gcp`).** Three new optional
+  providers join the existing `env` + `file` ones, each behind its
+  own extra so a deployment doesn't pay for every cloud SDK when
+  it only uses one:
+  - `vault` (`mcpg[vault]`, via the `hvac` SDK) — HashiCorp Vault
+    KV v2. Configured with `MCPG_VAULT_ADDR` + `MCPG_VAULT_TOKEN`,
+    plus optional `MCPG_VAULT_NAMESPACE` and
+    `MCPG_VAULT_PATH_PREFIX` (default `secret/mcpg`). Looked-up
+    names split on the last `/` so callers can address sub-paths
+    (`foo/bar` → read the `bar` field at `<prefix>/foo`); a bare
+    name reads the `value` field by convention.
+  - `aws` (`mcpg[aws]`, via `boto3`) — AWS Secrets Manager.
+    Authentication uses the standard AWS env / IAM-role chain;
+    the optional `MCPG_AWS_SECRETS_PREFIX` is prepended to every
+    name on lookup. `SecretString` payloads are auto-detected as
+    JSON (per-field) or single-value strings.
+  - `gcp` (`mcpg[gcp]`, via `google-cloud-secret-manager`) — GCP
+    Secret Manager. `MCPG_GCP_PROJECT_ID` is required; the
+    optional `MCPG_GCP_SECRETS_PREFIX` joins it to form the full
+    resource path `projects/{project}/secrets/{prefix+name}/versions/latest`.
+
+  Every provider preserves the `file`-backend semantics: a name
+  present in the backend wins, anything absent falls back to the
+  process environment, so partial backends and vendor-conventional
+  API-key env vars keep working. Each cloud provider caches
+  lookups in-process for the lifetime of the server (the latency +
+  per-call cost of a real secrets manager makes re-fetching on
+  every config touch impractical — restart to pick up rotated
+  values), lazily imports its SDK so the install error only fires
+  on first lookup (with a clear `install mcpg[xxx]` hint), and
+  distinguishes auth / permission failures (raised as
+  `SecretsError` so operators see the real problem) from
+  resource-not-found (silent env fallback).
+
 - **Inline usage examples in MCP tool descriptions.** Wrapped the
   descriptions of ~25 high-traffic tools (introspection — `list_schemas`,
   `list_tables`, `describe_table`, `list_indexes`, `list_constraints`,

--- a/docs/parallel-roadmap.md
+++ b/docs/parallel-roadmap.md
@@ -96,7 +96,7 @@ B1/B2 are independent; B3 is larger and best alone.
 |---|---|---|---|---|---|
 | C1 (✅ PR) | IP allowlist for HTTP transport (4.3) | `http_runtime.py` middleware | S | — | Tiny ASGI middleware + `MCPG_HTTP_IP_ALLOWLIST`. |
 | C2 (✅ PR) | mTLS for the HTTP transport (4.4) | `http_runtime.py` / `run_http` | S | — | Client-cert verification (uvicorn ssl params). |
-| C3 | Secrets cloud backends — Vault / AWS / GCP | extends `secrets.py` | L | — | Each behind an extra (`mcpg[vault]` …); same `MCPG_SECRETS_BACKEND` switch. Can split per provider. |
+| C3 (✅ PR) | Secrets cloud backends — Vault / AWS / GCP | extends `secrets.py` | L | — | Each behind an extra (`mcpg[vault]` / `mcpg[aws]` / `mcpg[gcp]`); same `MCPG_SECRETS_BACKEND` switch. |
 
 C1 and C2 both edit `http_runtime.py`'s middleware stack — **sequence
 them** (or coordinate) to avoid colliding on `build_http_app`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,7 +190,18 @@ ignore_missing_imports = true
 # Optional cloud-secrets SDKs ship without typed stubs we want to lean
 # on — the providers in mcpg.secrets import them lazily and convert
 # everything to plain ``str | None`` before re-exposing the API.
-module = ["hvac", "hvac.*", "boto3", "boto3.*", "google.cloud", "google.cloud.*"]
+module = [
+    "hvac",
+    "hvac.*",
+    "boto3",
+    "boto3.*",
+    "botocore",
+    "botocore.*",
+    "google.cloud",
+    "google.cloud.*",
+    "google.api_core",
+    "google.api_core.*",
+]
 ignore_missing_imports = true
 
 [tool.bandit]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,15 @@ otel = [
     "opentelemetry-sdk>=1.27",
     "opentelemetry-exporter-otlp-proto-http>=1.27",
 ]
+# Cloud secrets backends — selected by ``MCPG_SECRETS_BACKEND=vault|aws|gcp``.
+# Each is its own extra so a deployment doesn't pay for every cloud SDK
+# when it only uses one. The SDKs are imported lazily inside the
+# provider class, so the import / install error is surfaced with a
+# clear "install mcpg[xxx]" message on first lookup if the operator
+# selected a backend but forgot the extra.
+vault = ["hvac>=1.0"]
+aws = ["boto3>=1.28"]
+gcp = ["google-cloud-secret-manager>=2.16"]
 
 # Powers the "Project links" sidebar on https://pypi.org/project/mcpg/.
 # Order is preserved on the page; first entry doubles as the page header
@@ -175,6 +184,13 @@ ignore_errors = true
 [[tool.mypy.overrides]]
 # pglast ships no type stubs.
 module = ["pglast", "pglast.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+# Optional cloud-secrets SDKs ship without typed stubs we want to lean
+# on — the providers in mcpg.secrets import them lazily and convert
+# everything to plain ``str | None`` before re-exposing the API.
+module = ["hvac", "hvac.*", "boto3", "boto3.*", "google.cloud", "google.cloud.*"]
 ignore_missing_imports = true
 
 [tool.bandit]

--- a/src/mcpg/secrets.py
+++ b/src/mcpg/secrets.py
@@ -8,25 +8,40 @@ to load a flat ``name -> value`` map of JSON (always) or YAML (when
 PyYAML is importable).
 
 A provider only supplies *secret values*; non-secret configuration
-still comes from the environment. The ``file`` provider overlays the
-file on top of the environment — a name present in the file wins, and
-anything absent falls back to the env var — so partial files and the
+still comes from the environment. Every provider overlays its store
+on top of the environment — a name present in the backend wins, and
+anything absent falls back to the env var — so partial backends and
 vendor-conventional API-key env vars keep working.
 
-Cloud backends (Vault / AWS Secrets Manager / GCP Secret Manager) are
-designed for but not yet implemented; they will register here behind
-optional extras and be selected by the same ``MCPG_SECRETS_BACKEND``
-switch.
+Cloud backends:
+
+- ``vault`` — HashiCorp Vault KV v2 via the ``hvac`` SDK, behind the
+  ``mcpg[vault]`` extra. Configured with ``MCPG_VAULT_ADDR`` /
+  ``MCPG_VAULT_TOKEN`` (+ optional ``MCPG_VAULT_NAMESPACE`` /
+  ``MCPG_VAULT_PATH_PREFIX``).
+- ``aws`` — AWS Secrets Manager via the ``boto3`` SDK, behind the
+  ``mcpg[aws]`` extra. Authentication uses the standard AWS env /
+  IAM-role chain; the optional ``MCPG_AWS_SECRETS_PREFIX`` is
+  prepended to every name on lookup.
+- ``gcp`` — Google Cloud Secret Manager via
+  ``google-cloud-secret-manager``, behind the ``mcpg[gcp]`` extra.
+  ``MCPG_GCP_PROJECT_ID`` is required; ``MCPG_GCP_SECRETS_PREFIX`` is
+  the optional name prefix.
+
+Each cloud provider caches lookups in-process for the lifetime of the
+server — the latency + per-call cost of a real secrets manager makes
+re-fetching on every config touch impractical. Restart the server to
+pick up rotated values (or wire the rotation system to do so).
 """
 
 from __future__ import annotations
 
 import json
 from collections.abc import Mapping
-from dataclasses import dataclass
-from typing import Protocol, runtime_checkable
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
 
-_SUPPORTED_BACKENDS = frozenset({"env", "file"})
+_SUPPORTED_BACKENDS = frozenset({"env", "file", "vault", "aws", "gcp"})
 
 
 class SecretsError(Exception):
@@ -132,6 +147,211 @@ def _load_overlay(path: str) -> dict[str, str]:
     return overlay
 
 
+@dataclass
+class VaultSecretsProvider:
+    """Reads secrets from HashiCorp Vault's KV v2 backend.
+
+    Each looked-up ``name`` is split on the last ``/`` so callers can
+    address sub-paths (``MCPG_DATABASE_URL`` → ``<prefix>/MCPG_DATABASE_URL``
+    and read the ``value`` field; ``foo/bar`` → ``<prefix>/foo`` and
+    read the ``bar`` field). Anything not stored in Vault falls back
+    to the process environment.
+
+    The ``hvac`` client is cached on first use rather than created at
+    construction time so the provider can be instantiated cheaply (and
+    the SDK import only fires once a real read happens). Per-name
+    results are memoised because each Vault round-trip is a network
+    call, and config touches happen many times per startup.
+    """
+
+    addr: str
+    token: str
+    env: Mapping[str, str]
+    namespace: str | None = None
+    path_prefix: str = "secret/mcpg"
+    _client: Any = field(default=None, init=False, repr=False, compare=False)
+    _cache: dict[str, str | None] = field(default_factory=dict, init=False, repr=False, compare=False)
+
+    def get(self, name: str) -> str | None:
+        if name in self._cache:
+            cached = self._cache[name]
+            if cached is not None:
+                return cached
+            # ``None`` cache = "not in Vault" — fall through to env.
+            return self.env.get(name)
+
+        value = self._fetch(name)
+        self._cache[name] = value
+        if value is not None:
+            return value
+        return self.env.get(name)
+
+    def _ensure_client(self) -> Any:
+        if self._client is not None:
+            return self._client
+        try:
+            import hvac
+        except ImportError as exc:
+            raise SecretsError("MCPG_SECRETS_BACKEND=vault requires the `mcpg[vault]` extra (install `hvac`)") from exc
+        client = hvac.Client(url=self.addr, token=self.token, namespace=self.namespace)
+        if not client.is_authenticated():
+            raise SecretsError("Vault rejected the configured MCPG_VAULT_TOKEN")
+        self._client = client
+        return client
+
+    def _fetch(self, name: str) -> str | None:
+        # Split on the last ``/`` so callers can store grouped secrets
+        # at a single Vault path (the common pattern). When no ``/``
+        # appears, the ``name`` IS the path and we read the ``value``
+        # field by convention.
+        if "/" in name:
+            path, field_name = name.rsplit("/", 1)
+        else:
+            path, field_name = name, "value"
+        client = self._ensure_client()
+        full_path = f"{self.path_prefix.rstrip('/')}/{path}"
+        try:
+            response = client.secrets.kv.v2.read_secret_version(path=full_path)
+        except Exception:  # broad: hvac surfaces a wide error tree
+            return None
+        if not response:
+            return None
+        data = response.get("data", {}).get("data", {}) if isinstance(response, dict) else {}
+        value = data.get(field_name)
+        return str(value) if value is not None else None
+
+
+@dataclass
+class AWSSecretsProvider:
+    """Reads secrets from AWS Secrets Manager via boto3.
+
+    The optional ``prefix`` is prepended to the requested name on each
+    lookup so a deployment can scope its MCPg secrets under a single
+    path. Values can be either ``SecretString`` (returned verbatim)
+    or a JSON object — when the latter, the field whose key matches
+    the looked-up name (without prefix) is returned.
+
+    Authentication uses boto3's standard chain (env / IAM role /
+    config file); we never inject credentials into the SDK client. As
+    with the Vault provider, results are memoised in-process and the
+    SDK is lazily imported so the provider can be instantiated when
+    boto3 isn't installed yet (the failure surfaces on first lookup).
+    """
+
+    region: str | None
+    env: Mapping[str, str]
+    prefix: str = ""
+    _client: Any = field(default=None, init=False, repr=False, compare=False)
+    _cache: dict[str, str | None] = field(default_factory=dict, init=False, repr=False, compare=False)
+
+    def get(self, name: str) -> str | None:
+        if name in self._cache:
+            cached = self._cache[name]
+            return cached if cached is not None else self.env.get(name)
+        value = self._fetch(name)
+        self._cache[name] = value
+        if value is not None:
+            return value
+        return self.env.get(name)
+
+    def _ensure_client(self) -> Any:
+        if self._client is not None:
+            return self._client
+        try:
+            import boto3
+        except ImportError as exc:
+            raise SecretsError("MCPG_SECRETS_BACKEND=aws requires the `mcpg[aws]` extra (install `boto3`)") from exc
+        kwargs: dict[str, object] = {}
+        if self.region:
+            kwargs["region_name"] = self.region
+        self._client = boto3.client("secretsmanager", **kwargs)
+        return self._client
+
+    def _fetch(self, name: str) -> str | None:
+        client = self._ensure_client()
+        full_name = f"{self.prefix}{name}" if self.prefix else name
+        try:
+            response = client.get_secret_value(SecretId=full_name)
+        except Exception:  # broad: botocore raises ClientError subclasses we don't import
+            return None
+        if not isinstance(response, dict):
+            return None
+        raw = response.get("SecretString")
+        if raw is None:
+            return None
+        # SecretString is usually JSON for multi-value secrets and a
+        # bare string for single-value secrets — try to parse and
+        # pluck the matching field, fall back to the raw string.
+        try:
+            parsed = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            return str(raw)
+        if isinstance(parsed, dict):
+            value = parsed.get(name)
+            if value is None:
+                return None
+            return str(value)
+        return str(raw)
+
+
+@dataclass
+class GCPSecretsProvider:
+    """Reads secrets from Google Cloud Secret Manager.
+
+    Each looked-up name resolves to ``projects/{project_id}/secrets/{prefix+name}/versions/latest``;
+    the payload's UTF-8 string body is returned. As with Vault and
+    AWS, results are memoised and the SDK is lazily imported.
+    """
+
+    project_id: str
+    env: Mapping[str, str]
+    prefix: str = ""
+    _client: Any = field(default=None, init=False, repr=False, compare=False)
+    _cache: dict[str, str | None] = field(default_factory=dict, init=False, repr=False, compare=False)
+
+    def get(self, name: str) -> str | None:
+        if name in self._cache:
+            cached = self._cache[name]
+            return cached if cached is not None else self.env.get(name)
+        value = self._fetch(name)
+        self._cache[name] = value
+        if value is not None:
+            return value
+        return self.env.get(name)
+
+    def _ensure_client(self) -> Any:
+        if self._client is not None:
+            return self._client
+        try:
+            from google.cloud import secretmanager
+        except ImportError as exc:
+            raise SecretsError(
+                "MCPG_SECRETS_BACKEND=gcp requires the `mcpg[gcp]` extra (install `google-cloud-secret-manager`)"
+            ) from exc
+        self._client = secretmanager.SecretManagerServiceClient()
+        return self._client
+
+    def _fetch(self, name: str) -> str | None:
+        client = self._ensure_client()
+        full_name = f"{self.prefix}{name}" if self.prefix else name
+        resource = f"projects/{self.project_id}/secrets/{full_name}/versions/latest"
+        try:
+            response = client.access_secret_version(name=resource)
+        except Exception:  # broad: google.api_core surfaces a wide error tree
+            return None
+        payload = getattr(response, "payload", None)
+        if payload is None:
+            return None
+        data = getattr(payload, "data", None)
+        if data is None:
+            return None
+        try:
+            decoded = data.decode("utf-8")
+        except (UnicodeDecodeError, AttributeError):
+            return None
+        return str(decoded)
+
+
 def build_secrets_provider(env: Mapping[str, str]) -> tuple[SecretsProvider, str]:
     """Construct the secrets provider selected by ``MCPG_SECRETS_BACKEND``.
 
@@ -156,5 +376,37 @@ def build_secrets_provider(env: Mapping[str, str]) -> tuple[SecretsProvider, str
         if not path:
             raise SecretsError("MCPG_SECRETS_BACKEND=file requires MCPG_SECRETS_FILE_PATH")
         return FileSecretsProvider(overlay=_load_overlay(path), env=env), backend
+
+    if backend == "vault":
+        addr = (env.get("MCPG_VAULT_ADDR") or "").strip()
+        token = (env.get("MCPG_VAULT_TOKEN") or "").strip()
+        if not addr:
+            raise SecretsError("MCPG_SECRETS_BACKEND=vault requires MCPG_VAULT_ADDR")
+        if not token:
+            raise SecretsError("MCPG_SECRETS_BACKEND=vault requires MCPG_VAULT_TOKEN")
+        namespace = (env.get("MCPG_VAULT_NAMESPACE") or "").strip() or None
+        path_prefix = (env.get("MCPG_VAULT_PATH_PREFIX") or "secret/mcpg").strip() or "secret/mcpg"
+        return (
+            VaultSecretsProvider(
+                addr=addr,
+                token=token,
+                env=env,
+                namespace=namespace,
+                path_prefix=path_prefix,
+            ),
+            backend,
+        )
+
+    if backend == "aws":
+        region = (env.get("AWS_REGION") or env.get("AWS_DEFAULT_REGION") or "").strip() or None
+        prefix = (env.get("MCPG_AWS_SECRETS_PREFIX") or "").strip()
+        return AWSSecretsProvider(region=region, env=env, prefix=prefix), backend
+
+    if backend == "gcp":
+        project_id = (env.get("MCPG_GCP_PROJECT_ID") or "").strip()
+        if not project_id:
+            raise SecretsError("MCPG_SECRETS_BACKEND=gcp requires MCPG_GCP_PROJECT_ID")
+        prefix = (env.get("MCPG_GCP_SECRETS_PREFIX") or "").strip()
+        return GCPSecretsProvider(project_id=project_id, env=env, prefix=prefix), backend
 
     return EnvSecretsProvider(env=env), backend

--- a/src/mcpg/secrets.py
+++ b/src/mcpg/secrets.py
@@ -193,11 +193,16 @@ class VaultSecretsProvider:
             import hvac
         except ImportError as exc:
             raise SecretsError("MCPG_SECRETS_BACKEND=vault requires the `mcpg[vault]` extra (install `hvac`)") from exc
-        client = hvac.Client(url=self.addr, token=self.token, namespace=self.namespace)
-        if not client.is_authenticated():
-            raise SecretsError("Vault rejected the configured MCPG_VAULT_TOKEN")
-        self._client = client
-        return client
+        # Do NOT call ``client.is_authenticated()`` here. The real
+        # token-validation signal — Forbidden / Unauthorized on a
+        # read — is surfaced explicitly in ``_fetch`` below as a
+        # SecretsError, which gives the operator a clear "rotate the
+        # token" message. ``is_authenticated`` adds a round-trip at
+        # construction time AND was reviewed (PR #65) as misleading
+        # because some hvac versions implement it as a local bool
+        # check.
+        self._client = hvac.Client(url=self.addr, token=self.token, namespace=self.namespace)
+        return self._client
 
     def _fetch(self, name: str) -> str | None:
         # Split on the last ``/`` so callers can store grouped secrets
@@ -212,7 +217,22 @@ class VaultSecretsProvider:
         full_path = f"{self.path_prefix.rstrip('/')}/{path}"
         try:
             response = client.secrets.kv.v2.read_secret_version(path=full_path)
-        except Exception:  # broad: hvac surfaces a wide error tree
+        except Exception as exc:
+            # Distinguish "secret not present at this path" (fall
+            # through to env) from "Vault refused the token" (raise so
+            # the operator sees the real problem instead of silently
+            # falling back to env and getting a different config-error
+            # ten seconds later). The hvac exception tree is
+            # deliberately imported inside the except so the lazy-SDK
+            # contract still holds at module import time.
+            try:
+                from hvac import exceptions as hvac_exc
+            except ImportError:
+                return None
+            if isinstance(exc, (hvac_exc.Forbidden, hvac_exc.Unauthorized)):
+                raise SecretsError(
+                    f"Vault denied access to {full_path!r} — check MCPG_VAULT_TOKEN and policy: {exc}"
+                ) from exc
             return None
         if not response:
             return None
@@ -272,7 +292,28 @@ class AWSSecretsProvider:
         full_name = f"{self.prefix}{name}" if self.prefix else name
         try:
             response = client.get_secret_value(SecretId=full_name)
-        except Exception:  # broad: botocore raises ClientError subclasses we don't import
+        except Exception as exc:
+            # Distinguish "secret not present" (fall through to env)
+            # from "AWS refused the request" (raise so the operator
+            # sees the auth problem instead of silently falling back).
+            # ResourceNotFound stays None; access / signature errors
+            # become SecretsError. ClientError is the botocore base
+            # class; ``error_code`` lives under ``response.Error.Code``.
+            try:
+                from botocore import exceptions as boto_exc
+            except ImportError:
+                return None
+            if isinstance(exc, boto_exc.ClientError):
+                code = getattr(exc, "response", {}).get("Error", {}).get("Code", "")
+                if code in {
+                    "AccessDeniedException",
+                    "UnrecognizedClientException",
+                    "InvalidSignatureException",
+                    "ExpiredTokenException",
+                }:
+                    raise SecretsError(
+                        f"AWS Secrets Manager denied access to {full_name!r} (error code {code!r}): {exc}"
+                    ) from exc
             return None
         if not isinstance(response, dict):
             return None
@@ -280,17 +321,20 @@ class AWSSecretsProvider:
         if raw is None:
             return None
         # SecretString is usually JSON for multi-value secrets and a
-        # bare string for single-value secrets — try to parse and
-        # pluck the matching field, fall back to the raw string.
+        # bare string for single-value secrets. Try to parse: if
+        # parsing succeeds and the dict has a field matching the
+        # looked-up name, return that; otherwise fall back to the raw
+        # string so service-account JSON / OAuth-blob payloads
+        # (no key matching the secret name) still surface as values.
         try:
             parsed = json.loads(raw)
         except (json.JSONDecodeError, TypeError):
             return str(raw)
         if isinstance(parsed, dict):
-            value = parsed.get(name)
-            if value is None:
-                return None
-            return str(value)
+            if name in parsed:
+                value = parsed[name]
+                return str(value) if value is not None else None
+            return str(raw)
         return str(raw)
 
 
@@ -337,7 +381,19 @@ class GCPSecretsProvider:
         resource = f"projects/{self.project_id}/secrets/{full_name}/versions/latest"
         try:
             response = client.access_secret_version(name=resource)
-        except Exception:  # broad: google.api_core surfaces a wide error tree
+        except Exception as exc:
+            # Distinguish NotFound (fall through to env) from
+            # auth / permission failures (raise so the operator sees
+            # the real problem). google.api_core's exception classes
+            # are imported lazily to keep the lazy-SDK contract.
+            try:
+                from google.api_core import exceptions as google_exc
+            except ImportError:
+                return None
+            if isinstance(exc, (google_exc.PermissionDenied, google_exc.Unauthenticated)):
+                raise SecretsError(
+                    f"GCP Secret Manager denied access to {resource!r} — check the service account's roles: {exc}"
+                ) from exc
             return None
         payload = getattr(response, "payload", None)
         if payload is None:

--- a/tests/unit/test_secrets.py
+++ b/tests/unit/test_secrets.py
@@ -418,3 +418,141 @@ def test_gcp_provider_surfaces_install_hint_when_sdk_missing(monkeypatch: pytest
     provider = GCPSecretsProvider(project_id="p", env={})
     with pytest.raises(SecretsError, match="mcpg\\[gcp\\]"):
         provider.get("ANY")
+
+
+# --- cloud-backend error semantics -----------------------------------------
+
+
+def test_vault_provider_raises_secrets_error_on_forbidden(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Auth / permission failures must not silently fall through to
+    # env — they're operator-visible problems, not "secret missing".
+    import sys
+    import types
+
+    from mcpg.secrets import VaultSecretsProvider
+
+    class _Forbidden(Exception):  # noqa: N818  (mirrors hvac.exceptions.Forbidden naming)
+        pass
+
+    fake_hvac_exceptions = types.ModuleType("hvac.exceptions")
+    fake_hvac_exceptions.Forbidden = _Forbidden  # type: ignore[attr-defined]
+    fake_hvac_exceptions.Unauthorized = type("_Unauthorized", (Exception,), {})  # type: ignore[attr-defined]
+
+    fake_hvac = types.ModuleType("hvac")
+    fake_hvac.exceptions = fake_hvac_exceptions  # type: ignore[attr-defined]
+
+    class _RaisingClient:
+        def __init__(self, *_a: object, **_kw: object) -> None:
+            class _Sec:
+                class _Kv:
+                    class _V2:
+                        @staticmethod
+                        def read_secret_version(path: str) -> None:
+                            raise _Forbidden("permission denied")
+
+                    v2 = _V2()
+
+                kv = _Kv()
+
+            self.secrets = _Sec()
+
+    fake_hvac.Client = _RaisingClient  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "hvac", fake_hvac)
+    monkeypatch.setitem(sys.modules, "hvac.exceptions", fake_hvac_exceptions)
+
+    provider = VaultSecretsProvider(addr="http://vault:8200", token="bad", env={"FALLBACK": "from-env"})
+    with pytest.raises(SecretsError, match="Vault denied access"):
+        provider.get("SOMETHING")
+
+
+def test_aws_provider_raises_secrets_error_on_access_denied(monkeypatch: pytest.MonkeyPatch) -> None:
+    import sys
+    import types
+
+    from mcpg.secrets import AWSSecretsProvider
+
+    class _ClientError(Exception):
+        def __init__(self, response: dict[str, object]) -> None:
+            self.response = response
+            super().__init__(str(response))
+
+    fake_botocore_exceptions = types.ModuleType("botocore.exceptions")
+    fake_botocore_exceptions.ClientError = _ClientError  # type: ignore[attr-defined]
+    fake_botocore = types.ModuleType("botocore")
+    fake_botocore.exceptions = fake_botocore_exceptions  # type: ignore[attr-defined]
+
+    class _DenyingClient:
+        def get_secret_value(self, *, SecretId: str) -> dict[str, str]:  # noqa: N803  (boto3 API name)
+            raise _ClientError({"Error": {"Code": "AccessDeniedException", "Message": "denied"}})
+
+    fake_boto3 = types.ModuleType("boto3")
+    fake_boto3.client = lambda *_a, **_kw: _DenyingClient()  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "boto3", fake_boto3)
+    monkeypatch.setitem(sys.modules, "botocore", fake_botocore)
+    monkeypatch.setitem(sys.modules, "botocore.exceptions", fake_botocore_exceptions)
+
+    provider = AWSSecretsProvider(region="us-east-1", env={"FALLBACK": "from-env"})
+    with pytest.raises(SecretsError, match="AccessDeniedException"):
+        provider.get("ANY")
+
+
+def test_aws_provider_falls_back_to_raw_json_when_key_not_in_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Service-account JSON blobs / OAuth payloads don't have a top-
+    # level key matching the secret name; the provider must surface
+    # the raw JSON string rather than returning None.
+    import sys
+    import types
+
+    from mcpg.secrets import AWSSecretsProvider
+
+    class _FakeClient:
+        def get_secret_value(self, *, SecretId: str) -> dict[str, str]:  # noqa: N803
+            return {"SecretString": json.dumps({"client_id": "x", "private_key": "y"})}
+
+    fake_boto3 = types.ModuleType("boto3")
+    fake_boto3.client = lambda *_a, **_kw: _FakeClient()  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "boto3", fake_boto3)
+
+    provider = AWSSecretsProvider(region="us-east-1", env={})
+    result = provider.get("GCP_SERVICE_ACCOUNT_JSON")
+    assert result is not None
+    assert '"client_id": "x"' in result
+    assert '"private_key": "y"' in result
+
+
+def test_gcp_provider_raises_secrets_error_on_permission_denied(monkeypatch: pytest.MonkeyPatch) -> None:
+    import sys
+    import types
+
+    from mcpg.secrets import GCPSecretsProvider
+
+    class _PermissionDenied(Exception):  # noqa: N818  (mirrors google.api_core.exceptions naming)
+        pass
+
+    fake_api_core_exceptions = types.ModuleType("google.api_core.exceptions")
+    fake_api_core_exceptions.PermissionDenied = _PermissionDenied  # type: ignore[attr-defined]
+    fake_api_core_exceptions.Unauthenticated = type("_Unauthenticated", (Exception,), {})  # type: ignore[attr-defined]
+    fake_api_core = types.ModuleType("google.api_core")
+    fake_api_core.exceptions = fake_api_core_exceptions  # type: ignore[attr-defined]
+
+    class _DenyingClient:
+        def access_secret_version(self, *, name: str) -> object:
+            raise _PermissionDenied("perm denied")
+
+    class _FakeSecretManager:
+        SecretManagerServiceClient = _DenyingClient
+
+    fake_google = types.ModuleType("google")
+    fake_google_cloud = types.ModuleType("google.cloud")
+    fake_google_cloud.secretmanager = _FakeSecretManager()  # type: ignore[attr-defined]
+    fake_google.cloud = fake_google_cloud  # type: ignore[attr-defined]
+    fake_google.api_core = fake_api_core  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "google", fake_google)
+    monkeypatch.setitem(sys.modules, "google.cloud", fake_google_cloud)
+    monkeypatch.setitem(sys.modules, "google.api_core", fake_api_core)
+    monkeypatch.setitem(sys.modules, "google.api_core.exceptions", fake_api_core_exceptions)
+
+    provider = GCPSecretsProvider(project_id="p", env={"FALLBACK": "from-env"})
+    with pytest.raises(SecretsError, match="GCP Secret Manager denied"):
+        provider.get("ANY")

--- a/tests/unit/test_secrets.py
+++ b/tests/unit/test_secrets.py
@@ -27,7 +27,7 @@ def test_default_backend_is_env() -> None:
 
 def test_unknown_backend_raises() -> None:
     with pytest.raises(SecretsError, match="MCPG_SECRETS_BACKEND"):
-        build_secrets_provider({"MCPG_SECRETS_BACKEND": "vault"})
+        build_secrets_provider({"MCPG_SECRETS_BACKEND": "azure"})
 
 
 def test_file_backend_requires_a_path() -> None:
@@ -209,3 +209,212 @@ def test_secrets_backend_does_not_leak_secret_values_in_repr(tmp_path) -> None: 
     rendered = repr(settings)
     assert "super-secret-token" not in rendered
     assert "secrets_backend='file'" in rendered
+
+
+# --- cloud backends --------------------------------------------------------
+
+
+def test_vault_backend_requires_addr_and_token() -> None:
+    with pytest.raises(SecretsError, match="MCPG_VAULT_ADDR"):
+        build_secrets_provider({"MCPG_SECRETS_BACKEND": "vault"})
+    with pytest.raises(SecretsError, match="MCPG_VAULT_TOKEN"):
+        build_secrets_provider({"MCPG_SECRETS_BACKEND": "vault", "MCPG_VAULT_ADDR": "http://vault:8200"})
+
+
+def test_vault_provider_fetches_field_and_falls_back_to_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    from mcpg.secrets import VaultSecretsProvider
+
+    # A fake hvac module wired into ``sys.modules`` so the provider's
+    # lazy import picks it up without the real hvac client opening a
+    # socket. The provider passes path / token / namespace; we record
+    # them and respond with a fixed-shape KV v2 payload.
+    fake_calls: list[dict[str, object]] = []
+
+    class _FakeKVv2:
+        def __init__(self) -> None:
+            self.store = {
+                "secret/mcpg/MCPG_DATABASE_URL": {"value": "postgresql://from-vault/x"},
+                "secret/mcpg/auth": {"token": "vault-token"},
+            }
+
+        def read_secret_version(self, path: str) -> dict[str, object]:
+            fake_calls.append({"path": path})
+            data = self.store.get(path)
+            if data is None:
+                raise RuntimeError("not found")
+            return {"data": {"data": data}}
+
+    class _FakeKV:
+        def __init__(self) -> None:
+            self.v2 = _FakeKVv2()
+
+    class _FakeSecrets:
+        def __init__(self) -> None:
+            self.kv = _FakeKV()
+
+    class _FakeClient:
+        def __init__(self, *, url: str, token: str, namespace: str | None) -> None:
+            fake_calls.append({"init": (url, token, namespace)})
+            self.secrets = _FakeSecrets()
+
+        def is_authenticated(self) -> bool:
+            return True
+
+    import sys
+    import types
+
+    fake_hvac = types.ModuleType("hvac")
+    fake_hvac.Client = _FakeClient  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "hvac", fake_hvac)
+
+    provider = VaultSecretsProvider(
+        addr="http://vault:8200",
+        token="root",
+        env={"FALLBACK_ONLY": "from-env"},
+        namespace="team-a",
+    )
+
+    # Vault hit — value returned.
+    assert provider.get("MCPG_DATABASE_URL") == "postgresql://from-vault/x"
+    # Sub-path with explicit field name.
+    assert provider.get("auth/token") == "vault-token"
+    # Not in Vault → env fallback.
+    assert provider.get("FALLBACK_ONLY") == "from-env"
+    # Neither in Vault nor env → None.
+    assert provider.get("WHO_KNOWS") is None
+    # Namespace + URL were threaded through.
+    init_call = next(c for c in fake_calls if "init" in c)
+    assert init_call["init"] == ("http://vault:8200", "root", "team-a")
+    # Cached: a repeat lookup doesn't trigger another read_secret_version.
+    before = sum("path" in c for c in fake_calls)
+    assert provider.get("MCPG_DATABASE_URL") == "postgresql://from-vault/x"
+    after = sum("path" in c for c in fake_calls)
+    assert before == after
+
+
+def test_vault_provider_surfaces_install_hint_when_hvac_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Pretend hvac isn't installed by purging it from sys.modules and
+    # blocking the import. ``ImportError`` percolates up to the
+    # provider's SecretsError-with-installation-hint path.
+    import sys
+
+    from mcpg.secrets import VaultSecretsProvider
+
+    monkeypatch.setitem(sys.modules, "hvac", None)
+
+    provider = VaultSecretsProvider(addr="http://vault:8200", token="x", env={})
+    with pytest.raises(SecretsError, match="mcpg\\[vault\\]"):
+        provider.get("ANY")
+
+
+def test_aws_backend_constructs_with_optional_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
+    import sys
+    import types
+
+    from mcpg.secrets import AWSSecretsProvider
+
+    fake_calls: list[dict[str, object]] = []
+
+    class _FakeClient:
+        def get_secret_value(self, *, SecretId: str) -> dict[str, str]:  # noqa: N803  (boto3 API name)
+            fake_calls.append({"SecretId": SecretId})
+            # Provider can read both JSON-bundled and single-string secrets.
+            payloads = {
+                "mcpg/MCPG_DATABASE_URL": json.dumps({"MCPG_DATABASE_URL": "postgresql://aws/x"}),
+                "mcpg/SINGLE": "plain-value",
+            }
+            value = payloads.get(SecretId)
+            if value is None:
+                raise RuntimeError("not found")
+            return {"SecretString": value}
+
+    fake_boto3_module = types.ModuleType("boto3")
+    fake_boto3_module.client = lambda *_a, **_kw: _FakeClient()  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "boto3", fake_boto3_module)
+
+    provider = AWSSecretsProvider(
+        region="us-east-1",
+        env={"FALLBACK_ONLY": "from-env"},
+        prefix="mcpg/",
+    )
+    # JSON-bundled lookup matches the requested name field.
+    assert provider.get("MCPG_DATABASE_URL") == "postgresql://aws/x"
+    # Single-value secrets come back verbatim.
+    assert provider.get("SINGLE") == "plain-value"
+    # Not in AWS → env fallback.
+    assert provider.get("FALLBACK_ONLY") == "from-env"
+    # The prefix was applied to every fetch.
+    assert all(str(c["SecretId"]).startswith("mcpg/") for c in fake_calls)
+
+
+def test_aws_provider_surfaces_install_hint_when_boto3_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    import sys
+
+    from mcpg.secrets import AWSSecretsProvider
+
+    monkeypatch.setitem(sys.modules, "boto3", None)
+
+    provider = AWSSecretsProvider(region="us-east-1", env={})
+    with pytest.raises(SecretsError, match="mcpg\\[aws\\]"):
+        provider.get("ANY")
+
+
+def test_gcp_backend_requires_project_id() -> None:
+    with pytest.raises(SecretsError, match="MCPG_GCP_PROJECT_ID"):
+        build_secrets_provider({"MCPG_SECRETS_BACKEND": "gcp"})
+
+
+def test_gcp_provider_decodes_payload_and_falls_back_to_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    import sys
+    import types
+
+    from mcpg.secrets import GCPSecretsProvider
+
+    fake_calls: list[dict[str, object]] = []
+
+    class _Payload:
+        def __init__(self, data: bytes) -> None:
+            self.data = data
+
+    class _Response:
+        def __init__(self, payload: _Payload | None) -> None:
+            self.payload = payload
+
+    class _FakeClient:
+        def access_secret_version(self, *, name: str) -> _Response:
+            fake_calls.append({"name": name})
+            if name.endswith("/MCPG_DATABASE_URL/versions/latest"):
+                return _Response(_Payload(b"postgresql://from-gcp/x"))
+            raise RuntimeError("not found")
+
+    class _FakeSecretManagerModule:
+        SecretManagerServiceClient = _FakeClient
+
+    fake_google = types.ModuleType("google")
+    fake_google_cloud = types.ModuleType("google.cloud")
+    fake_google_cloud.secretmanager = _FakeSecretManagerModule()  # type: ignore[attr-defined]
+    fake_google.cloud = fake_google_cloud  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "google", fake_google)
+    monkeypatch.setitem(sys.modules, "google.cloud", fake_google_cloud)
+
+    provider = GCPSecretsProvider(
+        project_id="my-project",
+        env={"FALLBACK_ONLY": "from-env"},
+    )
+    assert provider.get("MCPG_DATABASE_URL") == "postgresql://from-gcp/x"
+    assert provider.get("FALLBACK_ONLY") == "from-env"
+    assert any("projects/my-project" in str(c["name"]) for c in fake_calls)
+
+
+def test_gcp_provider_surfaces_install_hint_when_sdk_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    import sys
+
+    from mcpg.secrets import GCPSecretsProvider
+
+    monkeypatch.setitem(sys.modules, "google.cloud", None)
+
+    provider = GCPSecretsProvider(project_id="p", env={})
+    with pytest.raises(SecretsError, match="mcpg\\[gcp\\]"):
+        provider.get("ANY")

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,9 @@ revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version < '3.15'",
+    "python_full_version == '3.14.*'",
+    "python_full_version == '3.13.*'",
+    "python_full_version < '3.13'",
 ]
 
 [[package]]
@@ -108,6 +110,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c4/cf/85379f13b76f3a69bca86b60237978af17d6aa0bc5998978c3b8cf05abb2/boolean_py-5.0.tar.gz", hash = "sha256:60cbc4bad079753721d32649545505362c754e121570ada4658b852a3a318d95", size = 37047, upload-time = "2025-04-03T10:39:49.734Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/ca/78d423b324b8d77900030fa59c4aa9054261ef0925631cd2501dd015b7b7/boolean_py-5.0-py3-none-any.whl", hash = "sha256:ef28a70bd43115208441b53a045d1549e2f0ec6e3d08a9d142cbc41c1938e8d9", size = 26577, upload-time = "2025-04-03T10:39:48.449Z" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.43.22"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/31/32388d5ec332ffe81d8f3650860f94b66294009172d188c390cad58c6f5f/boto3-1.43.22.tar.gz", hash = "sha256:2a7fe12d8e0731bb8aa7c1e59b4ccc770fda031b8659c2f6f497393bdcec3051", size = 113203, upload-time = "2026-06-03T19:33:13.39Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/6b/c2fb3b91e849882df5426e68cc15eb2b5ba6ac28325ab2aa3a1065da5884/boto3-1.43.22-py3-none-any.whl", hash = "sha256:0597fb9fe1613e636ac55219a5a54ad0fcb7c15e6be32c799301f7fb53ff04e1", size = 140536, upload-time = "2026-06-03T19:33:10.939Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.22"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/cf/840f1b8db16d45e3807c23d1ea779723eed1cd9cf3b6c49e16f372d2a777/botocore-1.43.22.tar.gz", hash = "sha256:b00de525e538289ed4a7a85263f1be4e47473c124cec87be6b23be49356bf745", size = 15458781, upload-time = "2026-06-03T19:33:02.882Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/6b/576a1b0f915871e35f14a33104f2bcae635f19c6a72486ba639db0d1fc70/botocore-1.43.22-py3-none-any.whl", hash = "sha256:ceec9f81d0891abe7b28ca2b2ee47e32de7b3360ad11e80d351470f015217379", size = 15141375, upload-time = "2026-06-03T19:32:58.324Z" },
 ]
 
 [[package]]
@@ -515,6 +545,58 @@ wheels = [
 ]
 
 [[package]]
+name = "google-api-core"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/22/155cadf1d49272a9cf48f3168c0f3874fa13397297e611a5ea00cd093880/google_api_core-2.31.0.tar.gz", hash = "sha256:2be84ee0f584c48e6bde1b36766e23348b361fb7e55e56135fc76ce1c397f9c2", size = 176492, upload-time = "2026-06-03T14:52:17.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/40/9bdbb60b03a332bd45acb8703da08bbc27d991d35286b62e42acc86d243a/google_api_core-2.31.0-py3-none-any.whl", hash = "sha256:ef79fb3784c71cbac89cbd03301ba0c8fb8ad2aa95d7f9204dd9628f7adf59ab", size = 173102, upload-time = "2026-06-03T14:51:26.729Z" },
+]
+
+[package.optional-dependencies]
+grpc = [
+    { name = "grpcio" },
+    { name = "grpcio-status" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.53.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/ad/ff781329bbbdc0974a098d996e89c9e1f7024262f9e3eec442fbb9ad1ac6/google_auth-2.53.0.tar.gz", hash = "sha256:e7e6aa16f6bee7b2b264830fd04f08087a1d5a836df516251a5d15327b246c9c", size = 335844, upload-time = "2026-05-15T20:53:07.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/c9/db44165ba7c581268c6d46017ef63339110378305062830104fc7fa144cb/google_auth-2.53.0-py3-none-any.whl", hash = "sha256:6e7449917c599b35126a99ec268ec6880301f2fea41dce198fe8fd83ff642b68", size = 246071, upload-time = "2026-05-15T20:53:05.609Z" },
+]
+
+[[package]]
+name = "google-cloud-secret-manager"
+version = "2.29.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
+    { name = "grpc-google-iam-v1" },
+    { name = "grpcio" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/7c/5c88cdde9664f6c75fb68aa11e0af4309a92bef38dd38df0456ffb0f469b/google_cloud_secret_manager-2.29.0.tar.gz", hash = "sha256:ee64133af8fdb3780affb65ec6ccf10ab15a0113d8edeba388665f4be87ce1be", size = 278437, upload-time = "2026-06-03T16:13:43.149Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/c2/fc3275bc42a522757cb5141d7dae51f048b93d2f5fe4574fcee5392cef03/google_cloud_secret_manager-2.29.0-py3-none-any.whl", hash = "sha256:21bac2d0adb0bb3c13c346d7223832f197c2266534528a1bf1402774e06395a3", size = 225042, upload-time = "2026-06-03T16:12:20.162Z" },
+]
+
+[[package]]
 name = "googleapis-common-protos"
 version = "1.75.0"
 source = { registry = "https://pypi.org/simple" }
@@ -524,6 +606,80 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
+]
+
+[package.optional-dependencies]
+grpc = [
+    { name = "grpcio" },
+]
+
+[[package]]
+name = "grpc-google-iam-v1"
+version = "0.14.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos", extra = ["grpc"] },
+    { name = "grpcio" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/4f/d098419ad0bfc06c9ce440575f05aa22d8973b6c276e86ac7890093d3c37/grpc_google_iam_v1-0.14.4.tar.gz", hash = "sha256:392b3796947ed6334e61171d9ab06bf7eb357f554e5fc7556ad7aab6d0e17038", size = 23706, upload-time = "2026-04-01T01:57:49.813Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/22/c2dd50c09bf679bd38173656cd4402d2511e563b33bc88f90009cf50613c/grpc_google_iam_v1-0.14.4-py3-none-any.whl", hash = "sha256:412facc320fcbd94034b4df3d557662051d4d8adfa86e0ddb4dca70a3f739964", size = 32675, upload-time = "2026-04-01T01:57:47.69Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.81.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/15/f3/23f47b24f8d8c2028eba501db3acfbb2f592cbb5995eaa6e363a627b74d7/grpcio-1.81.0.tar.gz", hash = "sha256:a5acd7efd3b1fe9b4eb0bcaaa1507eed68a0ad0678b654c3f7b464df9ba9dca5", size = 13032272, upload-time = "2026-06-01T05:56:22.827Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/d5/896a3aaf07068d707d88b282a04914b872db4d32d3c7e6d88e43a3b911fa/grpcio-1.81.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:57b3b0e73a518fa286959b40c3eddd02703504ca186e8b7b2945954519bd8b2c", size = 6053538, upload-time = "2026-06-01T05:54:58.965Z" },
+    { url = "https://files.pythonhosted.org/packages/68/6a/7e3eafa4727cd405ff917605ed2949e2af162f233f5cbdd773723a5fea7d/grpcio-1.81.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:8bb1789c94322a13336a2b6c58d9c14d68f8628b6e24205a799c69f5bf8516ce", size = 12053447, upload-time = "2026-06-01T05:55:01.862Z" },
+    { url = "https://files.pythonhosted.org/packages/16/79/a4302aa82428de48a922421f522b027a1a727ab4d0926368454aa953d36d/grpcio-1.81.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e4d053900a0d24b75d7521139a3872150301b3d6bde3bed5e12318fb25791e4d", size = 6595872, upload-time = "2026-06-01T05:55:04.946Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/1f/7ff2850eaefbecf99af3f624dbb28dd1ad6c5fd4c1d8c26909ed6482673b/grpcio-1.81.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:db217c2e52931719f9937bd12082cd4d7b495b35803d5760686975c285924bf8", size = 7303857, upload-time = "2026-06-01T05:55:07.205Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/98/1f3896a9baae1f2aedf4e99c55291d6fa1f30ad9603d63bc18bda967b53e/grpcio-1.81.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:19f201da7b4e5c0559198abe5a97157e726f3abe6e8f5e832d4a50740f6dcc22", size = 6809676, upload-time = "2026-06-01T05:55:09.513Z" },
+    { url = "https://files.pythonhosted.org/packages/34/8b/3441983718095208c5d797fd3239882e97ea89a629f41c8df94b4eef4df9/grpcio-1.81.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:275144b0115353339dbb8a6f28a9cf8997b5bf40e37f8f66ac0b0ea57e95b43f", size = 7412654, upload-time = "2026-06-01T05:55:12.777Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/98/1eddf07df6e4fe85cf67502a793f7b05468b2dca3d1ef35b972cf5d54468/grpcio-1.81.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5192857589f223e5a98ff0e31f6e551b19040e647d17bfe10116c8a2ce3b8696", size = 8408026, upload-time = "2026-06-01T05:55:15.514Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/73/3860341e6a1f5347be6ab35c6c0e1e3a8eb59d010388207fd561dcf01a88/grpcio-1.81.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c6ff087cb1f563f47b504b4e29e684129fc5ae4863faf3ebca08a327764ee6cb", size = 7849498, upload-time = "2026-06-01T05:55:18.078Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3f/0ea06bd85c701966aa3f8f37314f2ed83520d2b7590f42d643d445d8bc8b/grpcio-1.81.0-cp312-cp312-win32.whl", hash = "sha256:98c6240f563178fc5877bd50e6ff274463e53e1472128f4110742450739659fa", size = 4184161, upload-time = "2026-06-01T05:55:20.127Z" },
+    { url = "https://files.pythonhosted.org/packages/39/e3/a7c387406827a86f99ad7838b995bf9b4a182ffe2d2c439ed2873efec952/grpcio-1.81.0-cp312-cp312-win_amd64.whl", hash = "sha256:87e33b7afcfb3585121b5f007d2c52b8c534104d18f556e840d35193ca2a9141", size = 4929958, upload-time = "2026-06-01T05:55:22.736Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/29/779ee53c931d0fd55c1d459fde43e485172caa3ac87cbd43d003a13a0185/grpcio-1.81.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:62bbe463c9f0f2ff24e31bd25f8dd8b4bae78900e315915a3195a0ef1471a855", size = 6054973, upload-time = "2026-06-01T05:55:25.043Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/b6/7211807926b5a17f8d9a5d47c739a163d6812fefe3e4714e81cf92945ed7/grpcio-1.81.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:43c121e135ae44d1559b430db2b2dfad7421cbbe40e1deba506c7dc62b439719", size = 12048662, upload-time = "2026-06-01T05:55:28.453Z" },
+    { url = "https://files.pythonhosted.org/packages/64/89/b1b93ef6b34bd20bbaf707fa99133bc9cc302139d5ec6f77a165c7169796/grpcio-1.81.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f345de40ef2e65f63645d53d251824e6070e07804827c5b00ec2e44555f9f901", size = 6599116, upload-time = "2026-06-01T05:55:31.185Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/bc/c89f9b9d1c22895715356a1e009554dae66319e97826bb4d30bcda7d29e8/grpcio-1.81.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:8c0855a350886f713b9e458e2a10d208009dcaa849f574e39cd6067db1fe1279", size = 7307591, upload-time = "2026-06-01T05:55:33.463Z" },
+    { url = "https://files.pythonhosted.org/packages/65/4a/1df2a4cb4a1386e066ab7e4175e34bb884b35ccb60d3621c09c84af6aabb/grpcio-1.81.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a524cd530900bd24511fcb7f2ed144da4ea37711c4b094475d0bceca7a93a170", size = 6811797, upload-time = "2026-06-01T05:55:36.731Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/dc/fa189d20601a1be25b08850cfb733879bbb1047b62a8feec3a60e3e1a87b/grpcio-1.81.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e7746ba3e6efc9e2b748eff59470a2b8684d5a9ec607c6580bcaa5be175820bc", size = 7415131, upload-time = "2026-06-01T05:55:39.451Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/a3/5625c48cb48d23c6631b3e5294f88e4c751f22a52591ae78859fab96dca1/grpcio-1.81.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:aaaa4f7f2057d795952e4eacf3f342be8b5b156992f6ac85023c8b98794ebd47", size = 8408398, upload-time = "2026-06-01T05:55:42.219Z" },
+    { url = "https://files.pythonhosted.org/packages/75/34/0f8202c6809a46c2b4d69125ef3667c40b1c211f8e19930e5fa1f1197039/grpcio-1.81.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0fba53cb96004b2b7fb758b46b2288cb49d0b658316a4e73f3ef67230616ee65", size = 7844481, upload-time = "2026-06-01T05:55:44.849Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/95/c3366b5b5edf4c4adc90f2e29ca16e57965a8e56dc8d2ee89565ba1905bb/grpcio-1.81.0-cp313-cp313-win32.whl", hash = "sha256:c197e2ef75a442528072b29e9755da299110e8610e8bcbb59a6b4cf55384f005", size = 4182777, upload-time = "2026-06-01T05:55:47.459Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/a7/932f2f748511a32e641a2aba0d30dded3ed6e8bc330e0924e4d5d86853e6/grpcio-1.81.0-cp313-cp313-win_amd64.whl", hash = "sha256:194eddfacc84d80f50512e9fd4ee851d5f2499f18f299c95aa8fb4748f0537e0", size = 4928085, upload-time = "2026-06-01T05:55:50.158Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/1d/28b231333857deb840bc3d182ae087510170ea6d68f21393aeb0fe499530/grpcio-1.81.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:a9351055f52660b58f3d4890ea66188b5134399f82b11aa0c55bd4b99eff5390", size = 6055712, upload-time = "2026-06-01T05:55:52.889Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/b8/999c14f9dff0fc47549d2e827cba1343ddc18e1d1bf0d06d2cf628eecbd9/grpcio-1.81.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:300f3337b6425fd16ead9a4f9b2ac25801acb64aa5bc0b99eb69901645b2b1d2", size = 12057189, upload-time = "2026-06-01T05:55:55.952Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/3d/1fbde079572562af65351151d840525a13879eb7b481d35b55cd64c6127a/grpcio-1.81.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:97bbd623f7ded558fd4f7cb5a4f600c4d4de65c5dd364c83a5b14b2a10a2d3b5", size = 6608136, upload-time = "2026-06-01T05:55:59.069Z" },
+    { url = "https://files.pythonhosted.org/packages/32/89/1f17cb6882abfd8e5a303a25d5d1665abef5a8c499a96198c65a651d1b85/grpcio-1.81.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:ff83d889e3ebf6341c8c7864ad8031591ad5ca61599072fc511644d1eb962d2b", size = 7307045, upload-time = "2026-06-01T05:56:02.376Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5a/f98e91b2e755652e637ea2144318b0229b290062199f761b445fe1fa6015/grpcio-1.81.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c4fe218c5a35e1d87a5a26544237f1fa41dfd9cbd3c856b0810a30061f8b0aaf", size = 6812794, upload-time = "2026-06-01T05:56:05.777Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/0c/77892d715ac41e7ec0ace2a50080ffb64e189188056f607a66fe0014d1ee/grpcio-1.81.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b8b025b6af43ee0ad4a70307025d77bcab5adde7c4597786010d802c203e9fc5", size = 7422767, upload-time = "2026-06-01T05:56:08.524Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/b8/aa04590c6564714d94954515f15a236e59d4b9b3ad01e615f1b706d7792d/grpcio-1.81.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:3d4e0ce5a40a998cf608c8ba60ecfe18fdf364a9aa193ae4ac3faeecd0e86757", size = 8408551, upload-time = "2026-06-01T05:56:11.283Z" },
+    { url = "https://files.pythonhosted.org/packages/43/3d/4f4a3450a1973568910c6909cb74abbf2126f68aefae5976962f9f7ad50d/grpcio-1.81.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:aa948712c8e5fa40ec250870bda14bc7578e1bb832a8912d9d2a0f720518edbe", size = 7846468, upload-time = "2026-06-01T05:56:14.536Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f4/5827fd248221ad3b44161c23ce9b5f4ee405b04fc6da5fd402a9aa87a84a/grpcio-1.81.0-cp314-cp314-win32.whl", hash = "sha256:fbbe81314a9d92156abce8b62c09364eb8bafc0ca2a19919a45ec64b5c6cb664", size = 4264427, upload-time = "2026-06-01T05:56:17.192Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e8/127dc2b246096ad50ef7c8d9b7b31d757787aeb796368bcdd4454e4204c4/grpcio-1.81.0-cp314-cp314-win_amd64.whl", hash = "sha256:b93cee313cae4e113fbb3a0ce1ea5633db6f63cfde2b2dc1d817429026b2a50b", size = 5070848, upload-time = "2026-06-01T05:56:19.735Z" },
+]
+
+[[package]]
+name = "grpcio-status"
+version = "1.81.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/b6/cdc177114997d15c887fb09ccfd16705c8ceb8b4ca2487902b54a7bfd1af/grpcio_status-1.81.0.tar.gz", hash = "sha256:b6fe9788cfdd1f0f63c0528a1e0bfdb41e8ff0583e920d2d8e8888598c01bb69", size = 13900, upload-time = "2026-06-01T06:00:32.638Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/b7/5aa346bf1cdecd4ed64b86c10a4d5a089ce3da89145f8328caf0b22b240d/grpcio_status-1.81.0-py3-none-any.whl", hash = "sha256:10eb4c2309db902dc26c1873e80a821bf794be772c10dfd83030f7f59f165fab", size = 14634, upload-time = "2026-06-01T06:00:13.345Z" },
 ]
 
 [[package]]
@@ -570,6 +726,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "hvac"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/57/b46c397fb3842cfb02a44609aa834c887f38dd75f290c2fc5a34da4b2fee/hvac-2.4.0.tar.gz", hash = "sha256:e0056ad9064e7923e874e6769015b032580b639e29246f5ab1044f7959c1c7e0", size = 332543, upload-time = "2025-10-30T12:57:47.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/33/71e45a6bd6875f44a26f99da31c63b6840123e88bedf2c0b1ce429b8be12/hvac-2.4.0-py3-none-any.whl", hash = "sha256:008db5efd8c2f77bd37d2368ea5f713edceae1c65f11fd608393179478649e0f", size = 155921, upload-time = "2025-10-30T12:57:46.253Z" },
 ]
 
 [[package]]
@@ -651,6 +819,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -827,10 +1004,19 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+aws = [
+    { name = "boto3" },
+]
+gcp = [
+    { name = "google-cloud-secret-manager" },
+]
 otel = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
+]
+vault = [
+    { name = "hvac" },
 ]
 
 [package.dev-dependencies]
@@ -853,7 +1039,10 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "boto3", marker = "extra == 'aws'", specifier = ">=1.28" },
+    { name = "google-cloud-secret-manager", marker = "extra == 'gcp'", specifier = ">=2.16" },
     { name = "httpx", specifier = ">=0.27" },
+    { name = "hvac", marker = "extra == 'vault'", specifier = ">=1.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.25.0" },
     { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.27" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'otel'", specifier = ">=1.27" },
@@ -864,7 +1053,7 @@ requires-dist = [
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.8" },
     { name = "typing-extensions", specifier = ">=4.12" },
 ]
-provides-extras = ["otel"]
+provides-extras = ["otel", "vault", "aws", "gcp"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1280,6 +1469,18 @@ wheels = [
 ]
 
 [[package]]
+name = "proto-plus"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/56/e647b0c675392d2da368da7b6f158f7368b18542fd6f7d7400a2f39de000/proto_plus-1.28.0.tar.gz", hash = "sha256:38e5696342835b08fc116f30a25665b29531cda9d5d5643e9b81fc312385abd9", size = 57221, upload-time = "2026-05-07T08:04:50.811Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/20/b122d4626976acb81132036d2ad1bb35a1a8775fceb837ec30964622516a/proto_plus-1.28.0-py3-none-any.whl", hash = "sha256:a630604310899e73c59ec302e5765c058d412b2f090b9c79c8822589f14955b8", size = 50410, upload-time = "2026-05-07T08:03:31.962Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "6.33.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1374,6 +1575,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/73/21/d250cfca8ff30c2e5a7447bc13861541126ce9bd4426cd5d0c9f08b5547d/py_serializable-2.1.0.tar.gz", hash = "sha256:9d5db56154a867a9b897c0163b33a793c804c80cee984116d02d49e4578fc103", size = 52368, upload-time = "2025-07-21T09:56:48.07Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/bf/7595e817906a29453ba4d99394e781b6fabe55d21f3c15d240f85dd06bb1/py_serializable-2.1.0-py3-none-any.whl", hash = "sha256:b56d5d686b5a03ba4f4db5e769dc32336e142fc3bd4d68a8c25579ebb0a67304", size = 23045, upload-time = "2025-07-21T09:56:46.848Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -1571,6 +1793,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
 ]
 
 [[package]]
@@ -1888,6 +2122,18 @@ wheels = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/1f/12417f7f493fc45e1f9fd5d4a9b6c125cf8d2cf3f8ddbdfab3e76406e9d6/s3transfer-0.18.0.tar.gz", hash = "sha256:3760b8b7ec1315da54048b2d626276732bee4300d054d492d4e1d43e20d4ecbd", size = 160560, upload-time = "2026-05-28T19:39:09.124Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/58/a58fc997655386daa2e25784e30c288aa3e3819e401f77029ee4899fb55a/s3transfer-0.18.0-py3-none-any.whl", hash = "sha256:239c13b09e65ad0346e1be7348b8a202dcad44ac7ea7c6eb858fc881dce739b6", size = 88572, upload-time = "2026-05-28T19:39:07.999Z" },
+]
+
+[[package]]
 name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1907,6 +2153,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Three new optional secrets providers join the existing `env` + `file` pair, each behind its own extra so a deployment doesn't pay for every cloud SDK when it only uses one:
- `vault` (`mcpg[vault]`, via `hvac`) — HashiCorp Vault KV v2. `MCPG_VAULT_ADDR` + `MCPG_VAULT_TOKEN` (+ optional `MCPG_VAULT_NAMESPACE` / `MCPG_VAULT_PATH_PREFIX`).
- `aws` (`mcpg[aws]`, via `boto3`) — AWS Secrets Manager. Standard AWS env / IAM-role auth; optional `MCPG_AWS_SECRETS_PREFIX`. SecretString payloads auto-detected as JSON or single-value.
- `gcp` (`mcpg[gcp]`, via `google-cloud-secret-manager`) — GCP Secret Manager. `MCPG_GCP_PROJECT_ID` required; optional `MCPG_GCP_SECRETS_PREFIX`.

Every provider preserves the existing `file`-backend semantics — backend wins, env fallback. Each cloud provider caches lookups in-process for the server's lifetime, lazily imports its SDK so a "selected backend but forgot the extra" deployment gets a clear `install mcpg[xxx]` hint on first lookup (not at import time), and swallows the SDK's broad error tree as "secret not present" rather than crashing on a transient.

## Test plan
- [x] 13 new unit tests using fake SDK modules (stubbed via `monkeypatch.setitem(sys.modules, ...)`) cover the happy paths (field lookup + sub-path + env fallback + cache hit), the config-missing error paths, and the "SDK not installed → SecretsError with install hint" path for each provider.
- [x] Existing `test_unknown_backend_raises` switched from `vault` to `azure` (`vault` is now a valid backend).
- [x] `uv run ruff check . && uv run mypy src/mcpg` clean.
- [x] `uv run pytest tests/unit` — 1325 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_