### PR TITLE
feat: pg_search hybrid BM25 + pgvector via RRF (BM-3)

### DIFF
--- a/docs/plans/bm25-integration.md
+++ b/docs/plans/bm25-integration.md
@@ -180,19 +180,44 @@ Rationale and scope:
   incompatible with AGPL pick a different BM25 implementation
   (this doc's §1 lists alternatives).
 
-### 2.5 v2 hybrid-search arithmetic — still pending (BM-3 only)
+### 2.5 v2 hybrid-search arithmetic — resolved
 
-This unknown only gates **BM-3** (hybrid composition). BM-1 / BM-2
-/ BM-4 / BM-5 can proceed without it.
+A focused follow-up agent (2026-06-10) pinned the canonical v2
+arithmetic from two living upstream sources:
 
-ParadeDB's "Hybrid Search Missing Manual" documents the combination
-pattern (`pdb.score(key)` weighted against a pgvector distance
-expression), but the v2-exact arithmetic (linear blend with
-normalization, RRF, tunable weight knob, …) is not yet pinned to a
-verbatim source citation. **Action before BM-3:** read the v2 blog
-post + sample queries in `pg_search/tests/` to pin the arithmetic,
-or fall back to a documented linear blend with a clear "operator
-chooses the weights" interface.
+- **Blog post** (2025-10-22): "Hybrid Search in PostgreSQL: The
+  Missing Manual" — the canonical narrative since the dedicated
+  docs page was removed.
+- **`tests/tests/documentation.rs::hybrid_search`** — the
+  source-of-truth test that the removed docs page used to embed.
+
+Both agree on **Reciprocal Rank Fusion (RRF)** with the formula
+`sum(1.0 / (k + rank))` per source, summed via UNION ALL + GROUP
+BY. The literal `k = 60` constant matches both sources. Equal
+weights are the default; the blog's weighted variant uses literal
+float multipliers (`bm25_weight * 1.0/(k+rank)` + `vector_weight *
+1.0/(k+rank)`). There is **no** `paradedb.score_hybrid` /
+`paradedb.rank_hybrid` helper function in v2 (GitHub code search
+returned zero hits on `main`) — operators write the CTE inline.
+
+**MCPg's BM-3 wrapper ships RRF** as the documented default. The
+UNION ALL + GROUP BY SUM form is simpler than the test's FULL OUTER
+JOIN + COALESCE form; the arithmetic is identical. The wrapper
+exposes `k`, `bm25_weight`, `vector_weight`, `per_leg_limit`,
+`distance_op` (allowlist `<=>` / `<->` / `<#>`), and `final_limit`
+as kwargs. Linear blend is **not** offered because there is no
+upstream v2 source for min/max normalized linear blend — shipping
+it would be speculation.
+
+**Caveat — docs page removed.** The hybrid guide on
+`docs.paradedb.com` returns HTTP 404 as of 2026-06-10 (the
+`.prettierignore` still lists `docs/documentation/guides/hybrid.mdx`
+but the file is gone). The blog post is the current canonical
+reference; future ParadeDB versions may ship a more formal
+hybrid-search API (the docs-page removal suggests the public
+surface is in flux). MCPg's wrapper docstring cites both the
+blog URL with retrieval date and the test path so future
+maintainers can re-verify when upstream stabilizes.
 
 ## 3. Guardrails (apply to every phase)
 

--- a/src/mcpg/pg_search.py
+++ b/src/mcpg/pg_search.py
@@ -55,6 +55,7 @@ them up.
 from __future__ import annotations
 
 import json
+import math
 import re
 from dataclasses import dataclass, field
 from typing import Any
@@ -756,10 +757,14 @@ class HybridHit:
     vector_rank: int | None = None
 
 
-# RRF constant: matches the literal `60` both upstream sources use.
-# Exposed as a knob since the optimal k varies with corpus size and
-# leg overlap, but 60 is the canonical default.
-_RRF_DEFAULT_K = 60
+# RRF defaults — both upstream sources (blog + documentation.rs)
+# converge on these literals. Exposed publicly so the FastMCP tool
+# wrapper can keep its signature in sync with the API without
+# re-typing the literals.
+RRF_DEFAULT_K = 60
+HYBRID_DEFAULT_WEIGHT = 1.0
+HYBRID_DEFAULT_PER_LEG_LIMIT = 20
+HYBRID_DEFAULT_DISTANCE_OP = "<=>"
 
 
 def _validate_weight(name: str, value: float) -> None:
@@ -773,8 +778,6 @@ def _validate_weight(name: str, value: float) -> None:
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise PgSearchError(f"{name} must be a non-negative finite number; got {value!r}")
     fval = float(value)
-    import math  # local — only this validator needs it
-
     if math.isnan(fval) or math.isinf(fval) or fval < 0:
         raise PgSearchError(f"{name} must be a non-negative finite number; got {value!r}")
 
@@ -808,11 +811,11 @@ async def hybrid_bm25_vector_search(
     key_field: str,
     vector_column: str,
     bm25_columns: list[str] | None = None,
-    distance_op: str = "<=>",
-    k: int = _RRF_DEFAULT_K,
-    bm25_weight: float = 1.0,
-    vector_weight: float = 1.0,
-    per_leg_limit: int = 20,
+    distance_op: str = HYBRID_DEFAULT_DISTANCE_OP,
+    k: int = RRF_DEFAULT_K,
+    bm25_weight: float = HYBRID_DEFAULT_WEIGHT,
+    vector_weight: float = HYBRID_DEFAULT_WEIGHT,
+    per_leg_limit: int = HYBRID_DEFAULT_PER_LEG_LIMIT,
     final_limit: int,
 ) -> list[HybridHit]:
     """Combine a BM25 search and a pgvector search via Reciprocal Rank Fusion.
@@ -906,6 +909,15 @@ async def hybrid_bm25_vector_search(
 
     if not await extension_installed(driver, "pg_search"):
         raise PgSearchError("pg_search extension is not installed in this database")
+    # The vector leg renders `<op> %s::vector`, which only resolves
+    # when pgvector is installed. Fail fast with a clear message so
+    # callers don't see a confusing PostgreSQL "type 'vector' does
+    # not exist" error.
+    if not await extension_installed(driver, "vector"):
+        raise PgSearchError(
+            "pgvector extension is not installed in this database — "
+            "hybrid_bm25_vector_search needs both pg_search and pgvector"
+        )
 
     qualified_table = f"{_pg_quote_ident(schema)}.{_pg_quote_ident(table)}"
     quoted_key = _pg_quote_ident(key_field)

--- a/src/mcpg/pg_search.py
+++ b/src/mcpg/pg_search.py
@@ -1,18 +1,19 @@
-"""pg_search integration: observability + search execution (phases BM-1, BM-2).
+"""pg_search integration: observability + search + hybrid (phases BM-1, BM-2, BM-3).
 
 `pg_search <https://github.com/paradedb/paradedb>`_ is a PostgreSQL
 extension by ParadeDB that ships a Tantivy-backed BM25 index access
 method (``USING bm25``) + a `pdb.*` schema of query-building and
-projection helpers. This module covers the *observability* and
-*search-execution* slices — catalog enumeration, metadata fetch,
-keyword search, more-like-this, and query-string parsing. Subsequent
-phases will add hybrid composition (BM-3), DDL (BM-4), and advisor +
-audit (BM-5).
+projection helpers. This module covers the *observability*,
+*search-execution*, and *hybrid-composition* slices — catalog
+enumeration, metadata fetch, keyword search, more-like-this,
+query-string parsing, and BM25+pgvector hybrid retrieval.
+Subsequent phases will add DDL (BM-4) and advisor + audit (BM-5).
 
 * :func:`list_pg_search_indexes`,
   :func:`get_pg_search_index_metadata` — observability.
 * :func:`pg_search_run`, :func:`pg_search_more_like_this`,
   :func:`pg_search_parse_query` — search execution.
+* :func:`hybrid_bm25_vector_search` — BM25 + pgvector RRF fusion.
 
 Reads return cleanly (empty list / raise) when the extension is not
 installed, so callers can treat absence as "no BM25 in use" rather
@@ -709,3 +710,257 @@ async def pg_search_parse_query(
         return PgSearchParsedQuery(parsed="")
     parsed = rows[0].cells.get("parsed")
     return PgSearchParsedQuery(parsed=str(parsed) if parsed is not None else "")
+
+
+# --- BM-3: hybrid BM25 + pgvector search -----------------------------------
+#
+# Arithmetic grounded in two upstream sources (BM-0 §2.5 follow-up,
+# 2026-06-10):
+#
+# * Blog: "Hybrid Search in PostgreSQL: The Missing Manual"
+#   (2025-10-22, paradedb.com) — canonical narrative.
+# * `tests/tests/documentation.rs::hybrid_search` — source-of-truth
+#   test that the deprecated docs page used to embed.
+#
+# Both agree on Reciprocal Rank Fusion (RRF) — `sum(1.0 / (k + rank))`
+# over per-source ranks, no min/max normalization of raw scores. There
+# is **no** `paradedb.score_hybrid` / `paradedb.rank_hybrid` helper in
+# v2; operators write the CTE inline. The blog form (UNION ALL +
+# GROUP BY SUM) is simpler than the test's FULL OUTER JOIN form; the
+# arithmetic is identical. MCPg ships the UNION ALL form.
+
+
+# pgvector distance-operator allowlist. RRF arithmetic operates on
+# ranks (not raw scores), so all three operators yield well-formed
+# hybrid scores without any per-operator normalization. The choice
+# only changes which vectors come back as the top-K from the vector
+# leg; the fusion math is operator-agnostic.
+_PGVECTOR_DISTANCE_OPS: frozenset[str] = frozenset({"<=>", "<->", "<#>"})
+
+
+@dataclass(frozen=True, slots=True)
+class HybridHit:
+    """A single row returned by :func:`hybrid_bm25_vector_search`.
+
+    :attr:`id` is the caller-supplied ``key_field`` value. :attr:`score`
+    is the summed RRF score across both legs. :attr:`bm25_rank` and
+    :attr:`vector_rank` carry the row's per-leg ranks for transparency
+    — either can be ``None`` if the row only appeared in one leg's
+    top-K (RRF naturally extends partial-coverage rows by treating
+    the absent leg's contribution as zero).
+    """
+
+    id: Any
+    score: float
+    bm25_rank: int | None = None
+    vector_rank: int | None = None
+
+
+# RRF constant: matches the literal `60` both upstream sources use.
+# Exposed as a knob since the optimal k varies with corpus size and
+# leg overlap, but 60 is the canonical default.
+_RRF_DEFAULT_K = 60
+
+
+def _validate_weight(name: str, value: float) -> None:
+    """Weights must be finite non-negative reals.
+
+    Allowing negative weights would invert one leg's ranking — almost
+    certainly a caller bug. NaN / inf would corrupt the SUM aggregation
+    silently. The bool-as-int / bool-as-float trap is caught by
+    explicitly rejecting bools before the numeric check.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise PgSearchError(f"{name} must be a non-negative finite number; got {value!r}")
+    fval = float(value)
+    import math  # local — only this validator needs it
+
+    if math.isnan(fval) or math.isinf(fval) or fval < 0:
+        raise PgSearchError(f"{name} must be a non-negative finite number; got {value!r}")
+
+
+def _validate_distance_op(op: str) -> None:
+    if op not in _PGVECTOR_DISTANCE_OPS:
+        expected = ", ".join(sorted(_PGVECTOR_DISTANCE_OPS))
+        raise PgSearchError(f"distance_op must be one of {{{expected}}}; got {op!r}")
+
+
+def _format_vector_literal(query_vector: list[float] | str) -> str:
+    """Serialize a Python list to pgvector text format ``[v1,v2,...]``.
+
+    Pre-formatted strings pass through. Mirrors the same shape the
+    turboquant query wrappers accept.
+    """
+    if isinstance(query_vector, str):
+        return query_vector
+    if not isinstance(query_vector, list):
+        raise PgSearchError(f"query_vector must be list[float] or str; got {type(query_vector).__name__}")
+    return "[" + ",".join(str(float(v)) for v in query_vector) + "]"
+
+
+async def hybrid_bm25_vector_search(
+    driver: SqlDriver,
+    schema: str,
+    table: str,
+    *,
+    query_text: str,
+    query_vector: list[float] | str,
+    key_field: str,
+    vector_column: str,
+    bm25_columns: list[str] | None = None,
+    distance_op: str = "<=>",
+    k: int = _RRF_DEFAULT_K,
+    bm25_weight: float = 1.0,
+    vector_weight: float = 1.0,
+    per_leg_limit: int = 20,
+    final_limit: int,
+) -> list[HybridHit]:
+    """Combine a BM25 search and a pgvector search via Reciprocal Rank Fusion.
+
+    Builds and executes the canonical v2 hybrid pattern documented
+    by ParadeDB in the 2025-10-22 "Hybrid Search Missing Manual"
+    blog post and pinned in
+    ``tests/tests/documentation.rs::hybrid_search``::
+
+        WITH
+        bm25_leg AS (
+            SELECT t."<key>",
+                   ROW_NUMBER() OVER (ORDER BY pdb.score(t) DESC) AS rank
+            FROM "<schema>"."<table>" AS t
+            WHERE <search_target> @@@ %s
+            ORDER BY pdb.score(t) DESC
+            LIMIT %s
+        ),
+        vector_leg AS (
+            SELECT t."<key>",
+                   ROW_NUMBER() OVER (ORDER BY t."<vec>" <op> %s::vector) AS rank
+            FROM "<schema>"."<table>" AS t
+            ORDER BY t."<vec>" <op> %s::vector
+            LIMIT %s
+        ),
+        fused AS (
+            SELECT id,
+                   <bm25_weight> * 1.0 / (<k> + rank) AS score,
+                   rank AS bm25_rank,
+                   NULL::int AS vector_rank
+            FROM bm25_leg
+            UNION ALL
+            SELECT id,
+                   <vector_weight> * 1.0 / (<k> + rank) AS score,
+                   NULL::int AS bm25_rank,
+                   rank AS vector_rank
+            FROM vector_leg
+        )
+        SELECT id,
+               SUM(score) AS score,
+               MAX(bm25_rank) AS bm25_rank,
+               MAX(vector_rank) AS vector_rank
+        FROM fused
+        GROUP BY id
+        ORDER BY score DESC
+        LIMIT %s
+
+    RRF is operator-agnostic: ``distance_op`` (``<=>`` cosine,
+    ``<->`` L2, ``<#>`` negative inner product) only affects which
+    vectors land in the vector leg's top-K, not the fusion arithmetic.
+    Defaults match upstream's demonstrated form (cosine,
+    ``k = 60``, equal weights, ``per_leg_limit = 20``).
+
+    :data:`bm25_columns` mirrors :func:`pg_search_run`'s
+    ``columns`` semantics: ``None`` searches the whole BM25 index;
+    ``[one_col]`` restricts the BM25 leg to a single field;
+    multi-column raises. The vector leg always uses the
+    caller-supplied ``vector_column``.
+
+    Composes naturally with the RAG efficiency suite — once the
+    operator picks knobs for the vector leg via
+    ``analyze_vector_search_efficiency``, the same knobs feed this
+    wrapper's :data:`distance_op` and :data:`per_leg_limit`.
+
+    Raises:
+        PgSearchError: extension missing, identifier validation
+            fails, multi-column BM25 search requested, invalid
+            distance_op, non-finite weight, or any limit/k out of
+            bounds.
+
+    References:
+        * https://www.paradedb.com/blog/hybrid-search-in-postgresql-the-missing-manual
+          (retrieved 2026-06-10)
+        * paradedb/paradedb@main ``tests/tests/documentation.rs``
+          function ``hybrid_search``.
+    """
+    _validate_identifier(schema, "schema")
+    _validate_identifier(table, "table")
+    _validate_identifier(key_field, "key_field")
+    _validate_identifier(vector_column, "vector_column")
+    _validate_distance_op(distance_op)
+    if not isinstance(query_text, str):
+        raise PgSearchError(f"query_text must be str; got {type(query_text).__name__}")
+    bm25_column = _validate_columns_arg(bm25_columns)
+    _validate_positive_int("k", k)
+    _validate_weight("bm25_weight", bm25_weight)
+    _validate_weight("vector_weight", vector_weight)
+    _validate_limit(per_leg_limit)
+    _validate_limit(final_limit)
+    vector_literal = _format_vector_literal(query_vector)
+
+    if not await extension_installed(driver, "pg_search"):
+        raise PgSearchError("pg_search extension is not installed in this database")
+
+    qualified_table = f"{_pg_quote_ident(schema)}.{_pg_quote_ident(table)}"
+    quoted_key = _pg_quote_ident(key_field)
+    quoted_vec = _pg_quote_ident(vector_column)
+    bm25_target = f"{_TABLE_ALIAS}.{_pg_quote_ident(bm25_column)}" if bm25_column else _TABLE_ALIAS
+
+    # k, weights, and per-leg limits are validated numerics, so
+    # rendering them as literals is safe and keeps the bind list to
+    # just the per-call values (query_text, vector x 2, final_limit).
+    sql = (
+        f"WITH "
+        f"bm25_leg AS ("
+        f" SELECT {_TABLE_ALIAS}.{quoted_key} AS id,"
+        f" ROW_NUMBER() OVER (ORDER BY pdb.score({_TABLE_ALIAS}) DESC) AS rank"
+        f" FROM {qualified_table} AS {_TABLE_ALIAS}"
+        f" WHERE {bm25_target} @@@ %s"
+        f" ORDER BY pdb.score({_TABLE_ALIAS}) DESC"
+        f" LIMIT {per_leg_limit}"
+        f"),"
+        f" vector_leg AS ("
+        f" SELECT {_TABLE_ALIAS}.{quoted_key} AS id,"
+        f" ROW_NUMBER() OVER (ORDER BY {_TABLE_ALIAS}.{quoted_vec} {distance_op} %s::vector) AS rank"
+        f" FROM {qualified_table} AS {_TABLE_ALIAS}"
+        f" ORDER BY {_TABLE_ALIAS}.{quoted_vec} {distance_op} %s::vector"
+        f" LIMIT {per_leg_limit}"
+        f"),"
+        f" fused AS ("
+        f" SELECT id,"
+        f" {bm25_weight} * 1.0 / ({k} + rank) AS score,"
+        f" rank AS bm25_rank,"
+        f" NULL::int AS vector_rank"
+        f" FROM bm25_leg"
+        f" UNION ALL"
+        f" SELECT id,"
+        f" {vector_weight} * 1.0 / ({k} + rank) AS score,"
+        f" NULL::int AS bm25_rank,"
+        f" rank AS vector_rank"
+        f" FROM vector_leg"
+        f") "
+        f"SELECT id, SUM(score) AS score,"
+        f" MAX(bm25_rank) AS bm25_rank,"
+        f" MAX(vector_rank) AS vector_rank "
+        f"FROM fused "
+        f"GROUP BY id "
+        f"ORDER BY score DESC "
+        f"LIMIT %s"
+    )
+    params: list[Any] = [query_text, vector_literal, vector_literal, final_limit]
+    rows = await driver.execute_query(sql, params=params, force_readonly=True)
+    return [
+        HybridHit(
+            id=row.cells["id"],
+            score=float(row.cells["score"]),
+            bm25_rank=_maybe_int(row.cells.get("bm25_rank")),
+            vector_rank=_maybe_int(row.cells.get("vector_rank")),
+        )
+        for row in rows or []
+    ]

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -3150,11 +3150,11 @@ def _register_pg_search_reads(server: FastMCP[AppContext]) -> None:
         vector_column: str,
         final_limit: int,
         bm25_columns: list[str] | None = None,
-        distance_op: str = "<=>",
-        k: int = 60,
-        bm25_weight: float = 1.0,
-        vector_weight: float = 1.0,
-        per_leg_limit: int = 20,
+        distance_op: str = pg_search.HYBRID_DEFAULT_DISTANCE_OP,
+        k: int = pg_search.RRF_DEFAULT_K,
+        bm25_weight: float = pg_search.HYBRID_DEFAULT_WEIGHT,
+        vector_weight: float = pg_search.HYBRID_DEFAULT_WEIGHT,
+        per_leg_limit: int = pg_search.HYBRID_DEFAULT_PER_LEG_LIMIT,
     ) -> list[dict[str, Any]]:
         hits = await pg_search.hybrid_bm25_vector_search(
             _driver(ctx),

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -3121,6 +3121,59 @@ def _register_pg_search_reads(server: FastMCP[AppContext]) -> None:
         )
         return asdict(parsed)
 
+    @server.tool(
+        name="hybrid_bm25_vector_search",
+        description=(
+            "Combine a BM25 search and a pgvector search via Reciprocal "
+            "Rank Fusion — the canonical v2 pattern ParadeDB documents in "
+            "the 2025-10-22 'Hybrid Search Missing Manual' blog post. "
+            "Returns hits as {id, score, bm25_rank, vector_rank}. ``score`` "
+            "is the summed ``sum(weight * 1.0 / (k + rank))`` across both "
+            "legs; per-leg ranks are surfaced for transparency (either can "
+            "be NULL if a row only appeared in one leg's top-K). "
+            "``distance_op`` is the pgvector operator ('<=>'/'<->'/'<#>' "
+            "— RRF is operator-agnostic). ``bm25_columns=None`` searches "
+            'the whole BM25 index; ``bm25_columns=["col"]`` restricts '
+            "the BM25 leg to a single field. Defaults mirror upstream's "
+            "demonstrated form (cosine, k=60, equal weights, "
+            "per_leg_limit=20). Requires the pg_search and pgvector "
+            "extensions."
+        ),
+    )
+    async def hybrid_bm25_vector_search(
+        ctx: _Ctx,
+        schema: str,
+        table: str,
+        query_text: str,
+        query_vector: list[float] | str,
+        key_field: str,
+        vector_column: str,
+        final_limit: int,
+        bm25_columns: list[str] | None = None,
+        distance_op: str = "<=>",
+        k: int = 60,
+        bm25_weight: float = 1.0,
+        vector_weight: float = 1.0,
+        per_leg_limit: int = 20,
+    ) -> list[dict[str, Any]]:
+        hits = await pg_search.hybrid_bm25_vector_search(
+            _driver(ctx),
+            schema,
+            table,
+            query_text=query_text,
+            query_vector=query_vector,
+            key_field=key_field,
+            vector_column=vector_column,
+            bm25_columns=bm25_columns,
+            distance_op=distance_op,
+            k=k,
+            bm25_weight=bm25_weight,
+            vector_weight=vector_weight,
+            per_leg_limit=per_leg_limit,
+            final_limit=final_limit,
+        )
+        return [asdict(hit) for hit in hits]
+
 
 def _register_turboquant_writes(server: FastMCP[AppContext]) -> None:
     @server.tool(

--- a/tests/unit/test_pg_search.py
+++ b/tests/unit/test_pg_search.py
@@ -7,11 +7,13 @@ from mcp.shared.memory import create_connected_server_and_client_session
 from mcpg.config import load_settings
 from mcpg.extensions import ENABLEABLE_EXTENSIONS
 from mcpg.pg_search import (
+    HybridHit,
     PgSearchError,
     PgSearchHit,
     PgSearchIndexInfo,
     PgSearchParsedQuery,
     get_pg_search_index_metadata,
+    hybrid_bm25_vector_search,
     list_pg_search_indexes,
     pg_search_more_like_this,
     pg_search_parse_query,
@@ -628,3 +630,366 @@ async def test_pg_search_parse_query_rejects_non_bool_flags() -> None:
 
     with pytest.raises(PgSearchError, match="lenient must be a bool"):
         await pg_search_parse_query(driver, "rust", lenient="yes")  # type: ignore[arg-type]
+
+
+# --- BM-3: hybrid_bm25_vector_search ---------------------------------------
+
+
+_HYBRID_FUSED_RESULT = [
+    {"id": 1, "score": 0.0328, "bm25_rank": 1, "vector_rank": 2},
+    {"id": 7, "score": 0.0247, "bm25_rank": None, "vector_rank": 1},
+    {"id": 3, "score": 0.0163, "bm25_rank": 2, "vector_rank": None},
+]
+
+
+async def test_hybrid_bm25_vector_search_raises_when_extension_absent() -> None:
+    driver = FakeRoutingDriver({"pg_extension": []})
+
+    with pytest.raises(PgSearchError, match="not installed"):
+        await hybrid_bm25_vector_search(  # type: ignore[arg-type]
+            driver,
+            "public",
+            "docs",
+            query_text="rust",
+            query_vector=[1.0, 2.0, 3.0],
+            key_field="id",
+            vector_column="embedding",
+            final_limit=5,
+        )
+
+
+async def test_hybrid_bm25_vector_search_returns_fused_hits() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "WITH bm25_leg": _HYBRID_FUSED_RESULT,
+        }
+    )
+
+    hits = await hybrid_bm25_vector_search(  # type: ignore[arg-type]
+        driver,
+        "public",
+        "docs",
+        query_text="rust",
+        query_vector=[1.0, 2.0, 3.0],
+        key_field="id",
+        vector_column="embedding",
+        final_limit=5,
+    )
+
+    assert hits == [
+        HybridHit(id=1, score=0.0328, bm25_rank=1, vector_rank=2),
+        HybridHit(id=7, score=0.0247, bm25_rank=None, vector_rank=1),
+        HybridHit(id=3, score=0.0163, bm25_rank=2, vector_rank=None),
+    ]
+
+
+async def test_hybrid_bm25_vector_search_renders_canonical_rrf_sql() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "WITH bm25_leg": [],
+        }
+    )
+
+    await hybrid_bm25_vector_search(  # type: ignore[arg-type]
+        driver,
+        "public",
+        "docs",
+        query_text="rust",
+        query_vector=[1.0, 2.0, 3.0],
+        key_field="id",
+        vector_column="embedding",
+        final_limit=5,
+    )
+
+    sql, params, force_readonly = driver.calls[-1]
+    assert force_readonly is True
+    # CTE shape per the 2025-10-22 blog + tests/tests/documentation.rs.
+    assert "WITH bm25_leg AS" in sql
+    assert "ROW_NUMBER() OVER (ORDER BY pdb.score(t) DESC)" in sql
+    assert " vector_leg AS" in sql
+    assert ' t."embedding" <=> %s::vector' in sql
+    assert " fused AS" in sql
+    assert " UNION ALL" in sql
+    # Defaults render as literals: k=60, equal 1.0 weights, per-leg
+    # LIMIT 20.
+    assert "1.0 / (60 + rank)" in sql
+    assert "1.0 * 1.0 / (60 + rank)" in sql
+    assert "LIMIT 20" in sql
+    # Bound params: query_text, vector (x2), final_limit.
+    assert params == ["rust", "[1.0,2.0,3.0]", "[1.0,2.0,3.0]", 5]
+    # Top-level GROUP BY + SUM is what makes this RRF (not a join).
+    assert "GROUP BY id" in sql
+    assert "SUM(score)" in sql
+
+
+async def test_hybrid_bm25_vector_search_weights_and_k_render_as_literals() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "WITH bm25_leg": [],
+        }
+    )
+
+    await hybrid_bm25_vector_search(  # type: ignore[arg-type]
+        driver,
+        "public",
+        "docs",
+        query_text="rust",
+        query_vector=[1.0],
+        key_field="id",
+        vector_column="embedding",
+        k=42,
+        bm25_weight=0.7,
+        vector_weight=0.3,
+        per_leg_limit=15,
+        final_limit=5,
+    )
+
+    sql, _, _ = driver.calls[-1]
+    assert "0.7 * 1.0 / (42 + rank)" in sql
+    assert "0.3 * 1.0 / (42 + rank)" in sql
+    assert "LIMIT 15" in sql
+
+
+async def test_hybrid_bm25_vector_search_single_column_bm25_target() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "WITH bm25_leg": [],
+        }
+    )
+
+    await hybrid_bm25_vector_search(  # type: ignore[arg-type]
+        driver,
+        "public",
+        "docs",
+        query_text="rust",
+        query_vector=[1.0],
+        key_field="id",
+        vector_column="embedding",
+        bm25_columns=["body"],
+        final_limit=5,
+    )
+
+    sql, _, _ = driver.calls[-1]
+    assert ' t."body" @@@ %s' in sql
+
+
+async def test_hybrid_bm25_vector_search_multi_column_bm25_raises() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(PgSearchError, match="multi-column"):
+        await hybrid_bm25_vector_search(  # type: ignore[arg-type]
+            driver,
+            "public",
+            "docs",
+            query_text="rust",
+            query_vector=[1.0],
+            key_field="id",
+            vector_column="embedding",
+            bm25_columns=["body", "title"],
+            final_limit=5,
+        )
+
+
+@pytest.mark.parametrize("op", ["<=>", "<->", "<#>"])
+async def test_hybrid_bm25_vector_search_accepts_each_distance_op(op: str) -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "WITH bm25_leg": [],
+        }
+    )
+
+    await hybrid_bm25_vector_search(  # type: ignore[arg-type]
+        driver,
+        "public",
+        "docs",
+        query_text="rust",
+        query_vector=[1.0],
+        key_field="id",
+        vector_column="embedding",
+        distance_op=op,
+        final_limit=5,
+    )
+
+    sql, _, _ = driver.calls[-1]
+    assert f' t."embedding" {op} %s::vector' in sql
+
+
+@pytest.mark.parametrize("op", ["<>", "@@", "drop", ""])
+async def test_hybrid_bm25_vector_search_rejects_unknown_distance_op(op: str) -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(PgSearchError, match="distance_op"):
+        await hybrid_bm25_vector_search(  # type: ignore[arg-type]
+            driver,
+            "public",
+            "docs",
+            query_text="rust",
+            query_vector=[1.0],
+            key_field="id",
+            vector_column="embedding",
+            distance_op=op,
+            final_limit=5,
+        )
+
+
+@pytest.mark.parametrize(
+    ("bm25_weight", "vector_weight"),
+    [
+        (-1.0, 1.0),
+        (1.0, -0.1),
+        (float("nan"), 1.0),
+        (1.0, float("inf")),
+        (True, 1.0),  # bool-as-int trap
+        ("0.5", 1.0),
+    ],
+)
+async def test_hybrid_bm25_vector_search_rejects_bad_weights(bm25_weight: object, vector_weight: object) -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(PgSearchError, match="weight"):
+        await hybrid_bm25_vector_search(  # type: ignore[arg-type]
+            driver,
+            "public",
+            "docs",
+            query_text="rust",
+            query_vector=[1.0],
+            key_field="id",
+            vector_column="embedding",
+            bm25_weight=bm25_weight,
+            vector_weight=vector_weight,
+            final_limit=5,
+        )
+
+
+@pytest.mark.parametrize("bad_limit", [0, -1, 10_001, True, "10"])
+async def test_hybrid_bm25_vector_search_rejects_bad_limits(bad_limit: object) -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(PgSearchError, match="limit"):
+        await hybrid_bm25_vector_search(  # type: ignore[arg-type]
+            driver,
+            "public",
+            "docs",
+            query_text="rust",
+            query_vector=[1.0],
+            key_field="id",
+            vector_column="embedding",
+            final_limit=bad_limit,
+        )
+
+
+@pytest.mark.parametrize("bad_k", [0, -1, True])
+async def test_hybrid_bm25_vector_search_rejects_bad_k(bad_k: object) -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(PgSearchError, match="k"):
+        await hybrid_bm25_vector_search(  # type: ignore[arg-type]
+            driver,
+            "public",
+            "docs",
+            query_text="rust",
+            query_vector=[1.0],
+            key_field="id",
+            vector_column="embedding",
+            k=bad_k,
+            final_limit=5,
+        )
+
+
+@pytest.mark.parametrize(
+    ("schema", "table", "key_field", "vector_column"),
+    [
+        ("public; --", "docs", "id", "embedding"),
+        ("public", "docs; DROP", "id", "embedding"),
+        ("public", "docs", "id'or'1", "embedding"),
+        ("public", "docs", "id", "embedding); --"),
+    ],
+)
+async def test_hybrid_bm25_vector_search_identifier_validation(
+    schema: str, table: str, key_field: str, vector_column: str
+) -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(PgSearchError, match="invalid"):
+        await hybrid_bm25_vector_search(  # type: ignore[arg-type]
+            driver,
+            schema,
+            table,
+            query_text="rust",
+            query_vector=[1.0],
+            key_field=key_field,
+            vector_column=vector_column,
+            final_limit=5,
+        )
+
+
+async def test_hybrid_bm25_vector_search_query_text_must_be_str() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(PgSearchError, match="query_text must be str"):
+        await hybrid_bm25_vector_search(  # type: ignore[arg-type]
+            driver,
+            "public",
+            "docs",
+            query_text=42,
+            query_vector=[1.0],
+            key_field="id",
+            vector_column="embedding",
+            final_limit=5,
+        )
+
+
+async def test_hybrid_bm25_vector_search_accepts_preformatted_vector_string() -> None:
+    """Pre-formatted ``[1,2,3]`` strings pass through unchanged — mirrors
+    the turboquant query wrappers' behavior."""
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "WITH bm25_leg": [],
+        }
+    )
+
+    await hybrid_bm25_vector_search(  # type: ignore[arg-type]
+        driver,
+        "public",
+        "docs",
+        query_text="rust",
+        query_vector="[0.1,0.2,0.3]",
+        key_field="id",
+        vector_column="embedding",
+        final_limit=5,
+    )
+
+    _, params, _ = driver.calls[-1]
+    assert params == ["rust", "[0.1,0.2,0.3]", "[0.1,0.2,0.3]", 5]
+
+
+async def test_hybrid_bm25_vector_search_rejects_bad_vector_type() -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(PgSearchError, match="query_vector"):
+        await hybrid_bm25_vector_search(  # type: ignore[arg-type]
+            driver,
+            "public",
+            "docs",
+            query_text="rust",
+            query_vector=42,
+            key_field="id",
+            vector_column="embedding",
+            final_limit=5,
+        )
+
+
+# --- Tool registration for BM-3 --------------------------------------------
+
+
+async def test_hybrid_bm25_vector_search_tool_registered() -> None:
+    server = create_server(_SETTINGS, database=FakeDatabase(FakeDriver()))  # type: ignore[arg-type]
+    async with create_connected_server_and_client_session(server) as client:
+        listed = {tool.name for tool in (await client.list_tools()).tools}
+    assert "hybrid_bm25_vector_search" in listed

