### PR TITLE
feat: pg_search search execution + snippet projection (BM-2)

### DIFF
--- a/docs/plans/bm25-integration.md
+++ b/docs/plans/bm25-integration.md
@@ -80,14 +80,42 @@ Verbatim from `pg_search/src/bootstrap/` Rust declarations
   §6 "out of scope (until needed)" — usable surface, but BM-2's
   `pg_search_parse_query` covers the common path.
 
-**Honest gap.** The investigation agent could not locate the
-`pdb.snippet` / `pdb.snippets` definition in source — the v2 blog
-documents them, but `grep` over the source tree did not return a
-`CREATE FUNCTION` or pgrx declaration. **Action before BM-2:**
-confirm the source location (likely a Rust macro-generated
-declaration the simple grep missed) and pin the return type
-verbatim. If the source can't be located, BM-2 ships without
-snippet support and revisits when ParadeDB documents it.
+**Snippet source — resolved (post-BM-0 follow-up investigation).**
+The first sweep missed `pdb.snippet` / `pdb.snippets` because they
+do not live in `pg_search/src/bootstrap/`. A targeted follow-up
+agent located them in
+`pg_search/src/postgres/customscan/basescan/projections/snippet.rs`
+(paradedb/paradedb@`8bb9a64`). Verbatim signatures:
+
+- `pdb.snippet(field anyelement, start_tag text DEFAULT '<b>',
+  end_tag text DEFAULT '</b>', max_num_chars int4 DEFAULT 150,
+  "limit" int4 DEFAULT NULL, "offset" int4 DEFAULT NULL) → text`
+- `pdb.snippets(field anyelement, start_tag text DEFAULT '<b>',
+  end_tag text DEFAULT '</b>', max_num_chars int4 DEFAULT 150,
+  "limit" int4 DEFAULT NULL, "offset" int4 DEFAULT NULL,
+  sort_by text DEFAULT 'score') → text[]`
+
+Both are `#[pg_extern(stable, parallel_safe)]` Rust functions; the
+pgrx-generated SQL declarations register them under schema `pdb`.
+Two independent functions, not wrappers of each other —
+`pdb.snippets` adds `sort_by` and returns the multi-snippet array.
+
+**Caveat.** These are pgrx stubs marked
+`#[allow(unused_variables)]`; the actual highlight generation
+happens during custom-scan projection rewriting (see
+`pg_search/src/postgres/customscan/projections.rs` →
+`tantivy::snippet::SnippetGenerator`). Calling `pdb.snippet(...)`
+outside a `pg_search`-driven SELECT executes the stub, not real
+highlight code. BM-2's `pg_search_run` wires the snippet
+projection together with the `@@@` predicate so this is
+transparent for callers; bare-call wrappers (if ever needed) must
+document the constraint.
+
+`pdb.snippet_positions(field anyelement, "limit" int4, "offset"
+int4) → int[][]` also lives in the same file via an explicit
+`sql = r#"..."#` override. Deferred — the `int[][]` return shape
+needs extra marshaling and there's no current MCPg consumer for
+character positions.
 
 ### 2.2 `bm25` index `WITH (...)` options — resolved
 

--- a/src/mcpg/pg_search.py
+++ b/src/mcpg/pg_search.py
@@ -546,14 +546,17 @@ async def pg_search_run(
         f"{_TABLE_ALIAS}.{_pg_quote_ident(key_field)} AS id",
         f"pdb.score({_TABLE_ALIAS}) AS score",
     ]
-    params: list[Any] = [query]
+    # Build params in placeholder order. Snippet placeholders appear
+    # in the SELECT projection (rendered first), so their bind values
+    # must come before `query` (WHERE) and `limit` (LIMIT).
+    params: list[Any] = []
     if snippet_field_validated is not None:
         select_parts.append(
             f"pdb.snippets({_TABLE_ALIAS}.{_pg_quote_ident(snippet_field_validated)}, "
             f"%s, %s, %s, NULL, NULL, '{_SNIPPET_DEFAULT_SORT_BY}') AS snippets"
         )
         params.extend([snippet_start_tag, snippet_end_tag, snippet_max_num_chars])
