### PR TITLE
feat(pg_search): expose pdb.more_like_this tuning args

### DIFF
--- a/src/mcpg/pg_search.py
+++ b/src/mcpg/pg_search.py
@@ -613,6 +613,45 @@ def _normalize_snippets(value: Any) -> list[str]:
     return []
 
 
+# Bounds for pdb.more_like_this int4 tuning args. int4 ranges are
+# [0, 2^31-1] but realistic doc/term frequency thresholds and word
+# lengths sit well below that — keeping the cap at 1_000_000_000
+# matches the spirit of pg_search_run's _LIMIT_MAX, just bumped to
+# accommodate corpus-scale int signals.
+_MLT_INT_MIN, _MLT_INT_MAX = 0, 1_000_000_000
+
+
+def _validate_mlt_int(name: str, value: int) -> None:
+    """``min/max_doc_frequency``, ``min/max_term_frequency``,
+    ``max_query_terms``, ``min/max_word_length`` validation.
+
+    Bool-as-int rejected explicitly (a stray True would coerce to 1
+    silently and skew the upstream MLT computation)."""
+    if not isinstance(value, int) or isinstance(value, bool) or not _MLT_INT_MIN <= value <= _MLT_INT_MAX:
+        raise PgSearchError(f"{name} must be an int in [{_MLT_INT_MIN}..{_MLT_INT_MAX}]; got {value!r}")
+
+
+def _validate_mlt_boost(value: float) -> None:
+    """``boost_factor`` is float4 — accept any finite number."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise PgSearchError(f"boost_factor must be a finite number; got {value!r}")
+    fval = float(value)
+    if math.isnan(fval) or math.isinf(fval):
+        raise PgSearchError(f"boost_factor must be finite; got {value!r}")
+
+
+def _validate_mlt_stop_words(value: list[str]) -> None:
+    """``stop_words`` is text[] — list[str] mapped to PG ``text[]``."""
+    if not isinstance(value, list) or not all(isinstance(w, str) for w in value):
+        raise PgSearchError(f"stop_words must be list[str]; got {value!r}")
+
+
+def _validate_mlt_fields(value: dict[str, Any]) -> None:
+    """``fields`` is jsonb — dict serialized to JSON for binding."""
+    if not isinstance(value, dict):
+        raise PgSearchError(f"fields must be a dict (serialized to JSONB); got {type(value).__name__}")
+
+
 async def pg_search_more_like_this(
     driver: SqlDriver,
     schema: str,
@@ -621,19 +660,35 @@ async def pg_search_more_like_this(
     key_field: str,
     *,
     limit: int,
+    fields: dict[str, Any] | None = None,
+    min_doc_frequency: int | None = None,
+    max_doc_frequency: int | None = None,
+    min_term_frequency: int | None = None,
+    max_query_terms: int | None = None,
+    min_word_length: int | None = None,
+    max_word_length: int | None = None,
+    boost_factor: float | None = None,
+    stop_words: list[str] | None = None,
 ) -> list[PgSearchHit]:
     """Find rows similar to the row identified by ``document_id``.
 
-    Wraps ``pdb.more_like_this(anyelement, ...)`` with only the row
-    reference arg — the eight tuning knobs (min/max doc frequency,
-    term frequency, query terms, word length, boost factor,
-    stopwords) are documented as out-of-scope for BM-2 (see
-    `docs/plans/bm25-integration.md` §6) and stay at upstream's
-    defaults. The seed row is loaded from the same table via a
-    correlated subquery so the wrapper takes ``document_id`` as an
-    opaque key value rather than a row tuple.
+    Wraps ``pdb.more_like_this(anyelement, fields jsonb,
+    min_doc_frequency int4, max_doc_frequency int4,
+    min_term_frequency int4, max_query_terms int4,
+    min_word_length int4, max_word_length int4, boost_factor float4,
+    stop_words text[]) → pdb.query`` (verbatim signature from
+    `docs/plans/bm25-integration.md` §2.1). The seed row is loaded
+    from the same table via a correlated subquery so the wrapper
+    takes ``document_id`` as an opaque key value rather than a row
+    tuple.
 
-    Built SQL::
+    Every tuning arg is optional. When omitted, the wrapper does not
+    mention it in the SQL — upstream's defaults apply. Args that
+    *are* supplied use named-arg syntax (``name => %s``) so the bind
+    list stays minimal and each value goes through a parameter
+    rather than getting spliced into SQL.
+
+    Built SQL (no tuning args)::
 
         SELECT t."<key>", pdb.score(t) AS score
         FROM "<schema>"."<table>" AS t