--- a/tests/unit/test_pg_search.py
+++ b/tests/unit/test_pg_search.py
@@ -867,10 +867,46 @@ async def test_hybrid_bm25_vector_search_rejects_bad_weights(bm25_weight: object
 
 
 @pytest.mark.parametrize("bad_limit", [0, -1, 10_001, True, "10"])
-async def test_hybrid_bm25_vector_search_rejects_bad_limits(bad_limit: object) -> None:
+@pytest.mark.parametrize("which", ["final_limit", "per_leg_limit"])
+async def test_hybrid_bm25_vector_search_rejects_bad_limits(bad_limit: object, which: str) -> None:
+    """Both limit kwargs go through _validate_limit; the parametrize
+    sweep covers each so neither path can regress unnoticed."""
     driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
 
+    kwargs: dict[str, object] = {
+        "schema": "public",
+        "table": "docs",
+        "query_text": "rust",
+        "query_vector": [1.0],
+        "key_field": "id",
+        "vector_column": "embedding",
+        # Defaults; the parametrize swaps one of these out below.
+        "final_limit": 5,
+        "per_leg_limit": 20,
+    }
+    kwargs[which] = bad_limit
     with pytest.raises(PgSearchError, match="limit"):
+        await hybrid_bm25_vector_search(driver, **kwargs)  # type: ignore[arg-type]
+
+
+async def test_hybrid_bm25_vector_search_raises_when_pgvector_absent() -> None:
+    """pg_search is installed but pgvector is not — the vector leg
+    needs %s::vector to resolve, so the wrapper must fail fast with
+    a clear message rather than letting PostgreSQL raise 'type
+    vector does not exist'."""
+    # FakeRoutingDriver matches the first substring whose key appears
+    # in the query. Both extension presence checks use the same
+    # `pg_extension` query, so we need to discriminate by params.
+    from _fakes import FakeParamRoutingDriver
+
+    driver = FakeParamRoutingDriver(
+        {
+            ("pg_extension", ("pg_search",)): [{"present": 1}],
+            ("pg_extension", ("vector",)): [],
+        }
+    )
+
+    with pytest.raises(PgSearchError, match="pgvector"):
         await hybrid_bm25_vector_search(  # type: ignore[arg-type]
             driver,
             "public",
@@ -879,7 +915,7 @@ async def test_hybrid_bm25_vector_search_rejects_bad_limits(bad_limit: object) -
             query_vector=[1.0],
             key_field="id",
             vector_column="embedding",
-            final_limit=bad_limit,
+            final_limit=5,
         )
 
 


### PR DESCRIPTION
## Summary

Wraps the canonical ParadeDB v2 hybrid-search pattern as an MCPg tool. The §2.5 hybrid arithmetic question is resolved from two living upstream sources: the **2025-10-22 "Hybrid Search in PostgreSQL: The Missing Manual"** blog post and **`tests/tests/documentation.rs::hybrid_search`** in `paradedb/paradedb@main`. Both agree on **Reciprocal Rank Fusion (RRF)** with formula `sum(weight * 1.0 / (k + rank))`. There is **no** `paradedb.score_hybrid` / `paradedb.rank_hybrid` helper function in v2 — operators write the CTE inline.

### `src/mcpg/pg_search.py`

- **`HybridHit`** dataclass — `id`, `score` (summed RRF), `bm25_rank`, `vector_rank` (either can be `None` when a row only appears in one leg's top-K).
- **`hybrid_bm25_vector_search(...)`** — builds the canonical 3-CTE RRF query (`bm25_leg`, `vector_leg`, `fused`) with UNION ALL + GROUP BY SUM (matches the blog's simpler form; equivalent to the test's FULL OUTER JOIN + COALESCE form).
  - Defaults match upstream: cosine `<=>`, `k=60`, equal weights, `per_leg_limit=20`.
  - `distance_op` allowlisted to `<=>`/`<->`/`<#>`. RRF is operator-agnostic — choice only affects which vectors land in the vector leg's top-K, not the fusion arithmetic.
  - `bm25_columns` mirrors `pg_search_run`'s semantics (None = whole index, single column = field restriction, multi-column rejected).
  - Weights must be finite non-negative reals; NaN / inf / negatives / bools / strings all rejected so a typo can't corrupt the SUM aggregation.

### `src/mcpg/tools.py`

Registers `hybrid_bm25_vector_search` under the READ capability gate.

### `docs/plans/bm25-integration.md` §2.5 — resolved

Records both sources, the verbatim formula, the `k=60` constant, and the **docs-page-removal caveat** (`docs.paradedb.com/.../hybrid` returns HTTP 404 as of 2026-06-10; the `.prettierignore` still lists the path but the file is gone — the blog post is the canonical reference today). Also explains why **linear blend is not offered**: no upstream v2 source for min/max normalized linear blend, so shipping it would be speculation.

### Tests — 35 new (85 total in the module)

Fused-row mapping with partial-coverage rows, canonical SQL shape assertions (RRF CTEs / UNION ALL / GROUP BY SUM / `ROW_NUMBER` ordering), defaults-as-literals rendering, single-column BM25 target, multi-column rejection, distance-op allowlist (positive + negative cases), weight validation (negative / NaN / inf / bool / str), `limit` and `k` bounds, identifier validation against injection patterns, vector-type handling (list + pre-formatted string), and MCP tool registration.

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run mypy src/mcpg` — clean
- [x] `uv run pytest tests/unit -q` — 1689 passed (35 new)
- [ ] Reviewer sanity-check the RRF SQL against a real `pg_search + pgvector` install
- [ ] Reviewer confirm the rendered weight/k literals don't trip plan caching badly when only weights change between calls

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Add a BM25 + pgvector hybrid search entry point using Reciprocal Rank Fusion and expose it as an MCP tool, with validation and tests aligned to ParadeDB’s canonical v2 hybrid pattern.

New Features:
- Introduce a HybridHit result type and hybrid_bm25_vector_search API to perform BM25 + pgvector hybrid retrieval via Reciprocal Rank Fusion.
- Register hybrid_bm25_vector_search as a server tool under the read capability, returning fused hits with per-leg ranks.

Documentation:
- Document and finalize the ParadeDB v2 hybrid-search arithmetic decision (RRF with k=60 and weighted legs) in the BM25 integration plan, including rationale and constraints.

Tests:
- Add extensive unit tests for the hybrid_bm25_vector_search API covering SQL shape, parameter rendering, validation of inputs, vector handling, and tool registration.