### PR TITLE
feat: maintain_turboquant_index write tool (TQ-3) + defer TQ-5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **`maintain_turboquant_index` write tool (TQ-3).** Wraps upstream
+  `tq_maintain_index(<schema>.<index>::regclass)` for lightweight
+  merge / compaction of a turboquant index's physical delta tier.
+  Identifier validation runs first; a catalog pre-flight
+  (`pg_index ⨝ pg_am WHERE am.amname = 'turboquant'`) then confirms
+  the named index is actually a turboquant index before invoking
+  upstream — without this, an attacker could probe arbitrary
+  catalogs via upstream's error messages. The wrapper measures
+  client-side timings (start, end, elapsed) and returns those in a
+  `MaintenanceResult`; the PG return value of `tq_maintain_index`
+  is intentionally not parsed because upstream doesn't document a
+  return shape and inventing one would invite a breaking change
+  later. Gated under WRITE (unrestricted mode); registered in a new
+  `_register_turboquant_writes` family.
+
 - **pg_turboquant maintenance advisor + audit category (TQ-2).** New
   `recommend_turboquant_maintenance` tool walks every turboquant
   index and emits stable-coded findings:

--- a/docs/feature-shortlist.md
+++ b/docs/feature-shortlist.md
@@ -121,9 +121,9 @@ composes with this lives in
 | # | Item | Effort | Value | Notes |
 |---|---|---|---|---|
 | 10.1 | ✅ **Shipped (TQ-1).** Read advisors for [pg_turboquant](https://github.com/mayflower/pg_turboquant): `list_turboquant_indexes`, `get_turboquant_index_metadata`, `get_turboquant_heap_stats`, `get_turboquant_last_scan_stats`. Defensive JSON parsing — documented fields are typed; the full upstream payload is preserved in `raw_metadata` / `raw` so future-added fields stay reachable. Each index info also carries `index_options` — the `WITH (...)` build-time options (`bits`, `lists`, `transform`, `normalized`) parsed from `pg_class.reloptions` into typed values. Returns empty list / `None` when the extension is absent. Lives in `mcpg.turboquant`. | S | Medium | Mirrors how `cron` / `partman` are surfaced. `pg_turboquant` added to `ENABLEABLE_EXTENSIONS`. |
-| 10.2 | `turboquant_approx_candidates` + `turboquant_rerank_candidates` + `recommend_turboquant_query_knobs` — query-execution wrappers around the dedicated `tq_*_candidates(...)` functions so callers actually exercise the extension's SIMD fast path (the pgvector operators may not), plus the per-query knob advisor. Composes the TQ-1 `tq_last_scan_stats` helper to include scan diagnostics in the response. Promoted ahead of 10.3/10.4/10.5 because it both unblocks adoption and is a hard prerequisite for the RAG efficiency suite's turboquant arm (11.1). | M | High | TQ-5 — the new ordering puts this right after TQ-1. |
+| 10.2 | ⏸ **Deferred to backlog (TQ-5).** Query-execution wrappers around `tq_approx_candidates` / `tq_rerank_candidates` and a per-query knob advisor `recommend_turboquant_query_knobs`. The upstream README documents the function names but **not** the `query_vector` parameter's PG type, the accepted `metric text` values, or the return column shape — for the latter two functions the entire signature is undocumented. Per the no-speculation principle (a wrapper with guessed args / return shape would either break on first real use or force a breaking change later), this is deferred until upstream documents those pieces, or until we have a real install to verify against. **Consequence:** the RAG efficiency suite's turboquant arm (11.1) is also deferred until then — HNSW + IVFFlat still land. | M | High | See `plans/pg_turboquant-integration.md` Phase 5. |
 | 10.3 | ✅ **Shipped (TQ-2).** `recommend_turboquant_maintenance` advisor + `audit_turboquant_indexes` category wired into `audit_database`. Stable-coded rules: `prerequisites_unmet` (CRITICAL — pgvector missing), `format_v1_reindex_needed` (CRITICAL — algorithm_version starts with v1), `maintenance_due` (WARNING — `maintenance_recommended=true`), `fast_path_ineligible` (WARNING — `fast_path_eligible=false`, explicit-false only). Reads exclusively from `TurboQuantIndexInfo` so it composes on TQ-1 without duplicate catalog queries. Category returns `None` when the extension is absent so `audit_database` cleanly omits it on stock clusters. `delta_tier_large` is on backlog pending upstream contract for a delta-rows key in `tq_index_heap_stats`. | S-M | Medium-High | Lives in `mcpg.turboquant`. |
-| 10.4 | `maintain_turboquant_index` — write tool wrapping `tq_maintain_index`; pre-flight confirms the named index is actually a turboquant index. Unrestricted-only. | S | Medium | TQ-3. |
+| 10.4 | ✅ **Shipped (TQ-3).** `maintain_turboquant_index` — write tool wrapping `tq_maintain_index(...)`. Identifier validation + catalog pre-flight (`pg_index ⨝ pg_am`) confirms the named index is actually a turboquant index before invoking upstream. Client-side wall-time measurement; upstream's PG return value is intentionally not parsed (no documented return shape). WRITE-gated. Lives in `mcpg.turboquant`. | S | Medium | Composes directly on TQ-2's `maintenance_due` suggested action. |
 | 10.5 | `create_turboquant_index` + `reindex_turboquant_index` — DDL tools with bits/lists/transform/normalized allowlists and a single-source-of-truth metric→opclass mapping (`tq_cosine_ops` / `tq_inner_product_ops` / `tq_l2_ops`). Unrestricted + `MCPG_ALLOW_DDL`. | M | Medium-High | TQ-4. |
 
 ## 11. RAG efficiency suite
@@ -161,6 +161,16 @@ Full design plan in
   `tq_index_heap_stats`. Shipping a rule against an unverified
   payload would produce noise rather than signal. Will return when
   the upstream contract is verifiable.
+- **pg_turboquant query-execution wrappers (TQ-5)** — `turboquant_approx_candidates`,
+  `turboquant_rerank_candidates`, `recommend_turboquant_query_knobs`.
+  Deferred under the no-speculation principle: the README documents
+  function *names* but not the `query_vector` PG type, the accepted
+  `metric text` values, or any return column shape. Two of three
+  functions have entirely undocumented signatures. Will return when
+  upstream documents inputs + return shape, or when a real install
+  is available to verify against. The RAG efficiency suite's
+  turboquant arm depends on this and is deferred in parallel; HNSW
+  and IVFFlat coverage in that suite is not affected.
 
 ---
 

--- a/docs/plans/pg_turboquant-integration.md
+++ b/docs/plans/pg_turboquant-integration.md
@@ -214,7 +214,7 @@ CHANGELOG bullet, one line in `docs/tour.md`.
 
 ---
 
-## Phase 3 — write tool: `tq_maintain_index` (single PR, small)
+## Phase 3 — write tool: `tq_maintain_index` ✅ shipped (TQ-3)
 
 **Goal:** let agents act on the Phase-2 recommendations.
 
@@ -315,10 +315,39 @@ bullet, `docs/tour.md` line.
 
 ---
 
-## Phase 5 — query execution + per-query advisor (single PR)
+## Phase 5 — query execution + per-query advisor ⏸ deferred to backlog
 
-**Status:** promoted from "out of scope" to in-scope after a coverage
-sweep. Two reasons:
+**Status update.** A second coverage sweep — run under a strict
+no-speculation principle — surfaced that the upstream README
+documents the function *names* but not:
+
+- the `query_vector` parameter's PG type (placeholder in the README,
+  not an actual type),
+- the accepted values of `metric text` (`'cosine'`? `'l2'`? the
+  opclass names?),
+- the return column shape (column names and types) of either
+  candidate function.
+
+`tq_approx_candidates(...)` and `tq_recommended_query_knobs(...)`
+also have entirely undocumented signatures. Implementing any of the
+three would require guessing pieces that upstream could change at
+any time — a wrapper built on guesses either breaks on first real
+use or forces a breaking change later. Both outcomes erode adoption
+confidence, so the phase is deferred.
+
+**Return condition:** ship when upstream documents the `query_vector`
+PG type, the accepted `metric` values, and the candidate-function
+return shape; or when a real install is available to verify against.
+
+**Consequence:** the RAG efficiency suite's turboquant arm depends
+on `tq_rerank_candidates` and is deferred in parallel. The HNSW and
+IVFFlat arms of that suite are unaffected.
+
+---
+
+## Phase 5 (original design — kept for reference) — query execution + per-query advisor
+
+Two reasons for the original promotion ahead of TQ-2/3/4:
 
 1. **Adoption.** Without these, callers can list and inspect a
    turboquant index but can't actually issue a turboquant-aware
