### PR TITLE
feat: pg_search observability + extension allowlist entry (BM-1)

### DIFF
--- a/src/mcpg/extensions.py
+++ b/src/mcpg/extensions.py
@@ -41,6 +41,7 @@ ENABLEABLE_EXTENSIONS = frozenset(
         "pg_buffercache",
         "pg_walinspect",
         "pg_turboquant",
+        "pg_search",
     }
 )
 

--- a/src/mcpg/pg_search.py
+++ b/src/mcpg/pg_search.py
@@ -129,7 +129,7 @@ SELECT
     t.relname AS table,
     (
         SELECT array_agg(a.attname ORDER BY k.ord)
-        FROM unnest(ix.indkey) WITH ORDINALITY AS k(attnum, ord)
+        FROM unnest(ix.indkey::int[]) WITH ORDINALITY AS k(attnum, ord)
         JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = k.attnum
     ) AS columns,
     i.reloptions AS reloptions
@@ -149,7 +149,7 @@ SELECT
     t.relname AS table,
     (
         SELECT array_agg(a.attname ORDER BY k.ord)
-        FROM unnest(ix.indkey) WITH ORDINALITY AS k(attnum, ord)
+        FROM unnest(ix.indkey::int[]) WITH ORDINALITY AS k(attnum, ord)
         JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = k.attnum
     ) AS columns,
     i.reloptions AS reloptions

--- a/src/mcpg/pg_search.py
+++ b/src/mcpg/pg_search.py
@@ -223,12 +223,12 @@ def _parse_reloptions(raw: Any) -> dict[str, Any]:
 def _columns_from_cell(cell: Any) -> list[str]:
     """Normalize the ``columns`` cell into a list of attribute names.
 
-    psycopg returns PG ``text[]`` as a Python list, but defensive
-    handling keeps the mapper from blowing up if the driver returns
-    ``None`` (no rows in the subquery) or a stringified array.
+    psycopg returns PG ``text[]`` as a Python list. ``None`` (no rows
+    matched in the indkey subquery, e.g. an expression-only index) is
+    normalized to ``[]``. Anything else also falls back to ``[]``
+    rather than raising — the upstream column list is informational,
+    not a contract.
     """
-    if cell is None:
-        return []
     if isinstance(cell, list):
         return [str(c) for c in cell if c is not None]
     return []