-    params.append(limit)
+    params.extend([query, limit])
 
     sql = (
         f"SELECT {', '.join(select_parts)} "

--- a/src/mcpg/pg_search.py
+++ b/src/mcpg/pg_search.py
@@ -510,6 +510,21 @@ async def pg_search_run(
             fails, limit out of bounds, multi-column search
             requested, or ``return_snippets=True`` without a
             ``snippet_field``.
+
+    Security:
+        ``snippet_start_tag`` / ``snippet_end_tag`` are bound as
+        PostgreSQL string literals via ``%s`` parameters — there is
+        no SQL-injection surface. The defaults match upstream's
+        (``<b>`` / ``</b>``) for HTML rendering, and most callers
+        will leave them at the defaults or set them to other
+        rendering-context tags. If a caller forwards
+        attacker-controlled values and a downstream consumer
+        renders the returned :attr:`PgSearchHit.snippets` as HTML
+        without escaping the surrounding match text, those tags
+        become a cross-site scripting (XSS) vector. **MCPg returns
+        the raw ``text[]`` from PostgreSQL; output escaping is the
+        renderer's responsibility.** Treat the snippet strings as
+        untrusted at the rendering layer.
     """
     _validate_identifier(schema, "schema")
     _validate_identifier(table, "table")

--- a/src/mcpg/pg_search.py
+++ b/src/mcpg/pg_search.py
@@ -1,15 +1,18 @@
-"""pg_search integration: observability surface (phase BM-1).
+"""pg_search integration: observability + search execution (phases BM-1, BM-2).
 
 `pg_search <https://github.com/paradedb/paradedb>`_ is a PostgreSQL
 extension by ParadeDB that ships a Tantivy-backed BM25 index access
 method (``USING bm25``) + a `pdb.*` schema of query-building and
-projection helpers. This module covers the *observability* slice —
-catalog enumeration and metadata fetch for every BM25 index in the
-database. Subsequent phases will add search execution (BM-2), hybrid
-composition (BM-3), DDL (BM-4), and advisor + audit (BM-5).
+projection helpers. This module covers the *observability* and
+*search-execution* slices — catalog enumeration, metadata fetch,
+keyword search, more-like-this, and query-string parsing. Subsequent
+phases will add hybrid composition (BM-3), DDL (BM-4), and advisor +
+audit (BM-5).
 
 * :func:`list_pg_search_indexes`,
   :func:`get_pg_search_index_metadata` — observability.
+* :func:`pg_search_run`, :func:`pg_search_more_like_this`,
+  :func:`pg_search_parse_query` — search execution.
 
 Reads return cleanly (empty list / raise) when the extension is not
 installed, so callers can treat absence as "no BM25 in use" rather
@@ -27,6 +30,25 @@ The two ``int`` options (``target_segment_count``,
 ``mutable_segment_rows``) are coerced; the rest stay as strings.
 :attr:`PgSearchIndexInfo.index_options` always carries the full
 parsed reloptions dict for fidelity.
+
+The BM-2 surface is grounded in two upstream source files:
+
+* `pg_search/src/bootstrap/` — ``pdb.score(anyelement) → float4``,
+  ``pdb.parse(text, bool, bool) → pdb.query``,
+  ``pdb.more_like_this(anyelement, jsonb, int4, int4, int4, int4,
+  int4, int4, float4, text[]) → pdb.query``.
+* `pg_search/src/postgres/customscan/basescan/projections/snippet.rs`
+  (paradedb/paradedb@``8bb9a64``) — ``pdb.snippet(anyelement, text,
+  text, int4, int4, int4) → text`` and ``pdb.snippets(anyelement,
+  text, text, int4, int4, int4, text) → text[]``. The wrapper uses
+  the multi-snippet form (``pdb.snippets``).
+
+The snippet functions are pgrx ``#[pg_extern]`` stubs that only
+produce highlights when invoked inside a ``pg_search``-driven SELECT
+(the planner rewrites them during custom-scan projection). Callers
+should only request ``return_snippets=True`` in conjunction with a
+``@@@`` predicate, which is how :func:`pg_search_run` already wires
+them up.
 """
 
 from __future__ import annotations
@@ -306,3 +328,366 @@ async def get_pg_search_index_metadata(driver: SqlDriver, schema: str, index: st
     if not rows:
         raise PgSearchError(f"no BM25 index named {schema}.{index} found")
     return _index_info_from_row(rows[0].cells)
+
+
+# --- BM-2: search execution ------------------------------------------------
+
+
+def _pg_quote_ident(name: str) -> str:
+    """Quote a PostgreSQL identifier the way ``format('%I')`` would.
+
+    Inputs reaching this helper have already passed
+    :func:`_validate_identifier`, so they're plain unquoted names.
+    Wrapping in double quotes (with doubled internal quotes) keeps
+    the rendered SQL legal even for caller-supplied names that
+    happen to share a keyword.
+    """
+    return '"' + name.replace('"', '""') + '"'
+
+
+def _validate_positive_int(name: str, value: int, *, allow_zero: bool = False) -> None:
+    """Bounded integer validation that rejects the bool-as-int trap.
+
+    ``bool`` is a subclass of ``int`` in Python; accepting ``True``
+    as a positive int would let a caller bug slip through silently.
+    """
+    minimum = 0 if allow_zero else 1
+    if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+        op = ">=" if allow_zero else ">"
+        raise PgSearchError(f"{name} must be an int {op} 0; got {value!r}")
+
+
+def _validate_bool(value: bool, kind: str) -> None:
+    if not isinstance(value, bool):
+        raise PgSearchError(f"{kind} must be a bool; got {value!r}")
+
+
+@dataclass(frozen=True, slots=True)
+class PgSearchHit:
+    """A single row returned by :func:`pg_search_run` or :func:`pg_search_more_like_this`.
+
+    :attr:`id` is the value of the caller-supplied ``key_field``
+    column (kept as ``Any`` so int / uuid / text primary keys all
+    pass through). :attr:`score` is the BM25 score from
+    ``pdb.score(t)``. :attr:`snippets` is empty unless the caller
+    requested ``return_snippets=True``; when populated, it carries
+    the multi-snippet array ``pdb.snippets`` produces for the
+    designated ``snippet_field``.
+    """
+
+    id: Any
+    score: float
+    snippets: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True, slots=True)
+class PgSearchParsedQuery:
+    """The string form of a parsed ``pdb.query``.
+
+    ``pdb.parse`` returns the opaque ``pdb.query`` type; casting to
+    ``text`` is the canonical way to inspect what the parser made of
+    a query string. Useful for debugging unexpected hit counts (e.g.
+    "did the parser interpret my phrase as a phrase or as two
+    independent terms?").
+    """
+
+    parsed: str
+
+
+# Snippet-projection defaults match the pgrx source exactly. Defining
+# them in one place keeps the SQL builder and the public function
+# signature in lockstep, and surfaces them as constants for callers
+# building wrappers on top.
+_SNIPPET_DEFAULT_START_TAG = "<b>"
+_SNIPPET_DEFAULT_END_TAG = "</b>"
+_SNIPPET_DEFAULT_MAX_NUM_CHARS = 150
+_SNIPPET_DEFAULT_SORT_BY = "score"
+
+# Safety bounds for limit args. The upstream functions accept any
+# int4, but exposing unbounded LIMIT through MCPg makes accidental
+# server-side OOMs trivial. 10_000 mirrors the cap used elsewhere in
+# the codebase for paginated reads.
+_LIMIT_MIN, _LIMIT_MAX = 1, 10_000
+
+
+def _validate_limit(value: int) -> None:
+    """``limit`` must be a sane positive int within MCPg's pagination cap."""
+    if not isinstance(value, int) or isinstance(value, bool) or not _LIMIT_MIN <= value <= _LIMIT_MAX:
+        raise PgSearchError(f"limit must be an int in [{_LIMIT_MIN}..{_LIMIT_MAX}]; got {value!r}")
+
+
+def _validate_columns_arg(columns: list[str] | None) -> str | None:
+    """Validate the ``columns`` arg and pick the single search target.
+
+    BM-2 supports two search shapes:
+
+    * ``columns=None`` → search the whole BM25 index
+      (``WHERE alias @@@ query``). This is the default; the index can
+      cover one or many columns.
+    * ``columns=[one_col]`` → restrict the search to a single field
+      (``WHERE alias.col @@@ query``).
+
+    Multi-column search requires the ``pdb.parse`` per-field config
+    JSON which is deferred to a follow-up phase (the eight
+    ``pdb.more_like_this`` tuning args are deferred for the same
+    reason — see ``docs/plans/bm25-integration.md`` §6). Passing
+    more than one column raises rather than silently picking the
+    first.
+
+    Returns the chosen single-column identifier (already validated),
+    or ``None`` for the whole-table form.
+    """
+    if columns is None:
+        return None
+    if not isinstance(columns, list) or not all(isinstance(c, str) for c in columns):
+        raise PgSearchError(f"columns must be list[str] or None; got {columns!r}")
+    if len(columns) == 0:
+        raise PgSearchError("columns must be None or a non-empty list; pass None to search the whole index")
+    if len(columns) > 1:
+        raise PgSearchError(
+            "multi-column search is not yet supported in BM-2 — needs the pdb.parse per-field "
+            "config JSON, deferred to a follow-up phase. Pass a single column or None."
+        )
+    column = columns[0]
+    _validate_identifier(column, "column")
+    return column
+
+
+# Table alias used in every BM-2 SQL builder. Pulled out so the
+# `pdb.score(t)` and `t @@@ ...` references stay in sync with the
+# `FROM` clause without copy-paste drift.
+_TABLE_ALIAS = "t"
+
+
+def _bm25_predicate(column: str | None) -> str:
+    """Render the search-target side of the ``@@@`` predicate."""
+    return f"{_TABLE_ALIAS}.{_pg_quote_ident(column)}" if column else _TABLE_ALIAS
+
+
+async def pg_search_run(
+    driver: SqlDriver,
+    schema: str,
+    table: str,
+    query: str,
+    key_field: str,
+    *,
+    columns: list[str] | None = None,
+    limit: int,
+    return_snippets: bool = False,
+    snippet_field: str | None = None,
+    snippet_start_tag: str = _SNIPPET_DEFAULT_START_TAG,
+    snippet_end_tag: str = _SNIPPET_DEFAULT_END_TAG,
+    snippet_max_num_chars: int = _SNIPPET_DEFAULT_MAX_NUM_CHARS,
+) -> list[PgSearchHit]:
+    """Run a BM25 keyword search against the named table.
+
+    Builds and executes::
+
+        SELECT t."<key_field>", pdb.score(t) AS score [, pdb.snippets(...)]
+        FROM "<schema>"."<table>" AS t
+        WHERE <search_target> @@@ <query>
+        ORDER BY pdb.score(t) DESC
+        LIMIT <limit>
+
+    where ``<search_target>`` is ``t`` (whole index) or
+    ``t."<col>"`` (single-column form), per the ``columns`` arg's
+    validation in :func:`_validate_columns_arg`.
+
+    The ``key_field`` arg is the caller's primary-key column (matches
+    the ``key_field`` reloption set on the BM25 index — discoverable
+    via :func:`list_pg_search_indexes`). It is returned as
+    :attr:`PgSearchHit.id` and is the only projection MCPg surfaces
+    by default; richer projections are a follow-up phase.
+
+    When ``return_snippets=True``, ``snippet_field`` is required and
+    must name a single ``text`` column the BM25 index covers. The
+    wrapper projects ``pdb.snippets(t."<snippet_field>", start_tag,
+    end_tag, max_num_chars, NULL, NULL, 'score') → text[]`` and
+    surfaces the array as :attr:`PgSearchHit.snippets`.
+
+    Raises:
+        PgSearchError: extension missing, identifier validation
+            fails, limit out of bounds, multi-column search
+            requested, or ``return_snippets=True`` without a
+            ``snippet_field``.
+    """
+    _validate_identifier(schema, "schema")
+    _validate_identifier(table, "table")
+    _validate_identifier(key_field, "key_field")
+    _validate_bool(return_snippets, "return_snippets")
+    _validate_limit(limit)
+    if not isinstance(query, str):
+        raise PgSearchError(f"query must be str; got {type(query).__name__}")
+    column = _validate_columns_arg(columns)
+
+    snippet_field_validated: str | None = None
+    if return_snippets:
+        if snippet_field is None:
+            raise PgSearchError("return_snippets=True requires a snippet_field — the text column to highlight")
+        _validate_identifier(snippet_field, "snippet_field")
+        if not isinstance(snippet_start_tag, str) or not isinstance(snippet_end_tag, str):
+            raise PgSearchError("snippet_start_tag / snippet_end_tag must be str")
+        _validate_positive_int("snippet_max_num_chars", snippet_max_num_chars)
+        snippet_field_validated = snippet_field
+    elif snippet_field is not None:
+        raise PgSearchError("snippet_field is only valid when return_snippets=True")
+
+    if not await extension_installed(driver, "pg_search"):
+        raise PgSearchError("pg_search extension is not installed in this database")
+
+    qualified_table = f"{_pg_quote_ident(schema)}.{_pg_quote_ident(table)}"
+    search_target = _bm25_predicate(column)
+
+    # Bind params: query, [snippet args if any], limit. Snippet bind
+    # order follows pdb.snippets' positional arg list (start_tag,
+    # end_tag, max_num_chars). The NULL/NULL/sort_by tail uses
+    # literals — no caller input flows there.
+    select_parts = [
+        f"{_TABLE_ALIAS}.{_pg_quote_ident(key_field)} AS id",
+        f"pdb.score({_TABLE_ALIAS}) AS score",
+    ]
+    params: list[Any] = [query]
+    if snippet_field_validated is not None:
+        select_parts.append(
+            f"pdb.snippets({_TABLE_ALIAS}.{_pg_quote_ident(snippet_field_validated)}, "
+            f"%s, %s, %s, NULL, NULL, '{_SNIPPET_DEFAULT_SORT_BY}') AS snippets"
+        )
+        params.extend([snippet_start_tag, snippet_end_tag, snippet_max_num_chars])
+    params.append(limit)
+
+    sql = (
+        f"SELECT {', '.join(select_parts)} "
+        f"FROM {qualified_table} AS {_TABLE_ALIAS} "
+        f"WHERE {search_target} @@@ %s "
+        f"ORDER BY pdb.score({_TABLE_ALIAS}) DESC "
+        f"LIMIT %s"
+    )
+    rows = await driver.execute_query(sql, params=params, force_readonly=True)
+    return [
+        PgSearchHit(
+            id=row.cells["id"],
+            score=float(row.cells["score"]),
+            snippets=_normalize_snippets(row.cells.get("snippets")),
+        )
+        for row in rows or []
+    ]
+
+
+def _normalize_snippets(value: Any) -> list[str]:
+    """Coerce ``pdb.snippets``' return to ``list[str]``.
+
+    psycopg returns PG ``text[]`` as a Python list; drivers that
+    hand back ``None`` (no snippets generated for this row) or any
+    other shape fall through to ``[]`` rather than raising — the
+    snippet projection is best-effort, not a hit-correctness signal.
+    """
+    if isinstance(value, list):
+        return [str(s) for s in value if s is not None]
+    return []
+
+
+async def pg_search_more_like_this(
+    driver: SqlDriver,
+    schema: str,
+    table: str,
+    document_id: Any,
+    key_field: str,
+    *,
+    limit: int,
+) -> list[PgSearchHit]:
+    """Find rows similar to the row identified by ``document_id``.
+
+    Wraps ``pdb.more_like_this(anyelement, ...)`` with only the row
+    reference arg — the eight tuning knobs (min/max doc frequency,
+    term frequency, query terms, word length, boost factor,
+    stopwords) are documented as out-of-scope for BM-2 (see
+    `docs/plans/bm25-integration.md` §6) and stay at upstream's
+    defaults. The seed row is loaded from the same table via a
+    correlated subquery so the wrapper takes ``document_id`` as an
+    opaque key value rather than a row tuple.
+
+    Built SQL::
+
+        SELECT t."<key>", pdb.score(t) AS score
+        FROM "<schema>"."<table>" AS t
+        WHERE t @@@ (
+            SELECT pdb.more_like_this(seed)
+            FROM "<schema>"."<table>" AS seed
+            WHERE seed."<key>" = <document_id>
+        )
+        ORDER BY pdb.score(t) DESC
+        LIMIT <limit>
+
+    Raises:
+        PgSearchError: extension missing, identifier validation
+            fails, or limit out of bounds.
+    """
+    _validate_identifier(schema, "schema")
+    _validate_identifier(table, "table")
+    _validate_identifier(key_field, "key_field")
+    _validate_limit(limit)
+
+    if not await extension_installed(driver, "pg_search"):
+        raise PgSearchError("pg_search extension is not installed in this database")
+
+    qualified_table = f"{_pg_quote_ident(schema)}.{_pg_quote_ident(table)}"
+    quoted_key = _pg_quote_ident(key_field)
+
+    sql = (
+        f"SELECT {_TABLE_ALIAS}.{quoted_key} AS id, pdb.score({_TABLE_ALIAS}) AS score "
+        f"FROM {qualified_table} AS {_TABLE_ALIAS} "
+        f"WHERE {_TABLE_ALIAS} @@@ ("
+        f"SELECT pdb.more_like_this(seed) "
+        f"FROM {qualified_table} AS seed "
+        f"WHERE seed.{quoted_key} = %s"
+        f") "
+        f"ORDER BY pdb.score({_TABLE_ALIAS}) DESC "
+        f"LIMIT %s"
+    )
+    rows = await driver.execute_query(sql, params=[document_id, limit], force_readonly=True)
+    return [PgSearchHit(id=row.cells["id"], score=float(row.cells["score"])) for row in rows or []]
+
+
+async def pg_search_parse_query(
+    driver: SqlDriver,
+    query_string: str,
+    *,
+    lenient: bool = False,
+    conjunction_mode: bool = False,
+) -> PgSearchParsedQuery:
+    """Surface the canonical text form of a parsed ``pdb.query`` for debugging.
+
+    Calls ``pdb.parse(query_string, lenient, conjunction_mode)`` and
+    casts the resulting opaque ``pdb.query`` value to ``text``. Useful
+    for diagnosing surprising hit counts — e.g. "did the parser
+    interpret my phrase as a phrase or as two independent terms?".
+
+    Note ``conjunction_mode`` exists in the upstream signature even
+    though the v2 blog only documented the first two args (BM-0 §2.1
+    finding). When ``True``, the parser treats space-separated terms
+    as AND-joined rather than OR-joined.
+
+    Raises:
+        PgSearchError: extension missing, or ``query_string`` is not
+            a string.
+    """
+    if not isinstance(query_string, str):
+        raise PgSearchError(f"query_string must be str; got {type(query_string).__name__}")
+    _validate_bool(lenient, "lenient")
+    _validate_bool(conjunction_mode, "conjunction_mode")
+
+    if not await extension_installed(driver, "pg_search"):
+        raise PgSearchError("pg_search extension is not installed in this database")
+
+    rows = await driver.execute_query(
+        "SELECT pdb.parse(%s, %s, %s)::text AS parsed",
+        params=[query_string, lenient, conjunction_mode],
+        force_readonly=True,
+    )
+    if not rows:
+        # Defensive — pdb.parse always returns a row, but a fake
+        # driver under test might not. Returning an empty parsed
+        # form is more useful than raising.
+        return PgSearchParsedQuery(parsed="")
+    parsed = rows[0].cells.get("parsed")
+    return PgSearchParsedQuery(parsed=str(parsed) if parsed is not None else "")

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -3017,6 +3017,105 @@ def _register_pg_search_reads(server: FastMCP[AppContext]) -> None:
         info = await pg_search.get_pg_search_index_metadata(_driver(ctx), schema, index)
         return asdict(info)
 
+    @server.tool(
+        name="pg_search_run",
+        description=(
+            "Run a BM25 keyword search against a pg_search-indexed table. "
+            "Returns hits as {id, score, snippets} where ``id`` is the value "
+            "of the caller-supplied ``key_field`` and ``score`` is "
+            "``pdb.score(t)``. ``columns=None`` searches the whole index; "
+            '``columns=["col"]`` restricts to a single text field. '
+            "Multi-column search needs the pdb.parse per-field config JSON "
+            "and is deferred to a follow-up phase. ``return_snippets=True`` "
+            "requires ``snippet_field`` and projects ``pdb.snippets`` over "
+            "that column. Requires the pg_search extension."
+        ),
+    )
+    async def pg_search_run(
+        ctx: _Ctx,
+        schema: str,
+        table: str,
+        query: str,
+        key_field: str,
+        limit: int,
+        columns: list[str] | None = None,
+        return_snippets: bool = False,
+        snippet_field: str | None = None,
+        snippet_start_tag: str = "<b>",
+        snippet_end_tag: str = "</b>",
+        snippet_max_num_chars: int = 150,
+    ) -> list[dict[str, Any]]:
+        hits = await pg_search.pg_search_run(
+            _driver(ctx),
+            schema,
+            table,
+            query,
+            key_field,
+            columns=columns,
+            limit=limit,
+            return_snippets=return_snippets,
+            snippet_field=snippet_field,
+            snippet_start_tag=snippet_start_tag,
+            snippet_end_tag=snippet_end_tag,
+            snippet_max_num_chars=snippet_max_num_chars,
+        )
+        return [asdict(hit) for hit in hits]
+
+    @server.tool(
+        name="pg_search_more_like_this",
+        description=(
+            "Find rows similar to a seed document via ``pdb.more_like_this`` "
+            "+ ``@@@``. ``document_id`` is the value of ``key_field`` for the "
+            "seed row. The eight pdb.more_like_this tuning args (min/max "
+            "doc-frequency, term-frequency, query-terms, word-length, boost, "
+            "stopwords) stay at upstream defaults — exposing them is a "
+            "future phase. Returns the same {id, score} hit shape as "
+            "``pg_search_run``. Requires the pg_search extension."
+        ),
+    )
+    async def pg_search_more_like_this(
+        ctx: _Ctx,
+        schema: str,
+        table: str,
+        document_id: Any,
+        key_field: str,
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        hits = await pg_search.pg_search_more_like_this(
+            _driver(ctx),
+            schema,
+            table,
+            document_id,
+            key_field,
+            limit=limit,
+        )
+        return [asdict(hit) for hit in hits]
+
+    @server.tool(
+        name="pg_search_parse_query",
+        description=(
+            "Parse a query string through ``pdb.parse`` and return its "
+            "canonical text form for debugging — useful for confirming the "
+            "parser interpreted a phrase as expected. ``lenient=True`` "
+            "relaxes syntax checking; ``conjunction_mode=True`` treats "
+            "space-separated terms as AND-joined rather than OR-joined. "
+            "Requires the pg_search extension."
+        ),
+    )
+    async def pg_search_parse_query(
+        ctx: _Ctx,
+        query_string: str,
+        lenient: bool = False,
+        conjunction_mode: bool = False,
+    ) -> dict[str, Any]:
+        parsed = await pg_search.pg_search_parse_query(
+            _driver(ctx),
+            query_string,
+            lenient=lenient,
+            conjunction_mode=conjunction_mode,
+        )
+        return asdict(parsed)
+
 
 def _register_turboquant_writes(server: FastMCP[AppContext]) -> None:
     @server.tool(

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -3028,7 +3028,12 @@ def _register_pg_search_reads(server: FastMCP[AppContext]) -> None:
             "Multi-column search needs the pdb.parse per-field config JSON "
             "and is deferred to a follow-up phase. ``return_snippets=True`` "
             "requires ``snippet_field`` and projects ``pdb.snippets`` over "
-            "that column. Requires the pg_search extension."
+            "that column. Requires the pg_search extension. SECURITY: "
+            "``snippet_start_tag`` / ``snippet_end_tag`` are not sanitized "
+            "(they pass through to upstream as-is). The defaults match "
+            "pg_search's HTML defaults; if callers forward untrusted values "
+            "and a downstream consumer renders snippets as HTML, that's an "
+            "XSS vector — output escaping is the renderer's responsibility."
         ),
     )
     async def pg_search_run(

--- a/tests/unit/test_pg_search.py
+++ b/tests/unit/test_pg_search.py
@@ -1,4 +1,4 @@
-"""Tests for the pg_search BM-1 observability surface."""
+"""Tests for the pg_search BM-1 observability + BM-2 search surfaces."""
 
 import pytest
 from _fakes import FakeDatabase, FakeDriver, FakeRoutingDriver
@@ -8,9 +8,14 @@ from mcpg.config import load_settings
 from mcpg.extensions import ENABLEABLE_EXTENSIONS
 from mcpg.pg_search import (
     PgSearchError,
+    PgSearchHit,
     PgSearchIndexInfo,
+    PgSearchParsedQuery,
     get_pg_search_index_metadata,
     list_pg_search_indexes,
+    pg_search_more_like_this,
+    pg_search_parse_query,
+    pg_search_run,
 )
 from mcpg.server import create_server
 
@@ -282,9 +287,305 @@ def test_pg_search_on_enableable_extensions_allowlist() -> None:
 
 
 async def test_pg_search_tools_registered_for_read_access() -> None:
-    """Both BM-1 tools should be visible via list_tools when running with
-    default (READ-capable) access."""
+    """BM-1 and BM-2 tools should be visible via list_tools when running
+    with default (READ-capable) access."""
     server = create_server(_SETTINGS, database=FakeDatabase(FakeDriver()))  # type: ignore[arg-type]
     async with create_connected_server_and_client_session(server) as client:
         listed = {tool.name for tool in (await client.list_tools()).tools}
-    assert {"list_pg_search_indexes", "get_pg_search_index_metadata"} <= listed
+    assert {
+        "list_pg_search_indexes",
+        "get_pg_search_index_metadata",
+        "pg_search_run",
+        "pg_search_more_like_this",
+        "pg_search_parse_query",
+    } <= listed
+
+
+# --- BM-2: pg_search_run ----------------------------------------------------
+
+
+async def test_pg_search_run_raises_when_extension_absent() -> None:
+    driver = FakeRoutingDriver({"pg_extension": []})
+
+    with pytest.raises(PgSearchError, match="not installed"):
+        await pg_search_run(driver, "public", "docs", "rust", "id", limit=10)  # type: ignore[arg-type]
+
+
+async def test_pg_search_run_whole_index_search_returns_hits() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "@@@": [
+                {"id": 1, "score": 9.5, "snippets": None},
+                {"id": 2, "score": 7.1, "snippets": None},
+            ],
+        }
+    )
+
+    hits = await pg_search_run(driver, "public", "docs", "rust", "id", limit=10)  # type: ignore[arg-type]
+
+    assert hits == [
+        PgSearchHit(id=1, score=9.5, snippets=[]),
+        PgSearchHit(id=2, score=7.1, snippets=[]),
+    ]
+    # SQL inspection: whole-index form omits the column qualifier on
+    # the @@@ predicate.
+    sql, params, force_readonly = driver.calls[-1]
+    assert force_readonly is True
+    assert " t @@@ %s " in sql
+    assert "ORDER BY pdb.score(t) DESC" in sql
+    assert params == ["rust", 10]
+
+
+async def test_pg_search_run_single_column_search_emits_column_qualifier() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "@@@": [{"id": 1, "score": 5.0, "snippets": None}],
+        }
+    )
+
+    await pg_search_run(
+        driver,  # type: ignore[arg-type]
+        "public",
+        "docs",
+        "rust",
+        "id",
+        columns=["body"],
+        limit=5,
+    )
+
+    sql, params, _ = driver.calls[-1]
+    assert ' t."body" @@@ %s ' in sql
+    assert params == ["rust", 5]
+
+
+async def test_pg_search_run_with_snippets_projects_pdb_snippets() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "@@@": [
+                {"id": 1, "score": 9.5, "snippets": ["<b>rust</b> programming", "<b>rust</b>aceans"]},
+            ],
+        }
+    )
+
+    hits = await pg_search_run(
+        driver,  # type: ignore[arg-type]
+        "public",
+        "docs",
+        "rust",
+        "id",
+        limit=5,
+        return_snippets=True,
+        snippet_field="body",
+    )
+
+    assert hits[0].snippets == ["<b>rust</b> programming", "<b>rust</b>aceans"]
+    sql, params, _ = driver.calls[-1]
+    assert 'pdb.snippets(t."body", %s, %s, %s, NULL, NULL, ' in sql
+    assert params == ["rust", "<b>", "</b>", 150, 5]
+
+
+async def test_pg_search_run_return_snippets_without_field_raises() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(PgSearchError, match="snippet_field"):
+        await pg_search_run(
+            driver,  # type: ignore[arg-type]
+            "public",
+            "docs",
+            "rust",
+            "id",
+            limit=5,
+            return_snippets=True,
+        )
+
+
+async def test_pg_search_run_snippet_field_without_return_snippets_raises() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(PgSearchError, match="snippet_field is only valid"):
+        await pg_search_run(
+            driver,  # type: ignore[arg-type]
+            "public",
+            "docs",
+            "rust",
+            "id",
+            limit=5,
+            return_snippets=False,
+            snippet_field="body",
+        )
+
+
+async def test_pg_search_run_multi_column_search_raises() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(PgSearchError, match="multi-column"):
+        await pg_search_run(
+            driver,  # type: ignore[arg-type]
+            "public",
+            "docs",
+            "rust",
+            "id",
+            columns=["body", "title"],
+            limit=5,
+        )
+
+
+async def test_pg_search_run_empty_columns_raises() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(PgSearchError, match="non-empty list"):
+        await pg_search_run(
+            driver,  # type: ignore[arg-type]
+            "public",
+            "docs",
+            "rust",
+            "id",
+            columns=[],
+            limit=5,
+        )
+
+
+@pytest.mark.parametrize("bad_limit", [0, -1, 10_001, True, "10", 1.5])
+async def test_pg_search_run_limit_validation(bad_limit: object) -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(PgSearchError, match="limit"):
+        await pg_search_run(driver, "public", "docs", "rust", "id", limit=bad_limit)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("schema", "table", "key_field"),
+    [
+        ("public; DROP TABLE x", "docs", "id"),
+        ("public", "docs; --", "id"),
+        ("public", "docs", "id'; DROP"),
+        ("", "docs", "id"),
+        ("public", "", "id"),
+        ("public", "docs", ""),
+    ],
+)
+async def test_pg_search_run_identifier_validation(schema: str, table: str, key_field: str) -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(PgSearchError, match="invalid"):
+        await pg_search_run(driver, schema, table, "rust", key_field, limit=5)  # type: ignore[arg-type]
+
+
+async def test_pg_search_run_query_must_be_str() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(PgSearchError, match="query must be str"):
+        await pg_search_run(driver, "public", "docs", 42, "id", limit=5)  # type: ignore[arg-type]
+
+
+# --- BM-2: pg_search_more_like_this ----------------------------------------
+
+
+async def test_pg_search_more_like_this_raises_when_extension_absent() -> None:
+    driver = FakeRoutingDriver({"pg_extension": []})
+
+    with pytest.raises(PgSearchError, match="not installed"):
+        await pg_search_more_like_this(  # type: ignore[arg-type]
+            driver, "public", "docs", 42, "id", limit=10
+        )
+
+
+async def test_pg_search_more_like_this_returns_hits_with_correlated_seed() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "pdb.more_like_this(seed)": [
+                {"id": 2, "score": 8.0},
+                {"id": 3, "score": 6.5},
+            ],
+        }
+    )
+
+    hits = await pg_search_more_like_this(  # type: ignore[arg-type]
+        driver, "public", "docs", 42, "id", limit=10
+    )
+
+    assert hits == [PgSearchHit(id=2, score=8.0), PgSearchHit(id=3, score=6.5)]
+    sql, params, force_readonly = driver.calls[-1]
+    assert force_readonly is True
+    # Seed sub-SELECT references the same table as the outer scan,
+    # joined by key_field.
+    assert 'WHERE seed."id" = %s' in sql
+    assert "pdb.more_like_this(seed)" in sql
+    assert params == [42, 10]
+
+
+async def test_pg_search_more_like_this_rejects_bad_limit() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(PgSearchError, match="limit"):
+        await pg_search_more_like_this(  # type: ignore[arg-type]
+            driver, "public", "docs", 42, "id", limit=0
+        )
+
+
+async def test_pg_search_more_like_this_validates_identifiers() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(PgSearchError, match="invalid"):
+        await pg_search_more_like_this(  # type: ignore[arg-type]
+            driver, "bad; schema", "docs", 42, "id", limit=10
+        )
+
+
+# --- BM-2: pg_search_parse_query -------------------------------------------
+
+
+async def test_pg_search_parse_query_raises_when_extension_absent() -> None:
+    driver = FakeRoutingDriver({"pg_extension": []})
+
+    with pytest.raises(PgSearchError, match="not installed"):
+        await pg_search_parse_query(driver, "rust AND programming")  # type: ignore[arg-type]
+
+
+async def test_pg_search_parse_query_returns_parsed_text() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "pdb.parse(%s, %s, %s)": [{"parsed": "(+rust +programming)"}],
+        }
+    )
+
+    parsed = await pg_search_parse_query(  # type: ignore[arg-type]
+        driver, "rust AND programming", lenient=True, conjunction_mode=True
+    )
+
+    assert parsed == PgSearchParsedQuery(parsed="(+rust +programming)")
+    sql, params, _ = driver.calls[-1]
+    assert params == ["rust AND programming", True, True]
+    assert "pdb.parse(%s, %s, %s)::text" in sql
+
+
+async def test_pg_search_parse_query_empty_result_yields_empty_string() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "pdb.parse": [],  # defensive — upstream always returns a row
+        }
+    )
+
+    parsed = await pg_search_parse_query(driver, "rust")  # type: ignore[arg-type]
+    assert parsed.parsed == ""
+
+
+@pytest.mark.parametrize("bad_query", [None, 42, ["rust"], b"rust"])
+async def test_pg_search_parse_query_rejects_non_string(bad_query: object) -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(PgSearchError, match="query_string must be str"):
+        await pg_search_parse_query(driver, bad_query)  # type: ignore[arg-type]
+
+
+async def test_pg_search_parse_query_rejects_non_bool_flags() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(PgSearchError, match="lenient must be a bool"):
+        await pg_search_parse_query(driver, "rust", lenient="yes")  # type: ignore[arg-type]