@@ -426,10 +455,19 @@ Each phase lands on its own branch / PR so reviews stay narrow and
 parallel work elsewhere isn't blocked:
 
 1. `claude/tq1-read-advisors` — Phase 1 ✅ (PR #71)
-2. `claude/tq2-audit-integration` — Phase 2 ✅ (in flight after coverage sweep agreed that TQ-2 composes most directly on TQ-1's outputs)
-3. `claude/tq5-query-execution` — Phase 5
-4. `claude/tq3-maintenance-write` — Phase 3
-5. `claude/tq4-ddl-tools` — Phase 4
+2. `claude/tq2-audit-integration` — Phase 2 ✅ (PR #72)
+3. `claude/tq3-maintenance-write` — Phase 3 ✅ (this PR)
+4. `claude/tq4-ddl-tools` — Phase 4
+5. `claude/tq5-query-execution` — Phase 5 ⏸ **deferred** until upstream documents the missing pieces
+
+**Re-ordering note.** TQ-5 was briefly promoted ahead of TQ-2/3/4
+under an adoption argument, then deferred during the TQ-3 coverage
+sweep when a strict no-speculation review surfaced that the upstream
+signatures aren't fully documented. The phasing rationale evolved:
+TQ-2 first because it composes most directly on TQ-1's outputs;
+TQ-3 next because `tq_maintain_index` has the lowest speculation
+surface of all remaining phases; TQ-4 next because the WITH options
+and opclasses are explicitly documented as user-facing.
 
 **Note on the deferred `delta_tier_large` rule.** TQ-2's rule table
 ships with four codes (`prerequisites_unmet`, `format_v1_reindex_needed`,

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -267,6 +267,12 @@ run_ddl(sql, schema=null, table=null)                # one DDL statement; option
 enable_extension(name)                               # allowlisted extensions only
 ```
 
+## "Maintain a pg_turboquant index" (`unrestricted` + pg_turboquant installed)
+
+```
+maintain_turboquant_index(schema, index)             # wraps tq_maintain_index; catalog-preflighted; client-side timings
+```
+
 ## "Schedule a job" (`unrestricted` + pg_cron installed)
 
 ```

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -2697,6 +2697,28 @@ def _register_turboquant_reads(server: FastMCP[AppContext]) -> None:
         return [asdict(f) for f in findings]
 
 
+def _register_turboquant_writes(server: FastMCP[AppContext]) -> None:
+    @server.tool(
+        name="maintain_turboquant_index",
+        description=(
+            "Run tq_maintain_index on a turboquant index — lightweight "
+            "merge / compaction of the physical delta tier. The wrapper "
+            "pre-flights that the named index is actually a turboquant "
+            "index (catalog lookup on pg_am) before invoking upstream, "
+            "so the call can't be turned into a way to probe arbitrary "
+            "indexes for error messages. Returns wall-clock timestamps "
+            "and elapsed duration measured client-side; the PG return "
+            "value of tq_maintain_index is intentionally not parsed "
+            "(upstream doesn't document a return shape). Available only "
+            "in unrestricted mode; requires pg_turboquant installed."
+        ),
+    )
+    async def maintain_turboquant_index(ctx: _Ctx, schema: str, index: str) -> dict[str, Any]:
+        result = await turboquant.maintain_turboquant_index(_driver(ctx), schema, index)
+        await ctx.request_context.lifespan_context.cache.clear()
+        return asdict(result)
+
+
 def _register_cron_write(server: FastMCP[AppContext]) -> None:
     @server.tool(
         name="schedule_cron_job",
@@ -3090,6 +3112,7 @@ def register_tools(server: FastMCP[AppContext], settings: Settings) -> None:
         _register_maintenance(server)
         _register_backend_control(server)
         _register_cron_write(server)
+        _register_turboquant_writes(server)
         _register_data_movement_writes(server)
     if is_permitted(settings.access_mode, Capability.DDL) and settings.allow_ddl:
         _register_ddl(server)

--- a/src/mcpg/turboquant.py
+++ b/src/mcpg/turboquant.py
@@ -1,9 +1,10 @@
-"""pg_turboquant read advisors.
+"""pg_turboquant read advisors + maintenance write.
 
 `pg_turboquant <https://github.com/mayflower/pg_turboquant>`_ is a
 PostgreSQL extension providing a custom ANN index access method
 (``USING turboquant``) over pgvector ``vector`` / ``halfvec`` columns.
-This module exposes the extension's read-only observability surface:
+This module exposes the extension's read-only observability surface
+plus a single maintenance write:
 
 * :func:`list_turboquant_indexes` — every turboquant index in the
   database, joined with its ``tq_index_metadata`` payload.
@@ -12,8 +13,13 @@ This module exposes the extension's read-only observability surface:
   index.
 * :func:`get_turboquant_last_scan_stats` — the backend-local JSON
   describing the most recent turboquant scan.
+* :func:`recommend_turboquant_maintenance` — rule-table advisor.
+* :func:`audit_turboquant_indexes` — scorecard category adapter.
+* :func:`maintain_turboquant_index` — wraps ``tq_maintain_index``;
+  pre-flights that the named index is actually a turboquant index so
+  the call can't be turned into a way to probe arbitrary catalogs.
 
-All four functions return cleanly (empty list / ``None``) when the
+All read functions return cleanly (empty list / ``None``) when the
 extension is not installed, so callers can treat absence as "no
 turboquant in use" rather than a hard error.
 
@@ -33,8 +39,10 @@ expected to land in a follow-up once the signature is pinned.
 
 from __future__ import annotations
 
+import datetime
 import json
 import re
+import time
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -127,6 +135,24 @@ class TurboQuantLastScanStats:
     simd_kernel: str | None
     pages_scanned: int | None
     pages_pruned: int | None
+
+
+@dataclass(frozen=True, slots=True)
+class MaintenanceResult:
+    """Outcome of a :func:`maintain_turboquant_index` call.
+
+    All four fields are observed client-side (start/end timestamps and
+    elapsed wall time around the ``tq_maintain_index`` call). The
+    function's PG return value is deliberately not parsed — upstream
+    doesn't document a return shape and inventing one would invite a
+    breaking change later.
+    """
+
+    schema: str
+    index: str
+    started_at: str  # ISO 8601 UTC
+    completed_at: str  # ISO 8601 UTC
+    duration_seconds: float
 
 
 # --- SQL --------------------------------------------------------------------
@@ -563,4 +589,68 @@ async def get_turboquant_last_scan_stats(driver: SqlDriver) -> TurboQuantLastSca
         simd_kernel=raw.get("simd_kernel"),
         pages_scanned=int(pages_scanned) if pages_scanned is not None else None,
         pages_pruned=int(pages_pruned) if pages_pruned is not None else None,
+    )
+
+
+# Pre-flight: confirm the named index actually uses the turboquant
+# access method before calling tq_maintain_index. Without this check,
+# upstream would raise a generic error on any non-turboquant index —
+# and the error text would leak a small amount of catalog information.
+_ASSERT_IS_TURBOQUANT_SQL = """
+SELECT 1
+FROM pg_index ix
+JOIN pg_class i  ON i.oid = ix.indexrelid
+JOIN pg_namespace n ON n.oid = i.relnamespace
+JOIN pg_am am ON am.oid = i.relam
+WHERE am.amname = 'turboquant' AND n.nspname = %s AND i.relname = %s
+"""
+
+# Identifier quoting happens PG-side via format('%I.%I')::regclass,
+# so the bound params can't escape into SQL syntax even before the
+# preflight check above runs.
+_MAINTAIN_INDEX_SQL = "SELECT tq_maintain_index(format('%I.%I', %s, %s)::regclass)"
+
+
+def _utc_iso_now() -> str:
+    return datetime.datetime.now(datetime.UTC).isoformat().replace("+00:00", "Z")
+
+
+async def maintain_turboquant_index(driver: SqlDriver, schema: str, index: str) -> MaintenanceResult:
+    """Run ``tq_maintain_index`` on a single turboquant index.
+
+    The call delegates the actual delta-tier merge / compaction work
+    to upstream; this wrapper handles validation, the pre-flight
+    catalog check, and client-side wall-time measurement. The PG
+    return value of ``tq_maintain_index`` is intentionally not parsed
+    — upstream doesn't document one, and inventing a shape now would
+    force a breaking change later.
+
+    Raises:
+        TurboQuantError: extension is not installed, the identifier
+            fails validation, or the named index is not a turboquant
+            index.
+    """
+    _validate_identifier(schema, "schema")
+    _validate_identifier(index, "index")
+    if not await extension_installed(driver, "pg_turboquant"):
+        raise TurboQuantError("pg_turboquant extension is not installed in this database")
+
+    preflight = await driver.execute_query(_ASSERT_IS_TURBOQUANT_SQL, params=[schema, index], force_readonly=True)
+    if not preflight:
+        raise TurboQuantError(
+            f"index {schema}.{index} is not a turboquant index (or does not exist); refusing to call tq_maintain_index"
+        )
+
+    started_at = _utc_iso_now()
+    started_mono = time.monotonic()
+    await driver.execute_query(_MAINTAIN_INDEX_SQL, params=[schema, index], force_readonly=False)
+    duration = time.monotonic() - started_mono
+    completed_at = _utc_iso_now()
+
+    return MaintenanceResult(
+        schema=schema,
+        index=index,
+        started_at=started_at,
+        completed_at=completed_at,
+        duration_seconds=round(duration, 6),
     )

--- a/tests/unit/test_turboquant.py
+++ b/tests/unit/test_turboquant.py
@@ -16,6 +16,7 @@ from mcpg.turboquant import (
     get_turboquant_index_metadata,
     get_turboquant_last_scan_stats,
     list_turboquant_indexes,
+    maintain_turboquant_index,
     recommend_turboquant_maintenance,
 )
 
@@ -613,6 +614,90 @@ async def test_audit_turboquant_indexes_score_clamped_at_zero() -> None:
     assert category.status == "CRITICAL"
 
 
+# --- maintain_turboquant_index ---------------------------------------------
+
+
+_PREFLIGHT_SUBSTR = "WHERE am.amname = 'turboquant' AND n.nspname"
+
+
+async def test_maintain_turboquant_index_raises_when_extension_absent() -> None:
+    driver = FakeRoutingDriver({"pg_extension": []})
+
+    with pytest.raises(TurboQuantError, match="not installed"):
+        await maintain_turboquant_index(driver, "public", "idx")  # type: ignore[arg-type]
+
+
+async def test_maintain_turboquant_index_raises_when_index_is_not_turboquant() -> None:
+    # Extension present, preflight returns no rows (the index is real
+    # but not a turboquant index, or doesn't exist at all). Refuse
+    # rather than let upstream's error message leak catalog info.
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            _PREFLIGHT_SUBSTR: [],
+        }
+    )
+
+    with pytest.raises(TurboQuantError, match="not a turboquant index"):
+        await maintain_turboquant_index(driver, "public", "some_other_idx")  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("schema", "index"),
+    [
+        ("public; DROP", "idx"),
+        ("public", "idx; DROP"),
+        ("", "idx"),
+        ("public", ""),
+        ("public.embeddings", "idx"),
+        ("public", "idx-name"),
+    ],
+)
+async def test_maintain_turboquant_index_rejects_unsafe_identifiers(schema: str, index: str) -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(TurboQuantError, match="invalid"):
+        await maintain_turboquant_index(driver, schema, index)  # type: ignore[arg-type]
+
+
+async def test_maintain_turboquant_index_happy_path_returns_timings() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            _PREFLIGHT_SUBSTR: [{"present": 1}],
+            "tq_maintain_index": [{"tq_maintain_index": None}],
+        }
+    )
+
+    result = await maintain_turboquant_index(driver, "public", "embeddings_tq_idx")  # type: ignore[arg-type]
+    assert result.schema == "public"
+    assert result.index == "embeddings_tq_idx"
+    assert result.started_at.endswith("Z")
+    assert result.completed_at.endswith("Z")
+    assert result.duration_seconds >= 0.0
+
+
+async def test_maintain_turboquant_index_runs_maintenance_under_write_capability() -> None:
+    # The third query call should be the actual maintain call and must
+    # NOT have force_readonly set — a write capability check from the
+    # SqlDriver layer relies on that flag.
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            _PREFLIGHT_SUBSTR: [{"present": 1}],
+            "tq_maintain_index": [{"tq_maintain_index": None}],
+        }
+    )
+
+    await maintain_turboquant_index(driver, "public", "embeddings_tq_idx")  # type: ignore[arg-type]
+
+    maintain_calls = [c for c in driver.calls if "tq_maintain_index" in c[0]]
+    assert len(maintain_calls) == 1
+    _query, params, force_readonly = maintain_calls[0]
+    assert params == ["public", "embeddings_tq_idx"]
+    assert force_readonly is False
+
+
 # --- MCP layer wiring ------------------------------------------------------
 
 
