### PR TITLE
docs: refresh living docs for post-v0.5.0 work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,43 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Docs
 
+- **Living-doc refresh.** Reconciled `docs/tools.md`,
+  `docs/user-guide.md`, `docs/security.md`, `docs/installation.md`,
+  `docs/architecture.md`, and `docs/PROGRESS.md` with the post-v0.5.0
+  work that had landed in code but not in docs:
+  - HTTP transport gates table in `docs/tools.md` now covers the
+    IP allowlist, TLS / mTLS, cloud secrets backends,
+    OpenTelemetry, slow-call logging, and HSTS / body-cap / CORS
+    settings.
+  - `docs/tools.md` tool index gains the missing rows for
+    `recommend_index_drops`, `monitor_index_build`,
+    `list_unapplied_migration_scripts`, and the pgvector-analytics
+    family (`cross_table_similarity`, `cluster_vectors`,
+    `detect_vector_outliers`, `monitor_embedding_drift`,
+    `migrate_vector_to_halfvec`, `analyze_distance_metric`,
+    `import_vectors`); reference section added for
+    `recommend_index_drops`.
+  - `docs/security.md` T6 covers IP allowlist + in-process TLS /
+    mTLS; new T9a / T9b threats document the cloud secrets
+    backends and the deliberately-narrow OpenTelemetry span
+    payload (argument values never attached so exporters can't
+    become side channels for credentials / PII).
+  - `docs/installation.md` adds rows to **Common scenarios** for
+    IP allowlist, in-process TLS, mTLS, the three secrets
+    backends, OpenTelemetry tracing, and slow-call logging, plus
+    an **HTTP transport TLS / mTLS** section. Stale "all 38
+    `MCPG_*` variables" claim corrected.
+  - `docs/architecture.md` module map gains `mcpg.secrets` and
+    `mcpg.otel_tracing` rows; `mcpg.http_runtime` row expanded to
+    cover IP allowlist and TLS termination.
+  - `docs/user-guide.md` adds a `recommend_index_drops` bullet
+    next to `recommend_indexes`, plus an OpenTelemetry tracing
+    section explaining the `mcpg[otel]` extra and the deliberate
+    no-argument-values policy.
+  - `docs/PROGRESS.md` top-of-file metadata refreshed (date
+    2026-05-27 → 2026-06-05, tool count 114 → 141) and the
+    post-v0.5.0 wave summary added; **Next action** block
+    refreshed.
 - **Tool count sync.** `docs/tour.md`, `docs/user-guide.md`, and
   `docs/tools.md` now report **141 tools** (was 124) — reconciled
   from `grep -c '@server.tool' src/mcpg/tools.py` per the

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -6,38 +6,33 @@
 
 ## Current state
 
-- **Phase:** post-v0.5.0 — full Tier-A/B/C shortlist closed +
-  Apache AGE property-graph support + read-replica routing +
-  OIDC / JWT bearer-token validation. Feature backlog from
-  `docs/feature-shortlist.md` is fully shipped.
-- **Last updated:** 2026-05-27
+- **Phase:** post-v0.5.0 — every Batch (A–G) from the original
+  shortlist closed, plus the following post-release waves:
+  - **Security (C1–C3):** IP allowlist, TLS / mTLS for the HTTP
+    transport, cloud secrets backends (Vault / AWS / GCP).
+  - **Observability (B2–B3):** slow-call logging + OpenTelemetry
+    tracing (one span per `call_tool`, argument-values omitted).
+  - **Migrations (E1–E4):** migration-history table integration,
+    pre-deployment validation, `list_unapplied_migration_scripts`.
+  - **pgvector analytics (A3–A8):** `cross_table_similarity`,
+    `cluster_vectors`, `detect_vector_outliers`,
+    `monitor_embedding_drift`, `migrate_vector_to_halfvec`,
+    `analyze_distance_metric`, `import_vectors`.
+  - **Advisors (6.1):** `recommend_index_drops`.
+  - **UX (F2 first wave):** inline usage examples in tool
+    descriptions.
+- **Last updated:** 2026-06-05
 - **Branch:** `main`
-- **Tool count:** 114
+- **Tool count:** 141
 - **Released:** v0.5.0 (2026-05-27)
