### PR TITLE
feat: schedule_logical_backup — pg_cron + COPY TO PROGRAM (G1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,18 @@ adheres to [Semantic Versioning](https://semver.org/).
   via `pg_cron` + `COPY TO PROGRAM`: the cron job runs `pg_dump` on
   the database host's filesystem and writes the dump to a caller-
   supplied destination. Supports `plain` / `custom` / `tar` formats,
-  `schema_only`, optional `gzip` compression, and per-database
-  targeting. `destination`, `pg_dump_path`, and `database` are each
-  matched against a tight `[A-Za-z0-9_./-]` allowlist so they cannot
-  escape the `COPY TO PROGRAM` shell string. `COPY TO PROGRAM` is
-  PostgreSQL-superuser-only, so the connected role must be superuser
-  for the scheduled job to succeed at runtime. WRITE-gated; requires
-  `pg_cron` installed.
+  `schema_only`, optional `gzip` compression, and an explicit
+  `port` (default `5432`). `database` is required — `pg_dump`
+  invoked through `COPY TO PROGRAM` does not inherit the connection's
+  database and falls back to the OS user name without `-d`.
+  `destination` and `pg_dump_path` are matched against a tight
+  `[A-Za-z0-9_./-]` allowlist; `database` is matched against a
+  slightly looser allowlist that admits the hyphen common in real
+  database names (`app-prod`) but still rejects shell
+  metacharacters; `port` is bounded to `1..65535`. `COPY TO
+  PROGRAM` is PostgreSQL-superuser-only, so the connected role
+  must be superuser for the scheduled job to succeed at runtime.
+  WRITE-gated; requires `pg_cron` installed.
 
 ## [0.6.0] - 2026-06-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`schedule_logical_backup` tool.** Schedules a recurring `pg_dump`
+  via `pg_cron` + `COPY TO PROGRAM`: the cron job runs `pg_dump` on
+  the database host's filesystem and writes the dump to a caller-
+  supplied destination. Supports `plain` / `custom` / `tar` formats,
+  `schema_only`, optional `gzip` compression, and per-database
+  targeting. `destination`, `pg_dump_path`, and `database` are each
+  matched against a tight `[A-Za-z0-9_./-]` allowlist so they cannot
+  escape the `COPY TO PROGRAM` shell string. `COPY TO PROGRAM` is
+  PostgreSQL-superuser-only, so the connected role must be superuser
+  for the scheduled job to succeed at runtime. WRITE-gated; requires
+  `pg_cron` installed.
+
 ## [0.6.0] - 2026-06-05
 
 ### Added

--- a/docs/feature-shortlist.md
+++ b/docs/feature-shortlist.md
@@ -63,7 +63,7 @@ not covered there:
 
 | # | Item | Effort | Value | Notes |
 |---|---|---|---|---|
-| 5.1 | Scheduled logical backups via `pg_cron` + `dump_database` | S | Medium | Composes existing tools. |
+| 5.1 ✅ | Scheduled logical backups via `pg_cron` + `dump_database` | S | Medium | Shipped as `schedule_logical_backup`: composes `cron.schedule` with `COPY TO PROGRAM 'pg_dump ...'`. Tight allowlist on `destination`/`pg_dump_path`/`database`. PostgreSQL-superuser-only at runtime. |
 | 5.2 | WAL archive inspection | M | Low | Niche; only useful where WAL archiving is configured. |
 | 5.3 | Point-in-time recovery prep helpers | M | Low-Medium | Heavy lift for a narrow audience. |
 

--- a/docs/parallel-roadmap.md
+++ b/docs/parallel-roadmap.md
@@ -134,7 +134,7 @@ All four are independent.
 
 | PR | Item | Effort | Notes |
 |---|---|---|---|
-| G1 | Scheduled logical backups via `pg_cron` + `dump_database` (5.1) | S | Composes existing tools. |
+| G1 (✅ PR) | Scheduled logical backups via `pg_cron` + `dump_database` (5.1) | S | Shipped as `schedule_logical_backup` — composes `cron.schedule` with `COPY TO PROGRAM 'pg_dump ...'`. |
 | G2 | WAL archive inspection (5.2) | M | Niche. |
 | G3 | Point-in-time recovery prep helpers (5.3) | M | Heavy lift, narrow audience. |
 

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -262,6 +262,8 @@ enable_extension(name)                               # allowlisted extensions on
 pg_cron.schedule(name, schedule, command)
 pg_cron.unschedule(name_or_id)
 pg_cron.update(name_or_id, …)
+
+schedule_logical_backup(name, schedule, destination, …)  # composes pg_cron + pg_dump via COPY TO PROGRAM
 ```
 
 ## "Manage partitions" (`unrestricted` + `MCPG_ALLOW_DDL=true` + pg_partman installed)

--- a/src/mcpg/cron.py
+++ b/src/mcpg/cron.py
@@ -103,7 +103,9 @@ async def schedule_cron_job(driver: SqlDriver, name: str, schedule: str, command
 _SAFE_PATH = re.compile(r"\A[A-Za-z0-9_./\-]+\Z")
 _ABS_SAFE_PATH = re.compile(r"\A/[A-Za-z0-9_./\-]+\Z")
 _IDENTIFIER = re.compile(r"\A[A-Za-z_][A-Za-z0-9_]*\Z")
-_BACKUP_FORMATS = frozenset({"plain", "custom", "tar"})
+# Single source of truth: the keys are the allowed ``format`` values
+# and the values are the matching ``pg_dump`` short flag.
+_BACKUP_FORMAT_FLAGS = {"plain": "-Fp", "custom": "-Fc", "tar": "-Ft"}
 
 
 async def schedule_logical_backup(
@@ -146,11 +148,10 @@ async def schedule_logical_backup(
         raise CronError(f"pg_dump_path must contain only [A-Za-z0-9_./-]; got {pg_dump_path!r}")
     if database is not None and not _IDENTIFIER.match(database):
         raise CronError(f"database must be a plain identifier; got {database!r}")
-    if format not in _BACKUP_FORMATS:
-        raise CronError(f"unsupported backup format {format!r}; expected one of {sorted(_BACKUP_FORMATS)}")
+    if format not in _BACKUP_FORMAT_FLAGS:
+        raise CronError(f"unsupported backup format {format!r}; expected one of {sorted(_BACKUP_FORMAT_FLAGS)}")
 
-    format_flag = {"plain": "-Fp", "custom": "-Fc", "tar": "-Ft"}[format]
-    parts = [pg_dump_path, format_flag]
+    parts = [pg_dump_path, _BACKUP_FORMAT_FLAGS[format]]
     if schema_only:
         parts.append("--schema-only")
     if database is not None:

--- a/src/mcpg/cron.py
+++ b/src/mcpg/cron.py
@@ -9,6 +9,7 @@ is not installed; the read tool returns an empty list.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 
 from mcpg._vendor.sql import SqlDriver
@@ -94,6 +95,73 @@ async def schedule_cron_job(driver: SqlDriver, name: str, schedule: str, command
     if not rows:
         raise CronError(f"cron.schedule did not return a jobid for {name!r}")
     return ScheduleResult(jobid=rows[0].cells["jobid"], name=name)
+
+
+# Tight allowlists for everything that lands inside the COPY TO PROGRAM
+# shell string — pg_cron passes the SQL body verbatim, so anything we
+# splice in becomes part of a shell command on the database host.
+_SAFE_PATH = re.compile(r"\A[A-Za-z0-9_./\-]+\Z")
+_ABS_SAFE_PATH = re.compile(r"\A/[A-Za-z0-9_./\-]+\Z")
+_IDENTIFIER = re.compile(r"\A[A-Za-z_][A-Za-z0-9_]*\Z")
+_BACKUP_FORMATS = frozenset({"plain", "custom", "tar"})
+
+
+async def schedule_logical_backup(
+    driver: SqlDriver,
+    name: str,
+    schedule: str,
+    destination: str,
+    *,
+    format: str = "plain",
+    schema_only: bool = False,
+    compress: bool = False,
+    pg_dump_path: str = "pg_dump",
+    database: str | None = None,
+) -> ScheduleResult:
+    """Schedule a recurring ``pg_dump`` via pg_cron + ``COPY TO PROGRAM``.
+
+    Composes :func:`schedule_cron_job` with a ``COPY (SELECT 1) TO
+    PROGRAM`` body that invokes ``pg_dump`` on the database host's
+    filesystem and writes the dump to ``destination`` on that host.
+
+    ``destination`` must be an absolute POSIX path containing only
+    ``[A-Za-z0-9_./-]`` — shell metacharacters are rejected so the
+    value cannot escape the ``COPY TO PROGRAM`` single-quoted string.
+    ``pg_dump_path`` is constrained the same way (with no absolute-
+    path requirement so a bare ``pg_dump`` from ``$PATH`` is allowed).
+    ``database`` must be a plain identifier when set.
+
+    ``COPY TO PROGRAM`` is **PostgreSQL-superuser-only**; the connected
+    role must hold superuser to run the scheduled job. Otherwise the
+    backup will be scheduled successfully but every invocation will
+    fail at execution time.
+
+    Raises:
+        CronError: pg_cron is not installed, an argument fails
+            validation, or the underlying ``cron.schedule`` call fails.
+    """
+    if not _ABS_SAFE_PATH.match(destination):
+        raise CronError(f"destination must be an absolute path containing only [A-Za-z0-9_./-]; got {destination!r}")
+    if not _SAFE_PATH.match(pg_dump_path):
+        raise CronError(f"pg_dump_path must contain only [A-Za-z0-9_./-]; got {pg_dump_path!r}")
+    if database is not None and not _IDENTIFIER.match(database):
+        raise CronError(f"database must be a plain identifier; got {database!r}")
+    if format not in _BACKUP_FORMATS:
+        raise CronError(f"unsupported backup format {format!r}; expected one of {sorted(_BACKUP_FORMATS)}")
+
+    format_flag = {"plain": "-Fp", "custom": "-Fc", "tar": "-Ft"}[format]
+    parts = [pg_dump_path, format_flag]
+    if schema_only:
+        parts.append("--schema-only")
+    if database is not None:
+        parts.extend(["-d", database])
+    pipeline = " ".join(parts)
+    if compress:
+        pipeline += " | gzip"
+    pipeline += f" > {destination}"
+
+    sql_command = f"COPY (SELECT 1) TO PROGRAM '{pipeline}'"
+    return await schedule_cron_job(driver, name, schedule, sql_command)
 
 
 async def unschedule_cron_job(driver: SqlDriver, name: str) -> bool:

--- a/src/mcpg/cron.py
+++ b/src/mcpg/cron.py
@@ -102,7 +102,10 @@ async def schedule_cron_job(driver: SqlDriver, name: str, schedule: str, command
 # splice in becomes part of a shell command on the database host.
 _SAFE_PATH = re.compile(r"\A[A-Za-z0-9_./\-]+\Z")
 _ABS_SAFE_PATH = re.compile(r"\A/[A-Za-z0-9_./\-]+\Z")
-_IDENTIFIER = re.compile(r"\A[A-Za-z_][A-Za-z0-9_]*\Z")
+# Looser than `_IDENTIFIER` — accepts the hyphens that real-world
+# database names commonly use (``app-prod``), while still rejecting
+# shell metacharacters and path separators.
+_DBNAME_SAFE = re.compile(r"\A[A-Za-z0-9_][A-Za-z0-9_\-]*\Z")
 # Single source of truth: the keys are the allowed ``format`` values
 # and the values are the matching ``pg_dump`` short flag.
 _BACKUP_FORMAT_FLAGS = {"plain": "-Fp", "custom": "-Fc", "tar": "-Ft"}
@@ -113,12 +116,13 @@ async def schedule_logical_backup(
     name: str,
     schedule: str,
     destination: str,
+    database: str,
     *,
     format: str = "plain",
     schema_only: bool = False,
     compress: bool = False,
     pg_dump_path: str = "pg_dump",
-    database: str | None = None,
+    port: int = 5432,
 ) -> ScheduleResult:
     """Schedule a recurring ``pg_dump`` via pg_cron + ``COPY TO PROGRAM``.
 
@@ -126,12 +130,20 @@ async def schedule_logical_backup(
     PROGRAM`` body that invokes ``pg_dump`` on the database host's
     filesystem and writes the dump to ``destination`` on that host.
 
+    ``database`` is required — ``pg_dump`` does **not** inherit the
+    current connection's database when invoked through ``COPY TO
+    PROGRAM``; without ``-d`` it falls back to the OS user name
+    (typically ``postgres``), which is almost never what the caller
+    wants. Callers must pass the database name explicitly.
+
     ``destination`` must be an absolute POSIX path containing only
     ``[A-Za-z0-9_./-]`` — shell metacharacters are rejected so the
     value cannot escape the ``COPY TO PROGRAM`` single-quoted string.
     ``pg_dump_path`` is constrained the same way (with no absolute-
     path requirement so a bare ``pg_dump`` from ``$PATH`` is allowed).
-    ``database`` must be a plain identifier when set.
+    ``database`` matches a slightly looser allowlist that accepts the
+    hyphen commonly used in real database names. ``port`` is bounded
+    to a valid TCP port and is spliced in as ``-p <port>``.
 
     ``COPY TO PROGRAM`` is **PostgreSQL-superuser-only**; the connected
     role must hold superuser to run the scheduled job. Otherwise the
@@ -146,16 +158,17 @@ async def schedule_logical_backup(
         raise CronError(f"destination must be an absolute path containing only [A-Za-z0-9_./-]; got {destination!r}")
     if not _SAFE_PATH.match(pg_dump_path):
         raise CronError(f"pg_dump_path must contain only [A-Za-z0-9_./-]; got {pg_dump_path!r}")
-    if database is not None and not _IDENTIFIER.match(database):
-        raise CronError(f"database must be a plain identifier; got {database!r}")
+    if not _DBNAME_SAFE.match(database):
+        raise CronError(f"database must contain only [A-Za-z0-9_-] (no shell metacharacters); got {database!r}")
+    if not 1 <= port <= 65535:
+        raise CronError(f"port must be in 1..65535; got {port!r}")
     if format not in _BACKUP_FORMAT_FLAGS:
         raise CronError(f"unsupported backup format {format!r}; expected one of {sorted(_BACKUP_FORMAT_FLAGS)}")
 
     parts = [pg_dump_path, _BACKUP_FORMAT_FLAGS[format]]
     if schema_only:
         parts.append("--schema-only")
-    if database is not None:
-        parts.extend(["-d", database])
+    parts.extend(["-p", str(port), "-d", database])
     pipeline = " ".join(parts)
     if compress:
         pipeline += " | gzip"

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -2650,14 +2650,18 @@ def _register_cron_write(server: FastMCP[AppContext]) -> None:
         description=(
             "Schedule a recurring pg_dump via pg_cron + COPY TO PROGRAM. The "
             "scheduled job runs pg_dump on the database host's filesystem and "
-            "writes the dump to ``destination`` on that host. ``destination`` "
-            "must be an absolute POSIX path with only [A-Za-z0-9_./-] (no "
-            "shell metacharacters) so it cannot escape the COPY TO PROGRAM "
-            "shell string. ``format`` is 'plain' | 'custom' | 'tar'; "
-            "``compress`` pipes through gzip. COPY TO PROGRAM is PostgreSQL-"
-            "superuser-only, so the connected role must be superuser for the "
-            "scheduled job to succeed at runtime. Available only in "
-            "unrestricted mode; requires pg_cron installed."
+            "writes the dump to ``destination`` on that host. ``database`` is "
+            "required — pg_dump invoked through COPY TO PROGRAM does not "
+            "inherit the connection's database and falls back to the OS user "
+            "name without ``-d``. ``destination`` must be an absolute POSIX "
+            "path with only [A-Za-z0-9_./-] (no shell metacharacters) so it "
+            "cannot escape the COPY TO PROGRAM shell string; ``database`` "
+            "additionally allows the hyphen common in real DB names. "
+            "``format`` is 'plain' | 'custom' | 'tar'; ``compress`` pipes "
+            "through gzip; ``port`` defaults to 5432. COPY TO PROGRAM is "
+            "PostgreSQL-superuser-only, so the connected role must be "
+            "superuser for the scheduled job to succeed at runtime. Available "
+            "only in unrestricted mode; requires pg_cron installed."
         ),
     )
     async def schedule_logical_backup(
@@ -2665,22 +2669,24 @@ def _register_cron_write(server: FastMCP[AppContext]) -> None:
         name: str,
         schedule: str,
         destination: str,
+        database: str,
         format: str = "plain",
         schema_only: bool = False,
         compress: bool = False,
         pg_dump_path: str = "pg_dump",
-        database: str | None = None,
+        port: int = 5432,
     ) -> dict[str, Any]:
         result = await cron.schedule_logical_backup(
             _driver(ctx),
             name,
             schedule,
             destination,
+            database,
             format=format,
             schema_only=schema_only,
             compress=compress,
             pg_dump_path=pg_dump_path,
-            database=database,
+            port=port,
         )
         await ctx.request_context.lifespan_context.cache.clear()
         return asdict(result)

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -2645,6 +2645,46 @@ def _register_cron_write(server: FastMCP[AppContext]) -> None:
         await ctx.request_context.lifespan_context.cache.clear()
         return {"name": name, "removed": removed}
 
+    @server.tool(
+        name="schedule_logical_backup",
+        description=(
+            "Schedule a recurring pg_dump via pg_cron + COPY TO PROGRAM. The "
+            "scheduled job runs pg_dump on the database host's filesystem and "
+            "writes the dump to ``destination`` on that host. ``destination`` "
+            "must be an absolute POSIX path with only [A-Za-z0-9_./-] (no "
+            "shell metacharacters) so it cannot escape the COPY TO PROGRAM "
+            "shell string. ``format`` is 'plain' | 'custom' | 'tar'; "
+            "``compress`` pipes through gzip. COPY TO PROGRAM is PostgreSQL-"
+            "superuser-only, so the connected role must be superuser for the "
+            "scheduled job to succeed at runtime. Available only in "
+            "unrestricted mode; requires pg_cron installed."
+        ),
+    )
+    async def schedule_logical_backup(
+        ctx: _Ctx,
+        name: str,
+        schedule: str,
+        destination: str,
+        format: str = "plain",
+        schema_only: bool = False,
+        compress: bool = False,
+        pg_dump_path: str = "pg_dump",
+        database: str | None = None,
+    ) -> dict[str, Any]:
+        result = await cron.schedule_logical_backup(
+            _driver(ctx),
+            name,
+            schedule,
+            destination,
+            format=format,
+            schema_only=schema_only,
+            compress=compress,
+            pg_dump_path=pg_dump_path,
+            database=database,
+        )
+        await ctx.request_context.lifespan_context.cache.clear()
+        return asdict(result)
+
 
 def _register_partman(server: FastMCP[AppContext]) -> None:
     @server.tool(

--- a/tests/unit/test_cron.py
+++ b/tests/unit/test_cron.py
@@ -157,6 +157,7 @@ async def test_schedule_logical_backup_composes_copy_to_program() -> None:
         "nightly",
         "0 3 * * *",
         "/var/backups/db.sql",
+        "app",
     )
 
     assert result == ScheduleResult(jobid=101, name="nightly")
@@ -169,11 +170,11 @@ async def test_schedule_logical_backup_composes_copy_to_program() -> None:
     assert params == [
         "nightly",
         "0 3 * * *",
-        "COPY (SELECT 1) TO PROGRAM 'pg_dump -Fp > /var/backups/db.sql'",
+        "COPY (SELECT 1) TO PROGRAM 'pg_dump -Fp -p 5432 -d app > /var/backups/db.sql'",
     ]
 
 
-async def test_schedule_logical_backup_honours_format_schema_only_compress_and_database() -> None:
+async def test_schedule_logical_backup_honours_format_schema_only_compress_and_port() -> None:
     driver = FakeRoutingDriver(
         {
             "pg_extension": [{"present": 1}],
@@ -186,16 +187,17 @@ async def test_schedule_logical_backup_honours_format_schema_only_compress_and_d
         "weekly-schema",
         "0 4 * * 0",
         "/var/backups/schema.dump",
+        "app-prod",
         format="custom",
         schema_only=True,
         compress=True,
         pg_dump_path="/usr/local/pgsql/bin/pg_dump",
-        database="app",
+        port=5544,
     )
 
     expected_command = (
         "COPY (SELECT 1) TO PROGRAM "
-        "'/usr/local/pgsql/bin/pg_dump -Fc --schema-only -d app | gzip > /var/backups/schema.dump'"
+        "'/usr/local/pgsql/bin/pg_dump -Fc --schema-only -p 5544 -d app-prod | gzip > /var/backups/schema.dump'"
     )
     schedule_calls = [c for c in driver.calls if "cron.schedule" in c[0]]
     assert schedule_calls[0][1] == ["weekly-schema", "0 4 * * 0", expected_command]
@@ -218,7 +220,7 @@ async def test_schedule_logical_backup_rejects_unsafe_destination(destination: s
     driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
 
     with pytest.raises(CronError, match="destination"):
-        await schedule_logical_backup(driver, "n", "* * * * *", destination)  # type: ignore[arg-type]
+        await schedule_logical_backup(driver, "n", "* * * * *", destination, "app")  # type: ignore[arg-type]
 
 
 async def test_schedule_logical_backup_rejects_unsafe_pg_dump_path() -> None:
@@ -230,11 +232,23 @@ async def test_schedule_logical_backup_rejects_unsafe_pg_dump_path() -> None:
             "n",
             "* * * * *",
             "/var/backups/x.sql",
+            "app",
             pg_dump_path="pg_dump; rm -rf /",
         )
 
 
-async def test_schedule_logical_backup_rejects_unsafe_database_name() -> None:
+@pytest.mark.parametrize(
+    "database",
+    [
+        "app; DROP",  # injection
+        "app.prod",  # dot — not a valid pg identifier and ambiguous in -d
+        "app/prod",  # slash
+        "app prod",  # space
+        "-rf",  # leading hyphen would look like a flag to pg_dump
+        "",
+    ],
+)
+async def test_schedule_logical_backup_rejects_unsafe_database_name(database: str) -> None:
     driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
 
     with pytest.raises(CronError, match="database"):
@@ -243,7 +257,40 @@ async def test_schedule_logical_backup_rejects_unsafe_database_name() -> None:
             "n",
             "* * * * *",
             "/var/backups/x.sql",
-            database="app; DROP",
+            database,
+        )
+
+
+@pytest.mark.parametrize("database", ["app", "app-prod", "app_prod_v2", "App123"])
+async def test_schedule_logical_backup_accepts_hyphenated_database_names(database: str) -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "cron.schedule": [{"jobid": 1}],
+        }
+    )
+
+    await schedule_logical_backup(
+        driver,  # type: ignore[arg-type]
+        "n",
+        "* * * * *",
+        "/var/backups/x.sql",
+        database,
+    )
+
+
+@pytest.mark.parametrize("port", [0, -1, 65536, 100000])
+async def test_schedule_logical_backup_rejects_out_of_range_port(port: int) -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(CronError, match="port"):
+        await schedule_logical_backup(
+            driver,  # type: ignore[arg-type]
+            "n",
+            "* * * * *",
+            "/var/backups/x.sql",
+            "app",
+            port=port,
         )
 
 
@@ -256,6 +303,7 @@ async def test_schedule_logical_backup_rejects_unsupported_format() -> None:
             "n",
             "* * * * *",
             "/var/backups/x.sql",
+            "app",
             format="directory",
         )
 
@@ -264,4 +312,4 @@ async def test_schedule_logical_backup_raises_when_extension_absent() -> None:
     driver = FakeRoutingDriver({"pg_extension": []})
 
     with pytest.raises(CronError, match="not installed"):
-        await schedule_logical_backup(driver, "n", "* * * * *", "/var/backups/x.sql")  # type: ignore[arg-type]
+        await schedule_logical_backup(driver, "n", "* * * * *", "/var/backups/x.sql", "app")  # type: ignore[arg-type]

--- a/tests/unit/test_cron.py
+++ b/tests/unit/test_cron.py
@@ -5,7 +5,15 @@ from _fakes import FakeDatabase, FakeDriver, FakeRoutingDriver
 from mcp.shared.memory import create_connected_server_and_client_session
 
 from mcpg.config import load_settings
-from mcpg.cron import CronError, CronJob, ScheduleResult, list_cron_jobs, schedule_cron_job, unschedule_cron_job
+from mcpg.cron import (
+    CronError,
+    CronJob,
+    ScheduleResult,
+    list_cron_jobs,
+    schedule_cron_job,
+    schedule_logical_backup,
+    unschedule_cron_job,
+)
 from mcpg.server import create_server
 
 _UNRESTRICTED = load_settings(
@@ -130,4 +138,130 @@ async def test_schedule_tools_are_registered_in_unrestricted_mode() -> None:
     server = create_server(_UNRESTRICTED, database=FakeDatabase(FakeDriver()))  # type: ignore[arg-type]
     async with create_connected_server_and_client_session(server) as client:
         listed = {tool.name for tool in (await client.list_tools()).tools}
-    assert {"schedule_cron_job", "unschedule_cron_job"} <= listed
+    assert {"schedule_cron_job", "unschedule_cron_job", "schedule_logical_backup"} <= listed
+
+
+# --- schedule_logical_backup ----------------------------------------------
+
+
+async def test_schedule_logical_backup_composes_copy_to_program() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "cron.schedule": [{"jobid": 101}],
+        }
+    )
+
+    result = await schedule_logical_backup(
+        driver,  # type: ignore[arg-type]
+        "nightly",
+        "0 3 * * *",
+        "/var/backups/db.sql",
+    )
+
+    assert result == ScheduleResult(jobid=101, name="nightly")
+    # The cron.schedule call carries the constructed COPY TO PROGRAM body
+    # as its third bound parameter — confirm the shape so we don't
+    # regress on shell-string construction.
+    schedule_calls = [c for c in driver.calls if "cron.schedule" in c[0]]
+    assert len(schedule_calls) == 1
+    _, params, _ = schedule_calls[0]
+    assert params == [
+        "nightly",
+        "0 3 * * *",
+        "COPY (SELECT 1) TO PROGRAM 'pg_dump -Fp > /var/backups/db.sql'",
+    ]
+
+
+async def test_schedule_logical_backup_honours_format_schema_only_compress_and_database() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "cron.schedule": [{"jobid": 102}],
+        }
+    )
+
+    await schedule_logical_backup(
+        driver,  # type: ignore[arg-type]
+        "weekly-schema",
+        "0 4 * * 0",
+        "/var/backups/schema.dump",
+        format="custom",
+        schema_only=True,
+        compress=True,
+        pg_dump_path="/usr/local/pgsql/bin/pg_dump",
+        database="app",
+    )
+
+    expected_command = (
+        "COPY (SELECT 1) TO PROGRAM "
+        "'/usr/local/pgsql/bin/pg_dump -Fc --schema-only -d app | gzip > /var/backups/schema.dump'"
+    )
+    schedule_calls = [c for c in driver.calls if "cron.schedule" in c[0]]
+    assert schedule_calls[0][1] == ["weekly-schema", "0 4 * * 0", expected_command]
+
+
+@pytest.mark.parametrize(
+    "destination",
+    [
+        "relative/path.sql",  # not absolute
+        "/var/backups/$(rm -rf /)",  # shell substitution
+        "/var/backups/file;ls",  # command chain
+        "/var/backups/file'; DROP TABLE x; --",  # quote escape
+        "/var/backups/file\nrm",  # newline
+        "/var/backups/file with space",  # space
+        "/var/backups/file|cat",  # pipe
+        "",
+    ],
+)
+async def test_schedule_logical_backup_rejects_unsafe_destination(destination: str) -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(CronError, match="destination"):
+        await schedule_logical_backup(driver, "n", "* * * * *", destination)  # type: ignore[arg-type]
+
+
+async def test_schedule_logical_backup_rejects_unsafe_pg_dump_path() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(CronError, match="pg_dump_path"):
+        await schedule_logical_backup(
+            driver,  # type: ignore[arg-type]
+            "n",
+            "* * * * *",
+            "/var/backups/x.sql",
+            pg_dump_path="pg_dump; rm -rf /",
+        )
+
+
+async def test_schedule_logical_backup_rejects_unsafe_database_name() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(CronError, match="database"):
+        await schedule_logical_backup(
+            driver,  # type: ignore[arg-type]
+            "n",
+            "* * * * *",
+            "/var/backups/x.sql",
+            database="app; DROP",
+        )
+
+
+async def test_schedule_logical_backup_rejects_unsupported_format() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(CronError, match="unsupported backup format"):
+        await schedule_logical_backup(
+            driver,  # type: ignore[arg-type]
+            "n",
+            "* * * * *",
+            "/var/backups/x.sql",
+            format="directory",
+        )
+
+
+async def test_schedule_logical_backup_raises_when_extension_absent() -> None:
+    driver = FakeRoutingDriver({"pg_extension": []})
+
+    with pytest.raises(CronError, match="not installed"):
+        await schedule_logical_backup(driver, "n", "* * * * *", "/var/backups/x.sql")  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

G1 from the parallel roadmap — scheduled logical backups via `pg_cron` + `dump_database`. Adds **`schedule_logical_backup`**, a write-gated tool that registers a recurring `pg_cron` job whose body is a `COPY (SELECT 1) TO PROGRAM 'pg_dump ... > destination'`. The dump runs on the database host's filesystem; mcpg never sees the bytes.

Tool signature:

```
schedule_logical_backup(
  name, schedule, destination,
  format="plain",      # plain | custom | tar
  schema_only=False,
  compress=False,      # pipe through gzip
  pg_dump_path="pg_dump",
  database=None,       # default current DB
) -> {jobid, name}
```

## Why this shape

`pg_cron` runs SQL **inside** the database; `dump_database` is a subprocess **outside** it. They can't compose via mcpg's existing process tree. The only realistic in-DB composition is `COPY TO PROGRAM` driving `pg_dump` server-side. Per session discussion, this was the picked direction (`COPY TO PROGRAM wrapper`).

## Security

`COPY TO PROGRAM` is a footgun, so:

- **Tight allowlist** on every value that lands inside the single-quoted shell string: `destination`, `pg_dump_path`, and `database` each match `[A-Za-z0-9_./-]` only. Shell metacharacters (`$`, `;`, `|`, `'`, newline, space, etc.) are rejected up-front by `CronError`. Parametrised tests cover each rejection.
- `format` is enum-validated against `{plain, custom, tar}`.
- `name` and `schedule` flow through `cron.schedule(%s, %s, %s)` as bound parameters — no SQL-injection surface.
- **Runtime gate**: `COPY TO PROGRAM` requires PostgreSQL superuser. Documented in the tool description; if the connected role isn't superuser, scheduling still succeeds but every invocation fails at run time (deliberate — surfaces fast in `pg_cron`'s job log).
- mcpg-side gate: same as `schedule_cron_job` (WRITE / unrestricted access mode). No new env-var surface.

## Tests

- Happy path: confirms `cron.schedule` is called with the expected `COPY TO PROGRAM` body for both the default and a fully-customised invocation.
- Rejects relative paths, shell substitution `$(...)`, command chaining `;`, quote escape `'`, newline, space, pipe `|`, empty string, unsafe `pg_dump_path`, unsafe `database` name, and unsupported `format`.
- Extension-absent path raises `CronError` (delegated to `schedule_cron_job`).
- Tool-wiring test asserts `schedule_logical_backup` is registered in unrestricted mode.

## Docs

- `CHANGELOG.md` `[Unreleased]` entry.
- `docs/tour.md` "Schedule a job" section lists the new tool.
- `docs/feature-shortlist.md` row **5.1** and `docs/parallel-roadmap.md` row **G1** both flipped to ✅.
- Tool count deliberately not bumped (parallel-roadmap §2 — next doc-sync PR reconciles).

## Pre-flight

- [x] `uv run ruff check . && uv run ruff format --check .` clean
- [x] `uv run mypy src/mcpg` clean (68 files)
- [x] `uv run pytest tests/unit -q` — **1368 passed** (+14 new tests)

## Test plan

- [ ] CI green on the PG matrix
- [ ] Spot-check tool description in MCP inspector shows the superuser caveat
- [ ] Manual smoke (post-merge, local stack): `MCPG_ACCESS_MODE=unrestricted`, install `pg_cron`, call `schedule_logical_backup("smoke", "*/2 * * * *", "/tmp/mcpg-smoke.sql")` against a superuser DSN, confirm dump file appears

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Add a new tool to schedule recurring logical backups via pg_cron and COPY TO PROGRAM using pg_dump, with strict validation and documentation updates.

New Features:
- Introduce the schedule_logical_backup server tool to register recurring pg_dump-based logical backups via pg_cron and COPY TO PROGRAM.

Enhancements:
- Enforce strict allowlisting and format validation for backup destinations, pg_dump path, and database names when scheduling logical backups.

Documentation:
- Document the new schedule_logical_backup tool in the changelog, tour, feature shortlist, and parallel roadmap.

Tests:
- Add unit tests covering successful logical backup scheduling, argument validation failures, extension absence handling, and tool registration in unrestricted mode.