### PR TITLE
fix(turboquant): wrap CREATE INDEX / REINDEX driver errors as TurboQuantError

### DIFF
--- a/src/mcpg/turboquant.py
+++ b/src/mcpg/turboquant.py
@@ -916,7 +916,15 @@ async def create_turboquant_index(
 
     started_at = _utc_iso_now()
     started_mono = time.monotonic()
-    await database.run_unmanaged(sql)
+    try:
+        await database.run_unmanaged(sql)
+    except Exception as exc:
+        # Mirrors the pg_search pattern (pg_search.py:1265): catch the
+        # raw driver / DatabaseError and re-raise as TurboQuantError so
+        # callers always see a typed error class for DDL failures
+        # (duplicate name, locked relation, missing table, etc.) rather
+        # than a psycopg traceback leaking out of the wrapper.
+        raise TurboQuantError(f"CREATE INDEX failed: {exc}") from exc
     duration = time.monotonic() - started_mono
     completed_at = _utc_iso_now()
 
@@ -976,7 +984,14 @@ async def reindex_turboquant_index(
 
     started_at = _utc_iso_now()
     started_mono = time.monotonic()
-    await database.run_unmanaged(sql)
+    try:
+        await database.run_unmanaged(sql)
+    except Exception as exc:
+        # Same pattern as create_turboquant_index above: convert raw
+        # driver errors (lock contention, missing index, etc.) into a
+        # typed TurboQuantError so callers don't get a psycopg
+        # traceback bleeding out of the wrapper.
+        raise TurboQuantError(f"REINDEX failed: {exc}") from exc
     duration = time.monotonic() - started_mono
     completed_at = _utc_iso_now()
 

--- a/tests/unit/test_turboquant.py
+++ b/tests/unit/test_turboquant.py
@@ -867,6 +867,37 @@ async def test_create_turboquant_index_quotes_mixed_case_identifiers() -> None:
     assert result.create_sql == expected
 
 
+async def test_create_turboquant_index_wraps_driver_failure_as_turboquant_error() -> None:
+    """Regression: a raw psycopg / RuntimeError from run_unmanaged
+    must surface as TurboQuantError so callers always see a typed
+    error class for DDL failures. Mirrors the equivalent pg_search
+    regression test (test_pg_search.py)."""
+    db = FakeDatabase(  # type: ignore[arg-type]
+        FakeRoutingDriver({"pg_extension": [{"present": 1}]}),
+        unmanaged_fail=True,
+    )
+    with pytest.raises(TurboQuantError, match="CREATE INDEX failed"):
+        await create_turboquant_index(  # type: ignore[arg-type]
+            db, "public", "embeddings", "embedding", "idx", "cosine"
+        )
+
+
+async def test_create_turboquant_index_preserves_cause_chain() -> None:
+    """``raise … from exc`` must keep the original exception accessible
+    on ``__cause__`` so debugging tools (and pytest's ``-tb``) see the
+    real psycopg error rather than only the wrapper message."""
+    db = FakeDatabase(  # type: ignore[arg-type]
+        FakeRoutingDriver({"pg_extension": [{"present": 1}]}),
+        unmanaged_fail=True,
+    )
+    with pytest.raises(TurboQuantError) as excinfo:
+        await create_turboquant_index(  # type: ignore[arg-type]
+            db, "public", "embeddings", "embedding", "idx", "cosine"
+        )
+    assert isinstance(excinfo.value.__cause__, RuntimeError)
+    assert "maintenance failed" in str(excinfo.value.__cause__)
+
+
 # --- reindex_turboquant_index ----------------------------------------------
 
 
@@ -924,6 +955,42 @@ async def test_reindex_turboquant_index_rejects_non_bool_concurrently(bad: Any) 
     db = _ddl_db_with_extension_installed()
     with pytest.raises(TurboQuantError, match="concurrently must be a bool"):
         await reindex_turboquant_index(db, "public", "idx", concurrently=bad)  # type: ignore[arg-type]
+
+
+async def test_reindex_turboquant_index_wraps_driver_failure_as_turboquant_error() -> None:
+    """Regression: raw driver failures during REINDEX (e.g. lock
+    contention from a concurrent index build, disk full) must surface
+    as TurboQuantError. Mirrors the create_turboquant_index wrap and
+    the pg_search equivalent."""
+    db = FakeDatabase(  # type: ignore[arg-type]
+        FakeRoutingDriver(
+            {
+                "pg_extension": [{"present": 1}],
+                # _ASSERT_IS_TURBOQUANT_SQL pre-flight must succeed so we
+                # reach the run_unmanaged call and exercise the wrap.
+                _PREFLIGHT_SUBSTR: [{"present": 1}],
+            }
+        ),
+        unmanaged_fail=True,
+    )
+    with pytest.raises(TurboQuantError, match="REINDEX failed"):
+        await reindex_turboquant_index(db, "public", "embeddings_tq_idx")  # type: ignore[arg-type]
+
+
+async def test_reindex_turboquant_index_preserves_cause_chain() -> None:
+    db = FakeDatabase(  # type: ignore[arg-type]
+        FakeRoutingDriver(
+            {
+                "pg_extension": [{"present": 1}],
+                _PREFLIGHT_SUBSTR: [{"present": 1}],
+            }
+        ),
+        unmanaged_fail=True,
+    )
+    with pytest.raises(TurboQuantError) as excinfo:
+        await reindex_turboquant_index(db, "public", "embeddings_tq_idx")  # type: ignore[arg-type]
+    assert isinstance(excinfo.value.__cause__, RuntimeError)
+    assert "maintenance failed" in str(excinfo.value.__cause__)
 
 
 # --- TQ-5: query execution + per-query knobs --------------------------------


### PR DESCRIPTION
## Summary

Closes a backlog gap: turboquant's two DDL sites (`create_turboquant_index`, `reindex_turboquant_index`) called `database.run_unmanaged(sql)` without exception handling, so any `psycopg.Error` or `DatabaseError` (duplicate index name, missing table, lock contention, REINDEX-on-non-existent index, autocommit setup failure) would bubble up as a raw driver traceback instead of the typed `TurboQuantError` that the docstrings promise.

Each `run_unmanaged` call now sits inside `try / except Exception as exc: raise TurboQuantError(...) from exc` — same pattern that `pg_search.py:1265` already uses for the parallel CREATE INDEX / REINDEX wrappers. The `from exc` clause keeps the original cause on `__cause__` so debugging tools and pytest's traceback still surface the real driver error.

## Tests (4 new, 103 total in the module)

- `test_create_turboquant_index_wraps_driver_failure_as_turboquant_error`: `unmanaged_fail=True` FakeDatabase → expect `TurboQuantError` with "CREATE INDEX failed" prefix.
- `test_create_turboquant_index_preserves_cause_chain`: `__cause__` is the original RuntimeError.
- `test_reindex_turboquant_index_wraps_driver_failure_as_turboquant_error`: same for the REINDEX site, with the `_ASSERT_IS_TURBOQUANT_SQL` pre-flight stubbed to succeed so we reach the `run_unmanaged` call.
- `test_reindex_turboquant_index_preserves_cause_chain`: `__cause__` check for the REINDEX path.

Drive-by: switched the new tests to use the `_PREFLIGHT_SUBSTR` constant rather than inlining the substring, matching the established convention in the module.

## Test plan

- [x] 99 existing module tests still pass
- [x] 4 new tests cover both DDL sites and verify the cause chain
- [x] `ruff check`, `ruff format`, `mypy src/mcpg`, full unit suite (1742 tests) all green

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_