--- a/tests/unit/test_pg_search.py
+++ b/tests/unit/test_pg_search.py
@@ -384,7 +384,46 @@ async def test_pg_search_run_with_snippets_projects_pdb_snippets() -> None:
     assert hits[0].snippets == ["<b>rust</b> programming", "<b>rust</b>aceans"]
     sql, params, _ = driver.calls[-1]
     assert 'pdb.snippets(t."body", %s, %s, %s, NULL, NULL, ' in sql
-    assert params == ["rust", "<b>", "</b>", 150, 5]
+    # Param order must match placeholder positions: snippet args appear
+    # in SELECT (first), then query (WHERE), then limit (LIMIT).
+    assert params == ["<b>", "</b>", 150, "rust", 5]
+
+
+async def test_pg_search_run_param_count_matches_placeholder_count() -> None:
+    """Regression: the snippet projection adds three %s placeholders in
+    SELECT that must appear in params before the WHERE/LIMIT binds.
+    Mismatched ordering would silently rotate the query arg into the
+    snippet slot, returning whatever rows happen to match the start_tag
+    literal."""
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "@@@": [{"id": 1, "score": 1.0, "snippets": []}],
+        }
+    )
+
+    # No-snippet case: 2 placeholders (query, limit).
+    await pg_search_run(driver, "public", "docs", "rust", "id", limit=5)  # type: ignore[arg-type]
+    sql, params, _ = driver.calls[-1]
+    assert sql.count("%s") == len(params)
+    assert params[-2:] == ["rust", 5]
+
+    # Snippet case: 5 placeholders (3 snippet, query, limit).
+    await pg_search_run(  # type: ignore[arg-type]
+        driver,
+        "public",
+        "docs",
+        "rust",
+        "id",
+        limit=5,
+        return_snippets=True,
+        snippet_field="body",
+    )
+    sql, params, _ = driver.calls[-1]
+    assert sql.count("%s") == len(params) == 5
+    # Snippet args first (they appear in SELECT), then query (WHERE),
+    # then limit (LIMIT).
+    assert params == ["<b>", "</b>", 150, "rust", 5]
 
 
 async def test_pg_search_run_return_snippets_without_field_raises() -> None:


