### PR TITLE
docs(bm25-integration): mark pdb.more_like_this tuning args as landed

### DIFF
--- a/docs/plans/bm25-integration.md
+++ b/docs/plans/bm25-integration.md
@@ -366,10 +366,14 @@ BM-2/BM-4 and BM-3/BM-4 could land in parallel.
   (discovered during §2.1). Usable surface, but BM-2's
   `pg_search_parse_query` covers the common path. Wrap when a
   concrete use case appears.
-- **`pdb.more_like_this` tuning args.** Eight defaulted knobs
-  (min/max doc frequency, term frequency, query terms, word length,
-  boost, stopwords). BM-2 exposes only the document-identifier arg;
-  the tuning surface is deferred to a follow-up phase.
+- **`pdb.more_like_this` tuning args.** ~~Eight defaulted knobs~~
+  **Landed in #91 (post-BM-2 follow-up).** All nine documented
+  upstream args (`fields` jsonb, `min_doc_frequency`,
+  `max_doc_frequency`, `min_term_frequency`, `max_query_terms`,
+  `min_word_length`, `max_word_length`, `boost_factor`,
+  `stop_words`) are now optional kwargs on
+  `pg_search_more_like_this`. Omitted kwargs are not mentioned in
+  the SQL so upstream's defaults apply unchanged.
 - **`pg_textsearch` and `vchord_bm25` wrappers.** Deferred per
   §1. Documented return conditions: PG 14–16 support for
   `pg_textsearch`; 1.0 release + hybrid-pattern docs for


### PR DESCRIPTION
## Summary

Doc-only sync. After #91 merged, `docs/plans/bm25-integration.md` §6 still listed the `pdb.more_like_this` tuning knobs as a deferred follow-up phase. Updates the bullet in place: keeps the original text struck-through for historical context, then notes the PR # and the full nine-kwarg surface that's now exposed (`fields` jsonb plus the eight from the original list).

The companion multi-column-search deferral (§ Phase BM-2) was already worded as `list[str] | None` with no "currently raises" caveat — that paragraph stays as-is; it was already forward-looking and matches what #93 shipped.

No source changes.

## Test plan

- [x] No code touched; CI's lint/type/test stages skip cleanly
- [x] Doc renders as expected on the GitHub markdown preview

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Documentation:
- Revise BM25 integration planning document to mark `pdb.more_like_this` tuning arguments as implemented, detailing the full set of supported optional kwargs and their behavior.