@@ -645,14 +700,43 @@ async def pg_search_more_like_this(
         ORDER BY pdb.score(t) DESC
         LIMIT <limit>
 
+    With tuning args, the inner ``pdb.more_like_this(seed)`` call
+    grows extra ``, name => %s`` pairs in caller order.
+
     Raises:
         PgSearchError: extension missing, identifier validation
-            fails, or limit out of bounds.
+            fails, limit out of bounds, or any tuning-arg type /
+            bounds check fails.
     """
     _validate_identifier(schema, "schema")
     _validate_identifier(table, "table")
     _validate_identifier(key_field, "key_field")
     _validate_limit(limit)
+
+    # Build the tuning-arg pieces. Order matters for the final params
+    # list: we append (name, bound_value) tuples to mlt_args so the
+    # SQL fragment renders in the same order as the bind list.
+    mlt_args: list[tuple[str, Any, str]] = []  # (name, value, type_cast_suffix)
+    if fields is not None:
+        _validate_mlt_fields(fields)
+        mlt_args.append(("fields", json.dumps(fields, sort_keys=True), "::jsonb"))
+    for arg_name, arg_value in (
+        ("min_doc_frequency", min_doc_frequency),
+        ("max_doc_frequency", max_doc_frequency),
+        ("min_term_frequency", min_term_frequency),
+        ("max_query_terms", max_query_terms),
+        ("min_word_length", min_word_length),
+        ("max_word_length", max_word_length),
+    ):
+        if arg_value is not None:
+            _validate_mlt_int(arg_name, arg_value)
+            mlt_args.append((arg_name, arg_value, ""))
+    if boost_factor is not None:
+        _validate_mlt_boost(boost_factor)
+        mlt_args.append(("boost_factor", float(boost_factor), "::real"))
+    if stop_words is not None:
+        _validate_mlt_stop_words(stop_words)
+        mlt_args.append(("stop_words", stop_words, "::text[]"))
 
     if not await extension_installed(driver, "pg_search"):
         raise PgSearchError("pg_search extension is not installed in this database")
@@ -660,18 +744,25 @@ async def pg_search_more_like_this(
     qualified_table = f"{_pg_quote_ident(schema)}.{_pg_quote_ident(table)}"
     quoted_key = _pg_quote_ident(key_field)
 
+    mlt_named_args = "".join(f", {name} => %s{cast}" for name, _, cast in mlt_args)
+    mlt_param_values = [value for _, value, _ in mlt_args]
+
     sql = (
         f"SELECT {_TABLE_ALIAS}.{quoted_key} AS id, pdb.score({_TABLE_ALIAS}) AS score "
         f"FROM {qualified_table} AS {_TABLE_ALIAS} "
         f"WHERE {_TABLE_ALIAS} @@@ ("
-        f"SELECT pdb.more_like_this(seed) "
+        f"SELECT pdb.more_like_this(seed{mlt_named_args}) "
         f"FROM {qualified_table} AS seed "
         f"WHERE seed.{quoted_key} = %s"
         f") "
         f"ORDER BY pdb.score({_TABLE_ALIAS}) DESC "
         f"LIMIT %s"
     )
-    rows = await driver.execute_query(sql, params=[document_id, limit], force_readonly=True)
+    # Bind order matches placeholder order: tuning args appear inside
+    # the inner SELECT (rendered first), then the seed key in the
+    # inner WHERE, then the outer LIMIT.
+    params: list[Any] = [*mlt_param_values, document_id, limit]
+    rows = await driver.execute_query(sql, params=params, force_readonly=True)
     return [PgSearchHit(id=row.cells["id"], score=float(row.cells["score"])) for row in rows or []]
 
 

--- a/src/mcpg/pg_search.py
+++ b/src/mcpg/pg_search.py
@@ -647,9 +647,22 @@ def _validate_mlt_stop_words(value: list[str]) -> None:
 
 
 def _validate_mlt_fields(value: dict[str, Any]) -> None:
-    """``fields`` is jsonb — dict serialized to JSON for binding."""
+    """``fields`` is jsonb — dict serialized to JSON for binding.
+
+    Two-step validation: shape (must be a dict), then
+    JSON-serializability (try-encode it). The wrapper's contract is
+    "all validation failures surface as PgSearchError", so a bare
+    ``TypeError`` from a later ``json.dumps`` call on a dict
+    containing non-serializable values (datetimes, custom objects,
+    sets, etc.) would be a contract leak. Probing here keeps the
+    encode-for-bind site downstream simple.
+    """
     if not isinstance(value, dict):
         raise PgSearchError(f"fields must be a dict (serialized to JSONB); got {type(value).__name__}")
+    try:
+        json.dumps(value, sort_keys=True)
+    except TypeError as exc:
+        raise PgSearchError(f"fields must be JSON-serializable; got {value!r} ({exc})") from exc
 
 
 async def pg_search_more_like_this(

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -3090,11 +3090,14 @@ def _register_pg_search_reads(server: FastMCP[AppContext]) -> None:
         description=(
             "Find rows similar to a seed document via ``pdb.more_like_this`` "
             "+ ``@@@``. ``document_id`` is the value of ``key_field`` for the "
-            "seed row. The eight pdb.more_like_this tuning args (min/max "
-            "doc-frequency, term-frequency, query-terms, word-length, boost, "
-            "stopwords) stay at upstream defaults — exposing them is a "
-            "future phase. Returns the same {id, score} hit shape as "
-            "``pg_search_run``. Requires the pg_search extension."
+            "seed row. All nine documented pdb.more_like_this tuning args "
+            "(``fields`` jsonb, ``min_doc_frequency``, ``max_doc_frequency``, "
+            "``min_term_frequency``, ``max_query_terms``, ``min_word_length``, "
+            "``max_word_length``, ``boost_factor``, ``stop_words``) are "
+            "optional kwargs — when omitted the wrapper does not mention them "
+            "in the SQL so upstream's defaults apply. Returns the same "
+            "{id, score} hit shape as ``pg_search_run``. Requires the "
+            "pg_search extension."
         ),
     )
     async def pg_search_more_like_this(
@@ -3104,6 +3107,15 @@ def _register_pg_search_reads(server: FastMCP[AppContext]) -> None:
         document_id: Any,
         key_field: str,
         limit: int,
+        fields: dict[str, Any] | None = None,
+        min_doc_frequency: int | None = None,
+        max_doc_frequency: int | None = None,
+        min_term_frequency: int | None = None,
+        max_query_terms: int | None = None,
+        min_word_length: int | None = None,
+        max_word_length: int | None = None,
+        boost_factor: float | None = None,
+        stop_words: list[str] | None = None,
     ) -> list[dict[str, Any]]:
         hits = await pg_search.pg_search_more_like_this(
             _driver(ctx),
@@ -3112,6 +3124,15 @@ def _register_pg_search_reads(server: FastMCP[AppContext]) -> None:
             document_id,
             key_field,
             limit=limit,
+            fields=fields,
+            min_doc_frequency=min_doc_frequency,
+            max_doc_frequency=max_doc_frequency,
+            min_term_frequency=min_term_frequency,
+            max_query_terms=max_query_terms,
+            min_word_length=min_word_length,
+            max_word_length=max_word_length,
+            boost_factor=boost_factor,
+            stop_words=stop_words,
         )
         return [asdict(hit) for hit in hits]
 

--- a/tests/unit/test_pg_search.py
+++ b/tests/unit/test_pg_search.py
@@ -586,6 +586,172 @@ async def test_pg_search_more_like_this_validates_identifiers() -> None:
         )
 
 
+# --- pdb.more_like_this tuning args (backlog follow-up) --------------------
+
+
+async def test_pg_search_more_like_this_no_tuning_args_omits_them_from_sql() -> None:
+    """Sanity check: the wrapper's default behavior renders exactly the
+    minimal pdb.more_like_this(seed) call, no named args, so upstream's
+    defaults apply unchanged."""
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "pdb.more_like_this(seed)": [{"id": 2, "score": 8.0}],
+        }
+    )
+
+    await pg_search_more_like_this(driver, "public", "docs", 42, "id", limit=10)  # type: ignore[arg-type]
+
+    sql, params, _ = driver.calls[-1]
+    assert "pdb.more_like_this(seed)" in sql
+    # No named-arg syntax should appear when no tuning kwargs are set.
+    assert " => " not in sql
+    assert params == [42, 10]
+
+
+async def test_pg_search_more_like_this_int_tuning_args_render_as_named() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "pdb.more_like_this(seed,": [],
+        }
+    )
+
+    await pg_search_more_like_this(  # type: ignore[arg-type]
+        driver,
+        "public",
+        "docs",
+        42,
+        "id",
+        limit=10,
+        min_doc_frequency=2,
+        max_doc_frequency=1000,
+        min_term_frequency=1,
+        max_query_terms=25,
+        min_word_length=2,
+        max_word_length=20,
+    )
+
+    sql, params, _ = driver.calls[-1]
+    # Each int tuning arg uses named-arg syntax against a bind param.
+    assert "min_doc_frequency => %s" in sql
+    assert "max_doc_frequency => %s" in sql
+    assert "min_term_frequency => %s" in sql
+    assert "max_query_terms => %s" in sql
+    assert "min_word_length => %s" in sql
+    assert "max_word_length => %s" in sql
+    # Bind order: tuning args (in caller order), then document_id, then limit.
+    assert params == [2, 1000, 1, 25, 2, 20, 42, 10]
+
+
+async def test_pg_search_more_like_this_fields_jsonb_serialized_and_cast() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "pdb.more_like_this(seed,": [],
+        }
+    )
+
+    await pg_search_more_like_this(  # type: ignore[arg-type]
+        driver,
+        "public",
+        "docs",
+        42,
+        "id",
+        limit=10,
+        fields={"body": {"boost": 2.0}},
+    )
+
+    sql, params, _ = driver.calls[-1]
+    assert "fields => %s::jsonb" in sql
+    # JSON-serialized with sort_keys for deterministic SQL.
+    assert params[0] == '{"body": {"boost": 2.0}}'
+
+
+async def test_pg_search_more_like_this_boost_factor_and_stop_words_render() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "pdb.more_like_this(seed,": [],
+        }
+    )
+
+    await pg_search_more_like_this(  # type: ignore[arg-type]
+        driver,
+        "public",
+        "docs",
+        42,
+        "id",
+        limit=10,
+        boost_factor=1.5,
+        stop_words=["the", "a", "an"],
+    )
+
+    sql, params, _ = driver.calls[-1]
+    assert "boost_factor => %s::real" in sql
+    assert "stop_words => %s::text[]" in sql
+    # boost_factor coerced to float; stop_words passed through as list.
+    assert 1.5 in params
+    assert ["the", "a", "an"] in params
+
+
+async def test_pg_search_more_like_this_param_count_matches_placeholders() -> None:
+    """Regression: bind list must align with placeholder positions across
+    every combination of tuning args. Same trap that bit pg_search_run
+    earlier in BM-2."""
+    driver = FakeRoutingDriver(
+        {
+            "pg_extension": [{"present": 1}],
+            "pdb.more_like_this(seed,": [],
+        }
+    )
+
+    await pg_search_more_like_this(  # type: ignore[arg-type]
+        driver,
+        "public",
+        "docs",
+        42,
+        "id",
+        limit=10,
+        fields={"body": {}},
+        min_doc_frequency=2,
+        boost_factor=1.0,
+        stop_words=["the"],
+    )
+
+    sql, params, _ = driver.calls[-1]
+    assert sql.count("%s") == len(params)
+    # Order: tuning args in their caller order, then document_id, then limit.
+    assert params == ['{"body": {}}', 2, 1.0, ["the"], 42, 10]
+
+
+@pytest.mark.parametrize(
+    ("kwarg", "value", "match"),
+    [
+        ("min_doc_frequency", -1, "min_doc_frequency"),
+        ("min_doc_frequency", True, "min_doc_frequency"),  # bool-as-int
+        ("max_doc_frequency", 1_000_000_001, "max_doc_frequency"),
+        ("max_query_terms", "25", "max_query_terms"),  # string, not int
+        ("boost_factor", float("nan"), "boost_factor"),
+        ("boost_factor", float("inf"), "boost_factor"),
+        ("boost_factor", True, "boost_factor"),  # bool-as-number
+        ("boost_factor", "1.5", "boost_factor"),
+        ("stop_words", "the", "stop_words"),  # str, not list
+        ("stop_words", [1, 2, 3], "stop_words"),  # list of non-str
+        ("fields", [1, 2], "fields"),  # not a dict
+        ("fields", "{}", "fields"),  # str, not dict
+    ],
+)
+async def test_pg_search_more_like_this_tuning_arg_validation(kwarg: str, value: object, match: str) -> None:
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    kwargs = {kwarg: value}
+    with pytest.raises(PgSearchError, match=match):
+        await pg_search_more_like_this(  # type: ignore[arg-type]
+            driver, "public", "docs", 42, "id", limit=10, **kwargs
+        )
+
+
 # --- BM-2: pg_search_parse_query -------------------------------------------
 
 

--- a/tests/unit/test_pg_search.py
+++ b/tests/unit/test_pg_search.py
@@ -752,6 +752,28 @@ async def test_pg_search_more_like_this_tuning_arg_validation(kwarg: str, value:
         )
 
 
+async def test_pg_search_more_like_this_fields_non_json_serializable_value_raises() -> None:
+    """Regression: a dict whose *shape* passes ``isinstance(..., dict)``
+    but contains a value json.dumps can't encode (sets, datetimes,
+    custom objects) used to escape validation and surface as a bare
+    TypeError from the JSON-encode step. The wrapper's contract is
+    "all validation failures surface as PgSearchError", so the
+    validator probes encodability up front."""
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    # `set` is the simplest non-JSON-serializable built-in.
+    with pytest.raises(PgSearchError, match="JSON-serializable"):
+        await pg_search_more_like_this(  # type: ignore[arg-type]
+            driver,
+            "public",
+            "docs",
+            42,
+            "id",
+            limit=10,
+            fields={"body": {"boost", "factor"}},
+        )
+
+
 # --- BM-2: pg_search_parse_query -------------------------------------------
 
 


### PR DESCRIPTION
## Summary

Lifts the deferred limitation from BM-2: `pg_search_more_like_this` now exposes all nine documented `pdb.more_like_this` tuning args as optional kwargs. When a kwarg is omitted the wrapper does not mention it in the SQL — upstream's defaults still apply unchanged (no behavior change for existing callers).

New kwargs: `fields` (jsonb), `min_doc_frequency`, `max_doc_frequency`, `min_term_frequency`, `max_query_terms`, `min_word_length`, `max_word_length` (all int4), `boost_factor` (float4), `stop_words` (text[]).

Supplied args render via PG named-arg syntax (`name => %s`) with appropriate type casts (`::jsonb`, `::real`, `::text[]`) — no string splicing, every value goes through a bind parameter.

## Changes

- **`src/mcpg/pg_search.py`**: kwargs on `pg_search_more_like_this`, validation helpers (bounded int4 with bool-as-int rejection, finite-float check, list[str] check, dict check).
- **`src/mcpg/tools.py`**: tool wrapper threads all nine kwargs through; description updated.

## Tests (17 new, 151 total in the module)

- Default behavior preserved: no tuning args → `pdb.more_like_this(seed)` with no named args.
- Each int tuning arg renders as named-arg + bind param in caller order.
- `fields` dict serialized via `json.dumps(sort_keys=True)` and cast `::jsonb`.
- `boost_factor` cast `::real`, `stop_words` cast `::text[]`.
- Regression test pinning `sql.count('%s') == len(params)` across a mixed-tuning-arg combination — same alignment trap that bit `pg_search_run` earlier in BM-2.
- Parametrized validation matrix: negative / out-of-bounds ints, bool-as-int trap, str-instead-of-int, NaN/inf/bool/str for `boost_factor`, str/non-str-list for `stop_words`, non-dict for `fields`.

## Test plan

- [x] Existing 134 module tests still pass (defaults preserve original SQL shape)
- [x] 17 new tests cover SQL rendering, bind ordering, and validation
- [x] `ruff check`, `ruff format`, `mypy src/mcpg`, full unit suite (1755 tests) all green

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Expose and validate optional tuning arguments for pg_search_more_like_this while preserving default behavior when they are omitted.

New Features:
- Add optional pdb.more_like_this tuning kwargs (fields, frequency and term limits, boost_factor, stop_words) to pg_search_more_like_this and its tool wrapper.

Enhancements:
- Validate tuning argument types and bounds, including JSONB fields, finite boost_factor, and stop_words as list[str], and wire them into SQL via named parameters without changing existing defaults.

Tests:
- Add unit tests to cover default behavior, SQL rendering and parameter ordering for all tuning args, JSONB and type casts, and validation failures for invalid argument values.