### PR TITLE
feat: pg_search DDL — create + reindex BM25 indexes (BM-4)

### DIFF
--- a/src/mcpg/pg_search.py
+++ b/src/mcpg/pg_search.py
@@ -1257,7 +1257,10 @@ async def create_pg_search_index(
 
     started_at = _utc_iso_now()
     started_mono = _time.monotonic()
-    await database.run_unmanaged(sql)
+    try:
+        await database.run_unmanaged(sql)
+    except Exception as exc:
+        raise PgSearchError(f"CREATE INDEX failed: {exc}") from exc
     duration = _time.monotonic() - started_mono
     completed_at = _utc_iso_now()
 
@@ -1316,7 +1319,10 @@ async def reindex_pg_search_index(
 
     started_at = _utc_iso_now()
     started_mono = _time.monotonic()
-    await database.run_unmanaged(sql)
+    try:
+        await database.run_unmanaged(sql)
+    except Exception as exc:
+        raise PgSearchError(f"REINDEX INDEX failed: {exc}") from exc
     duration = _time.monotonic() - started_mono
     completed_at = _utc_iso_now()
 

--- a/src/mcpg/pg_search.py
+++ b/src/mcpg/pg_search.py
@@ -54,13 +54,16 @@ them up.
 
 from __future__ import annotations
 
+import datetime as _datetime
 import json
 import math
 import re
+import time as _time
 from dataclasses import dataclass, field
 from typing import Any
 
 from mcpg._vendor.sql import SqlDriver
+from mcpg.database import Database
 from mcpg.extensions import extension_installed
 
 # Plain unquoted PostgreSQL identifier — same rule as turboquant /
@@ -976,3 +979,353 @@ async def hybrid_bm25_vector_search(
         )
         for row in rows or []
     ]
+
+
+# --- BM-4: DDL --------------------------------------------------------------
+#
+# All 13 reloptions surfaced on PgSearchIndexInfo are settable here. The
+# 7 JSONB-shaped options (text_fields, numeric_fields, boolean_fields,
+# json_fields, range_fields, datetime_fields, search_tokenizer) accept
+# Python dicts and serialize via json.dumps. The 2 int options
+# (target_segment_count, mutable_segment_rows) and 3 text options
+# (layer_sizes, background_layer_sizes, sort_by) pass through with type
+# validation. key_field is required.
+
+# Option-type routing for the WITH clause builder. Aligned with the BM-1
+# parser's groupings so a future addition only touches one place.
+_BM25_TEXT_OPTIONS: tuple[str, ...] = (
+    "key_field",
+    "layer_sizes",
+    "background_layer_sizes",
+    "sort_by",
+)
+_BM25_INT_OPTIONS_DDL: tuple[str, ...] = (
+    "target_segment_count",
+    "mutable_segment_rows",
+)
+_BM25_JSONB_OPTIONS_DDL: tuple[str, ...] = (
+    "text_fields",
+    "numeric_fields",
+    "boolean_fields",
+    "json_fields",
+    "range_fields",
+    "datetime_fields",
+    "search_tokenizer",
+)
+
+# Safety bounds — guards, not claims about what upstream accepts.
+# Mirror turboquant's stance: bound the surface so a single typo
+# doesn't push a billion-row int into PG without warning.
+_TARGET_SEGMENT_COUNT_MIN, _TARGET_SEGMENT_COUNT_MAX = 1, 100_000
+_MUTABLE_SEGMENT_ROWS_MIN, _MUTABLE_SEGMENT_ROWS_MAX = 1, 100_000_000
+
+
+@dataclass(frozen=True, slots=True)
+class CreatePgSearchIndexResult:
+    """Outcome of a :func:`create_pg_search_index` call.
+
+    The rendered ``create_sql`` is preserved verbatim for auditability
+    — every identifier in it has already passed through
+    :func:`_pg_quote_ident`, every JSONB value through
+    :func:`json.dumps` + PG literal escaping, and every int / text
+    value through its own bounds or type check.
+    """
+
+    schema: str
+    table: str
+    columns: list[str]
+    index_name: str
+    key_field: str
+    options: dict[str, Any]
+    concurrently: bool
+    create_sql: str
+    started_at: str
+    completed_at: str
+    duration_seconds: float
+
+
+@dataclass(frozen=True, slots=True)
+class ReindexPgSearchResult:
+    """Outcome of a :func:`reindex_pg_search_index` call."""
+
+    schema: str
+    index: str
+    concurrently: bool
+    reindex_sql: str
+    started_at: str
+    completed_at: str
+    duration_seconds: float
+
+
+def _validate_int_option_bounded(name: str, value: int, lo: int, hi: int) -> None:
+    """Validate a bounded int reloption. Bool-as-int rejected explicitly."""
+    if not isinstance(value, int) or isinstance(value, bool) or not lo <= value <= hi:
+        raise PgSearchError(f"{name} must be an int in [{lo}..{hi}]; got {value!r}")
+
+
+def _validate_text_option(name: str, value: str) -> None:
+    """Validate a text reloption is a non-empty string.
+
+    Layer-size strings (``layer_sizes`` / ``background_layer_sizes``)
+    expect comma-separated ints per upstream's grammar, but we let
+    upstream reject malformed shapes with its own (informative)
+    error message. We only enforce ``str`` here.
+    """
+    if not isinstance(value, str) or not value:
+        raise PgSearchError(f"{name} must be a non-empty str; got {value!r}")
+
+
+def _validate_jsonb_option(name: str, value: dict[str, Any]) -> None:
+    """JSONB reloption must be a dict; the contents are upstream's contract."""
+    if not isinstance(value, dict):
+        raise PgSearchError(f"{name} must be a dict (serialized to JSONB); got {type(value).__name__}")
+
+
+def _pg_quote_literal(text: str) -> str:
+    """Quote a PostgreSQL string literal the way ``format('%L')`` would."""
+    return "'" + text.replace("'", "''") + "'"
+
+
+def _render_option(name: str, value: Any) -> str:
+    """Render a single ``key = value`` pair for the WITH clause.
+
+    * Text options → PG single-quote-escaped literal.
+    * Int options → bare digit literal (already type-checked, can't
+      escape SQL).
+    * JSONB options → ``json.dumps`` + single-quote-escaped literal.
+    """
+    if name in _BM25_TEXT_OPTIONS:
+        return f"{name} = {_pg_quote_literal(value)}"
+    if name in _BM25_INT_OPTIONS_DDL:
+        return f"{name} = {int(value)}"
+    if name in _BM25_JSONB_OPTIONS_DDL:
+        return f"{name} = {_pg_quote_literal(json.dumps(value, sort_keys=True))}"
+    raise PgSearchError(f"unknown reloption {name!r} reached the renderer")  # pragma: no cover
+
+
+def _utc_iso_now() -> str:
+    return _datetime.datetime.now(_datetime.UTC).isoformat().replace("+00:00", "Z")
+
+
+# Pre-flight: confirm the named index actually uses the bm25 access
+# method before issuing REINDEX. Without this check, the call could
+# probe arbitrary catalogs via PostgreSQL's error messages.
+_ASSERT_IS_BM25_SQL = """
+SELECT 1
+FROM pg_index ix
+JOIN pg_class i  ON i.oid = ix.indexrelid
+JOIN pg_namespace n ON n.oid = i.relnamespace
+JOIN pg_am am ON am.oid = i.relam
+WHERE am.amname = 'bm25' AND n.nspname = %s AND i.relname = %s
+"""
+
+
+async def create_pg_search_index(
+    database: Database,
+    schema: str,
+    table: str,
+    columns: list[str],
+    index_name: str,
+    key_field: str,
+    *,
+    text_fields: dict[str, Any] | None = None,
+    numeric_fields: dict[str, Any] | None = None,
+    boolean_fields: dict[str, Any] | None = None,
+    json_fields: dict[str, Any] | None = None,
+    range_fields: dict[str, Any] | None = None,
+    datetime_fields: dict[str, Any] | None = None,
+    layer_sizes: str | None = None,
+    background_layer_sizes: str | None = None,
+    target_segment_count: int | None = None,
+    mutable_segment_rows: int | None = None,
+    sort_by: str | None = None,
+    search_tokenizer: dict[str, Any] | None = None,
+    concurrently: bool = True,
+) -> CreatePgSearchIndexResult:
+    """Build and execute ``CREATE INDEX … USING bm25``.
+
+    All 13 documented bm25 reloptions are exposed as kwargs (see
+    BM-0 §2.2). The 7 JSONB-shaped options accept Python dicts and
+    are serialized via :func:`json.dumps`; the 2 int options and 3
+    text options pass through type-aware validation.
+    ``key_field`` is required by upstream.
+
+    Identifier safety: every schema / table / column / index-name /
+    key-field string goes through :func:`_validate_identifier` +
+    :func:`_pg_quote_ident`. The full rendered statement is
+    preserved in :attr:`CreatePgSearchIndexResult.create_sql` for
+    auditability.
+
+    The statement runs on an autocommit connection via
+    :meth:`Database.run_unmanaged` because ``CREATE INDEX
+    CONCURRENTLY`` cannot run inside a transaction block.
+
+    Raises:
+        PgSearchError: extension not installed, any identifier fails
+            validation, any option fails its bounds / type check, or
+            the underlying DDL fails.
+    """
+    _validate_identifier(schema, "schema")
+    _validate_identifier(table, "table")
+    _validate_identifier(index_name, "index_name")
+    _validate_identifier(key_field, "key_field")
+    if not isinstance(columns, list) or not columns:
+        raise PgSearchError("columns must be a non-empty list of identifiers")
+    for col in columns:
+        if not isinstance(col, str):
+            raise PgSearchError(f"every column must be str; got {type(col).__name__}")
+        _validate_identifier(col, "column")
+    if not isinstance(concurrently, bool):
+        raise PgSearchError(f"concurrently must be a bool; got {concurrently!r}")
+
+    if target_segment_count is not None:
+        _validate_int_option_bounded(
+            "target_segment_count",
+            target_segment_count,
+            _TARGET_SEGMENT_COUNT_MIN,
+            _TARGET_SEGMENT_COUNT_MAX,
+        )
+    if mutable_segment_rows is not None:
+        _validate_int_option_bounded(
+            "mutable_segment_rows",
+            mutable_segment_rows,
+            _MUTABLE_SEGMENT_ROWS_MIN,
+            _MUTABLE_SEGMENT_ROWS_MAX,
+        )
+    for text_name, text_value in (
+        ("layer_sizes", layer_sizes),
+        ("background_layer_sizes", background_layer_sizes),
+        ("sort_by", sort_by),
+    ):
+        if text_value is not None:
+            _validate_text_option(text_name, text_value)
+    for jsonb_name, jsonb_value in (
+        ("text_fields", text_fields),
+        ("numeric_fields", numeric_fields),
+        ("boolean_fields", boolean_fields),
+        ("json_fields", json_fields),
+        ("range_fields", range_fields),
+        ("datetime_fields", datetime_fields),
+        ("search_tokenizer", search_tokenizer),
+    ):
+        if jsonb_value is not None:
+            _validate_jsonb_option(jsonb_name, jsonb_value)
+
+    if not await extension_installed(database.driver(), "pg_search"):
+        raise PgSearchError("pg_search extension is not installed in this database")
+
+    # Build the WITH clause. ``key_field`` always first for readability;
+    # the rest in their declaration order so the rendered SQL is
+    # deterministic and audit logs are diffable across runs.
+    options: dict[str, Any] = {"key_field": key_field}
+    if text_fields is not None:
+        options["text_fields"] = text_fields
+    if numeric_fields is not None:
+        options["numeric_fields"] = numeric_fields
+    if boolean_fields is not None:
+        options["boolean_fields"] = boolean_fields
+    if json_fields is not None:
+        options["json_fields"] = json_fields
+    if range_fields is not None:
+        options["range_fields"] = range_fields
+    if datetime_fields is not None:
+        options["datetime_fields"] = datetime_fields
+    if layer_sizes is not None:
+        options["layer_sizes"] = layer_sizes
+    if background_layer_sizes is not None:
+        options["background_layer_sizes"] = background_layer_sizes
+    if target_segment_count is not None:
+        options["target_segment_count"] = target_segment_count
+    if mutable_segment_rows is not None:
+        options["mutable_segment_rows"] = mutable_segment_rows
+    if sort_by is not None:
+        options["sort_by"] = sort_by
+    if search_tokenizer is not None:
+        options["search_tokenizer"] = search_tokenizer
+
+    with_clause = ", ".join(_render_option(n, v) for n, v in options.items())
+    concurrently_clause = " CONCURRENTLY" if concurrently else ""
+    qualified_table = f"{_pg_quote_ident(schema)}.{_pg_quote_ident(table)}"
+    quoted_columns = ", ".join(_pg_quote_ident(c) for c in columns)
+
+    sql = (
+        f"CREATE INDEX{concurrently_clause} {_pg_quote_ident(index_name)} "
+        f"ON {qualified_table} "
+        f"USING bm25 ({quoted_columns}) "
+        f"WITH ({with_clause})"
+    )
+
+    started_at = _utc_iso_now()
+    started_mono = _time.monotonic()
+    await database.run_unmanaged(sql)
+    duration = _time.monotonic() - started_mono
+    completed_at = _utc_iso_now()
+
+    return CreatePgSearchIndexResult(
+        schema=schema,
+        table=table,
+        columns=list(columns),
+        index_name=index_name,
+        key_field=key_field,
+        options=options,
+        concurrently=concurrently,
+        create_sql=sql,
+        started_at=started_at,
+        completed_at=completed_at,
+        duration_seconds=round(duration, 6),
+    )
+
+
+async def reindex_pg_search_index(
+    database: Database,
+    schema: str,
+    index: str,
+    *,
+    concurrently: bool = True,
+) -> ReindexPgSearchResult:
+    """Run ``REINDEX INDEX [CONCURRENTLY] schema.index``.
+
+    Same pre-flight pattern as :func:`turboquant.reindex_turboquant_index`:
+    confirm the named index actually uses the ``bm25`` access method
+    before running, so the call can't be turned into a way to probe
+    arbitrary catalogs via PostgreSQL's error messages.
+
+    Runs on an autocommit connection because ``REINDEX CONCURRENTLY``
+    cannot run inside a transaction block.
+
+    Raises:
+        PgSearchError: extension not installed, identifier fails
+            validation, or the named index is not a BM25 index.
+    """
+    _validate_identifier(schema, "schema")
+    _validate_identifier(index, "index")
+    if not isinstance(concurrently, bool):
+        raise PgSearchError(f"concurrently must be a bool; got {concurrently!r}")
+
+    driver = database.driver()
+    if not await extension_installed(driver, "pg_search"):
+        raise PgSearchError("pg_search extension is not installed in this database")
+
+    preflight = await driver.execute_query(_ASSERT_IS_BM25_SQL, params=[schema, index], force_readonly=True)
+    if not preflight:
+        raise PgSearchError(f"index {schema}.{index} is not a BM25 index (or does not exist); refusing to REINDEX")
+
+    concurrently_clause = " CONCURRENTLY" if concurrently else ""
+    qualified = f"{_pg_quote_ident(schema)}.{_pg_quote_ident(index)}"
+    sql = f"REINDEX INDEX{concurrently_clause} {qualified}"
+
+    started_at = _utc_iso_now()
+    started_mono = _time.monotonic()
+    await database.run_unmanaged(sql)
+    duration = _time.monotonic() - started_mono
+    completed_at = _utc_iso_now()
+
+    return ReindexPgSearchResult(
+        schema=schema,
+        index=index,
+        concurrently=concurrently,
+        reindex_sql=sql,
+        started_at=started_at,
+        completed_at=completed_at,
+        duration_seconds=round(duration, 6),
+    )

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -3445,6 +3445,98 @@ def _register_turboquant_ddl(server: FastMCP[AppContext]) -> None:
         return asdict(result)
 
 
+def _register_pg_search_ddl(server: FastMCP[AppContext]) -> None:
+    @server.tool(
+        name="create_pg_search_index",
+        description=(
+            "Build a CREATE INDEX … USING bm25 statement under tight "
+            "allowlists and run it on autocommit (CONCURRENTLY can't run "
+            "inside a transaction). ``columns`` is the list of attribute "
+            "names the index covers; ``key_field`` is the primary-key "
+            "column (required by upstream). All 13 documented bm25 "
+            "reloptions are exposed as kwargs — the 7 JSONB-shaped "
+            "options (``text_fields``, ``numeric_fields``, "
+            "``boolean_fields``, ``json_fields``, ``range_fields``, "
+            "``datetime_fields``, ``search_tokenizer``) accept Python "
+            "dicts and serialize via json.dumps; the 2 int options "
+            "(``target_segment_count``, ``mutable_segment_rows``) and "
+            "3 text options (``layer_sizes``, ``background_layer_sizes``, "
+            "``sort_by``) pass through type-aware validation. The "
+            "rendered CREATE INDEX SQL is returned in ``create_sql`` "
+            "for auditability. Performs DDL — requires unrestricted "
+            "mode + MCPG_ALLOW_DDL; pg_search installed."
+        ),
+    )
+    async def create_pg_search_index(
+        ctx: _Ctx,
+        schema: str,
+        table: str,
+        columns: list[str],
+        index_name: str,
+        key_field: str,
+        text_fields: dict[str, Any] | None = None,
+        numeric_fields: dict[str, Any] | None = None,
+        boolean_fields: dict[str, Any] | None = None,
+        json_fields: dict[str, Any] | None = None,
+        range_fields: dict[str, Any] | None = None,
+        datetime_fields: dict[str, Any] | None = None,
+        layer_sizes: str | None = None,
+        background_layer_sizes: str | None = None,
+        target_segment_count: int | None = None,
+        mutable_segment_rows: int | None = None,
+        sort_by: str | None = None,
+        search_tokenizer: dict[str, Any] | None = None,
+        concurrently: bool = True,
+    ) -> dict[str, Any]:
+        database = ctx.request_context.lifespan_context.database
+        result = await pg_search.create_pg_search_index(
+            database,
+            schema,
+            table,
+            columns,
+            index_name,
+            key_field,
+            text_fields=text_fields,
+            numeric_fields=numeric_fields,
+            boolean_fields=boolean_fields,
+            json_fields=json_fields,
+            range_fields=range_fields,
+            datetime_fields=datetime_fields,
+            layer_sizes=layer_sizes,
+            background_layer_sizes=background_layer_sizes,
+            target_segment_count=target_segment_count,
+            mutable_segment_rows=mutable_segment_rows,
+            sort_by=sort_by,
+            search_tokenizer=search_tokenizer,
+            concurrently=concurrently,
+        )
+        await ctx.request_context.lifespan_context.cache.clear()
+        return asdict(result)
+
+    @server.tool(
+        name="reindex_pg_search_index",
+        description=(
+            "REINDEX a pg_search BM25 index. Pre-flight confirms the "
+            "named index actually uses the bm25 access method (catalog "
+            "lookup on pg_am) before running. ``concurrently=True`` is "
+            "the default and runs on autocommit since REINDEX "
+            "CONCURRENTLY can't run inside a transaction. Performs DDL "
+            "— requires unrestricted mode + MCPG_ALLOW_DDL; pg_search "
+            "installed."
+        ),
+    )
+    async def reindex_pg_search_index(
+        ctx: _Ctx,
+        schema: str,
+        index: str,
+        concurrently: bool = True,
+    ) -> dict[str, Any]:
+        database = ctx.request_context.lifespan_context.database
+        result = await pg_search.reindex_pg_search_index(database, schema, index, concurrently=concurrently)
+        await ctx.request_context.lifespan_context.cache.clear()
+        return asdict(result)
+
+
 def _register_cron_write(server: FastMCP[AppContext]) -> None:
     @server.tool(
         name="schedule_cron_job",
@@ -3849,6 +3941,7 @@ def register_tools(server: FastMCP[AppContext], settings: Settings) -> None:
         _register_ddl(server)
         _register_partman(server)
         _register_turboquant_ddl(server)
+        _register_pg_search_ddl(server)
         _register_rag_telemetry_ddl(server)
         _register_timescaledb_writes(server)
         _register_graphs_writes(server)

--- a/tests/unit/test_pg_search.py
+++ b/tests/unit/test_pg_search.py
@@ -1257,6 +1257,34 @@ async def test_reindex_pg_search_index_rejects_unsafe_identifiers() -> None:
         await reindex_pg_search_index(db, "public; DROP", "docs_bm25_idx")  # type: ignore[arg-type]
 
 
+async def test_create_pg_search_index_wraps_driver_failure_as_pg_search_error() -> None:
+    """Regression: the docstring promises PgSearchError on DDL failure.
+    Without the try/except wrap, a psycopg.Error would propagate
+    directly and break that contract."""
+    db = FakeDatabase(  # type: ignore[arg-type]
+        FakeRoutingDriver({"pg_extension": [{"present": 1}]}),
+        unmanaged_fail=True,
+    )
+    with pytest.raises(PgSearchError, match="CREATE INDEX failed"):
+        await create_pg_search_index(  # type: ignore[arg-type]
+            db, "public", "docs", ["id"], "docs_bm25_idx", "id"
+        )
+
+
+async def test_reindex_pg_search_index_wraps_driver_failure_as_pg_search_error() -> None:
+    db = FakeDatabase(  # type: ignore[arg-type]
+        FakeRoutingDriver(
+            {
+                "pg_extension": [{"present": 1}],
+                "WHERE am.amname = 'bm25'": [{"present": 1}],
+            }
+        ),
+        unmanaged_fail=True,
+    )
+    with pytest.raises(PgSearchError, match="REINDEX INDEX failed"):
+        await reindex_pg_search_index(db, "public", "docs_bm25_idx")  # type: ignore[arg-type]
+
+
 # --- BM-4: tool registration -----------------------------------------------
 
 

--- a/tests/unit/test_pg_search.py
+++ b/tests/unit/test_pg_search.py
@@ -1296,10 +1296,29 @@ _DDL_SETTINGS = load_settings(
     }
 )
 
+_UNRESTRICTED_NO_DDL_SETTINGS = load_settings(
+    {
+        "MCPG_DATABASE_URL": "postgresql://u:p@localhost/db",
+        "MCPG_ACCESS_MODE": "unrestricted",
+        "MCPG_ALLOW_DDL": "false",
+    }
+)
+
 
 async def test_pg_search_ddl_tools_register_only_with_ddl_opt_in() -> None:
     # READ-only mode: DDL tools must NOT be visible.
     server = create_server(_SETTINGS, database=FakeDatabase(FakeDriver()))  # type: ignore[arg-type]
+    async with create_connected_server_and_client_session(server) as client:
+        listed = {tool.name for tool in (await client.list_tools()).tools}
+    assert "create_pg_search_index" not in listed
+    assert "reindex_pg_search_index" not in listed
+
+    # Unrestricted access but MCPG_ALLOW_DDL=false: DDL tools must still
+    # NOT be visible. Pins the AND condition explicitly so flipping
+    # either flag alone doesn't smuggle DDL tools through.
+    server = create_server(  # type: ignore[arg-type]
+        _UNRESTRICTED_NO_DDL_SETTINGS, database=FakeDatabase(FakeDriver())
+    )
     async with create_connected_server_and_client_session(server) as client:
         listed = {tool.name for tool in (await client.list_tools()).tools}
     assert "create_pg_search_index" not in listed

--- a/tests/unit/test_pg_search.py
+++ b/tests/unit/test_pg_search.py
@@ -7,17 +7,21 @@ from mcp.shared.memory import create_connected_server_and_client_session
 from mcpg.config import load_settings
 from mcpg.extensions import ENABLEABLE_EXTENSIONS
 from mcpg.pg_search import (
+    CreatePgSearchIndexResult,
     HybridHit,
     PgSearchError,
     PgSearchHit,
     PgSearchIndexInfo,
     PgSearchParsedQuery,
+    ReindexPgSearchResult,
+    create_pg_search_index,
     get_pg_search_index_metadata,
     hybrid_bm25_vector_search,
     list_pg_search_indexes,
     pg_search_more_like_this,
     pg_search_parse_query,
     pg_search_run,
+    reindex_pg_search_index,
 )
 from mcpg.server import create_server
 
@@ -1029,3 +1033,252 @@ async def test_hybrid_bm25_vector_search_tool_registered() -> None:
     async with create_connected_server_and_client_session(server) as client:
         listed = {tool.name for tool in (await client.list_tools()).tools}
     assert "hybrid_bm25_vector_search" in listed
+
+
+# --- BM-4: create_pg_search_index ------------------------------------------
+
+
+def _ddl_db_with_extension_installed() -> FakeDatabase:
+    """A FakeDatabase whose driver reports pg_search as installed."""
+    return FakeDatabase(FakeRoutingDriver({"pg_extension": [{"present": 1}]}))  # type: ignore[arg-type]
+
+
+async def test_create_pg_search_index_raises_when_extension_absent() -> None:
+    db = FakeDatabase(FakeRoutingDriver({"pg_extension": []}))  # type: ignore[arg-type]
+    with pytest.raises(PgSearchError, match="not installed"):
+        await create_pg_search_index(  # type: ignore[arg-type]
+            db, "public", "docs", ["id", "body"], "docs_bm25_idx", "id"
+        )
+
+
+async def test_create_pg_search_index_renders_minimal_sql_when_no_options() -> None:
+    db = _ddl_db_with_extension_installed()
+
+    result = await create_pg_search_index(  # type: ignore[arg-type]
+        db, "public", "docs", ["id", "body"], "docs_bm25_idx", "id"
+    )
+
+    assert isinstance(result, CreatePgSearchIndexResult)
+    assert result.schema == "public"
+    assert result.columns == ["id", "body"]
+    assert result.options == {"key_field": "id"}
+    # Verify the rendered DDL.
+    assert result.create_sql == (
+        'CREATE INDEX CONCURRENTLY "docs_bm25_idx" '
+        'ON "public"."docs" '
+        'USING bm25 ("id", "body") '
+        "WITH (key_field = 'id')"
+    )
+    # The DDL ran on autocommit via Database.run_unmanaged.
+    assert db.unmanaged == [result.create_sql]
+
+
+async def test_create_pg_search_index_renders_jsonb_int_text_options() -> None:
+    db = _ddl_db_with_extension_installed()
+
+    result = await create_pg_search_index(  # type: ignore[arg-type]
+        db,
+        "public",
+        "docs",
+        ["id", "body"],
+        "docs_bm25_idx",
+        "id",
+        text_fields={"body": {"tokenizer": "default"}},
+        numeric_fields={"price": {"fast": True}},
+        layer_sizes="100,1000,10000",
+        target_segment_count=8,
+        mutable_segment_rows=10_000,
+        sort_by="id",
+        search_tokenizer={"type": "default"},
+        concurrently=False,
+    )
+
+    # CONCURRENTLY omitted when explicit False.
+    assert " CONCURRENTLY" not in result.create_sql
+    # Options block contains all seven, in declaration order.
+    assert "key_field = 'id'" in result.create_sql
+    assert 'text_fields = \'{"body": {"tokenizer": "default"}}\'' in result.create_sql
+    assert 'numeric_fields = \'{"price": {"fast": true}}\'' in result.create_sql
+    assert "layer_sizes = '100,1000,10000'" in result.create_sql
+    assert "target_segment_count = 8" in result.create_sql
+    assert "mutable_segment_rows = 10000" in result.create_sql
+    assert "sort_by = 'id'" in result.create_sql
+    assert 'search_tokenizer = \'{"type": "default"}\'' in result.create_sql
+
+
+async def test_create_pg_search_index_escapes_single_quotes_in_text_options() -> None:
+    """Per the established pattern in turboquant DDL: PG single-quote
+    literals must double internal quotes."""
+    db = _ddl_db_with_extension_installed()
+
+    result = await create_pg_search_index(  # type: ignore[arg-type]
+        db,
+        "public",
+        "docs",
+        ["id"],
+        "docs_bm25_idx",
+        "id",
+        sort_by="O'Reilly",  # the canonical apostrophe-injection probe
+    )
+
+    assert "sort_by = 'O''Reilly'" in result.create_sql
+
+
+@pytest.mark.parametrize(
+    ("kwarg", "value", "match"),
+    [
+        ("target_segment_count", 0, "target_segment_count"),
+        ("target_segment_count", 100_001, "target_segment_count"),
+        ("target_segment_count", True, "target_segment_count"),
+        ("mutable_segment_rows", -1, "mutable_segment_rows"),
+        ("mutable_segment_rows", 100_000_001, "mutable_segment_rows"),
+        ("layer_sizes", "", "layer_sizes"),
+        ("layer_sizes", 42, "layer_sizes"),
+        ("text_fields", "not a dict", "text_fields"),
+        ("text_fields", [1, 2, 3], "text_fields"),
+    ],
+)
+async def test_create_pg_search_index_option_validation(kwarg: str, value: object, match: str) -> None:
+    db = _ddl_db_with_extension_installed()
+
+    kwargs: dict[str, object] = {kwarg: value}
+    with pytest.raises(PgSearchError, match=match):
+        await create_pg_search_index(  # type: ignore[arg-type]
+            db,
+            "public",
+            "docs",
+            ["id"],
+            "docs_bm25_idx",
+            "id",
+            **kwargs,
+        )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"schema": "public; DROP"},
+        {"table": "docs'; --"},
+        {"index_name": ""},
+        {"key_field": "id'or'1"},
+        {"columns": []},
+        {"columns": ["good", "bad; --"]},
+        {"columns": "id"},  # not a list
+    ],
+)
+async def test_create_pg_search_index_rejects_unsafe_identifiers(
+    kwargs: dict[str, object],
+) -> None:
+    db = _ddl_db_with_extension_installed()
+
+    base: dict[str, object] = {
+        "schema": "public",
+        "table": "docs",
+        "columns": ["id"],
+        "index_name": "docs_bm25_idx",
+        "key_field": "id",
+    }
+    base.update(kwargs)
+    with pytest.raises(PgSearchError):
+        await create_pg_search_index(  # type: ignore[arg-type]
+            db, **base
+        )
+
+
+async def test_create_pg_search_index_rejects_non_bool_concurrently() -> None:
+    db = _ddl_db_with_extension_installed()
+    with pytest.raises(PgSearchError, match="concurrently"):
+        await create_pg_search_index(  # type: ignore[arg-type]
+            db, "public", "docs", ["id"], "docs_bm25_idx", "id", concurrently="yes"
+        )
+
+
+# --- BM-4: reindex_pg_search_index -----------------------------------------
+
+
+async def test_reindex_pg_search_index_raises_when_extension_absent() -> None:
+    db = FakeDatabase(FakeRoutingDriver({"pg_extension": []}))  # type: ignore[arg-type]
+    with pytest.raises(PgSearchError, match="not installed"):
+        await reindex_pg_search_index(db, "public", "docs_bm25_idx")  # type: ignore[arg-type]
+
+
+async def test_reindex_pg_search_index_raises_when_index_is_not_bm25() -> None:
+    """Pre-flight catalog lookup confirms am.amname='bm25' before REINDEX
+    so the call can't probe arbitrary indexes via PG error messages."""
+    db = FakeDatabase(  # type: ignore[arg-type]
+        FakeRoutingDriver(
+            {
+                "pg_extension": [{"present": 1}],
+                "WHERE am.amname = 'bm25'": [],  # pre-flight finds nothing
+            }
+        )
+    )
+    with pytest.raises(PgSearchError, match="not a BM25 index"):
+        await reindex_pg_search_index(db, "public", "other_idx")  # type: ignore[arg-type]
+
+
+async def test_reindex_pg_search_index_renders_sql_and_runs_unmanaged() -> None:
+    db = FakeDatabase(  # type: ignore[arg-type]
+        FakeRoutingDriver(
+            {
+                "pg_extension": [{"present": 1}],
+                "WHERE am.amname = 'bm25'": [{"present": 1}],  # pre-flight passes
+            }
+        )
+    )
+
+    result = await reindex_pg_search_index(db, "public", "docs_bm25_idx")  # type: ignore[arg-type]
+
+    assert isinstance(result, ReindexPgSearchResult)
+    assert result.reindex_sql == 'REINDEX INDEX CONCURRENTLY "public"."docs_bm25_idx"'
+    assert db.unmanaged == [result.reindex_sql]
+
+
+async def test_reindex_pg_search_index_omits_concurrently_when_disabled() -> None:
+    db = FakeDatabase(  # type: ignore[arg-type]
+        FakeRoutingDriver(
+            {
+                "pg_extension": [{"present": 1}],
+                "WHERE am.amname = 'bm25'": [{"present": 1}],
+            }
+        )
+    )
+
+    result = await reindex_pg_search_index(  # type: ignore[arg-type]
+        db, "public", "docs_bm25_idx", concurrently=False
+    )
+
+    assert " CONCURRENTLY" not in result.reindex_sql
+
+
+async def test_reindex_pg_search_index_rejects_unsafe_identifiers() -> None:
+    db = FakeDatabase(FakeRoutingDriver({"pg_extension": [{"present": 1}]}))  # type: ignore[arg-type]
+    with pytest.raises(PgSearchError, match="invalid"):
+        await reindex_pg_search_index(db, "public; DROP", "docs_bm25_idx")  # type: ignore[arg-type]
+
+
+# --- BM-4: tool registration -----------------------------------------------
+
+
+_DDL_SETTINGS = load_settings(
+    {
+        "MCPG_DATABASE_URL": "postgresql://u:p@localhost/db",
+        "MCPG_ACCESS_MODE": "unrestricted",
+        "MCPG_ALLOW_DDL": "true",
+    }
+)
+
+
+async def test_pg_search_ddl_tools_register_only_with_ddl_opt_in() -> None:
+    # READ-only mode: DDL tools must NOT be visible.
+    server = create_server(_SETTINGS, database=FakeDatabase(FakeDriver()))  # type: ignore[arg-type]
+    async with create_connected_server_and_client_session(server) as client:
+        listed = {tool.name for tool in (await client.list_tools()).tools}
+    assert "create_pg_search_index" not in listed
+    assert "reindex_pg_search_index" not in listed
+
+    # DDL opt-in: both tools should appear.
+    server = create_server(_DDL_SETTINGS, database=FakeDatabase(FakeDriver()))  # type: ignore[arg-type]
+    async with create_connected_server_and_client_session(server) as client:
+        listed = {tool.name for tool in (await client.list_tools()).tools}
+    assert {"create_pg_search_index", "reindex_pg_search_index"} <= listed