@@ -627,3 +712,18 @@ async def test_turboquant_tools_register_in_read_only_mode() -> None:
         "get_turboquant_last_scan_stats",
         "recommend_turboquant_maintenance",
     } <= listed
+    # maintain_turboquant_index is WRITE-gated; must not be listed in
+    # read-only mode.
+    assert "maintain_turboquant_index" not in listed
+
+
+_UNRESTRICTED = load_settings(
+    {"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db", "MCPG_ACCESS_MODE": "unrestricted"}
+)
+
+
+async def test_maintain_turboquant_index_registers_in_unrestricted_mode() -> None:
+    server = create_server(_UNRESTRICTED, database=FakeDatabase(FakeDriver()))  # type: ignore[arg-type]
+    async with create_connected_server_and_client_session(server) as client:
+        listed = {tool.name for tool in (await client.list_tools()).tools}
+    assert "maintain_turboquant_index" in listed


### PR DESCRIPTION
## Summary

Phase 3 of the [pg_turboquant integration plan](docs/plans/pg_turboquant-integration.md). Wraps upstream `tq_maintain_index` for lightweight delta-tier merge / compaction of a single turboquant index. Composes directly on TQ-2's `maintenance_due` suggested_action.

**Design under the no-speculation discipline:**

- Inputs validated via `_validate_identifier`.
- Catalog pre-flight on `pg_index ⨝ pg_am` confirms the named index actually uses the turboquant access method before any upstream call — without this, upstream's "not a turboquant index" error message would leak a small amount of catalog information.
- `tq_maintain_index` invoked via `format('%I.%I', %s, %s)::regclass` so identifier quoting happens PG-side; bound params can't escape into SQL syntax.
- The PG return value of `tq_maintain_index` is deliberately **not** parsed — upstream doesn't document a return shape, and inventing one would force a breaking change later. The wrapper exposes only client-side observables: `started_at` / `completed_at` (ISO 8601 UTC) + `duration_seconds` (monotonic clock).
- Gated under `WRITE` (unrestricted mode); registered in a new `_register_turboquant_writes` family.

