### PR TITLE
release: cut v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-06-05
+
 ### Added
 
 - **`recommend_index_drops` tool.** Sibling of `recommend_indexes`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcpg"
-version = "0.5.1"
+version = "0.6.0"
 description = "A production-grade PostgreSQL Model Context Protocol (MCP) server."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/mcpg/__init__.py
+++ b/src/mcpg/__init__.py
@@ -1,3 +1,3 @@
 """MCPg — a PostgreSQL Model Context Protocol server."""
 
-__version__ = "0.5.1"
+__version__ = "0.6.0"

--- a/uv.lock
+++ b/uv.lock
@@ -991,7 +991,7 @@ cli = [
 
 [[package]]
 name = "mcpg"
-version = "0.5.1"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Cuts **v0.6.0** from `main`. Version bump in `pyproject.toml` + `src/mcpg/__init__.py` + `uv.lock`, and the `[Unreleased]` block in `CHANGELOG.md` rolled into `[0.6.0] - 2026-06-05` with a fresh empty `[Unreleased]` on top.

## What's in v0.6.0

Squash of ~30 PRs since **v0.5.1 (2026-05-29)**:

| Workstream | Highlights |
|---|---|
| **Security** | C1 IP allowlist (`MCPG_HTTP_IP_ALLOWLIST`), C2 in-process TLS / mTLS (`MCPG_HTTP_TLS_*`), C3 cloud secrets backends — Vault / AWS / GCP (`MCPG_SECRETS_BACKEND`). |
| **Observability** | B1 structured JSON logging (`MCPG_LOG_FORMAT=json`), B2 slow-call logging (`MCPG_SLOW_CALL_THRESHOLD_MS`), B3 OpenTelemetry tracing (`MCPG_OTEL_ENABLED` + `mcpg[otel]` extra; argument values deliberately omitted). |
| **Migrations** | E1 migration-history integration, E2 zero-downtime cookbook, E3 pre-deployment validation, E4 `list_unapplied_migration_scripts`. |
| **pgvector analytics** | `cross_table_similarity`, `cluster_vectors`, `detect_vector_outliers`, `monitor_embedding_drift`, `migrate_vector_to_halfvec`, `analyze_distance_metric`, `import_vectors`, `mmr_search`, `monitor_index_build`. |
| **Advisors** | `recommend_index_drops` (sibling of `recommend_indexes` — what to remove). |
| **Extension surface** | D2 `pg_buffercache`, D3 `pg_walinspect`, D4 `walk_blocking_chains` (deadlock-cycle walker). |
| **UX** | F1 `generate_schema_docs`, F2 inline usage examples in tool descriptions, F3 sample-data seeding. |

Final tool count: **141**. No breaking changes — every new env var defaults to the previous behaviour.

## Pre-flight (`docs/release-process.md` §5)

- [x] `uv lock` clean (mcpg 0.5.1 → 0.6.0)
- [x] `uv run ruff check . && uv run ruff format --check .` clean
- [x] `uv run mypy src/mcpg` clean (68 files)
- [x] `uv run pytest tests/unit -q` — **1354 passed**
- [x] `uv run python -m build` — `mcpg-0.6.0-py3-none-any.whl` + `mcpg-0.6.0.tar.gz`
- [x] `uv run twine check dist/*` — both **PASSED**

## Maintainer follow-up after merge

The publish workflow triggers on `v*.*.*` tag push, **not** on PR merge — your action is required.

```bash
git checkout main && git pull
git tag -s v0.6.0 -m "MCPg v0.6.0"      # signed tag (auto-attest needs it)
git push origin v0.6.0
```

Then watch **Actions → publish.yml**:
1. `build` + `publish-testpypi` + `smoke-testpypi` run automatically.
2. `publish-pypi` waits on **your manual approval** in the `pypi` environment (the reviewer gate per `docs/release-process.md` §6.3).
3. `github-release` cuts the GitHub Release with notes pulled from `CHANGELOG.md`.

If anything looks off on the TestPyPI page before approving, cancel the run, fix forward on a new PR, bump to `0.6.0` → `0.6.1` (PyPI burns version numbers permanently).

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Cut v0.6.0 release from main, updating version metadata and changelog for the new release.

Enhancements:
- Update CHANGELOG with a new 0.6.0 section for previously unreleased changes.

Build:
- Bump project version to 0.6.0 in pyproject metadata and package __version__.
- Regenerate uv.lock to reflect the 0.6.0 release state.