-- **Trunk additions since v0.5.0:** Apache AGE (PR #24, +6 tools),
-  read-replica routing (PR #23, +1 tool: `list_replicas`), OIDC /
-  JWT bearer-token validation (PR #23, runtime feature — no new
-  tools).
 
 ## Next action
 
-> Batch G follow-ons shipped — three new exporters sit alongside the
-> existing `generate_prisma_schema` under the schema→DSL umbrella.
-> `generate_drizzle_schema` emits a `drizzle-orm/pg-core` TS file
-> (tables + columns + single-column FK `.references()` + enums via
-> `pgEnum` + serial detection from `nextval` defaults). The
-> helper-import line is computed from what was actually emitted so
-> unused imports don't clutter the output.
-> `generate_sqlalchemy_models` emits a 2.0-style declarative file
-> (`DeclarativeBase` + `Mapped[T]` + `mapped_column`, jsonb via the
-> PG dialect, enum types as Python `enum.Enum` classes, composite
-> uniques in `__table_args__`). `generate_sqlc_schema` emits a clean
-> replayable `schema.sql` (CREATE SCHEMA → CREATE TYPE → CREATE
-> TABLE → ALTER TABLE ADD CONSTRAINT in PK→FK order → CREATE
-> INDEX), no subprocess needed. All three are read-only.
-> **Roadmap status: A–G all closed.** Next direction is open —
-> release prep (v0.2.0 cut from this branch with all post-1.0
-> features), additional Batch-G exporters, or new feature work.
+> All Tier-A/B/C shortlist + the post-v0.5.0 waves above are
+> shipped on trunk. Next direction is open — un-ticked rows in
+> `docs/feature-shortlist.md` are the queue, or a v0.6.0 cut
+> bundling the security / observability / analytics work since
+> v0.5.0.
 
 ## Phase 0 — Spike & foundation  ✅ COMPLETE
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -73,7 +73,9 @@ read-only / picks a pool / sets the tenant role.
 | `mcpg.replicas` | Read-replica pool registry; degraded-replica tracking; routing logic. |
 | `mcpg.context` | `AppContext` — the per-server state shared with every tool wrapper. |
 | `mcpg.server` | `FastMCP` bootstrap, `AuditedFastMCP` subclass, transport selection, `run` entry point. |
-| `mcpg.http_runtime` | Streamable-HTTP / SSE transport bring-up: bearer auth, OIDC validation, security middleware, `/metrics` / `/healthz` / `/readyz` endpoints. |
+| `mcpg.http_runtime` | Streamable-HTTP / SSE transport bring-up: bearer auth, OIDC validation, IP allowlist (applied before auth; `X-Forwarded-For` only honoured from loopback proxies), in-process TLS / mTLS termination, security middleware, `/metrics` / `/healthz` / `/readyz` endpoints. |
+| `mcpg.secrets` | Pluggable credentials resolver — env (default), HashiCorp Vault, AWS Secrets Manager, GCP Secret Manager. Each provider raises typed auth errors (`Forbidden` / `Unauthorized`, `AccessDenied` / `InvalidSignature` / `ExpiredToken`, `PermissionDenied`) so operators can tell missing-grant from missing-secret. |
+| `mcpg.otel_tracing` | OpenTelemetry integration — one span per `call_tool` carrying `mcp.tool.name`, `mcp.tool.argument_count`, and outcome status. Argument values are deliberately omitted so span exporters don't become side channels. |
 | `mcpg.oidc` | OIDC discovery + JWKS-backed JWT verification (asymmetric algorithms only). |
 | `mcpg.tenancy` | The `current_role` ContextVar that powers per-request `SET LOCAL ROLE`. |
 | `mcpg.middleware.rate_limit` | Token-bucket per-tool rate limiter. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -73,7 +73,7 @@ read-only / picks a pool / sets the tenant role.
 | `mcpg.replicas` | Read-replica pool registry; degraded-replica tracking; routing logic. |
 | `mcpg.context` | `AppContext` — the per-server state shared with every tool wrapper. |
 | `mcpg.server` | `FastMCP` bootstrap, `AuditedFastMCP` subclass, transport selection, `run` entry point. |
-| `mcpg.http_runtime` | Streamable-HTTP / SSE transport bring-up: bearer auth, OIDC validation, IP allowlist (applied before auth; `X-Forwarded-For` only honoured from loopback proxies), in-process TLS / mTLS termination, security middleware, `/metrics` / `/healthz` / `/readyz` endpoints. |
+| `mcpg.http_runtime` | Streamable-HTTP / SSE transport bring-up: bearer auth, OIDC validation, IP allowlist (matched against the immediate peer; `X-Forwarded-For` is deliberately not honoured — proxy deployments must enforce the allowlist at the proxy layer), in-process TLS / mTLS termination, security middleware, `/metrics` / `/healthz` / `/readyz` endpoints. |
 | `mcpg.secrets` | Pluggable credentials resolver — env (default), HashiCorp Vault, AWS Secrets Manager, GCP Secret Manager. Each provider raises typed auth errors (`Forbidden` / `Unauthorized`, `AccessDenied` / `InvalidSignature` / `ExpiredToken`, `PermissionDenied`) so operators can tell missing-grant from missing-secret. |
 | `mcpg.otel_tracing` | OpenTelemetry integration — one span per `call_tool` carrying `mcp.tool.name`, `mcp.tool.argument_count`, and outcome status. Argument values are deliberately omitted so span exporters don't become side channels. |
 | `mcpg.oidc` | OIDC discovery + JWKS-backed JWT verification (asymmetric algorithms only). |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -156,7 +156,7 @@ MCPg is configured **entirely through environment variables**. The
 only required one is `MCPG_DATABASE_URL`; all others have safe
 defaults.
 
-The full reference (all 38 `MCPG_*` variables, grouped by area, with
+The full reference (every `MCPG_*` variable, grouped by area, with
 defaults and descriptions) is in the
 [README](../README.md#configuration). The summaries below give you
 the minimum set per common scenario.
@@ -172,6 +172,14 @@ the minimum set per common scenario.
 | **`LISTEN/NOTIFY`** event streams | `MCPG_ACCESS_MODE=unrestricted` + `MCPG_ALLOW_LISTEN=true` |
 | **HTTP transport** with static bearer | `MCPG_TRANSPORT=streamable-http` + `MCPG_HTTP_AUTH_TOKEN=…` |
 | **HTTP transport** with OIDC | `MCPG_TRANSPORT=streamable-http` + `MCPG_AUTH_MODE=oidc` + `MCPG_OIDC_ISSUER=…` + `MCPG_OIDC_AUDIENCE=…` |
+| **HTTP transport** with IP allowlist | `MCPG_HTTP_IP_ALLOWLIST=10.0.0.0/8,192.168.1.0/24` (applied before auth; `X-Forwarded-For` only trusted from loopback proxies) |
+| **HTTP transport** with TLS | `MCPG_HTTP_TLS_CERTFILE=/etc/mcpg/cert.pem` + `MCPG_HTTP_TLS_KEYFILE=/etc/mcpg/key.pem` |
+| **HTTP transport** with mTLS | the TLS pair above + `MCPG_HTTP_TLS_CA_CERTS=/etc/mcpg/ca.pem` + `MCPG_HTTP_TLS_CLIENT_CERT_REQUIRED=true` |
+| **Cloud secrets** (Vault) | `MCPG_SECRETS_BACKEND=vault` + `MCPG_VAULT_ADDR=…` + `MCPG_VAULT_TOKEN=…` + `MCPG_VAULT_PATH=secret/data/mcpg` |
+| **Cloud secrets** (AWS) | `MCPG_SECRETS_BACKEND=aws` + `MCPG_AWS_SECRET_ID=arn:aws:secretsmanager:…` |
+| **Cloud secrets** (GCP) | `MCPG_SECRETS_BACKEND=gcp` + `MCPG_GCP_SECRET_NAME=projects/<id>/secrets/<name>/versions/latest` |
+| **OpenTelemetry tracing** | `pip install 'mcpg[otel]'` + `MCPG_OTEL_ENABLED=true` (+ optional `MCPG_OTEL_SERVICE_NAME=mcpg-prod`) — emits one span per `call_tool`; argument values are deliberately not attached |
+| **Slow-call logging** | `MCPG_SLOW_CALL_THRESHOLD_MS=500` (any tool slower than this logs a structured record); `MCPG_LOG_FORMAT=json` for structured logging |
 | **Multi-tenant SaaS** | `MCPG_DEFAULT_ROLE=tenant_a` + `MCPG_ALLOWED_ROLES=tenant_a,tenant_b,…` |
 | **Read-replica fan-out** | `MCPG_REPLICA_URLS=postgresql://…?sslmode=require,postgresql://…?sslmode=require` |
 | **NL→SQL** — single provider | Set `ANTHROPIC_API_KEY` (or `OPENAI_API_KEY` / `GEMINI_API_KEY`). MCPg auto-picks the default. |
@@ -208,6 +216,33 @@ export MCPG_ALLOW_INSECURE_TLS=true
 The startup error message names exactly which DSN failed the check
 (including the replica index if it was one of your
 `MCPG_REPLICA_URLS` entries).
+
+### HTTP transport TLS / mTLS
+
+The TLS settings above protect the **database** connection. The
+**HTTP transport** can be terminated by an external proxy
+(nginx / Envoy) or by MCPg directly — the in-process option drops
+the proxy dependency for small deployments.
+
+```bash
+export MCPG_HTTP_TLS_CERTFILE=/etc/mcpg/cert.pem
+export MCPG_HTTP_TLS_KEYFILE=/etc/mcpg/key.pem
+```
+
+Both must be set together; configuring only one is rejected at
+startup so a deployment can't silently fall back to plaintext.
+
+For mutual TLS (clients must present a cert chaining to a known
+CA — useful for service-to-service deployments where bearer tokens
+aren't enough):
+
+```bash
+export MCPG_HTTP_TLS_CA_CERTS=/etc/mcpg/ca.pem
+export MCPG_HTTP_TLS_CLIENT_CERT_REQUIRED=true
+```
+
+Setting `CLIENT_CERT_REQUIRED=true` without `CA_CERTS` is rejected
+at startup — there'd be nothing to verify against.
 
 ### Database privileges
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -172,10 +172,10 @@ the minimum set per common scenario.
 | **`LISTEN/NOTIFY`** event streams | `MCPG_ACCESS_MODE=unrestricted` + `MCPG_ALLOW_LISTEN=true` |
 | **HTTP transport** with static bearer | `MCPG_TRANSPORT=streamable-http` + `MCPG_HTTP_AUTH_TOKEN=…` |
 | **HTTP transport** with OIDC | `MCPG_TRANSPORT=streamable-http` + `MCPG_AUTH_MODE=oidc` + `MCPG_OIDC_ISSUER=…` + `MCPG_OIDC_AUDIENCE=…` |
-| **HTTP transport** with IP allowlist | `MCPG_HTTP_IP_ALLOWLIST=10.0.0.0/8,192.168.1.0/24` (applied before auth; `X-Forwarded-For` only trusted from loopback proxies) |
+| **HTTP transport** with IP allowlist | `MCPG_HTTP_IP_ALLOWLIST=10.0.0.0/8,192.168.1.0/24` (applied before auth; matched against the immediate peer — `X-Forwarded-For` is **not** honoured, so deployments behind a reverse proxy must enforce the allowlist at the proxy layer) |
 | **HTTP transport** with TLS | `MCPG_HTTP_TLS_CERTFILE=/etc/mcpg/cert.pem` + `MCPG_HTTP_TLS_KEYFILE=/etc/mcpg/key.pem` |
 | **HTTP transport** with mTLS | the TLS pair above + `MCPG_HTTP_TLS_CA_CERTS=/etc/mcpg/ca.pem` + `MCPG_HTTP_TLS_CLIENT_CERT_REQUIRED=true` |
-| **Cloud secrets** (Vault) | `MCPG_SECRETS_BACKEND=vault` + `MCPG_VAULT_ADDR=…` + `MCPG_VAULT_TOKEN=…` + `MCPG_VAULT_PATH=secret/data/mcpg` |
+| **Cloud secrets** (Vault) | `MCPG_SECRETS_BACKEND=vault` + `MCPG_VAULT_ADDR=…` + `MCPG_VAULT_TOKEN=…` (optional `MCPG_VAULT_NAMESPACE=…`, `MCPG_VAULT_PATH_PREFIX=secret/mcpg`) |
 | **Cloud secrets** (AWS) | `MCPG_SECRETS_BACKEND=aws` + `MCPG_AWS_SECRET_ID=arn:aws:secretsmanager:…` |
 | **Cloud secrets** (GCP) | `MCPG_SECRETS_BACKEND=gcp` + `MCPG_GCP_SECRET_NAME=projects/<id>/secrets/<name>/versions/latest` |
 | **OpenTelemetry tracing** | `pip install 'mcpg[otel]'` + `MCPG_OTEL_ENABLED=true` (+ optional `MCPG_OTEL_SERVICE_NAME=mcpg-prod`) — emits one span per `call_tool`; argument values are deliberately not attached |

--- a/docs/security.md
+++ b/docs/security.md
@@ -153,6 +153,22 @@ and every call is validated and audited.
 
 **Mitigation.**
 
+- **IP allowlist.** `MCPG_HTTP_IP_ALLOWLIST` (comma-separated
+  IPv4 / IPv6 / CIDR) gates the HTTP transport **before** auth.
+  Requests from outside the allowlist are dropped with 403 without
+  ever touching token comparison or JWT validation. `X-Forwarded-For`
+  is only trusted when the immediate peer is a same-host proxy
+  (loopback) — defends against client-supplied header spoofing.
+- **TLS at the transport.** `MCPG_HTTP_TLS_CERTFILE` /
+  `MCPG_HTTP_TLS_KEYFILE` terminate TLS in MCPg directly (no
+  external proxy needed). Both required or both unset — partial
+  config is rejected at startup so a deployment can't silently
+  serve plaintext.
+- **Mutual TLS (mTLS).** `MCPG_HTTP_TLS_CA_CERTS` +
+  `MCPG_HTTP_TLS_CLIENT_CERT_REQUIRED=true` require clients to
+  present a valid cert chaining to the configured CA. Setting the
+  flag without `CA_CERTS` is rejected — there'd be nothing to
+  verify against.
 - **Static bearer.** `MCPG_HTTP_AUTH_TOKEN` enforces
   `Authorization: Bearer <token>` with `hmac.compare_digest`
   constant-time comparison. `/metrics`, `/healthz`, `/readyz` are
@@ -196,6 +212,39 @@ and every call is validated and audited.
 - For per-tenant attribution, combine `MCPG_DEFAULT_ROLE` /
   `X-MCPG-Role` with `MCPG_AUDIT_PERSIST=true` so each row in
   `mcpg_audit.events` carries the responsible role.
+
+### T9a — Credentials in plaintext env / config files
+
+**Mitigation.**
+
+- **Cloud secrets backends.** `MCPG_SECRETS_BACKEND` swaps the
+  default env-var lookup for a remote secrets provider:
+  - `vault` — HashiCorp Vault KV v2 (`MCPG_VAULT_ADDR`,
+    `MCPG_VAULT_TOKEN`, `MCPG_VAULT_PATH`).
+  - `aws` — AWS Secrets Manager (`MCPG_AWS_SECRET_ID`, region picked
+    up from the standard AWS SDK chain).
+  - `gcp` — GCP Secret Manager
+    (`MCPG_GCP_SECRET_NAME=projects/<id>/secrets/<name>/versions/latest`).
+- Credentials are fetched lazily and live only in process memory —
+  never written back to disk or environment.
+- Auth-error surfaces are specific (`Forbidden` / `Unauthorized` for
+  Vault, `AccessDenied` / `UnrecognizedClient` / `InvalidSignature` /
+  `ExpiredToken` for AWS, `PermissionDenied` / `Unauthenticated` for
+  GCP) so operators can tell a missing-grant problem from a missing-
+  secret problem.
+
+### T9b — Observability leakage
+
+**Mitigation.**
+
+- **OpenTelemetry.** With `MCPG_OTEL_ENABLED=true` (and the
+  `mcpg[otel]` extra), MCPg emits one span per `call_tool`. The
+  span carries `mcp.tool.name`, `mcp.tool.argument_count`, and
+  outcome status — **argument values are deliberately not
+  attached** so a span exporter (Jaeger / Tempo / Honeycomb / SaaS
+  vendor) can't become a side-channel for credentials or PII.
+- Audit redaction (T4) runs on the local logger path; the OTel
+  path stays narrow for the same reason.
 
 ### T9 — Supply-chain compromise
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -156,9 +156,13 @@ and every call is validated and audited.
 - **IP allowlist.** `MCPG_HTTP_IP_ALLOWLIST` (comma-separated
   IPv4 / IPv6 / CIDR) gates the HTTP transport **before** auth.
   Requests from outside the allowlist are dropped with 403 without
-  ever touching token comparison or JWT validation. `X-Forwarded-For`
-  is only trusted when the immediate peer is a same-host proxy
-  (loopback) — defends against client-supplied header spoofing.
+  ever touching token comparison or JWT validation. The match is
+  against the immediate connecting peer; `X-Forwarded-For` is
+  deliberately **not** honoured (trusting a forwarded header
+  without a verified upstream is a well-known spoofing vector).
+  Deployments behind a reverse proxy must enforce the allowlist at
+  the proxy layer, which composes naturally with the proxy's own
+  auditing.
 - **TLS at the transport.** `MCPG_HTTP_TLS_CERTFILE` /
   `MCPG_HTTP_TLS_KEYFILE` terminate TLS in MCPg directly (no
   external proxy needed). Both required or both unset — partial
@@ -220,7 +224,8 @@ and every call is validated and audited.
 - **Cloud secrets backends.** `MCPG_SECRETS_BACKEND` swaps the
   default env-var lookup for a remote secrets provider:
   - `vault` — HashiCorp Vault KV v2 (`MCPG_VAULT_ADDR`,
-    `MCPG_VAULT_TOKEN`, `MCPG_VAULT_PATH`).
+    `MCPG_VAULT_TOKEN`, optional `MCPG_VAULT_NAMESPACE` /
+    `MCPG_VAULT_PATH_PREFIX` — default `secret/mcpg`).
   - `aws` — AWS Secrets Manager (`MCPG_AWS_SECRET_ID`, region picked
     up from the standard AWS SDK chain).
   - `gcp` — GCP Secret Manager

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -27,6 +27,13 @@ plumbing:
 | `MCPG_OIDC_ROLE_CLAIM` | Optional. Maps a named JWT claim to the per-request PG role (composes with multi-tenancy). |
 | `MCPG_DEFAULT_ROLE` / `MCPG_ALLOWED_ROLES` | Static default + allowlist for `SET LOCAL ROLE`-driven multi-tenancy. In static-auth mode, per-request override via `X-MCPG-Role` header. |
 | `MCPG_REPLICA_URLS` | Comma-separated read-replica DSNs. When set, `force_readonly` queries round-robin across healthy replicas; writes always go to the primary. |
+| `MCPG_HTTP_IP_ALLOWLIST` | Comma-separated IPv4/IPv6/CIDR allowlist applied to the HTTP transport before auth. Trusts `X-Forwarded-For` from same-host proxies only. |
+| `MCPG_HTTP_TLS_CERTFILE` / `MCPG_HTTP_TLS_KEYFILE` | PEM cert + key for terminating TLS at the HTTP transport (both required or both unset). |
+| `MCPG_HTTP_TLS_CA_CERTS` / `MCPG_HTTP_TLS_CLIENT_CERT_REQUIRED` | Optional CA bundle + flag to require client certificates (mutual TLS). Setting the flag without `CA_CERTS` is rejected at startup. |
+| `MCPG_HTTP_HSTS_MAX_AGE` / `MCPG_HTTP_MAX_BODY_BYTES` / `MCPG_HTTP_ALLOWED_ORIGINS` | HSTS header lifetime, request body cap, CORS allowlist for the HTTP transport. |
+| `MCPG_SECRETS_BACKEND` | `env` (default), `vault`, `aws`, or `gcp`. Resolves credential settings through HashiCorp Vault, AWS Secrets Manager, or GCP Secret Manager instead of plain env vars. Per-provider config: `MCPG_VAULT_*`, `MCPG_AWS_*`, `MCPG_GCP_*`. |
+| `MCPG_OTEL_ENABLED` / `MCPG_OTEL_SERVICE_NAME` | Emit one OpenTelemetry span per `call_tool` (tool name, argument count, status — never argument values). Requires the `mcpg[otel]` extra. |
+| `MCPG_SLOW_CALL_THRESHOLD_MS` / `MCPG_LOG_FORMAT` | Log a structured "slow call" record when a tool exceeds the threshold; switch the logger between `text` and `json` formats. |
 | `MCPG_NL2SQL_PROVIDER` / `MCPG_NL2SQL_API_KEY` / `MCPG_NL2SQL_MODEL` / `MCPG_NL2SQL_BASE_URL` / `MCPG_NL2SQL_MAX_TOKENS` | `translate_nl_to_sql` provider config (Anthropic / OpenAI / Gemini). |
 
 ## Tool index (141 tools)
@@ -39,18 +46,19 @@ plumbing:
 | **Query intelligence** | `run_select`, `run_select_parallel`, `explain_query`, `analyze_query_plan`, `translate_nl_to_sql` |
 | **Server-side cursors** | `open_cursor`, `fetch_cursor`, `close_cursor`, `list_cursors` |
 | **Composite + diagnostic** | `summarize_table`, `why_is_this_slow`, `find_unused_objects`, `find_sensitive_columns`, `detect_n_plus_one`, `lint_naming_conventions`, `test_rls_for_role`, `list_locks`, `find_blocking_chains`, `walk_blocking_chains`, `read_pg_stat_io`, `read_pg_buffercache_summary`, `read_pg_buffercache_relations`, `read_pg_wal_records`, `read_pg_wal_stats` |
-| **Health & tuning** | `check_database_health`, `audit_database`, `analyze_workload`, `recommend_indexes`, `run_advisors` |
+| **Health & tuning** | `check_database_health`, `audit_database`, `analyze_workload`, `recommend_indexes`, `recommend_index_drops`, `run_advisors` |
 | **Search** | `fuzzy_search`, `full_text_search`, `vector_search`, `vector_range_search`, `hybrid_search`, `geo_search` |
 | **Vector tuning advisors** | `recommend_vector_index`, `analyze_vector_search`, `analyze_vector_table`, `recommend_vector_quantization` |
+| **Vector analytics (pgvector)** | `cross_table_similarity`, `cluster_vectors`, `detect_vector_outliers`, `monitor_embedding_drift`, `migrate_vector_to_halfvec`, `analyze_distance_metric`, `import_vectors` |
 | **Apache AGE graph + Cypher** | `list_graphs`, `describe_graph`, `run_cypher`, `create_graph` (gated), `drop_graph` (gated) |
-| **Live ops** | `list_active_queries`, `list_replicas` |
+| **Live ops** | `list_active_queries`, `list_replicas`, `monitor_index_build` |
 | **Audit trail** | `list_audit_events` |
 | **Data movement — read** | `export_query`, `export_table` |
 | **Data movement — write (gated)** | `import_csv`, `import_json` |
 | **Data movement — subprocess (gated)** | `dump_database`, `restore_database`, `copy_table_between_databases` |
 | **LISTEN/NOTIFY bridge (gated)** | `subscribe_channel`, `poll_notifications`, `unsubscribe_channel`, `list_notification_subscriptions` |
 | **Staged migrations (gated)** | `prepare_migration`, `validate_migration`, `validate_migration_schema`, `complete_migration`, `cancel_migration`, `list_pending_migrations` |
-| **Migration history** | `read_migration_history` |
+| **Migration history** | `read_migration_history`, `list_unapplied_migration_scripts` |
 | **Test-data factory** | `generate_test_data` (generates SQL — does not execute), `seed_table_with_sample_data` (generates and executes; WRITE-gated) |
 | **TimescaleDB hypertables (gated for writes)** | `list_hypertables`, `list_chunks`, `create_hypertable`, `add_compression_policy`, `add_retention_policy` |
 | **ORM-DSL exporters** | `generate_prisma_schema`, `generate_drizzle_schema`, `generate_sqlalchemy_models`, `generate_sqlc_schema`, `generate_diesel_schema`, `generate_jooq_config`, `generate_ent_schemas`, `generate_ecto_schemas` |
@@ -255,6 +263,25 @@ array columns, trigram GIN for text columns. A flagged partition is rolled
 up to its partitioned parent (where the index belongs), with scan and row
 counts summed across partitions and a `partitioned` flag set. Parameter:
 `min_live_tuples` (int, default 10000).
+
+### `recommend_index_drops`
+Sibling of `recommend_indexes` for indexes to **remove**. Walks
+`pg_stat_user_indexes` + `pg_stat_user_tables` and flags existing
+indexes that look like pure cost — large on disk but never (or
+barely) scanned. Three reason codes, descending strength:
+`never_used` (no recorded `idx_scan`s since the last stats reset —
+candidate for drop, but verify before removal), `scan_no_fetch`
+(planner picks it but it returns no rows — usually an existence-
+check pattern), `rarely_used` (scan rate below `low_scan_ratio` of
+the table's total scan activity). Primary-key / unique / exclusion-
+constraint indexes are excluded (dropping those would be a schema
+change, not a performance win); indexes below `min_index_size_bytes`
+are skipped too. Returns a ready-to-run `DROP INDEX CONCURRENTLY`
+statement per candidate (with embedded `"` in identifiers escaped per
+the standard delimited-identifier convention). Read-only advisor —
+execution is on the operator. Parameters: `schema` (optional),
+`min_index_size_bytes` (int, default 1_000_000), `low_scan_ratio`
+(float, default 0.01).
 
 ### `fuzzy_search`
 Ranks a text column's values by `pg_trgm` trigram similarity to a search

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -27,7 +27,7 @@ plumbing:
 | `MCPG_OIDC_ROLE_CLAIM` | Optional. Maps a named JWT claim to the per-request PG role (composes with multi-tenancy). |
 | `MCPG_DEFAULT_ROLE` / `MCPG_ALLOWED_ROLES` | Static default + allowlist for `SET LOCAL ROLE`-driven multi-tenancy. In static-auth mode, per-request override via `X-MCPG-Role` header. |
 | `MCPG_REPLICA_URLS` | Comma-separated read-replica DSNs. When set, `force_readonly` queries round-robin across healthy replicas; writes always go to the primary. |
-| `MCPG_HTTP_IP_ALLOWLIST` | Comma-separated IPv4/IPv6/CIDR allowlist applied to the HTTP transport before auth. Trusts `X-Forwarded-For` from same-host proxies only. |
+| `MCPG_HTTP_IP_ALLOWLIST` | Comma-separated IPv4/IPv6/CIDR allowlist applied to the HTTP transport before auth. Matched against the immediate connecting peer; `X-Forwarded-For` is deliberately not honoured (spoofing-vector), so deployments behind a reverse proxy must enforce the allowlist at the proxy layer. |
 | `MCPG_HTTP_TLS_CERTFILE` / `MCPG_HTTP_TLS_KEYFILE` | PEM cert + key for terminating TLS at the HTTP transport (both required or both unset). |
 | `MCPG_HTTP_TLS_CA_CERTS` / `MCPG_HTTP_TLS_CLIENT_CERT_REQUIRED` | Optional CA bundle + flag to require client certificates (mutual TLS). Setting the flag without `CA_CERTS` is rejected at startup. |
 | `MCPG_HTTP_HSTS_MAX_AGE` / `MCPG_HTTP_MAX_BODY_BYTES` / `MCPG_HTTP_ALLOWED_ORIGINS` | HSTS header lifetime, request body cap, CORS allowlist for the HTTP transport. |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -182,6 +182,12 @@ storage advisor).
   read WAL record information and aggregated statistics over LSN ranges
   (requires the `pg_walinspect` extension).
 - `recommend_indexes` — missing-index heuristics.
+- `recommend_index_drops(schema=None, min_index_size_bytes=1_000_000,
+  low_scan_ratio=0.01)` — sibling for what to **drop**: walks
+  `pg_stat_user_indexes` for indexes that look like pure cost
+  (`never_used`, `scan_no_fetch`, `rarely_used`), emits a ready-to-run
+  `DROP INDEX CONCURRENTLY` per candidate. Execution stays with the
+  operator.
 - `find_unused_objects(schema)` — zero-scan tables and user
   indexes; great for "what can I drop?".
 - `detect_n_plus_one(min_calls=100)` — walks
@@ -515,6 +521,29 @@ export MCPG_SLOW_CALL_THRESHOLD_MS=1000  # Threshold in milliseconds (default: 1
 
 * When configured (defaults to `1000` ms), tool calls that exceed this threshold are logged as a warning to `mcpg.server`.
 * Set this to `0` or a negative value to disable slow-call logging.
+
+### OpenTelemetry tracing
+
+MCPg can emit one OpenTelemetry span per `call_tool` so traces from
+the agent → MCPg → PostgreSQL hop can be stitched together in
+Jaeger / Tempo / Honeycomb / your APM of choice.
+
+```bash
+pip install 'mcpg[otel]'                   # adds the OTel SDK + exporters
+export MCPG_OTEL_ENABLED=true
+export MCPG_OTEL_SERVICE_NAME=mcpg-prod    # optional, default "mcpg"
+```
+
+Standard OTel env vars (`OTEL_EXPORTER_OTLP_ENDPOINT`,
+`OTEL_RESOURCE_ATTRIBUTES`, …) are honoured by the SDK as usual.
+
+Each span carries `mcp.tool.name`, `mcp.tool.argument_count`, and
+the outcome status. **Argument values are deliberately not
+attached** — span exporters often ship to third-party SaaS, and
+attaching agent-supplied SQL or other args would turn the trace
+backend into a side channel for credentials or PII. Audit logging
+(local-only by default) is the place to look for full per-call
+payloads.
 
 ---
 

--- a/scratch/pr_review_report.md
+++ b/scratch/pr_review_report.md
@@ -5,7 +5,7 @@ This automated review checks proposed modifications against strict PostgreSQL, p
 ## Summary Metrics
 
 * **Review Status:** [🟢] **CLEAN & COMPLIANT**
-* **Files Analyzed:** 9
+* **Files Analyzed:** 7
 * **Total Findings:** 0
   * **Critical:** 0
   * **Errors:** 0
@@ -15,14 +15,12 @@ This automated review checks proposed modifications against strict PostgreSQL, p
 ### Files Checked:
 
 - `CHANGELOG.md`
-- `CONTRIBUTING.md`
-- `docs/feature-shortlist.md`
+- `docs/PROGRESS.md`
+- `docs/architecture.md`
+- `docs/installation.md`
+- `docs/security.md`
 - `docs/tools.md`
-- `docs/tour.md`
 - `docs/user-guide.md`
-- `src/mcpg/indexing.py`
-- `src/mcpg/tools.py`
-- `tests/unit/test_indexing.py`
 
 ---
 


### PR DESCRIPTION
## Summary

Documentation-only refresh that reconciles the living docs with the post-v0.5.0 work that had landed in code but not in docs (security workstream C1–C3, observability B2–B3, migrations E1–E4, pgvector analytics A3–A8, advisor 6.1).

No code changes; tool count stays at 141 (already reconciled by #66).

### What got refreshed

| File | What changed |
|---|---|
| `docs/tools.md` | HTTP transport gates table extended (IP allowlist, TLS / mTLS, cloud secrets, OTel, slow-call logging, HSTS / body-cap / CORS). Tool index gains rows for `recommend_index_drops`, `monitor_index_build`, `list_unapplied_migration_scripts`, and a new **Vector analytics** row. Reference section added for `recommend_index_drops`. |
| `docs/user-guide.md` | `recommend_index_drops` bullet next to `recommend_indexes`. New **OpenTelemetry tracing** section explaining the `mcpg[otel]` extra and the deliberate no-argument-values policy. |
| `docs/security.md` | T6 extended for IP allowlist + in-process TLS / mTLS. New T9a (cloud secrets backends) and T9b (OTel argument-values policy) threat sections. |
| `docs/installation.md` | **Common scenarios** gains rows for IP allowlist, in-process TLS, mTLS, the three secrets backends, OpenTelemetry, slow-call logging. New **HTTP transport TLS / mTLS** subsection. Stale "all 38 `MCPG_*` variables" claim corrected. |
| `docs/architecture.md` | Module map gains `mcpg.secrets` and `mcpg.otel_tracing` rows; `mcpg.http_runtime` row extended for IP allowlist + TLS. |
| `docs/PROGRESS.md` | Date 2026-05-27 → 2026-06-05, tool count 114 → 141. Phase summary refreshed for the post-v0.5.0 waves. Stale Batch G "Next action" block replaced with the live queue. |
| `CHANGELOG.md` | `### Docs` bullet describing the refresh added under `[Unreleased]`. |

## Test plan

- [x] `uv run pytest tests/unit -q` — 1354 passed
- [x] `uv run ruff check .` — clean
- [x] `uv run scratch/pr_review.py` — clean
- [ ] CI green on PR

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Refresh living documentation to cover post-v0.5.0 security, observability, migrations, pgvector analytics, and advisor features and align progress metadata with the current state.

Documentation:
- Document new HTTP transport security controls, including IP allowlists, in-process TLS/mTLS, and related headers.
- Describe cloud secrets backends and OpenTelemetry tracing, emphasizing reduced data exposure in observability paths.
- Expand installation guidance with common scenarios for IP allowlists, TLS/mTLS, secrets backends, OpenTelemetry, and slow-call logging, and correct configuration reference claims.
- Update the tools index and references for new advisors, vector analytics tools, live ops, and migration history utilities.
- Extend architecture docs with new modules for secrets management and OpenTelemetry tracing and the enhanced HTTP runtime.
- Refresh PROGRESS metadata, including phase narrative, tool count, and roadmap next steps, and record the documentation refresh in the changelog.