### PR DESCRIPTION
## Summary

Wraps the three documented `pg_search` query-surface entry points as MCPg tools, and folds the post-BM-0 follow-up investigation into the plan doc (resolves the last honest gap from §2.1).

### `src/mcpg/pg_search.py`

- **`PgSearchHit`** dataclass — `id`, `score`, `snippets`.
- **`PgSearchParsedQuery`** dataclass — canonical text form of `pdb.query`.
- **`pg_search_run(driver, schema, table, query, key_field, *, columns=None, limit, return_snippets=False, snippet_field=None, snippet_start_tag, snippet_end_tag, snippet_max_num_chars)`** — BM25 keyword search.
  - Whole-index form: `WHERE t @@@ %s` when `columns=None`.
  - Single-column form: `WHERE t."col" @@@ %s` when `columns=["col"]`.
  - Multi-column raises with a pointer to a future pdb.parse-based wrapper.
  - Optional snippet projection via `pdb.snippets` when `return_snippets=True` + `snippet_field`.
- **`pg_search_more_like_this(driver, schema, table, document_id, key_field, *, limit)`** — wraps `pdb.more_like_this` with the row-reference arg only; the eight tuning knobs stay at upstream defaults (out-of-scope for BM-2 per the plan).
- **`pg_search_parse_query(driver, query_string, *, lenient=False, conjunction_mode=False)`** — surfaces the parsed `pdb.query` as text for debugging. `conjunction_mode` exposed per the BM-0 §2.1 finding that the upstream signature has three args (the v2 blog documented only two).