### PR DESCRIPTION
## Summary

DDL slice for `pg_search` — `create_pg_search_index` (full 13-reloption surface) and `reindex_pg_search_index` (with pg_am pre-flight). Mirrors the turboquant DDL pattern.

### `src/mcpg/pg_search.py`

- **`CreatePgSearchIndexResult` / `ReindexPgSearchResult`** dataclasses — rendered SQL preserved for auditability, plus wall-clock timing.
- **`create_pg_search_index(database, schema, table, columns, index_name, key_field, *, text_fields, numeric_fields, boolean_fields, json_fields, range_fields, datetime_fields, layer_sizes, background_layer_sizes, target_segment_count, mutable_segment_rows, sort_by, search_tokenizer, concurrently=True)`**
  - All 13 documented `bm25` reloptions exposed as kwargs.
  - 7 JSONB-shaped options accept Python dicts → `json.dumps` + PG literal escape.
  - 2 int options have bounded ranges; 4 text options validate non-empty.
  - Single-quote escaping in text values (e.g. `sort_by="O'Reilly"`) doubles internal quotes the same way `format('%L')` would.
  - Runs on autocommit via `Database.run_unmanaged` since `CREATE INDEX CONCURRENTLY` can't run inside a transaction.
- **`reindex_pg_search_index(database, schema, index, *, concurrently=True)`**
  - Same pre-flight pattern as `reindex_turboquant_index`: refuses any index that doesn't use the `bm25` access method (catalog lookup on `pg_am`).
  - Renders `REINDEX INDEX [CONCURRENTLY] schema.index`; runs autocommit.