--- a/src/mcpg/pg_search.py
+++ b/src/mcpg/pg_search.py
@@ -1,0 +1,308 @@
+"""pg_search integration: observability surface (phase BM-1).
+
+`pg_search <https://github.com/paradedb/paradedb>`_ is a PostgreSQL
+extension by ParadeDB that ships a Tantivy-backed BM25 index access
+method (``USING bm25``) + a `pdb.*` schema of query-building and
+projection helpers. This module covers the *observability* slice —
+catalog enumeration and metadata fetch for every BM25 index in the
+database. Subsequent phases will add search execution (BM-2), hybrid
+composition (BM-3), DDL (BM-4), and advisor + audit (BM-5).
+
+* :func:`list_pg_search_indexes`,
+  :func:`get_pg_search_index_metadata` — observability.
+
+Reads return cleanly (empty list / raise) when the extension is not
+installed, so callers can treat absence as "no BM25 in use" rather
+than a hard error.
+
+**Upstream contract notes.** The 13 ``WITH (...)`` options surfaced
+on :class:`PgSearchIndexInfo` are sourced verbatim from
+`pg_search/src/api/index.rs` ``IndexOptions`` (BM-0 investigation
+checkpoint, see ``docs/plans/bm25-integration.md`` §2.2). Six of
+them (``text_fields``, ``numeric_fields``, ``boolean_fields``,
+``json_fields``, ``range_fields``, ``datetime_fields``) plus
+``search_tokenizer`` are JSONB-shaped; reloptions are stored as
+``text[]`` so the raw values are parsed back into Python dicts.
+The two ``int`` options (``target_segment_count``,
+``mutable_segment_rows``) are coerced; the rest stay as strings.
+:attr:`PgSearchIndexInfo.index_options` always carries the full
+parsed reloptions dict for fidelity.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from mcpg._vendor.sql import SqlDriver
+from mcpg.extensions import extension_installed
+
+# Plain unquoted PostgreSQL identifier — same rule as turboquant /
+# vector_tuning. Anything that would require delimited quoting is
+# refused rather than parsed out of an agent string.
+_IDENTIFIER = re.compile(r"\A[A-Za-z_][A-Za-z0-9_]*\Z")
+
+
+class PgSearchError(Exception):
+    """Raised when a pg_search operation cannot complete."""
+
+
+def _validate_identifier(name: str, kind: str) -> None:
+    if not _IDENTIFIER.match(name):
+        raise PgSearchError(f"invalid {kind} name: {name!r}")
+
+
+# Per §2.2 of the BM-0 investigation checkpoint, the ``bm25`` AM
+# accepts these 13 reloptions. Grouped here so the parser can route
+# each value through the right coercion.
+_JSONB_OPTIONS: frozenset[str] = frozenset(
+    {
+        "text_fields",
+        "numeric_fields",
+        "boolean_fields",
+        "json_fields",
+        "range_fields",
+        "datetime_fields",
+        "search_tokenizer",
+    }
+)
+_INT_OPTIONS: frozenset[str] = frozenset({"target_segment_count", "mutable_segment_rows"})
+# Remaining options (``key_field``, ``layer_sizes``,
+# ``background_layer_sizes``, ``sort_by``) are plain text and pass
+# through unchanged.
+
+
+@dataclass(frozen=True, slots=True)
+class PgSearchIndexInfo:
+    """A BM25 index and the reloptions ``pg_class`` reports for it.
+
+    Catalog-level fields (:attr:`schema`, :attr:`index`,
+    :attr:`table`, :attr:`columns`) come from
+    ``pg_index`` / ``pg_class`` / ``pg_attribute``; :attr:`columns`
+    is the ordered list of attribute names the index covers (a BM25
+    index can index one or many columns).
+
+    The typed ``WITH (...)`` accessors below surface the 13 documented
+    `bm25` options. JSONB-shaped options are parsed back from the
+    text-array reloptions storage into Python dicts; integer options
+    are coerced to int; text options pass through. Anything not on
+    the documented list lives in :attr:`index_options` unchanged so
+    future-added options stay reachable without a code change.
+    """
+
+    schema: str
+    index: str
+    table: str
+    columns: list[str] = field(default_factory=list)
+    # Documented bm25 WITH options, surfaced as typed accessors.
+    key_field: str | None = None
+    text_fields: dict[str, Any] = field(default_factory=dict)
+    numeric_fields: dict[str, Any] = field(default_factory=dict)
+    boolean_fields: dict[str, Any] = field(default_factory=dict)
+    json_fields: dict[str, Any] = field(default_factory=dict)
+    range_fields: dict[str, Any] = field(default_factory=dict)
+    datetime_fields: dict[str, Any] = field(default_factory=dict)
+    layer_sizes: str | None = None
+    background_layer_sizes: str | None = None
+    target_segment_count: int | None = None
+    mutable_segment_rows: int | None = None
+    sort_by: str | None = None
+    search_tokenizer: dict[str, Any] = field(default_factory=dict)
+    # Full parsed reloptions dict — always includes every key in the
+    # raw text[], whether or not it's surfaced as a typed attribute.
+    index_options: dict[str, Any] = field(default_factory=dict)
+
+
+# --- SQL --------------------------------------------------------------------
+
+# `array_agg(... ORDER BY ord)` against `unnest(indkey)` yields the
+# attribute names in indexed-column order. A BM25 index can cover one
+# or many columns, so we expose the full list rather than only
+# indkey[0] (which is what TQ does, since turboquant indexes a single
+# vector column by construction).
+_LIST_INDEXES_SQL = """
+SELECT
+    n.nspname AS schema,
+    i.relname AS index,
+    t.relname AS table,
+    (
+        SELECT array_agg(a.attname ORDER BY k.ord)
+        FROM unnest(ix.indkey) WITH ORDINALITY AS k(attnum, ord)
+        JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = k.attnum
+    ) AS columns,
+    i.reloptions AS reloptions
+FROM pg_index ix
+JOIN pg_class i      ON i.oid = ix.indexrelid
+JOIN pg_class t      ON t.oid = ix.indrelid
+JOIN pg_namespace n  ON n.oid = i.relnamespace
+JOIN pg_am am        ON am.oid = i.relam
+WHERE am.amname = 'bm25'
+ORDER BY n.nspname, i.relname
+"""
+
+_FETCH_ONE_INDEX_SQL = """
+SELECT
+    n.nspname AS schema,
+    i.relname AS index,
+    t.relname AS table,
+    (
+        SELECT array_agg(a.attname ORDER BY k.ord)
+        FROM unnest(ix.indkey) WITH ORDINALITY AS k(attnum, ord)
+        JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = k.attnum
+    ) AS columns,
+    i.reloptions AS reloptions
+FROM pg_index ix
+JOIN pg_class i      ON i.oid = ix.indexrelid
+JOIN pg_class t      ON t.oid = ix.indrelid
+JOIN pg_namespace n  ON n.oid = i.relnamespace
+JOIN pg_am am        ON am.oid = i.relam
+WHERE am.amname = 'bm25' AND n.nspname = %s AND i.relname = %s
+"""
+
+
+# --- helpers ---------------------------------------------------------------
+
+
+def _as_json_dict(raw: str) -> dict[str, Any]:
+    """Decode a JSONB-valued reloption into a dict.
+
+    Reloptions are stored as ``text[]`` — JSONB values come back as
+    their textual JSON serialization. Anything that fails to decode
+    or doesn't decode to a dict yields ``{}`` so a misshapen option
+    doesn't break the whole metadata read.
+    """
+    try:
+        decoded = json.loads(raw)
+    except (ValueError, TypeError):
+        return {}
+    return decoded if isinstance(decoded, dict) else {}
+
+
+def _maybe_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_reloptions(raw: Any) -> dict[str, Any]:
+    """Parse a ``pg_class.reloptions`` text[] into a typed dict.
+
+    PG stores reloptions as ``text[]`` of ``key=value`` strings. The
+    13 documented bm25 options are routed through type-aware
+    coercion (JSON → dict for the seven JSONB-shaped options, ``int``
+    for the two integer options, plain string for the remaining
+    four). Anything else passes through as its raw string so future
+    upstream additions stay reachable via :attr:`index_options`.
+    Malformed entries (no ``=``, empty key) are skipped silently.
+    """
+    if not isinstance(raw, list):
+        return {}
+    parsed: dict[str, Any] = {}
+    for item in raw:
+        if not isinstance(item, str) or "=" not in item:
+            continue
+        key, _, value = item.partition("=")
+        if not key:
+            continue
+        if key in _JSONB_OPTIONS:
+            parsed[key] = _as_json_dict(value)
+        elif key in _INT_OPTIONS:
+            coerced = _maybe_int(value)
+            if coerced is not None:
+                parsed[key] = coerced
+        else:
+            parsed[key] = value
+    return parsed
+
+
+def _columns_from_cell(cell: Any) -> list[str]:
+    """Normalize the ``columns`` cell into a list of attribute names.
+
+    psycopg returns PG ``text[]`` as a Python list, but defensive
+    handling keeps the mapper from blowing up if the driver returns
+    ``None`` (no rows in the subquery) or a stringified array.
+    """
+    if cell is None:
+        return []
+    if isinstance(cell, list):
+        return [str(c) for c in cell if c is not None]
+    return []
+
+
+def _as_str(value: Any) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_int(value: Any) -> int | None:
+    # Bools are an ``int`` subclass; reject them explicitly so a
+    # parser glitch that yielded ``True`` doesn't masquerade as 1.
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _index_info_from_row(row_cells: dict[str, Any]) -> PgSearchIndexInfo:
+    options = _parse_reloptions(row_cells.get("reloptions"))
+    return PgSearchIndexInfo(
+        schema=row_cells["schema"],
+        index=row_cells["index"],
+        table=row_cells["table"],
+        columns=_columns_from_cell(row_cells.get("columns")),
+        key_field=_as_str(options.get("key_field")),
+        text_fields=_as_dict(options.get("text_fields")),
+        numeric_fields=_as_dict(options.get("numeric_fields")),
+        boolean_fields=_as_dict(options.get("boolean_fields")),
+        json_fields=_as_dict(options.get("json_fields")),
+        range_fields=_as_dict(options.get("range_fields")),
+        datetime_fields=_as_dict(options.get("datetime_fields")),
+        layer_sizes=_as_str(options.get("layer_sizes")),
+        background_layer_sizes=_as_str(options.get("background_layer_sizes")),
+        target_segment_count=_as_int(options.get("target_segment_count")),
+        mutable_segment_rows=_as_int(options.get("mutable_segment_rows")),
+        sort_by=_as_str(options.get("sort_by")),
+        search_tokenizer=_as_dict(options.get("search_tokenizer")),
+        index_options=options,
+    )
+
+
+# --- public API ------------------------------------------------------------
+
+
+async def list_pg_search_indexes(driver: SqlDriver) -> list[PgSearchIndexInfo]:
+    """List every BM25 index plus its parsed reloptions.
+
+    Returns an empty list when the ``pg_search`` extension is not
+    installed.
+    """
+    if not await extension_installed(driver, "pg_search"):
+        return []
+    rows = await driver.execute_query(_LIST_INDEXES_SQL, force_readonly=True)
+    return [_index_info_from_row(row.cells) for row in rows or []]
+
+
+async def get_pg_search_index_metadata(driver: SqlDriver, schema: str, index: str) -> PgSearchIndexInfo:
+    """Fetch the parsed reloptions for a single BM25 index.
+
+    Identifier validation runs before any SQL is built so the schema
+    / index strings cannot drive arbitrary catalog lookups.
+
+    Raises:
+        PgSearchError: extension is not installed, the schema / index
+            name is not a plain identifier, or no BM25 index with that
+            name exists.
+    """
+    _validate_identifier(schema, "schema")
+    _validate_identifier(index, "index")
+    if not await extension_installed(driver, "pg_search"):
+        raise PgSearchError("pg_search extension is not installed in this database")
+    rows = await driver.execute_query(_FETCH_ONE_INDEX_SQL, params=[schema, index], force_readonly=True)
+    if not rows:
+        raise PgSearchError(f"no BM25 index named {schema}.{index} found")
+    return _index_info_from_row(rows[0].cells)

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -47,6 +47,7 @@ from mcpg import (
     naming,
     nl2sql,
     partman,
+    pg_search,
     prisma,
     query,
     rag_efficiency,
@@ -2982,6 +2983,41 @@ def _register_turboquant_reads(server: FastMCP[AppContext]) -> None:
         return asdict(knobs)
 
 
+def _register_pg_search_reads(server: FastMCP[AppContext]) -> None:
+    @server.tool(
+        name="list_pg_search_indexes",
+        description=(
+            "List every pg_search BM25 index in the database along with "
+            "the parsed reloptions (the ``WITH (...)`` config) for each. "
+            "Surfaces the 13 documented bm25 options (key_field, the six "
+            "*_fields jsonb configs, layer_sizes, background_layer_sizes, "
+            "target_segment_count, mutable_segment_rows, sort_by, "
+            "search_tokenizer). The full parsed dict is preserved in "
+            "``index_options`` so unsurfaced or future options stay "
+            "reachable. Returns an empty list when the pg_search extension "
+            "is not installed."
+        ),
+    )
+    async def list_pg_search_indexes(ctx: _Ctx) -> list[dict[str, Any]]:
+        infos = await pg_search.list_pg_search_indexes(_driver(ctx))
+        return [asdict(info) for info in infos]
+
+    @server.tool(
+        name="get_pg_search_index_metadata",
+        description=(
+            "Fetch the parsed reloptions for a single BM25 index "
+            "(schema.index). Same shape as one entry of "
+            "``list_pg_search_indexes`` — typed accessors for the 13 "
+            "documented options plus the raw ``index_options`` dict. "
+            "Raises when the extension is not installed or no BM25 "
+            "index by that name exists."
+        ),
+    )
+    async def get_pg_search_index_metadata(ctx: _Ctx, schema: str, index: str) -> dict[str, Any]:
+        info = await pg_search.get_pg_search_index_metadata(_driver(ctx), schema, index)
+        return asdict(info)
+
+
 def _register_turboquant_writes(server: FastMCP[AppContext]) -> None:
     @server.tool(
         name="maintain_turboquant_index",
@@ -3641,6 +3677,7 @@ def register_tools(server: FastMCP[AppContext], settings: Settings) -> None:
         _register_health(server)
         _register_liveops(server)
         _register_turboquant_reads(server)
+        _register_pg_search_reads(server)
         _register_timescaledb_reads(server)
         _register_graphs_reads(server)
     if is_permitted(settings.access_mode, Capability.WRITE):

--- a/tests/unit/test_pg_search.py
+++ b/tests/unit/test_pg_search.py
@@ -1,0 +1,290 @@
+"""Tests for the pg_search BM-1 observability surface."""
+
+import pytest
+from _fakes import FakeDatabase, FakeDriver, FakeRoutingDriver
+from mcp.shared.memory import create_connected_server_and_client_session
+
+from mcpg.config import load_settings
+from mcpg.extensions import ENABLEABLE_EXTENSIONS
+from mcpg.pg_search import (
+    PgSearchError,
+    PgSearchIndexInfo,
+    get_pg_search_index_metadata,
+    list_pg_search_indexes,
+)
+from mcpg.server import create_server
+
+_SETTINGS = load_settings({"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db"})
+
+
+# Fixture mirroring the 13 documented bm25 reloptions from
+# pg_search/src/api/index.rs IndexOptions (BM-0 §2.2 checkpoint).
+# Reloptions reach Python as text[] with JSONB values pre-stringified.
+_RELOPTIONS = [
+    "key_field=id",
+    'text_fields={"body": {"tokenizer": "default"}}',
+    'numeric_fields={"price": {"fast": true}}',
+    'boolean_fields={"active": {}}',
+    'json_fields={"meta": {}}',
+    'range_fields={"interval": {}}',
+    'datetime_fields={"created_at": {}}',
+    "layer_sizes=100,1000,10000",
+    "background_layer_sizes=10000,100000",
+    "target_segment_count=8",
+    "mutable_segment_rows=10000",
+    "sort_by=id",
+    'search_tokenizer={"type": "default"}',
+]
+
+
+# --- list_pg_search_indexes -------------------------------------------------
+
+
+async def test_list_pg_search_indexes_returns_empty_when_extension_absent() -> None:
+    driver = FakeRoutingDriver({"pg_extension": []})
+
+    assert await list_pg_search_indexes(driver) == []  # type: ignore[arg-type]
+
+
+async def test_list_pg_search_indexes_maps_rows_when_extension_present() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "WHERE am.amname = 'bm25'": [
+                {
+                    "schema": "public",
+                    "index": "docs_bm25_idx",
+                    "table": "docs",
+                    "columns": ["id", "body"],
+                    "reloptions": _RELOPTIONS,
+                }
+            ],
+        }
+    )
+
+    infos = await list_pg_search_indexes(driver)  # type: ignore[arg-type]
+
+    assert len(infos) == 1
+    info = infos[0]
+    assert info.schema == "public"
+    assert info.index == "docs_bm25_idx"
+    assert info.table == "docs"
+    assert info.columns == ["id", "body"]
+    assert info.key_field == "id"
+    assert info.text_fields == {"body": {"tokenizer": "default"}}
+    assert info.numeric_fields == {"price": {"fast": True}}
+    assert info.boolean_fields == {"active": {}}
+    assert info.json_fields == {"meta": {}}
+    assert info.range_fields == {"interval": {}}
+    assert info.datetime_fields == {"created_at": {}}
+    assert info.layer_sizes == "100,1000,10000"
+    assert info.background_layer_sizes == "10000,100000"
+    assert info.target_segment_count == 8
+    assert info.mutable_segment_rows == 10000
+    assert info.sort_by == "id"
+    assert info.search_tokenizer == {"type": "default"}
+    # Full parsed dict carries every documented key.
+    assert set(info.index_options.keys()) == {
+        "key_field",
+        "text_fields",
+        "numeric_fields",
+        "boolean_fields",
+        "json_fields",
+        "range_fields",
+        "datetime_fields",
+        "layer_sizes",
+        "background_layer_sizes",
+        "target_segment_count",
+        "mutable_segment_rows",
+        "sort_by",
+        "search_tokenizer",
+    }
+
+
+async def test_list_pg_search_indexes_tolerates_partial_reloptions() -> None:
+    # Only the required `key_field` set; everything else should fall back
+    # to its dataclass default rather than raise.
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "WHERE am.amname = 'bm25'": [
+                {
+                    "schema": "public",
+                    "index": "docs_bm25_idx",
+                    "table": "docs",
+                    "columns": ["id"],
+                    "reloptions": ["key_field=id"],
+                }
+            ],
+        }
+    )
+
+    infos = await list_pg_search_indexes(driver)  # type: ignore[arg-type]
+
+    assert infos == [
+        PgSearchIndexInfo(
+            schema="public",
+            index="docs_bm25_idx",
+            table="docs",
+            columns=["id"],
+            key_field="id",
+            index_options={"key_field": "id"},
+        )
+    ]
+
+
+async def test_list_pg_search_indexes_tolerates_null_reloptions() -> None:
+    # PG returns NULL for reloptions when no WITH clause is provided.
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "WHERE am.amname = 'bm25'": [
+                {
+                    "schema": "public",
+                    "index": "docs_bm25_idx",
+                    "table": "docs",
+                    "columns": ["id"],
+                    "reloptions": None,
+                }
+            ],
+        }
+    )
+
+    infos = await list_pg_search_indexes(driver)  # type: ignore[arg-type]
+
+    assert infos[0].index_options == {}
+    assert infos[0].key_field is None
+    assert infos[0].text_fields == {}
+
+
+async def test_list_pg_search_indexes_skips_malformed_reloption_entries() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "WHERE am.amname = 'bm25'": [
+                {
+                    "schema": "public",
+                    "index": "docs_bm25_idx",
+                    "table": "docs",
+                    "columns": ["id"],
+                    # No '=', empty key, junk JSON — every entry should be
+                    # silently skipped or recoverable.
+                    "reloptions": [
+                        "key_field=id",
+                        "no_equals_sign",
+                        "=no_key",
+                        "text_fields=not-valid-json",
+                    ],
+                }
+            ],
+        }
+    )
+
+    infos = await list_pg_search_indexes(driver)  # type: ignore[arg-type]
+    # Malformed JSONB option falls back to {} rather than blowing up.
+    assert infos[0].text_fields == {}
+    assert infos[0].key_field == "id"
+    assert "text_fields" in infos[0].index_options
+
+
+async def test_list_pg_search_indexes_tolerates_null_columns() -> None:
+    # When the indkey expansion subquery returns NULL (no attributes
+    # matched, e.g. expression index), columns should be empty list.
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "WHERE am.amname = 'bm25'": [
+                {
+                    "schema": "public",
+                    "index": "docs_bm25_idx",
+                    "table": "docs",
+                    "columns": None,
+                    "reloptions": ["key_field=id"],
+                }
+            ],
+        }
+    )
+
+    infos = await list_pg_search_indexes(driver)  # type: ignore[arg-type]
+    assert infos[0].columns == []
+
+
+# --- get_pg_search_index_metadata ------------------------------------------
+
+
+async def test_get_pg_search_index_metadata_raises_when_extension_absent() -> None:
+    driver = FakeRoutingDriver({"pg_extension": []})
+
+    with pytest.raises(PgSearchError, match="not installed"):
+        await get_pg_search_index_metadata(driver, "public", "docs_bm25_idx")  # type: ignore[arg-type]
+
+
+async def test_get_pg_search_index_metadata_raises_when_index_missing() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "WHERE am.amname = 'bm25'": [],  # no matching index
+        }
+    )
+
+    with pytest.raises(PgSearchError, match="no BM25 index named"):
+        await get_pg_search_index_metadata(driver, "public", "docs_bm25_idx")  # type: ignore[arg-type]
+
+
+async def test_get_pg_search_index_metadata_returns_parsed_info() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "WHERE am.amname = 'bm25'": [
+                {
+                    "schema": "public",
+                    "index": "docs_bm25_idx",
+                    "table": "docs",
+                    "columns": ["id", "body"],
+                    "reloptions": _RELOPTIONS,
+                }
+            ],
+        }
+    )
+
+    info = await get_pg_search_index_metadata(driver, "public", "docs_bm25_idx")  # type: ignore[arg-type]
+    assert info.key_field == "id"
+    assert info.target_segment_count == 8
+
+
+@pytest.mark.parametrize(
+    ("schema", "index"),
+    [
+        ("public; DROP TABLE x", "docs_bm25_idx"),
+        ("public", "docs_bm25_idx; --"),
+        ("", "docs"),
+        ("public", ""),
+        ("123bad", "docs"),
+    ],
+)
+async def test_get_pg_search_index_metadata_validates_identifiers(schema: str, index: str) -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(PgSearchError, match="invalid"):
+        await get_pg_search_index_metadata(driver, schema, index)  # type: ignore[arg-type]
+
+
+# --- extension allowlist ---------------------------------------------------
+
+
+def test_pg_search_on_enableable_extensions_allowlist() -> None:
+    """enable_extension must accept 'pg_search'; the allowlist is the
+    only injection guard since CREATE EXTENSION takes an identifier."""
+    assert "pg_search" in ENABLEABLE_EXTENSIONS
+
+
+# --- tool registration ------------------------------------------------------
+
+
+async def test_pg_search_tools_registered_for_read_access() -> None:
+    """Both BM-1 tools should be visible via list_tools when running with
+    default (READ-capable) access."""
+    server = create_server(_SETTINGS, database=FakeDatabase(FakeDriver()))  # type: ignore[arg-type]
+    async with create_connected_server_and_client_session(server) as client:
+        listed = {tool.name for tool in (await client.list_tools()).tools}
+    assert {"list_pg_search_indexes", "get_pg_search_index_metadata"} <= listed


### PR DESCRIPTION
## Summary

First slice of the BM25 integration. Adds the **BM-1 observability** surface: enumerate every `pg_search` BM25 index in the database and surface its parsed `WITH (...)` options.

### `src/mcpg/pg_search.py` (new)

- **`PgSearchIndexInfo` dataclass** — typed attributes for all 13 documented `bm25` reloptions sourced verbatim from `pg_search/src/api/index.rs` `IndexOptions` (the BM-0 §2.2 checkpoint):
  - `key_field` (text, required)
  - 6 per-field jsonb configs: `text_fields`, `numeric_fields`, `boolean_fields`, `json_fields`, `range_fields`, `datetime_fields`
  - segment tuning: `layer_sizes`, `background_layer_sizes`, `target_segment_count`, `mutable_segment_rows`, `sort_by`
  - `search_tokenizer` (jsonb)
  - Full parsed reloptions dict preserved as `index_options` so future-added options stay reachable without a code change.
- **`list_pg_search_indexes(driver)`** — returns `[]` when the extension is absent, mirroring the turboquant read surface.
- **`get_pg_search_index_metadata(driver, schema, index)`** — identifier validation before any SQL is built; raises `PgSearchError` on missing extension / invalid identifier / unknown index.

`columns` is exposed as the full ordered list of attribute names (BM25 indexes can cover one or many columns), via `array_agg(... ORDER BY ord)` over `unnest(indkey) WITH ORDINALITY`.

### `src/mcpg/extensions.py`

Adds `pg_search` to `ENABLEABLE_EXTENSIONS` so the existing `enable_extension` tool can install it. The allowlist is the injection guard for `CREATE EXTENSION`.

### `src/mcpg/tools.py`

Registers `list_pg_search_indexes` and `get_pg_search_index_metadata` under the READ capability gate.

### Tests — 16 cases

Row mapper coverage (full + partial reloptions, NULL reloptions, malformed entries, NULL columns subquery), extension-absent fallback, identifier validation (injection patterns + empty + non-identifier), MCP tool registration, allowlist presence.

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run mypy src/mcpg` — clean
- [x] `uv run pytest tests/unit -q` — 1620 passed (16 new)
- [ ] Reviewer sanity-check the SQL against a real `pg_search` install
- [ ] Reviewer confirm the reloption JSONB parsing matches how psycopg surfaces `pg_class.reloptions::text[]`

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Add an observability surface for ParadeDB pg_search BM25 indexes, exposing their configuration and metadata via new read-only tools and allowing the pg_search extension to be enabled.

New Features:
- Introduce PgSearchIndexInfo dataclass to represent bm25 index metadata and parsed reloptions.
- Add list_pg_search_indexes API and MCP tool to enumerate all pg_search BM25 indexes with their parsed configuration.
- Add get_pg_search_index_metadata API and MCP tool to fetch metadata for a specific BM25 index.

Enhancements:
- Extend the extension allowlist to support enabling the pg_search extension.
- Register pg_search read tools behind the existing READ capability gate.

Tests:
- Add unit test coverage for pg_search index listing and metadata retrieval, including reloptions parsing, identifier validation, extension-absent behavior, and MCP tool registration.