### PR TITLE
perf: bound four scalability P0 cliffs in vector_ops / mmr_search / verify_audit_chain

### DIFF
--- a/src/mcpg/audit_integrity.py
+++ b/src/mcpg/audit_integrity.py
@@ -18,6 +18,13 @@ AUDIT_SCHEMA = "mcpg_audit"
 AUDIT_TABLE = "events"
 _QUALIFIED = f"{AUDIT_SCHEMA}.{AUDIT_TABLE}"
 
+# Batch size for the keyset-paginated walk in :func:`verify_audit_chain`.
+# Each batch carries one (id, arguments jsonb, result jsonb) round-trip;
+# 1000 keeps memory bounded (~ a few MB at typical row sizes) and keeps
+# the round-trip count reasonable (1k calls per million rows). Tuned to
+# match list_audit_events' default page size for cross-tool consistency.
+_VERIFY_BATCH_SIZE = 1_000
+
 
 async def verify_audit_chain(driver: SqlDriver) -> dict[str, Any]:
     """Verify the integrity of the audit events signature chain.
@@ -55,73 +62,91 @@ async def verify_audit_chain(driver: SqlDriver) -> dict[str, Any]:
             "reason": "No audit events recorded (audit table does not exist).",
         }
 
-    # Retrieve all rows sorted by ID ascending to verify sequentially
-    rows = await driver.execute_query(
-        f"SELECT id, occurred_at, tool, arguments, status, error, result, prev_hmac, event_hmac "
-        f"FROM {_QUALIFIED} ORDER BY id ASC",
-        force_readonly=True,
-    )
-    if not rows:
+    # Walk events in keyset-paginated batches. The previous shape pulled
+    # every row into the process in one SELECT — fine for the toy case,
+    # but on a million-row audit table that's gigabytes of jsonb in
+    # memory before the chain check even starts. Keyset pagination
+    # (``WHERE id > last_id``) is index-friendly (the PRIMARY KEY does
+    # the work), order-stable (id is monotonic for an append-only audit
+    # surface), and bounds peak memory at one batch.
+    expected_prev_hmac = ""
+    key_bytes = key_str.encode("utf-8")
+    last_seen_id: int = 0
+    walked_anything = False
+
+    while True:
+        rows = await driver.execute_query(
+            f"SELECT id, occurred_at, tool, arguments, status, error, result, prev_hmac, event_hmac "
+            f"FROM {_QUALIFIED} WHERE id > %s ORDER BY id ASC LIMIT %s",
+            params=[last_seen_id, _VERIFY_BATCH_SIZE],
+            force_readonly=True,
+        )
+        if not rows:
+            break
+        for row in rows:
+            walked_anything = True
+            row_id = row.cells["id"]
+            occurred_at = row.cells["occurred_at"]
+            if hasattr(occurred_at, "astimezone"):
+                from datetime import UTC
+
+                occurred_at_str = occurred_at.astimezone(UTC).isoformat()
+            elif hasattr(occurred_at, "isoformat"):
+                occurred_at_str = occurred_at.isoformat()
+            else:
+                occurred_at_str = str(occurred_at)
+
+            # Formulate payload exactly matches insertion
+            payload_data = {
+                "occurred_at": occurred_at_str,
+                "tool": row.cells["tool"],
+                "arguments": row.cells["arguments"],
+                "status": row.cells["status"],
+                "error": row.cells["error"],
+                "result": row.cells["result"],
+            }
+            payload_bytes = json.dumps(payload_data, sort_keys=True, default=str).encode("utf-8")
+
+            # Verify prev_hmac
+            current_prev_hmac = row.cells.get("prev_hmac") or ""
+            if current_prev_hmac != expected_prev_hmac:
+                return {
+                    "status": "tampered",
+                    "broken_at_id": row_id,
+                    "reason": f"Mismatch in prev_hmac: expected {expected_prev_hmac!r}, got {current_prev_hmac!r}",
+                }
+
+            # Verify event_hmac signature
+            current_event_hmac = row.cells.get("event_hmac") or ""
+            if not current_event_hmac:
+                return {
+                    "status": "tampered",
+                    "broken_at_id": row_id,
+                    "reason": "Missing event_hmac signature.",
+                }
+
+            # Compute computed_hmac
+            data_to_sign = current_prev_hmac.encode("utf-8") + payload_bytes
+            computed_hmac = hmac.new(key_bytes, data_to_sign, hashlib.sha256).hexdigest()
+
+            if current_event_hmac != computed_hmac:
+                return {
+                    "status": "tampered",
+                    "broken_at_id": row_id,
+                    "reason": f"Mismatch in event_hmac: expected {computed_hmac!r}, got {current_event_hmac!r}",
+                }
+
+            expected_prev_hmac = computed_hmac
+            last_seen_id = row_id
+
+        # Short batch → we reached the tail; don't issue an extra empty
+        # SELECT just to discover that.
+        if len(rows) < _VERIFY_BATCH_SIZE:
+            break
+
+    if not walked_anything:
         return {
             "status": "ok",
             "reason": "No audit events recorded (table is empty).",
         }
-
-    expected_prev_hmac = ""
-    key_bytes = key_str.encode("utf-8")
-
-    for row in rows:
-        row_id = row.cells["id"]
-        occurred_at = row.cells["occurred_at"]
-        if hasattr(occurred_at, "astimezone"):
-            from datetime import UTC
-
-            occurred_at_str = occurred_at.astimezone(UTC).isoformat()
-        elif hasattr(occurred_at, "isoformat"):
-            occurred_at_str = occurred_at.isoformat()
-        else:
-            occurred_at_str = str(occurred_at)
-
-        # Formulate payload exactly matches insertion
-        payload_data = {
-            "occurred_at": occurred_at_str,
-            "tool": row.cells["tool"],
-            "arguments": row.cells["arguments"],
-            "status": row.cells["status"],
-            "error": row.cells["error"],
-            "result": row.cells["result"],
-        }
-        payload_bytes = json.dumps(payload_data, sort_keys=True, default=str).encode("utf-8")
-
-        # Verify prev_hmac
-        current_prev_hmac = row.cells.get("prev_hmac") or ""
-        if current_prev_hmac != expected_prev_hmac:
-            return {
-                "status": "tampered",
-                "broken_at_id": row_id,
-                "reason": f"Mismatch in prev_hmac: expected {expected_prev_hmac!r}, got {current_prev_hmac!r}",
-            }
-
-        # Verify event_hmac signature
-        current_event_hmac = row.cells.get("event_hmac") or ""
-        if not current_event_hmac:
-            return {
-                "status": "tampered",
-                "broken_at_id": row_id,
-                "reason": "Missing event_hmac signature.",
-            }
-
-        # Compute computed_hmac
-        data_to_sign = current_prev_hmac.encode("utf-8") + payload_bytes
-        computed_hmac = hmac.new(key_bytes, data_to_sign, hashlib.sha256).hexdigest()
-
-        if current_event_hmac != computed_hmac:
-            return {
-                "status": "tampered",
-                "broken_at_id": row_id,
-                "reason": f"Mismatch in event_hmac: expected {computed_hmac!r}, got {current_event_hmac!r}",
-            }
-
-        expected_prev_hmac = computed_hmac
-
     return {"status": "ok"}

--- a/src/mcpg/audit_integrity.py
+++ b/src/mcpg/audit_integrity.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+from datetime import UTC
 from os import environ
 from typing import Any
 
@@ -88,8 +89,9 @@ async def verify_audit_chain(driver: SqlDriver) -> dict[str, Any]:
             row_id = row.cells["id"]
             occurred_at = row.cells["occurred_at"]
             if hasattr(occurred_at, "astimezone"):
-                from datetime import UTC
-
+                # ``UTC`` imported at module scope — keeping it out of
+                # the inner row loop saves the import-lookup cost on
+                # large audit tables (sourcery review on #99).
                 occurred_at_str = occurred_at.astimezone(UTC).isoformat()
             elif hasattr(occurred_at, "isoformat"):
                 occurred_at_str = occurred_at.isoformat()
@@ -109,7 +111,12 @@ async def verify_audit_chain(driver: SqlDriver) -> dict[str, Any]:
 
             # Verify prev_hmac
             current_prev_hmac = row.cells.get("prev_hmac") or ""
-            if current_prev_hmac != expected_prev_hmac:
+            # constant-time HMAC compare — verification-side timing
+            # isn't a sensitive oracle here (verify is operator-
+            # initiated, not a per-request hot path), but inconsistency
+            # with the rest of the codebase's hmac.compare_digest usage
+            # was flagged in deep-review P2 #7 and gemini review on #99.
+            if not hmac.compare_digest(current_prev_hmac, expected_prev_hmac):
                 return {
                     "status": "tampered",
                     "broken_at_id": row_id,
@@ -129,7 +136,8 @@ async def verify_audit_chain(driver: SqlDriver) -> dict[str, Any]:
             data_to_sign = current_prev_hmac.encode("utf-8") + payload_bytes
             computed_hmac = hmac.new(key_bytes, data_to_sign, hashlib.sha256).hexdigest()
 
-            if current_event_hmac != computed_hmac:
+            # constant-time HMAC compare — see comment above.
+            if not hmac.compare_digest(current_event_hmac, computed_hmac):
                 return {
                     "status": "tampered",
                     "broken_at_id": row_id,

--- a/src/mcpg/textsearch.py
+++ b/src/mcpg/textsearch.py
@@ -344,6 +344,15 @@ async def vector_range_search(
 
 DEFAULT_MMR_LAMBDA = 0.5
 
+# MMR's diversity pass is O(pool · k) cosine similarities in pure
+# Python with every candidate's embedding in memory. The bounds keep
+# the worst-case sane: at k=1000 + pool=10000 = 10M similarities, the
+# loop is in seconds-not-minutes territory on a typical box. Callers
+# wanting more should reach for a vector-DB-side ANN library, not
+# crank these knobs.
+_MAX_MMR_K = 1_000
+_MAX_MMR_FETCH_K = 10_000
+
 
 def _parse_embedding(value: Any) -> list[float]:
     """Coerce a pgvector cell into a list of floats.
