### PR TITLE
feat: pg_turboquant maintenance advisor + audit category (TQ-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **pg_turboquant maintenance advisor + audit category (TQ-2).** New
+  `recommend_turboquant_maintenance` tool walks every turboquant
+  index and emits stable-coded findings:
+  - `prerequisites_unmet` (CRITICAL) — pg_turboquant is installed but
+    its hard dependency (pgvector) is not. Short-circuits before any
+    per-index work since no working index can exist in that state.
+  - `format_v1_reindex_needed` (CRITICAL) — `algorithm_version`
+    starts with `v1`; emits `REINDEX INDEX CONCURRENTLY` as the
+    suggested action.
+  - `maintenance_due` (WARNING) — `tq_index_metadata` reports
+    `maintenance_recommended=true`; emits `SELECT tq_maintain_index(...)`.
+  - `fast_path_ineligible` (WARNING) — `fast_path_eligible=false`
+    (explicit `False` — `None` means "not reported" and does not
+    fire).
+  The advisor reads exclusively from `TurboQuantIndexInfo` fields
+  TQ-1 already surfaces, so it composes cleanly without duplicating
+  catalog queries. A scorecard adapter (`audit_turboquant_indexes`)
+  produces a `CategoryResult` named `"pg_turboquant Indexes"`,
+  scored 100-down with CRITICAL = -30 / WARNING = -15 (clamped at 0).
+  When the extension is not installed, the adapter returns `None` and
+  `audit_database` cleanly omits the category — stock clusters'
+  scorecards aren't padded or score-diluted. The fifth planned rule
+  (`delta_tier_large`) is deferred to backlog: the upstream
+  `tq_index_heap_stats` payload doesn't yet document a delta-row key
+  we can rely on, and shipping a rule against an unverified contract
+  would produce noise rather than signal. Will return when the
+  contract is verifiable.
 - **pg_turboquant read advisors (TQ-1).** Four read-only tools wrapping
   the [pg_turboquant](https://github.com/mayflower/pg_turboquant) ANN
   index extension's observability surface:

--- a/docs/feature-shortlist.md
+++ b/docs/feature-shortlist.md
@@ -122,7 +122,7 @@ composes with this lives in
 |---|---|---|---|---|
 | 10.1 | ✅ **Shipped (TQ-1).** Read advisors for [pg_turboquant](https://github.com/mayflower/pg_turboquant): `list_turboquant_indexes`, `get_turboquant_index_metadata`, `get_turboquant_heap_stats`, `get_turboquant_last_scan_stats`. Defensive JSON parsing — documented fields are typed; the full upstream payload is preserved in `raw_metadata` / `raw` so future-added fields stay reachable. Each index info also carries `index_options` — the `WITH (...)` build-time options (`bits`, `lists`, `transform`, `normalized`) parsed from `pg_class.reloptions` into typed values. Returns empty list / `None` when the extension is absent. Lives in `mcpg.turboquant`. | S | Medium | Mirrors how `cron` / `partman` are surfaced. `pg_turboquant` added to `ENABLEABLE_EXTENSIONS`. |
 | 10.2 | `turboquant_approx_candidates` + `turboquant_rerank_candidates` + `recommend_turboquant_query_knobs` — query-execution wrappers around the dedicated `tq_*_candidates(...)` functions so callers actually exercise the extension's SIMD fast path (the pgvector operators may not), plus the per-query knob advisor. Composes the TQ-1 `tq_last_scan_stats` helper to include scan diagnostics in the response. Promoted ahead of 10.3/10.4/10.5 because it both unblocks adoption and is a hard prerequisite for the RAG efficiency suite's turboquant arm (11.1). | M | High | TQ-5 — the new ordering puts this right after TQ-1. |
-| 10.3 | `recommend_turboquant_maintenance` advisor + `audit_turboquant_indexes` category wired into `audit_database` — `format_v1_reindex_needed`, `maintenance_due`, `fast_path_ineligible`, `delta_tier_large` rules. | S-M | Medium-High | TQ-2. |
+| 10.3 | ✅ **Shipped (TQ-2).** `recommend_turboquant_maintenance` advisor + `audit_turboquant_indexes` category wired into `audit_database`. Stable-coded rules: `prerequisites_unmet` (CRITICAL — pgvector missing), `format_v1_reindex_needed` (CRITICAL — algorithm_version starts with v1), `maintenance_due` (WARNING — `maintenance_recommended=true`), `fast_path_ineligible` (WARNING — `fast_path_eligible=false`, explicit-false only). Reads exclusively from `TurboQuantIndexInfo` so it composes on TQ-1 without duplicate catalog queries. Category returns `None` when the extension is absent so `audit_database` cleanly omits it on stock clusters. `delta_tier_large` is on backlog pending upstream contract for a delta-rows key in `tq_index_heap_stats`. | S-M | Medium-High | Lives in `mcpg.turboquant`. |
 | 10.4 | `maintain_turboquant_index` — write tool wrapping `tq_maintain_index`; pre-flight confirms the named index is actually a turboquant index. Unrestricted-only. | S | Medium | TQ-3. |
 | 10.5 | `create_turboquant_index` + `reindex_turboquant_index` — DDL tools with bits/lists/transform/normalized allowlists and a single-source-of-truth metric→opclass mapping (`tq_cosine_ops` / `tq_inner_product_ops` / `tq_l2_ops`). Unrestricted + `MCPG_ALLOW_DDL`. | M | Medium-High | TQ-4. |
 
@@ -149,13 +149,18 @@ Full design plan in
 
 ## Currently deferred (no commitments)
 
-- **Multi-database support** (10.1 above) — very ambitious;
+- **Multi-database support** (12.1 above) — very ambitious;
   preferred shape today is one MCPg instance per database.
 - **Backups & DR** beyond what `dump_database` /
   `restore_database` already cover — narrow audience.
 - **Alembic / Flyway / Liquibase script ingestion** (7.1) — large
   surface; `validate_migration` + `prepare_migration` already
   cover the high-value reviewer workflow.
+- **`delta_tier_large` turboquant advisor rule** — planned as part
+  of TQ-2 but deferred until upstream documents a delta-row key in
+  `tq_index_heap_stats`. Shipping a rule against an unverified
+  payload would produce noise rather than signal. Will return when
+  the upstream contract is verifiable.
 
 ---
 

--- a/docs/plans/pg_turboquant-integration.md
+++ b/docs/plans/pg_turboquant-integration.md
@@ -151,7 +151,7 @@ the tool count); CHANGELOG bullet under `### Added`.
 
 ---
 
-## Phase 2 — advisor surface + `audit_database` integration (single PR)
+## Phase 2 — advisor surface + `audit_database` integration ✅ shipped (TQ-2)
 
 **Goal:** turn the metadata into MCPg-native recommendations and feed
 them into the existing `audit_database` scorecard.
@@ -182,7 +182,7 @@ async def recommend_turboquant_maintenance(driver) -> list[TurboQuantAdvisorFind
 | `format_v1_reindex_needed` | `algorithm_version` starts with `v1` | CRITICAL | `REINDEX INDEX CONCURRENTLY <idx>` |
 | `maintenance_due` | metadata flag says delta tier should merge | WARNING | `SELECT tq_maintain_index('<idx>')` |
 | `fast_path_ineligible` | `fast_path_eligible = false` | WARNING | text — usually a knob mismatch; link to the README's tuning table |
-| `delta_tier_large` | heap-stats delta rows > N% of base | WARNING | `SELECT tq_maintain_index('<idx>')` |
+| `delta_tier_large` | heap-stats delta rows > N% of base | WARNING | `SELECT tq_maintain_index('<idx>')` — **deferred to backlog**, see note below |
 
 **Tool registered:**
 
@@ -426,10 +426,18 @@ Each phase lands on its own branch / PR so reviews stay narrow and
 parallel work elsewhere isn't blocked:
 
 1. `claude/tq1-read-advisors` — Phase 1 ✅ (PR #71)
-2. `claude/tq5-query-execution` — Phase 5 (promoted ahead of 2/3/4)
-3. `claude/tq2-audit-integration` — Phase 2
+2. `claude/tq2-audit-integration` — Phase 2 ✅ (in flight after coverage sweep agreed that TQ-2 composes most directly on TQ-1's outputs)
+3. `claude/tq5-query-execution` — Phase 5
 4. `claude/tq3-maintenance-write` — Phase 3
 5. `claude/tq4-ddl-tools` — Phase 4
+
+**Note on the deferred `delta_tier_large` rule.** TQ-2's rule table
+ships with four codes (`prerequisites_unmet`, `format_v1_reindex_needed`,
+`maintenance_due`, `fast_path_ineligible`). The fifth — `delta_tier_large`
+— is on backlog: upstream's `tq_index_heap_stats` payload doesn't yet
+document a delta-row key we can rely on, and shipping a rule against an
+unverified payload would produce noise rather than signal. Returns when
+the upstream contract is verifiable.
 
 **Why TQ-5 ahead of TQ-2/3/4:** TQ-5 unblocks both adoption ("I can
 actually query the index from MCPg") and the RAG efficiency suite's

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -177,6 +177,8 @@ list_turboquant_indexes()                          # every turboquant index + tq
 get_turboquant_index_metadata(schema, index)       # algorithm_version, quantizer_family, capability_flags, …
 get_turboquant_heap_stats(schema, index)           # exact heap row count from tq_index_heap_stats
 get_turboquant_last_scan_stats()                   # most recent backend-local scan diagnostics
+recommend_turboquant_maintenance()                 # advisor — prerequisites_unmet, format_v1_reindex_needed,
+                                                   # maintenance_due, fast_path_ineligible (also feeds audit_database)
 ```
 
 ## "Move data in / out"

--- a/src/mcpg/audit.py
+++ b/src/mcpg/audit.py
@@ -1141,6 +1141,8 @@ async def _check_custom_logs(driver: SqlDriver, log_table: str | None) -> list[T
 
 async def audit_database(driver: SqlDriver, schema: str, log_table: str | None = None) -> AuditReport:
     """Execute comprehensive performance checks, compile scores, recommendations, and issues."""
+    from mcpg.turboquant import audit_turboquant_indexes
+
     ver, dbname = await _get_version_and_db(driver)
 
     # 1. Execute categories
@@ -1150,7 +1152,14 @@ async def audit_database(driver: SqlDriver, schema: str, log_table: str | None =
     cat_bloat = await audit_cleanliness_bloat(driver, schema)
     cat_slow = await audit_slow_queries(driver)
 
+    # Optional categories — only included when the relevant extension
+    # is installed, so a stock cluster's scorecard isn't padded with
+    # empty sections and the overall score isn't diluted.
+    cat_turboquant = await audit_turboquant_indexes(driver)
+
     categories = [cat_mem, cat_tx, cat_lock, cat_bloat, cat_slow]
+    if cat_turboquant is not None:
+        categories.append(cat_turboquant)
 
     # 2. Dynamic scoring
     overall_score = round(sum(cat.score for cat in categories) / len(categories))

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -2678,6 +2678,24 @@ def _register_turboquant_reads(server: FastMCP[AppContext]) -> None:
         stats = await turboquant.get_turboquant_last_scan_stats(_driver(ctx))
         return asdict(stats) if stats is not None else None
 
+    @server.tool(
+        name="recommend_turboquant_maintenance",
+        description=(
+            "Walk every pg_turboquant index and emit advisor findings. Rules "
+            "currently surfaced: ``prerequisites_unmet`` (CRITICAL — pgvector "
+            "is missing), ``format_v1_reindex_needed`` (CRITICAL — algorithm_version "
+            "starts with v1, needs REINDEX), ``maintenance_due`` (WARNING — "
+            "tq_index_metadata reports maintenance_recommended=true), and "
+            "``fast_path_ineligible`` (WARNING — fast_path_eligible=false). Each "
+            "finding carries a ready-to-run ``suggested_action`` SQL statement. "
+            "Returns an empty list when the extension is not installed. Also "
+            "feeds the ``pg_turboquant Indexes`` category in audit_database."
+        ),
+    )
+    async def recommend_turboquant_maintenance(ctx: _Ctx) -> list[dict[str, Any]]:
+        findings = await turboquant.recommend_turboquant_maintenance(_driver(ctx))
+        return [asdict(f) for f in findings]
+
 
 def _register_cron_write(server: FastMCP[AppContext]) -> None:
     @server.tool(

--- a/src/mcpg/turboquant.py
+++ b/src/mcpg/turboquant.py
@@ -56,6 +56,25 @@ def _validate_identifier(name: str, kind: str) -> None:
         raise TurboQuantError(f"invalid {kind} name: {name!r}")
 
 
+def _pg_quote_ident(name: str) -> str:
+    """Quote a PostgreSQL identifier the way ``format('%I')`` would.
+
+    Wraps ``name`` in double quotes and doubles any embedded ``"``.
+    Used for suggested-action SQL where the schema / index names come
+    from the catalog (mixed-case and special characters are legal in
+    PG via delimited identifiers).
+    """
+    return '"' + name.replace('"', '""') + '"'
+
+
+def _pg_quote_literal(text: str) -> str:
+    """Quote a PostgreSQL string literal the way ``format('%L')`` would.
+
+    Wraps ``text`` in single quotes and doubles any embedded ``'``.
+    """
+    return "'" + text.replace("'", "''") + "'"
+
+
 @dataclass(frozen=True, slots=True)
 class TurboQuantIndexInfo:
     """A turboquant index and the metadata `tq_index_metadata` reports for it.
@@ -339,13 +358,14 @@ def _finding_format_v1(info: TurboQuantIndexInfo) -> TurboQuantAdvisorFinding | 
     version = info.algorithm_version or ""
     if not version.lower().startswith("v1"):
         return None
+    qualified = f"{_pg_quote_ident(info.schema)}.{_pg_quote_ident(info.index)}"
     return TurboQuantAdvisorFinding(
         code=_RULE_FORMAT_V1,
         severity="CRITICAL",
         schema=info.schema,
         index=info.index,
         evidence=f"algorithm_version={version!r} — v1 indexes must be rebuilt to use the v2 on-disk format.",
-        suggested_action=f'REINDEX INDEX CONCURRENTLY "{info.schema}"."{info.index}";',
+        suggested_action=f"REINDEX INDEX CONCURRENTLY {qualified};",
     )
 
 
@@ -353,13 +373,20 @@ def _finding_maintenance_due(info: TurboQuantIndexInfo) -> TurboQuantAdvisorFind
     if info.maintenance_recommended is not True:
         return None
     state = info.delta_state or "unknown"
+    # Two-layer escaping: identifiers go inside a string literal that
+    # itself becomes a regclass. Identifier-quote first (so case and
+    # specials survive PG's identifier parsing), then literal-quote
+    # the whole qualified name (so the surrounding 'string' survives
+    # parsing too — important when the name contains a single quote).
+    qualified = f"{_pg_quote_ident(info.schema)}.{_pg_quote_ident(info.index)}"
+    literal = _pg_quote_literal(qualified)
     return TurboQuantAdvisorFinding(
         code=_RULE_MAINTENANCE_DUE,
         severity="WARNING",
         schema=info.schema,
         index=info.index,
         evidence=f"tq_index_metadata reports maintenance_recommended=true (delta_state={state!r}).",
-        suggested_action=f"SELECT tq_maintain_index('{info.schema}.{info.index}'::regclass);",
+        suggested_action=f"SELECT tq_maintain_index({literal}::regclass);",
     )
 
 

--- a/src/mcpg/turboquant.py
+++ b/src/mcpg/turboquant.py
@@ -300,6 +300,219 @@ async def get_turboquant_heap_stats(driver: SqlDriver, schema: str, index: str) 
     )
 
 
+# --- advisor + audit -------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class TurboQuantAdvisorFinding:
+    """A single rule-table hit produced by :func:`recommend_turboquant_maintenance`.
+
+    ``code`` is the stable identifier — ``severity`` and the human-
+    readable ``evidence`` / ``suggested_action`` may evolve, but ``code``
+    is the contract callers script against. ``schema`` / ``index`` are
+    empty strings for cluster-level findings like ``prerequisites_unmet``
+    that don't attach to a specific index.
+    """
+
+    code: str
+    severity: str  # GOOD / WARNING / CRITICAL
+    schema: str
+    index: str
+    evidence: str
+    suggested_action: str
+
+
+# Rule codes — stable identifiers. The mapping lives here as the single
+# source of truth so the audit-database adapter and any external
+# consumers (e.g. the RAG efficiency suite once it lands) read from one
+# place. ``delta_tier_large`` is intentionally absent: the upstream
+# ``tq_index_heap_stats`` payload does not yet document a delta-row key
+# we can rely on, so the rule is deferred to a follow-up once the
+# contract is verifiable.
+_RULE_FORMAT_V1 = "format_v1_reindex_needed"
+_RULE_MAINTENANCE_DUE = "maintenance_due"
+_RULE_FAST_PATH_INELIGIBLE = "fast_path_ineligible"
+_RULE_PREREQUISITES_UNMET = "prerequisites_unmet"
+
+
+def _finding_format_v1(info: TurboQuantIndexInfo) -> TurboQuantAdvisorFinding | None:
+    version = info.algorithm_version or ""
+    if not version.lower().startswith("v1"):
+        return None
+    return TurboQuantAdvisorFinding(
+        code=_RULE_FORMAT_V1,
+        severity="CRITICAL",
+        schema=info.schema,
+        index=info.index,
+        evidence=f"algorithm_version={version!r} — v1 indexes must be rebuilt to use the v2 on-disk format.",
+        suggested_action=f'REINDEX INDEX CONCURRENTLY "{info.schema}"."{info.index}";',
+    )
+
+
+def _finding_maintenance_due(info: TurboQuantIndexInfo) -> TurboQuantAdvisorFinding | None:
+    if info.maintenance_recommended is not True:
+        return None
+    state = info.delta_state or "unknown"
+    return TurboQuantAdvisorFinding(
+        code=_RULE_MAINTENANCE_DUE,
+        severity="WARNING",
+        schema=info.schema,
+        index=info.index,
+        evidence=f"tq_index_metadata reports maintenance_recommended=true (delta_state={state!r}).",
+        suggested_action=f"SELECT tq_maintain_index('{info.schema}.{info.index}'::regclass);",
+    )
+
+
+def _finding_fast_path_ineligible(info: TurboQuantIndexInfo) -> TurboQuantAdvisorFinding | None:
+    # Explicit ``is False`` — ``None`` means upstream didn't report,
+    # which is not the same as reporting "ineligible".
+    if info.fast_path_eligible is not False:
+        return None
+    return TurboQuantAdvisorFinding(
+        code=_RULE_FAST_PATH_INELIGIBLE,
+        severity="WARNING",
+        schema=info.schema,
+        index=info.index,
+        evidence=(
+            "tq_index_metadata reports fast_path_eligible=false — queries against this index will not use "
+            "the SIMD fast path. Common causes: incompatible bits/transform combination, dimension below the "
+            "fast-path threshold, or a missing capability flag."
+        ),
+        suggested_action=(
+            "Review the index's WITH (...) options against the upstream tuning matrix; "
+            "rebuild with a compatible configuration if a fast-path build is desired."
+        ),
+    )
+
+
+_PER_INDEX_RULES = (
+    _finding_format_v1,
+    _finding_maintenance_due,
+    _finding_fast_path_ineligible,
+)
+
+
+async def recommend_turboquant_maintenance(driver: SqlDriver) -> list[TurboQuantAdvisorFinding]:
+    """Walk every turboquant index and emit advisor findings.
+
+    Returns an empty list when the extension is not installed (so the
+    surface composes the same way as :func:`list_turboquant_indexes`).
+    The cluster-level rule ``prerequisites_unmet`` fires when
+    pg_turboquant is installed but its hard dependency (pgvector) is
+    not — without pgvector, no turboquant index can be created or
+    queried, so the finding short-circuits before any per-index work.
+    """
+    if not await extension_installed(driver, "pg_turboquant"):
+        return []
+
+    findings: list[TurboQuantAdvisorFinding] = []
+
+    if not await extension_installed(driver, "vector"):
+        findings.append(
+            TurboQuantAdvisorFinding(
+                code=_RULE_PREREQUISITES_UNMET,
+                severity="CRITICAL",
+                schema="",
+                index="",
+                evidence=(
+                    "pg_turboquant is installed but its hard dependency (pgvector / the ``vector`` extension) "
+                    "is not. Every turboquant index requires pgvector at CREATE INDEX time and at query time."
+                ),
+                suggested_action='CREATE EXTENSION IF NOT EXISTS "vector";',
+            )
+        )
+        # Skip per-index walking — without pgvector there can't be any
+        # working turboquant indexes anyway, and any catalog rows would
+        # produce noise rather than signal.
+        return findings
+
+    for info in await list_turboquant_indexes(driver):
+        for rule in _PER_INDEX_RULES:
+            if (finding := rule(info)) is not None:
+                findings.append(finding)
+
+    return findings
+
+
+# Score deductions by severity — single source of truth for both the
+# adapter below and any external consumers.
+_SEVERITY_DEDUCTION = {"CRITICAL": 30, "WARNING": 15, "GOOD": 0}
+
+
+# Lazily-imported audit types kept out of the module-level imports to
+# avoid a circular import: ``audit`` ultimately re-exports tools that
+# may pull in this module. The adapter lives here (not in audit.py) so
+# the rule-table contract stays in one file.
+def _adapt_finding_to_metric(finding: TurboQuantAdvisorFinding) -> Any:
+    from mcpg.audit import MetricResult
+
+    target = finding.index or "(cluster)"
+    return MetricResult(
+        name=f"turboquant:{finding.code} on {finding.schema}.{target}"
+        if finding.index
+        else f"turboquant:{finding.code}",
+        value=finding.code,
+        unit="finding",
+        target="no findings",
+        status=finding.severity,
+        severity=3 if finding.severity == "CRITICAL" else 2 if finding.severity == "WARNING" else 0,
+        evidence=finding.evidence,
+        suggestion=finding.suggested_action,
+    )
+
+
+async def audit_turboquant_indexes(driver: SqlDriver) -> Any:
+    """Scorecard adapter — returns a CategoryResult or None.
+
+    Returns ``None`` when pg_turboquant is not installed so
+    :func:`audit.audit_database` cleanly omits the category for
+    deployments that don't use the extension. Otherwise produces a
+    CategoryResult whose metrics are the advisor findings, with the
+    standard 100-point-down scoring.
+    """
+    from mcpg.audit import CategoryResult
+
+    if not await extension_installed(driver, "pg_turboquant"):
+        return None
+
+    findings = await recommend_turboquant_maintenance(driver)
+
+    score = 100
+    metrics = []
+    for finding in findings:
+        score -= _SEVERITY_DEDUCTION.get(finding.severity, 0)
+        metrics.append(_adapt_finding_to_metric(finding))
+
+    score = max(0, score)
+    status_label = "GOOD" if score >= 90 else ("WARNING" if score >= 70 else "CRITICAL")
+
+    if not metrics:
+        # No findings → emit a single GOOD baseline metric so the
+        # scorecard surfaces "category checked, all good" rather than
+        # an empty list that looks like the category didn't run.
+        from mcpg.audit import MetricResult
+
+        metrics.append(
+            MetricResult(
+                name="turboquant:no_findings",
+                value="ok",
+                unit="finding",
+                target="no findings",
+                status="GOOD",
+                severity=0,
+                evidence="All turboquant indexes pass the advisor rules.",
+                suggestion="",
+            )
+        )
+
+    return CategoryResult(
+        category="pg_turboquant Indexes",
+        status=status_label,
+        score=score,
+        metrics=metrics,
+    )
+
+
 async def get_turboquant_last_scan_stats(driver: SqlDriver) -> TurboQuantLastScanStats | None:
     """Return the backend-local diagnostic JSON for the most recent scan.
 

--- a/tests/unit/test_turboquant.py
+++ b/tests/unit/test_turboquant.py
@@ -459,6 +459,69 @@ async def test_recommend_turboquant_maintenance_silent_when_fast_path_unreported
     assert await recommend_turboquant_maintenance(driver) == []  # type: ignore[arg-type]
 
 
+async def test_recommend_turboquant_maintenance_quotes_identifiers_in_suggested_sql() -> None:
+    # PG allows mixed-case names, embedded quotes, and embedded
+    # apostrophes via delimited identifiers — catalog rows can carry
+    # any of these. The suggested SQL must survive PG parsing in all
+    # three cases.
+    nasty_row = {
+        "schema": 'My"Schema',  # embedded double quote → double it inside ident
+        "index": "Mixed-Case Index",  # mixed case + space → must stay quoted
+        "table": "embeddings",
+        "column": "embedding",
+        "reloptions": None,
+        "metadata": {
+            "algorithm_version": "v1.0",
+            "maintenance_recommended": True,
+        },
+    }
+    driver = FakeParamRoutingDriver(
+        {
+            _TQ_PRESENT: [{"present": 1}],
+            _VECTOR_PRESENT: [{"present": 1}],
+            _LIST_INDEXES: [nasty_row],
+        }
+    )
+
+    findings = await recommend_turboquant_maintenance(driver)  # type: ignore[arg-type]
+    by_code = {f.code: f for f in findings}
+
+    # REINDEX is identifier-quoted: schema's " is doubled, both names
+    # are kept quoted (so case + space survive).
+    assert (
+        by_code["format_v1_reindex_needed"].suggested_action
+        == 'REINDEX INDEX CONCURRENTLY "My""Schema"."Mixed-Case Index";'
+    )
+    # tq_maintain_index takes a regclass string — needs both layers
+    # (identifier-quote first, literal-quote second).
+    assert by_code["maintenance_due"].suggested_action == (
+        'SELECT tq_maintain_index(\'"My""Schema"."Mixed-Case Index"\'::regclass);'
+    )
+
+
+async def test_recommend_turboquant_maintenance_quotes_apostrophe_in_regclass_literal() -> None:
+    # If an identifier contains a single quote, the regclass literal's
+    # outer ' would close prematurely without escaping.
+    row = {
+        "schema": "O'Reilly",
+        "index": "idx",
+        "table": "embeddings",
+        "column": "embedding",
+        "reloptions": None,
+        "metadata": {"algorithm_version": "v2", "maintenance_recommended": True},
+    }
+    driver = FakeParamRoutingDriver(
+        {
+            _TQ_PRESENT: [{"present": 1}],
+            _VECTOR_PRESENT: [{"present": 1}],
+            _LIST_INDEXES: [row],
+        }
+    )
+
+    [finding] = await recommend_turboquant_maintenance(driver)  # type: ignore[arg-type]
+    assert finding.suggested_action == "SELECT tq_maintain_index('\"O''Reilly\".\"idx\"'::regclass);"
+
+
 async def test_recommend_turboquant_maintenance_combines_findings_across_indexes() -> None:
     driver = FakeParamRoutingDriver(
         {

--- a/tests/unit/test_turboquant.py
+++ b/tests/unit/test_turboquant.py
@@ -1,7 +1,7 @@
 """Tests for the pg_turboquant read-only advisor surface."""
 
 import pytest
-from _fakes import FakeDatabase, FakeDriver, FakeRoutingDriver
+from _fakes import FakeDatabase, FakeDriver, FakeParamRoutingDriver, FakeRoutingDriver
 from mcp.shared.memory import create_connected_server_and_client_session
 
 from mcpg.config import load_settings
@@ -11,10 +11,12 @@ from mcpg.turboquant import (
     TurboQuantHeapStats,
     TurboQuantIndexInfo,
     TurboQuantLastScanStats,
+    audit_turboquant_indexes,
     get_turboquant_heap_stats,
     get_turboquant_index_metadata,
     get_turboquant_last_scan_stats,
     list_turboquant_indexes,
+    recommend_turboquant_maintenance,
 )
 
 _READ_ONLY = load_settings({"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db"})
@@ -345,6 +347,209 @@ async def test_get_turboquant_last_scan_stats_parses_full_payload() -> None:
     )
 
 
+# --- recommend_turboquant_maintenance --------------------------------------
+
+
+_TQ_PRESENT: tuple[str, tuple[str, ...]] = ("pg_extension", ("pg_turboquant",))
+_VECTOR_PRESENT: tuple[str, tuple[str, ...]] = ("pg_extension", ("vector",))
+_LIST_INDEXES = ("WHERE am.amname = 'turboquant'", None)
+
+
+def _index_row(metadata: dict, *, index: str = "embeddings_tq_idx") -> dict:
+    return {
+        "schema": "public",
+        "index": index,
+        "table": "embeddings",
+        "column": "embedding",
+        "reloptions": ["bits=4", "lists=100"],
+        "metadata": metadata,
+    }
+
+
+async def test_recommend_turboquant_maintenance_returns_empty_when_extension_absent() -> None:
+    driver = FakeParamRoutingDriver({_TQ_PRESENT: []})
+
+    assert await recommend_turboquant_maintenance(driver) == []  # type: ignore[arg-type]
+
+
+async def test_recommend_turboquant_maintenance_fires_prerequisites_unmet_when_vector_missing() -> None:
+    # pg_turboquant installed, pgvector not — cluster-level critical
+    # finding, no per-index walking.
+    driver = FakeParamRoutingDriver(
+        {
+            _TQ_PRESENT: [{"present": 1}],
+            _VECTOR_PRESENT: [],
+        }
+    )
+
+    findings = await recommend_turboquant_maintenance(driver)  # type: ignore[arg-type]
+    assert len(findings) == 1
+    [finding] = findings
+    assert finding.code == "prerequisites_unmet"
+    assert finding.severity == "CRITICAL"
+    assert finding.schema == ""
+    assert finding.index == ""
+    assert "vector" in finding.suggested_action.lower()
+
+
+async def test_recommend_turboquant_maintenance_fires_format_v1_rule() -> None:
+    driver = FakeParamRoutingDriver(
+        {
+            _TQ_PRESENT: [{"present": 1}],
+            _VECTOR_PRESENT: [{"present": 1}],
+            _LIST_INDEXES: [_index_row({"algorithm_version": "v1.3"})],
+        }
+    )
+
+    [finding] = await recommend_turboquant_maintenance(driver)  # type: ignore[arg-type]
+    assert finding.code == "format_v1_reindex_needed"
+    assert finding.severity == "CRITICAL"
+    assert finding.index == "embeddings_tq_idx"
+    assert finding.suggested_action.startswith("REINDEX INDEX CONCURRENTLY")
+
+
+async def test_recommend_turboquant_maintenance_fires_maintenance_due_rule() -> None:
+    driver = FakeParamRoutingDriver(
+        {
+            _TQ_PRESENT: [{"present": 1}],
+            _VECTOR_PRESENT: [{"present": 1}],
+            _LIST_INDEXES: [
+                _index_row(
+                    {
+                        "algorithm_version": "v2",
+                        "maintenance_recommended": True,
+                        "delta_state": "compaction_pending",
+                    }
+                )
+            ],
+        }
+    )
+
+    [finding] = await recommend_turboquant_maintenance(driver)  # type: ignore[arg-type]
+    assert finding.code == "maintenance_due"
+    assert finding.severity == "WARNING"
+    assert "tq_maintain_index" in finding.suggested_action
+
+
+async def test_recommend_turboquant_maintenance_fires_fast_path_ineligible_rule() -> None:
+    driver = FakeParamRoutingDriver(
+        {
+            _TQ_PRESENT: [{"present": 1}],
+            _VECTOR_PRESENT: [{"present": 1}],
+            _LIST_INDEXES: [_index_row({"algorithm_version": "v2", "fast_path_eligible": False})],
+        }
+    )
+
+    [finding] = await recommend_turboquant_maintenance(driver)  # type: ignore[arg-type]
+    assert finding.code == "fast_path_ineligible"
+    assert finding.severity == "WARNING"
+
+
+async def test_recommend_turboquant_maintenance_silent_when_fast_path_unreported() -> None:
+    # ``None`` (key missing or null) is distinct from explicit ``False`` —
+    # don't fire on the absence of information.
+    driver = FakeParamRoutingDriver(
+        {
+            _TQ_PRESENT: [{"present": 1}],
+            _VECTOR_PRESENT: [{"present": 1}],
+            _LIST_INDEXES: [_index_row({"algorithm_version": "v2"})],
+        }
+    )
+
+    assert await recommend_turboquant_maintenance(driver) == []  # type: ignore[arg-type]
+
+
+async def test_recommend_turboquant_maintenance_combines_findings_across_indexes() -> None:
+    driver = FakeParamRoutingDriver(
+        {
+            _TQ_PRESENT: [{"present": 1}],
+            _VECTOR_PRESENT: [{"present": 1}],
+            _LIST_INDEXES: [
+                _index_row({"algorithm_version": "v1.4"}, index="old_idx"),
+                _index_row(
+                    {"algorithm_version": "v2", "maintenance_recommended": True},
+                    index="needs_compaction_idx",
+                ),
+                _index_row({"algorithm_version": "v2", "fast_path_eligible": False}, index="slow_idx"),
+            ],
+        }
+    )
+
+    findings = await recommend_turboquant_maintenance(driver)  # type: ignore[arg-type]
+    codes = sorted((f.code, f.index) for f in findings)
+    assert codes == [
+        ("fast_path_ineligible", "slow_idx"),
+        ("format_v1_reindex_needed", "old_idx"),
+        ("maintenance_due", "needs_compaction_idx"),
+    ]
+
+
+# --- audit_turboquant_indexes (scorecard adapter) --------------------------
+
+
+async def test_audit_turboquant_indexes_returns_none_when_extension_absent() -> None:
+    driver = FakeParamRoutingDriver({_TQ_PRESENT: []})
+
+    assert await audit_turboquant_indexes(driver) is None  # type: ignore[arg-type]
+
+
+async def test_audit_turboquant_indexes_emits_good_when_no_findings() -> None:
+    driver = FakeParamRoutingDriver(
+        {
+            _TQ_PRESENT: [{"present": 1}],
+            _VECTOR_PRESENT: [{"present": 1}],
+            _LIST_INDEXES: [],  # no turboquant indexes — clean baseline
+        }
+    )
+
+    category = await audit_turboquant_indexes(driver)  # type: ignore[arg-type]
+    assert category is not None
+    assert category.category == "pg_turboquant Indexes"
+    assert category.status == "GOOD"
+    assert category.score == 100
+    assert [m.status for m in category.metrics] == ["GOOD"]
+
+
+async def test_audit_turboquant_indexes_scores_drop_with_findings() -> None:
+    # One CRITICAL (-30) + one WARNING (-15) = score 55 → CRITICAL band.
+    driver = FakeParamRoutingDriver(
+        {
+            _TQ_PRESENT: [{"present": 1}],
+            _VECTOR_PRESENT: [{"present": 1}],
+            _LIST_INDEXES: [
+                _index_row({"algorithm_version": "v1.0"}, index="old_idx"),
+                _index_row(
+                    {"algorithm_version": "v2", "maintenance_recommended": True},
+                    index="warn_idx",
+                ),
+            ],
+        }
+    )
+
+    category = await audit_turboquant_indexes(driver)  # type: ignore[arg-type]
+    assert category is not None
+    assert category.score == 55
+    assert category.status == "CRITICAL"
+    severities = sorted(m.status for m in category.metrics)
+    assert severities == ["CRITICAL", "WARNING"]
+
+
+async def test_audit_turboquant_indexes_score_clamped_at_zero() -> None:
+    # Four CRITICALs would deduct 120; score must not go negative.
+    driver = FakeParamRoutingDriver(
+        {
+            _TQ_PRESENT: [{"present": 1}],
+            _VECTOR_PRESENT: [{"present": 1}],
+            _LIST_INDEXES: [_index_row({"algorithm_version": "v1.0"}, index=f"old_{i}") for i in range(4)],
+        }
+    )
+
+    category = await audit_turboquant_indexes(driver)  # type: ignore[arg-type]
+    assert category is not None
+    assert category.score == 0
+    assert category.status == "CRITICAL"
+
+
 # --- MCP layer wiring ------------------------------------------------------
 
 
@@ -357,4 +562,5 @@ async def test_turboquant_tools_register_in_read_only_mode() -> None:
         "get_turboquant_index_metadata",
         "get_turboquant_heap_stats",
         "get_turboquant_last_scan_stats",
+        "recommend_turboquant_maintenance",
     } <= listed


### PR DESCRIPTION
## Summary

Phase 2 of the [pg_turboquant integration plan](docs/plans/pg_turboquant-integration.md). Builds directly on TQ-1's `TurboQuantIndexInfo` / `index_options` surface — no duplicate catalog queries.

**New API in `mcpg.turboquant`:**
- `recommend_turboquant_maintenance(driver) -> list[TurboQuantAdvisorFinding]` — the rule-table advisor.
- `audit_turboquant_indexes(driver) -> CategoryResult | None` — scorecard adapter wired into `audit_database`.

**Rule table (4 codes, stable contracts):**

| Code | Severity | Trigger | Suggested action |
|---|---|---|---|
| `prerequisites_unmet` | CRITICAL | pg_turboquant installed but pgvector isn't | `CREATE EXTENSION "vector";` |
| `format_v1_reindex_needed` | CRITICAL | `algorithm_version` starts with `v1` | `REINDEX INDEX CONCURRENTLY` |
| `maintenance_due` | WARNING | `maintenance_recommended=true` | `SELECT tq_maintain_index(...)` |
| `fast_path_ineligible` | WARNING | `fast_path_eligible=false` (explicit-False only) | review WITH options |

`fast_path_ineligible` deliberately treats `None` (key absent / not reported) as **not a finding** — absence of information ≠ negative finding.

**Deferred to backlog: `delta_tier_large`** — upstream's `tq_index_heap_stats` payload doesn't yet document a delta-row key. Shipping a rule against an unverified contract would produce noise. CHANGELOG + plan + feature-shortlist deferred section all note the condition for return.

**Scorecard adapter behaviour:**
- Returns `None` when pg_turboquant isn't installed — `audit_database` cleanly omits the category on stock clusters.
- Scores 100-down: CRITICAL -30, WARNING -15, clamped at 0.
- Emits a single GOOD baseline metric when there are zero findings, so "category checked, all good" surfaces visibly rather than as an empty list that could look like the category didn't run.

**Cycle-safe wiring:** `audit_database` lazy-imports `audit_turboquant_indexes` at call time. Direction stays audit → turboquant, no module-level cycle.

## Files

- `src/mcpg/turboquant.py` — advisor + adapter + rule helpers.
- `src/mcpg/audit.py` — lazy-imported integration in `audit_database`.
- `src/mcpg/tools.py` — `recommend_turboquant_maintenance` registered in `_register_turboquant_reads`.
- `tests/unit/test_turboquant.py` — +11 tests.
- `CHANGELOG.md`, `docs/tour.md`, `docs/feature-shortlist.md`, `docs/plans/pg_turboquant-integration.md`.

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format .` — clean
- [x] `uv run mypy src/mcpg` — clean
- [x] `uv run pytest tests/unit` — **1416 passed** (1403 main + 11 new + 2 untouched)
- [ ] PG matrix (CI) green across PG 14-18
- [ ] Sourcery + reviewer pass

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_