Also lifted `import datetime` + `import time` to module scope (alongside the existing `math` import) so the DDL helpers don't pay per-call import cost.

### `src/mcpg/tools.py`

New `_register_pg_search_ddl` block under the **DDL + `MCPG_ALLOW_DDL` gate**, parallel to `_register_turboquant_ddl`. Surfaces both tools with full option pass-through.

### Tests — 27 new (118 total in the module)

- Minimal SQL rendering (no options → just `key_field`).
- Full option matrix render shape + declaration order.
- Single-quote escaping in text options (apostrophe-injection probe).
- `CONCURRENTLY` toggle (default on, omits when `False`).
- Option validation: bounds for ints, bool-as-int trap, empty string for text, non-dict for JSONB.
- Identifier validation: injection patterns across all id args, empty list, columns as non-list.
- Pre-flight refuses non-BM25 index in REINDEX path.
- Tool registration gated correctly: absent in READ-only, present in `unrestricted + MCPG_ALLOW_DDL`.

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run mypy src/mcpg` — clean
- [x] `uv run pytest tests/unit -q` — 1722 passed (27 new)
- [ ] Reviewer sanity-check the rendered CREATE INDEX SQL against a real `pg_search` install
- [ ] Reviewer confirm the JSONB option serialization (especially `text_fields`) lands in the form pg_search's reloption parser expects

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Add managed DDL support for pg_search BM25 indexes, including creation and reindexing tools wired into the MCPG DDL tool registry.

New Features:
- Introduce create_pg_search_index API to build and run CREATE INDEX ... USING bm25 with the full pg_search reloption surface and audit metadata.
- Introduce reindex_pg_search_index API that safely REINDEXes only bm25-backed pg_search indexes after catalog pre-flight checks.
- Expose create_pg_search_index and reindex_pg_search_index as FastMCP tools, gated behind unrestricted mode and MCPG_ALLOW_DDL with pg_search installed.

Enhancements:
- Add validation and safe rendering for pg_search BM25 reloptions, including identifier checks, bounded integer options, JSONB dict enforcement, and literal escaping.
- Extend pg_search test coverage with cases for DDL SQL rendering, option and identifier validation, REINDEX pre-flight behavior, and DDL tool registration gating.