All wrappers validate identifiers, reject bool-as-int, bound `limit` to `[1, 10_000]`, and short-circuit cleanly when the extension is absent.

### `src/mcpg/tools.py`

Registers `pg_search_run`, `pg_search_more_like_this`, and `pg_search_parse_query` under the READ capability gate.

### `docs/plans/bm25-integration.md` §2.1

Folds in the snippet-source follow-up. Both `pdb.snippet (→ text)` and `pdb.snippets (→ text[])` are pgrx `#[pg_extern(stable, parallel_safe)]` declarations in `pg_search/src/postgres/customscan/basescan/projections/snippet.rs` (paradedb/paradedb@`8bb9a64`). Caveat surfaced: these are stubs that only produce highlights when invoked during a pg_search-driven SELECT — BM-2's `pg_search_run` wires them with the `@@@` predicate so this is transparent for callers.

### Tests — 33 new (49 total in the module)

Whole-index vs single-column search, snippet projection (success + missing-field + extra-field validation), multi-column rejection, limit/identifier/type validation across all three entry points, `more_like_this` seed-row sub-SELECT shape, `parse_query` text return and arg passthrough.

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run mypy src/mcpg` — clean
- [x] `uv run pytest tests/unit -q` — 1653 passed (33 new)
- [ ] Reviewer sanity-check the SQL against a real `pg_search` install with snippets enabled
- [ ] Reviewer confirm the `pdb.more_like_this(seed)` correlated sub-SELECT pattern works as written (vs. requiring the row-reference to land via lateral join)

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Add MCPg search-execution tools on top of ParadeDB pg_search, exposing BM25 keyword search, more-like-this, and query parsing alongside existing index observability.

New Features:
- Expose pg_search BM25 keyword search as a pg_search_run tool that returns id, score, and optional text snippets from bm25-indexed tables.
- Expose pg_search more-like-this search as a pg_search_more_like_this tool that finds documents similar to a seed row by key.
- Expose pg_search query parsing as a pg_search_parse_query tool that returns the canonical text form of parsed queries for debugging.

Enhancements:
- Extend the pg_search integration module to cover search execution, including limit and identifier validation, snippet handling, and extension-presence checks.
- Document the resolved design and source of pg_search snippet functions and their constraints in the BM25 integration plan.

Tests:
- Add comprehensive unit tests covering the new pg_search search-execution tools, including SQL shape, parameter validation, snippet projection behavior, and extension-absence handling.