### PR TITLE
Add registry.modelcontextprotocol.io publishing integration

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -159,3 +159,19 @@ jobs:
           gh release create "$GITHUB_REF_NAME" dist/* \
             --title "MCPg ${GITHUB_REF_NAME}" \
             --notes-file /tmp/notes.md
+
+  publish-mcp-registry:
+    name: Publish to MCP Registry
+    needs: publish-pypi
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          sudo mv mcp-publisher /usr/local/bin/
+      - name: Authenticate to MCP Registry
+        run: mcp-publisher login github-oidc
+      - name: Publish server to MCP Registry
+        run: mcp-publisher publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+## [0.6.1] - 2026-06-09
+
+### Added
+
+- **MCP Registry Integration.** Added `server.json` configuration and automated publishing workflow to register MCPg on the official Model Context Protocol registry (`registry.modelcontextprotocol.io`). Added `mcp-name` verification comment in `README.md` to satisfy PyPI ownership verification.
+
 - **RAG reranker analytics + advisor + audit category (RAG-D).** Five
   read-only tools over the `mcpg_rag.rerank_events` table shipped in
   RAG-C, plus a new `audit_rag_pipeline` category wired into

--- a/README.md
+++ b/README.md
@@ -517,3 +517,5 @@ for provenance.
 > **Disclaimer.** Best efforts have been made to bring MCPg to
 > production grade, but it remains an actively developed project and
 > may contain issues. See the License terms for indemnity details.
+
+<!-- mcp-name: io.github.devopam/mcpg -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcpg"
-version = "0.6.0"
+version = "0.6.1"
 description = "A production-grade PostgreSQL Model Context Protocol (MCP) server."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/server.json
+++ b/server.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.devopam/mcpg",
+  "version": "0.6.1",
+  "description": "A production-grade PostgreSQL Model Context Protocol (MCP) server.",
+  "repository": {
+    "url": "https://github.com/devopam/MCPg",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "mcpg",
+      "version": "0.6.1",
+      "runtimeHint": "uvx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/src/mcpg/__init__.py
+++ b/src/mcpg/__init__.py
@@ -1,3 +1,3 @@
 """MCPg — a PostgreSQL Model Context Protocol server."""
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/tests/unit/test_migration_ingestion.py
+++ b/tests/unit/test_migration_ingestion.py
@@ -415,7 +415,7 @@ async def test_list_pending_migrations_dedup_identifiers_in_report(
 async def test_list_pending_migrations_records_size_bytes(tmp_path: Path) -> None:
     d = _migrations_dir(tmp_path)
     contents = "-- hello\nCREATE TABLE t (id int);\n"
-    (d / "V1__init.sql").write_text(contents)
+    (d / "V1__init.sql").write_text(contents, newline="\n")
     driver = FakeRoutingDriver({"information_schema.tables": []})
 
     report = await list_pending_migrations(

--- a/uv.lock
+++ b/uv.lock
@@ -991,7 +991,7 @@ cli = [
 
 [[package]]
 name = "mcpg"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
This PR adds the server.json manifest, bumps the package version to 0.6.1, adds the PyPI verification marker, and integrates automated publishing to the MCP Registry into the GitHub Actions release workflow.

## Summary by Sourcery

Integrate MCP Registry publishing and associated release metadata updates for the 0.6.1 release.

Enhancements:
- Add MCP Registry manifest and configuration to register the server with registry.modelcontextprotocol.io.

Build:
- Update GitHub Actions release workflow to publish the package to the MCP Registry after a successful PyPI release.

Documentation:
- Document MCP Registry integration and PyPI verification marker in the changelog and README.

Tests:
- Adjust migration ingestion test fixture to write migration files with explicit LF newlines for consistent behavior across environments.

Chores:
- Bump project version to 0.6.1 and update release-related metadata files.