## TQ-5 deferred to backlog

A second coverage sweep under the strict no-speculation principle surfaced that the upstream README documents function *names* but not:

- the `query_vector` parameter's PG type,
- the accepted values of `metric text`,
- the return column shape of either `*_candidates(...)` function,
- and the entire signatures of `tq_approx_candidates` and `tq_recommended_query_knobs`.

A wrapper built on guesses either breaks on first real use or forces a breaking change later — both erode adoption confidence. TQ-5 returns when upstream documents the missing pieces, or when a real install is available to verify against. **Consequence:** the RAG efficiency suite's turboquant arm depends on this and is deferred in parallel; HNSW and IVFFlat arms of that suite are unaffected.

## Files

- `src/mcpg/turboquant.py` — `MaintenanceResult` + `maintain_turboquant_index`.
- `src/mcpg/tools.py` — new `_register_turboquant_writes` registrar, wired under `Capability.WRITE`.
- `tests/unit/test_turboquant.py` — +11 tests.
- `CHANGELOG.md`, `docs/tour.md`, `docs/feature-shortlist.md`, `docs/plans/pg_turboquant-integration.md`.

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format .` — clean
- [x] `uv run mypy src/mcpg` — clean
- [x] `uv run pytest tests/unit` — **1429 passed** (1418 baseline + 11 new)
- [ ] PG matrix (CI) green across PG 14-18
- [ ] Sourcery + reviewer pass

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Add a write-capable maintenance tool for pg_turboquant indexes and update planning/docs to mark this phase as shipped while deferring query-execution wrappers to the backlog.

New Features:
- Introduce maintain_turboquant_index wrapper around tq_maintain_index, returning client-side maintenance timing metadata.
- Expose maintain_turboquant_index as an unrestricted WRITE-gated MCP tool for pg_turboquant index maintenance.

Enhancements:
- Extend turboquant module documentation to cover the new maintenance operation alongside existing read advisors.
- Update tool registration to include a dedicated turboquant write registrar invoked in unrestricted mode.
- Refine pg_turboquant integration plan and feature shortlist to mark TQ-3 as shipped and TQ-5 as deferred under no-speculation constraints.

Documentation:
- Document the maintain_turboquant_index tool in the user tour and integration plan, and note the deferral conditions and implications for TQ-5 query-execution wrappers.

Tests:
- Add unit tests covering maintain_turboquant_index validation, catalog preflight behavior, write capability gating, and tool registration in different access modes.