@@ -426,11 +435,24 @@ async def mmr_search(
         raise SearchError("query_vector must contain only finite numbers")
     if k < 1:
         raise SearchError("k must be at least 1")
+    if k > _MAX_MMR_K:
+        raise SearchError(f"k must be ≤ {_MAX_MMR_K} (MMR's selection step is O(k²) in pure Python)")
     if not 0.0 <= lambda_mult <= 1.0:
         raise SearchError("lambda_mult must be between 0 and 1")
     pool = fetch_k if fetch_k is not None else max(4 * k, 20)
     if pool < k:
         raise SearchError("fetch_k must be >= k")
+    # The recall pass returns ``pool`` rows that get pulled into the
+    # process (each carries the embedding for the diversity pass), and
+    # the inner MMR loop runs O(pool·k) cosine similarities in pure
+    # Python. Without a cap, ``fetch_k=100_000`` is a process killer.
+    if pool > _MAX_MMR_FETCH_K:
+        raise SearchError(
+            f"fetch_k must be ≤ {_MAX_MMR_FETCH_K} "
+            f"(MMR pulls every candidate's embedding into memory and runs "
+            f"O(pool·k) similarities in pure Python; raise the cap with a "
+            f"smaller k or split the query)"
+        )
 
     operator = _VECTOR_METRICS[metric]
     relation = f"{_quoted(schema, 'schema')}.{_quoted(table, 'table')}"

--- a/src/mcpg/vector_ops.py
+++ b/src/mcpg/vector_ops.py
@@ -33,6 +33,29 @@ _IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
 # the magnitude-distribution heuristic a stable signal.
 DEFAULT_SAMPLE_SIZE = 1000
 
+# Upper bound on every sample_size argument across this module. The
+# tools all pull `sample_size` rows into the Python process and run
+# in-process algorithms (k-means, MMR's diversity pass, centroid
+# computation, per-row z-scores) — without a ceiling, a request for
+# 10M rows is a process killer. 50k matches the ceiling used by the
+# rag_efficiency module's _MAX_SAMPLE_SIZE so the two co-located
+# vector-analytics surfaces share one mental model. Above this you
+# want a vector-DB ANN library, not an in-process Python loop.
+_MAX_SAMPLE_SIZE = 50_000
+
+
+def _validate_sample_size(value: int) -> None:
+    """Shared sample_size validator used by every vector-ops tool."""
+    if value < 1:
+        raise VectorOpsError("sample_size must be at least 1")
+    if value > _MAX_SAMPLE_SIZE:
+        raise VectorOpsError(
+            f"sample_size must be ≤ {_MAX_SAMPLE_SIZE} "
+            f"(rows are pulled into the process and the per-row work runs in "
+            f"pure Python). Reach for a vector-DB ANN library instead of "
+            f"raising this cap."
+        )
+
 
 # Below this coefficient of variation we treat the magnitudes as
 # "essentially constant" — in that regime cosine / L2 / inner-product
@@ -226,8 +249,7 @@ async def analyze_distance_metric(
         VectorOpsError: On an invalid identifier or a non-positive
             ``sample_size``.
     """
-    if sample_size < 1:
-        raise VectorOpsError("sample_size must be at least 1")
+    _validate_sample_size(sample_size)
     if not await extension_installed(driver, "vector"):
         return DistanceMetricRecommendation(
             available=False,
@@ -722,8 +744,7 @@ async def cluster_vectors(
     """
     if metric not in {"l2", "cosine"}:
         raise VectorOpsError(f"unknown metric for clustering: {metric!r}; expected 'l2' or 'cosine'")
-    if sample_size < 1:
-        raise VectorOpsError("sample_size must be at least 1")
+    _validate_sample_size(sample_size)
     if max_iterations < 1:
         raise VectorOpsError("max_iterations must be at least 1")
     if k < 2:
@@ -924,8 +945,7 @@ async def detect_vector_outliers(
     """
     if metric not in {"l2", "cosine"}:
         raise VectorOpsError(f"unknown metric for clustering: {metric!r}; expected 'l2' or 'cosine'")
-    if sample_size < 1:
-        raise VectorOpsError("sample_size must be at least 1")
+    _validate_sample_size(sample_size)
     if max_iterations < 1:
         raise VectorOpsError("max_iterations must be at least 1")
     if k < 2:
@@ -1270,8 +1290,7 @@ async def monitor_embedding_drift(
             pgvector, ``sample_size <= 0``, ``drift_threshold < 0``,
             or a window whose ``end <= start``.
     """
-    if sample_size < 1:
-        raise VectorOpsError("sample_size must be at least 1")
+    _validate_sample_size(sample_size)
     if drift_threshold < 0:
         raise VectorOpsError("drift_threshold must be >= 0")
     if baseline_end <= baseline_start:

--- a/src/mcpg/vector_ops.py
+++ b/src/mcpg/vector_ops.py
@@ -45,12 +45,18 @@ _MAX_SAMPLE_SIZE = 50_000
 
 
 def _validate_sample_size(value: int) -> None:
-    """Shared sample_size validator used by every vector-ops tool."""
+    """Shared sample_size validator used by every vector-ops tool.
+
+    Echoes the offending value in the error message so a caller
+    debugging a stack trace can spot which tool was misconfigured
+    without having to also log the call's arguments (sourcery review
+    on #99).
+    """
     if value < 1:
-        raise VectorOpsError("sample_size must be at least 1")
+        raise VectorOpsError(f"sample_size={value!r} must be at least 1")
     if value > _MAX_SAMPLE_SIZE:
         raise VectorOpsError(
-            f"sample_size must be ≤ {_MAX_SAMPLE_SIZE} "
+            f"sample_size={value!r} must be ≤ {_MAX_SAMPLE_SIZE} "
             f"(rows are pulled into the process and the per-row work runs in "
             f"pure Python). Reach for a vector-DB ANN library instead of "
             f"raising this cap."

--- a/tests/unit/test_audit_integrity.py
+++ b/tests/unit/test_audit_integrity.py
@@ -4,6 +4,7 @@ import datetime
 import hashlib
 import hmac
 import json
+from typing import Any
 
 import pytest
 from _fakes import FakeDatabase, FakeDriver, FakeRoutingDriver
@@ -206,6 +207,138 @@ async def test_verify_audit_chain_flags_row_with_blank_event_hmac(monkeypatch: p
     assert res["status"] == "tampered"
     assert res["broken_at_id"] == 1
     assert "Missing event_hmac" in res["reason"]
+
+
+async def test_verify_audit_chain_uses_keyset_pagination(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Regression for deep-review scalability P0 #2: the old verify
+    issued one ``SELECT … FROM events ORDER BY id ASC`` with no LIMIT,
+    loading the whole table (potentially gigabytes of jsonb) before
+    the chain check even started. The fix walks the chain in keyset-
+    paginated batches: ``WHERE id > %s ORDER BY id LIMIT batch_size``.
+    Asserting via SQL shape rather than a million-row fake."""
+    monkeypatch.setenv("MCPG_AUDIT_HMAC_KEY", "secret_key")
+    monkeypatch.setenv("MCPG_AUDIT_INTEGRITY", "true")
+
+    driver = FakeRoutingDriver(
+        {
+            "FROM pg_class c": [{"present": 1}],
+            "FROM mcpg_audit.events": [],  # empty table → one keyset query then stop
+        }
+    )
+    await verify_audit_chain(driver)  # type: ignore[arg-type]
+
+    walk_calls = [call for call in driver.calls if "FROM mcpg_audit.events" in call[0]]
+    assert walk_calls, "expected at least one events SELECT"
+    sql = walk_calls[0][0]
+    params = walk_calls[0][1]
+    # Keyset shape: WHERE id > %s ORDER BY id ASC LIMIT %s. Both
+    # placeholders are bound (no literal LIMIT splice).
+    assert "WHERE id > %s" in sql
+    assert "ORDER BY id ASC" in sql
+    assert "LIMIT %s" in sql
+    assert params is not None
+    # First batch: start from id 0 (sentinel) with the documented
+    # batch size. The constant is module-level; the test asserts
+    # *that* a positive bound was passed, not its exact value, so
+    # future tuning doesn't require rewriting the test.
+    assert params[0] == 0
+    assert isinstance(params[1], int) and params[1] > 0
+
+
+async def test_verify_audit_chain_walks_multiple_batches(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With more rows than fit in one batch, the verifier should
+    issue another keyset SELECT with the highest seen id. We force
+    a tiny batch_size and use a paged fake driver that filters by
+    ``WHERE id > last_seen`` so the streaming actually progresses
+    rather than re-serving the same rows forever."""
+    monkeypatch.setenv("MCPG_AUDIT_HMAC_KEY", "secret_key")
+    monkeypatch.setenv("MCPG_AUDIT_INTEGRITY", "true")
+
+    # Patch the batch size to something small to force multiple iterations.
+    import mcpg.audit_integrity as audit_integrity_mod
+
+    monkeypatch.setattr(audit_integrity_mod, "_VERIFY_BATCH_SIZE", 2)
+
+    key = "secret_key"
+    now_dt = datetime.datetime.now(datetime.UTC)
+    occurred_at_str = now_dt.isoformat()
+
+    def _payload(sql: str) -> dict[str, Any]:
+        return {
+            "occurred_at": occurred_at_str,
+            "tool": "run_write",
+            "arguments": {"sql": sql},
+            "status": "ok",
+            "error": None,
+            "result": None,
+        }
+
+    # Sign three events in a real chain.
+    p1 = _payload("SELECT 1")
+    pb1 = json.dumps(p1, sort_keys=True, default=str).encode("utf-8")
+    h1 = hmac.new(key.encode("utf-8"), b"" + pb1, hashlib.sha256).hexdigest()
+    p2 = _payload("SELECT 2")
+    pb2 = json.dumps(p2, sort_keys=True, default=str).encode("utf-8")
+    h2 = hmac.new(key.encode("utf-8"), h1.encode("utf-8") + pb2, hashlib.sha256).hexdigest()
+    p3 = _payload("SELECT 3")
+    pb3 = json.dumps(p3, sort_keys=True, default=str).encode("utf-8")
+    h3 = hmac.new(key.encode("utf-8"), h2.encode("utf-8") + pb3, hashlib.sha256).hexdigest()
+
+    all_rows = [
+        {
+            "id": idx,
+            "occurred_at": now_dt,
+            "tool": "run_write",
+            "arguments": {"sql": sql},
+            "status": "ok",
+            "error": None,
+            "result": None,
+            "prev_hmac": prev,
+            "event_hmac": event,
+        }
+        for idx, (sql, prev, event) in enumerate(
+            [
+                ("SELECT 1", "", h1),
+                ("SELECT 2", h1, h2),
+                ("SELECT 3", h2, h3),
+            ],
+            start=1,
+        )
+    ]
+
+    # Custom paged driver: applies the ``WHERE id > last_seen`` /
+    # ``LIMIT batch`` semantics that the real PG would, by inspecting
+    # the bound params. FakeRoutingDriver ignores params, so reuse it
+    # only for the pg_class probe and override the events route.
+    class _PagedFake:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, list[Any] | None, bool]] = []
+
+        async def execute_query(self, query: str, params: list[Any] | None = None, force_readonly: bool = False) -> Any:
+            from mcpg._vendor.sql import SqlDriver
+
+            self.calls.append((query, params, force_readonly))
+            if "FROM pg_class c" in query:
+                return [SqlDriver.RowResult(cells={"present": 1})]
+            if "FROM mcpg_audit.events" in query:
+                assert params is not None
+                start_after = int(params[0])
+                limit = int(params[1])
+                page = [r for r in all_rows if r["id"] > start_after][:limit]
+                return [SqlDriver.RowResult(cells=dict(r)) for r in page]
+            return []
+
+    driver = _PagedFake()
+    res = await verify_audit_chain(driver)  # type: ignore[arg-type]
+    assert res["status"] == "ok"
+
+    events_calls = [call for call in driver.calls if "FROM mcpg_audit.events" in call[0]]
+    # With 3 rows and batch=2: first batch returns 2, loop continues
+    # because it was full; second returns 1 (short), loop stops. So
+    # exactly 2 SELECTs.
+    assert len(events_calls) == 2
+    # Second batch's last_seen_id is the highest id from the first batch.
+    assert events_calls[1][1][0] == 2
 
 
 async def test_verify_audit_chain_tool_is_registered_in_read_mode() -> None:

--- a/tests/unit/test_textsearch.py
+++ b/tests/unit/test_textsearch.py
@@ -343,6 +343,14 @@ async def test_mmr_search_fetch_k_defaults_to_a_wider_pool() -> None:
         ({"k": 0}, "k must be"),
         ({"lambda_mult": 1.5}, "lambda_mult"),
         ({"k": 5, "fetch_k": 2}, "fetch_k"),
+        # Regression for deep-review scalability P0 #1: unbounded
+        # fetch_k pulls every candidate's embedding into memory and
+        # runs O(pool·k) similarities in pure Python. Cap kicks at
+        # 10_000.
+        ({"fetch_k": 100_000}, "fetch_k must be ≤"),
+        # k itself is also capped: MMR's selection loop is O(k²)
+        # because each pick compares against the already-picked set.
+        ({"k": 5000}, "k must be ≤"),
     ],
 )
 async def test_mmr_search_validates_arguments(kwargs: dict[str, object], match: str) -> None:

--- a/tests/unit/test_vector_ops.py
+++ b/tests/unit/test_vector_ops.py
@@ -41,6 +41,41 @@ from mcpg.vector_ops import (
 _SETTINGS = load_settings({"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db"})
 
 
+# --- shared sample_size cap (scalability P0) -------------------------------
+
+
+async def test_every_vector_ops_entry_point_rejects_oversized_sample_size() -> None:
+    """Regression for deep-review scalability P0 #3: cluster_vectors,
+    detect_vector_outliers, monitor_embedding_drift, and
+    analyze_distance_metric all pull ``sample_size`` rows into the
+    process for in-Python work (k-means, z-scores, centroid drift,
+    norm stats). Without a cap, ``sample_size=10_000_000`` is a
+    process killer. The shared ``_validate_sample_size`` helper now
+    enforces the same ceiling at every entry point; this test pins
+    that every tool actually wires it in."""
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+    oversize = 10_000_000
+    with pytest.raises(VectorOpsError, match="must be ≤"):
+        await analyze_distance_metric(driver, "app", "docs", "embedding", sample_size=oversize)  # type: ignore[arg-type]
+    with pytest.raises(VectorOpsError, match="must be ≤"):
+        await cluster_vectors(driver, "app", "docs", "embedding", k=2, sample_size=oversize)  # type: ignore[arg-type]
+    with pytest.raises(VectorOpsError, match="must be ≤"):
+        await detect_vector_outliers(driver, "app", "docs", "embedding", sample_size=oversize)  # type: ignore[arg-type]
+    with pytest.raises(VectorOpsError, match="must be ≤"):
+        await monitor_embedding_drift(  # type: ignore[arg-type]
+            driver,
+            "app",
+            "docs",
+            "embedding",
+            timestamp_column="created_at",
+            baseline_start="2026-01-01",
+            baseline_end="2026-01-02",
+            current_start="2026-02-01",
+            current_end="2026-02-02",
+            sample_size=oversize,
+        )
+
+
 # --- _parse_embedding ------------------------------------------------------
 
 
@@ -243,6 +278,17 @@ async def test_analyze_distance_metric_rejects_non_positive_sample_size() -> Non
 
     with pytest.raises(VectorOpsError, match="sample_size"):
         await analyze_distance_metric(driver, "app", "docs", "embedding", sample_size=0)  # type: ignore[arg-type]
+
+
+async def test_analyze_distance_metric_rejects_oversized_sample_size() -> None:
+    """Regression for deep-review scalability P0 #3: an unbounded
+    sample_size pulls every requested row into the process for in-
+    process work. The shared cap caps the cliff at 50k regardless of
+    which entry point is called."""
+    driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
+
+    with pytest.raises(VectorOpsError, match="must be ≤"):
+        await analyze_distance_metric(driver, "app", "docs", "embedding", sample_size=10_000_000)  # type: ignore[arg-type]
 
 
 @pytest.mark.parametrize("bad", ['docs"; DROP TABLE x', "1bad", "a-b"])

--- a/tests/unit/test_vector_ops.py
+++ b/tests/unit/test_vector_ops.py
@@ -1209,7 +1209,7 @@ async def test_detect_vector_outliers_raises_when_column_is_not_pgvector() -> No
     ("kwargs", "match"),
     [
         ({"k": 1}, "k must be at least 2"),
-        ({"sample_size": 0}, "sample_size must be at least 1"),
+        ({"sample_size": 0}, "must be at least 1"),
         ({"max_iterations": 0}, "max_iterations must be at least 1"),
         ({"metric": "manhattan"}, "unknown metric"),
         ({"zscore_threshold": 0.0}, "zscore_threshold must be > 0"),
@@ -1520,7 +1520,7 @@ async def test_monitor_embedding_drift_raises_when_column_is_not_pgvector() -> N
 @pytest.mark.parametrize(
     ("kwargs", "match"),
     [
-        ({"sample_size": 0}, "sample_size must be at least 1"),
+        ({"sample_size": 0}, "must be at least 1"),
         ({"drift_threshold": -0.1}, "drift_threshold must be >= 0"),
         ({"baseline_end": "2026-01-01"}, "baseline window end must be after start"),
         ({"current_end": "2026-02-01"}, "current window end must be after start"),


### PR DESCRIPTION
## Summary

**PR-D of seven.** Closes three of the four scalability P0s. Each finding was a callable surface that took an unvalidated caller-supplied size and either pulled it all into Python or did quadratic work on it.

| # | Module | Fix |
|---|---|---|
| **P0 #1** | `textsearch.py::mmr_search` | New `_MAX_MMR_FETCH_K=10_000` + `_MAX_MMR_K=1_000`. Old code's pure-Python O(pool·k) diversity loop with every candidate's embedding in memory could be killed by `fetch_k=100k`. |
| **P0 #2** | `audit_integrity.py::verify_audit_chain` | Keyset pagination: `WHERE id > %s ORDER BY id ASC LIMIT %s` walked in batches of `_VERIFY_BATCH_SIZE=1_000`. Old code loaded the entire events table into the process before the chain check started — gigabytes on a million-row table. |
| **P0 #3** | `vector_ops.py` × 4 entry points | Shared `_validate_sample_size` helper + `_MAX_SAMPLE_SIZE=50_000` (matches `rag_efficiency._MAX_SAMPLE_SIZE`). Applied to `cluster_vectors`, `detect_vector_outliers`, `monitor_embedding_drift`, `analyze_distance_metric`. |

### Why one cap value across each surface

- `_MAX_SAMPLE_SIZE=50_000` matches the existing rag_efficiency ceiling — vector-analytics callers already see this ceiling elsewhere.
- `_MAX_MMR_FETCH_K=10_000` × `_MAX_MMR_K=1_000` = 10M similarities worst case, in seconds-not-minutes territory.
- `_VERIFY_BATCH_SIZE=1_000` matches `list_audit_events`' default page size.

### Not addressed in this PR — **P0 #4** (`monitor_embedding_drift` `ORDER BY RANDOM() LIMIT n`)

The agent flagged the full-scan-and-sort cost on un-pre-pruned windows. `TABLESAMPLE BERNOULLI` doesn't compose cleanly with the timestamp WHERE filter (samples the whole table, not the window), and the current shape is intentional for unbiased drift sampling. The sample_size cap above transitively bounds the worst case via LIMIT, but a proper replacement (probability-based pre-filter with COUNT-driven calibration) is out of scope for the no-guesswork pass.

**Flagging explicitly so it surfaces in the followups queue rather than going silent.**

## Tests (+4, 1769 total)

- `mmr_search` parametrize gains `fetch_k=100_000` and `k=5000` rejection cases.
- `test_analyze_distance_metric_rejects_oversized_sample_size`.
- `test_every_vector_ops_entry_point_rejects_oversized_sample_size` — one shared-cap test that exercises every public tool so a future refactor dropping `_validate_sample_size` from one site can't slip through.
- `test_verify_audit_chain_uses_keyset_pagination` — pins the SQL shape (both placeholders bound, no literal splice).
- `test_verify_audit_chain_walks_multiple_batches` — uses a custom paged fake driver (FakeRoutingDriver ignores params and would re-serve the same rows) to prove `last_seen_id` tracking across iterations and termination on a short batch.

## Test plan

- [x] `ruff check` + `ruff format` + `mypy src/mcpg` + `bandit` all clean
- [x] `uv run pytest tests/unit` — 1769 passed
- [x] CI matrix PG 14 / 15 / 16 / 17 / 18 — expected green; keyset pagination uses only PG 7.x+ features

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Bound unvalidated size parameters in vector search, audit integrity verification, and vector analytics utilities to prevent unbounded in‑process work and memory usage on large datasets.

Bug Fixes:
- Paginate audit event chain verification with a bounded batch size to avoid loading the full events table into memory.

Enhancements:
- Introduce shared sample_size validation and an upper bound across vector_ops entry points to cap in‑process vector analytics workloads.
- Add maximum k and fetch_k limits to mmr_search to bound the size of the in‑memory candidate pool and the cost of the Python MMR diversity loop.

Tests:
- Add regression tests covering sample_size caps across vector_ops tools, argument caps for mmr_search, and keyset pagination behavior (including multi‑batch walks) in verify_audit_chain.