### PR TITLE
fix(rag_telemetry, maintenance): wrap DDL + record-the-SQL across setup paths

### DIFF
--- a/src/mcpg/maintenance.py
+++ b/src/mcpg/maintenance.py
@@ -27,10 +27,19 @@ class MaintenanceError(Exception):
 
 @dataclass(frozen=True, slots=True)
 class MaintenanceResult:
-    """The outcome of a maintenance run."""
+    """The outcome of a maintenance run.
+
+    :attr:`maintenance_sql` carries the rendered DDL that actually
+    executed (e.g. ``VACUUM (ANALYZE) "public"."docs"``) — same
+    record-the-SQL invariant ``CreateIndexResult.create_sql`` and
+    ``ReindexResult.reindex_sql`` enforce on the pg_search /
+    turboquant DDL surfaces. Audit / change-review callers get a
+    consistent shape across every DDL-emitting tool.
+    """
 
     operation: str
     target: str
+    maintenance_sql: str = ""
 
 
 def _quote_identifier(name: str) -> str:
@@ -59,8 +68,9 @@ async def run_maintenance(database: Database, operation: str, schema: str, table
         raise MaintenanceError(f"unknown operation {operation!r}; expected one of {expected}")
     target = f"{_quote_identifier(schema)}.{_quote_identifier(table)}"
     label = f"{schema}.{table}"
+    sql = f"{command} {target}"
     try:
-        await database.run_unmanaged(f"{command} {target}")
+        await database.run_unmanaged(sql)
     except Exception as exc:
         raise MaintenanceError(f"{operation} on {label} failed: {exc}") from exc
-    return MaintenanceResult(operation=operation, target=label)
+    return MaintenanceResult(operation=operation, target=label, maintenance_sql=sql)

--- a/src/mcpg/rag_telemetry.py
+++ b/src/mcpg/rag_telemetry.py
@@ -112,12 +112,17 @@ class RagTelemetrySetupResult:
     The booleans/counts report what actually changed in the catalog
     on this call. All-``False`` / zero means everything was already
     in place — the call was a no-op (intended; the operation is
-    idempotent).
+    idempotent). :attr:`setup_sql` carries every DDL statement that
+    actually ran (in execution order) so audit / change-review
+    callers can record exactly what hit the database — same
+    invariant ``CreateIndexResult.create_sql`` enforces on the
+    pg_search / turboquant DDL surfaces.
     """
 
     schema_created: bool
     table_created: bool
     indexes_created: int
+    setup_sql: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -130,6 +135,36 @@ class LogRerankEventResult:
 async def _exists(driver: SqlDriver, sql: str, params: list[Any]) -> bool:
     rows = await driver.execute_query(sql, params=params, force_readonly=True)
     return bool(rows)
+
+
+async def _run_setup_ddl(database: Database, sql: str, executed: list[str]) -> None:
+    """Run one setup-time DDL statement and record it for the result.
+
+    Mirrors the create_pg_search_index / create_turboquant_index
+    pattern: catch the raw driver exception (psycopg, DatabaseError,
+    or anything else that escapes ``run_unmanaged``) and re-raise as
+    the module's typed error so callers always see
+    :class:`RagTelemetryError` on a setup failure rather than a
+    psycopg traceback bleeding out of the wrapper. The successful
+    SQL is appended to ``executed`` so the caller can report the
+    full DDL sequence even if a later statement fails.
+    """
+    try:
+        await database.run_unmanaged(sql)
+    except Exception as exc:
+        raise RagTelemetryError(f"setup DDL failed ({_short_sql(sql)}): {exc}") from exc
+    executed.append(sql)
+
+
+def _short_sql(sql: str) -> str:
+    """A one-line preview of a DDL statement for error messages.
+
+    Collapses whitespace and caps at 80 chars — enough to identify
+    which statement failed without dumping the whole CREATE INDEX
+    body into the exception text.
+    """
+    flat = " ".join(sql.split())
+    return flat if len(flat) <= 80 else flat[:77] + "..."
 
 
 async def setup_rag_telemetry(database: Database) -> RagTelemetrySetupResult:
@@ -151,16 +186,17 @@ async def setup_rag_telemetry(database: Database) -> RagTelemetrySetupResult:
     for atomic ownership; treat it as advisory under concurrency.
     """
     driver = database.driver()
+    executed: list[str] = []
     had_schema = await _exists(driver, _PROBE_SCHEMA_SQL, [_SCHEMA_NAME])
-    await database.run_unmanaged(_SETUP_SQL_SCHEMA)
+    await _run_setup_ddl(database, _SETUP_SQL_SCHEMA, executed)
 
     had_table = await _exists(driver, _PROBE_TABLE_SQL, [_SCHEMA_NAME, _TABLE_NAME])
-    await database.run_unmanaged(_SETUP_SQL_TABLE)
+    await _run_setup_ddl(database, _SETUP_SQL_TABLE, executed)
 
     indexes_created = 0
     for index_name, sql in _SETUP_SQL_INDEXES:
         had_index = await _exists(driver, _PROBE_INDEX_SQL, [_SCHEMA_NAME, index_name])
-        await database.run_unmanaged(sql)
+        await _run_setup_ddl(database, sql, executed)
         if not had_index:
             indexes_created += 1
 
@@ -168,6 +204,7 @@ async def setup_rag_telemetry(database: Database) -> RagTelemetrySetupResult:
         schema_created=not had_schema,
         table_created=not had_table,
         indexes_created=indexes_created,
+        setup_sql=tuple(executed),
     )
 
 
@@ -381,11 +418,18 @@ _SETUP_SQL_EFFICIENCY_INDEXES: tuple[tuple[str, str], ...] = (
 
 @dataclass(frozen=True, slots=True)
 class EfficiencyObservationsSetupResult:
-    """Outcome of :func:`setup_efficiency_observations`."""
+    """Outcome of :func:`setup_efficiency_observations`.
+
+    :attr:`setup_sql` carries every DDL statement that actually ran
+    (in execution order) — same record-the-SQL invariant the
+    sibling :class:`RagTelemetrySetupResult` and the pg_search /
+    turboquant DDL surfaces hold.
+    """
 
     schema_created: bool
     table_created: bool
     indexes_created: int
+    setup_sql: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -444,16 +488,17 @@ async def setup_efficiency_observations(database: Database) -> EfficiencyObserva
     atomic).
     """
     driver = database.driver()
+    executed: list[str] = []
     had_schema = await _exists(driver, _PROBE_SCHEMA_SQL, [_SCHEMA_NAME])
-    await database.run_unmanaged(_SETUP_SQL_SCHEMA)
+    await _run_setup_ddl(database, _SETUP_SQL_SCHEMA, executed)
 
     had_table = await _exists(driver, _PROBE_TABLE_SQL, [_SCHEMA_NAME, _EFFICIENCY_TABLE])
-    await database.run_unmanaged(_SETUP_SQL_EFFICIENCY_TABLE)
+    await _run_setup_ddl(database, _SETUP_SQL_EFFICIENCY_TABLE, executed)
 
     indexes_created = 0
     for index_name, sql in _SETUP_SQL_EFFICIENCY_INDEXES:
         had_index = await _exists(driver, _PROBE_INDEX_SQL, [_SCHEMA_NAME, index_name])
-        await database.run_unmanaged(sql)
+        await _run_setup_ddl(database, sql, executed)
         if not had_index:
             indexes_created += 1
 
@@ -461,6 +506,7 @@ async def setup_efficiency_observations(database: Database) -> EfficiencyObserva
         schema_created=not had_schema,
         table_created=not had_table,
         indexes_created=indexes_created,
+        setup_sql=tuple(executed),
     )
 
 

--- a/tests/integration/test_maintenance_integration.py
+++ b/tests/integration/test_maintenance_integration.py
@@ -29,7 +29,11 @@ async def test_run_maintenance_vacuum_against_real_postgres(
     # autocommit path end to end.
     result = await run_maintenance(connected_database, "vacuum", "public", maintenance_table)
 
-    assert result == MaintenanceResult(operation="vacuum", target=f"public.{maintenance_table}")
+    assert result == MaintenanceResult(
+        operation="vacuum",
+        target=f"public.{maintenance_table}",
+        maintenance_sql=f'VACUUM "public"."{maintenance_table}"',
+    )
 
 
 async def test_run_maintenance_analyze_against_real_postgres(

--- a/tests/unit/test_maintenance.py
+++ b/tests/unit/test_maintenance.py
@@ -18,8 +18,16 @@ async def test_run_maintenance_issues_vacuum_for_a_table() -> None:
 
     result = await run_maintenance(database, "vacuum", "app", "widget")
 
-    assert result == MaintenanceResult(operation="vacuum", target="app.widget")
+    assert result == MaintenanceResult(
+        operation="vacuum",
+        target="app.widget",
+        maintenance_sql='VACUUM "app"."widget"',
+    )
     assert database.unmanaged == ['VACUUM "app"."widget"']
+    # The recorded SQL matches what actually ran — same record-the-SQL
+    # invariant create_pg_search_index / create_turboquant_index already
+    # hold for their CreateIndexResult / ReindexResult dataclasses.
+    assert result.maintenance_sql == database.unmanaged[0]
 
 
 async def test_run_maintenance_issues_analyze() -> None:

--- a/tests/unit/test_rag_telemetry.py
+++ b/tests/unit/test_rag_telemetry.py
@@ -10,8 +10,8 @@ from mcpg.config import load_settings
 from mcpg.rag_telemetry import (
     LogRerankEventResult,
     RagTelemetryError,
-    RagTelemetrySetupResult,
     log_rerank_event,
+    setup_efficiency_observations,
     setup_rag_telemetry,
 )
 from mcpg.server import create_server
@@ -52,15 +52,49 @@ async def test_setup_first_run_reports_everything_created() -> None:
     # Catalog probes all return empty → everything is "new".
     db = FakeDatabase(FakeRoutingDriver({}))  # type: ignore[arg-type]
     result = await setup_rag_telemetry(db)  # type: ignore[arg-type]
-    assert result == RagTelemetrySetupResult(
-        schema_created=True,
-        table_created=True,
-        indexes_created=3,
-    )
-    # Five run_unmanaged calls: schema + table + 3 indexes.
+    # Field-by-field assertions so the new setup_sql tuple doesn't
+    # force every caller to anticipate every executed statement.
+    assert result.schema_created is True
+    assert result.table_created is True
+    assert result.indexes_created == 3
+    # Five run_unmanaged calls: schema + table + 3 indexes. The
+    # result's setup_sql records the same five in execution order
+    # so audit / change-review callers don't have to also peek at
+    # the database double.
     assert len(db.unmanaged) == 5
     assert "CREATE SCHEMA IF NOT EXISTS mcpg_rag" in db.unmanaged[0]
     assert "CREATE TABLE IF NOT EXISTS mcpg_rag.rerank_events" in db.unmanaged[1]
+    assert result.setup_sql == tuple(db.unmanaged)
+
+
+async def test_setup_rag_telemetry_wraps_driver_failure_as_rag_telemetry_error() -> None:
+    """Regression for deep-review architecture P1: the four
+    run_unmanaged calls in setup_rag_telemetry let any raw
+    psycopg / DatabaseError leak past the RagTelemetryError
+    boundary. Same wrap pattern as PR #92 (turboquant DDL) and the
+    existing pg_search create/reindex paths."""
+    db = FakeDatabase(FakeRoutingDriver({}), unmanaged_fail=True)  # type: ignore[arg-type]
+
+    with pytest.raises(RagTelemetryError, match="setup DDL failed"):
+        await setup_rag_telemetry(db)  # type: ignore[arg-type]
+
+
+async def test_setup_rag_telemetry_preserves_cause_chain_on_failure() -> None:
+    db = FakeDatabase(FakeRoutingDriver({}), unmanaged_fail=True)  # type: ignore[arg-type]
+
+    with pytest.raises(RagTelemetryError) as excinfo:
+        await setup_rag_telemetry(db)  # type: ignore[arg-type]
+    assert isinstance(excinfo.value.__cause__, RuntimeError)
+    assert "maintenance failed" in str(excinfo.value.__cause__)
+
+
+async def test_setup_efficiency_observations_wraps_driver_failure() -> None:
+    """Same wrap on the second setup function — both paths must
+    typed-error consistently."""
+    db = FakeDatabase(FakeRoutingDriver({}), unmanaged_fail=True)  # type: ignore[arg-type]
+
+    with pytest.raises(RagTelemetryError, match="setup DDL failed"):
+        await setup_efficiency_observations(db)  # type: ignore[arg-type]
 
 
 async def test_setup_idempotent_when_everything_already_exists() -> None:
@@ -75,14 +109,15 @@ async def test_setup_idempotent_when_everything_already_exists() -> None:
         )
     )
     result = await setup_rag_telemetry(db)  # type: ignore[arg-type]
-    assert result == RagTelemetrySetupResult(
-        schema_created=False,
-        table_created=False,
-        indexes_created=0,
-    )
+    assert result.schema_created is False
+    assert result.table_created is False
+    assert result.indexes_created == 0
     # All five DDL statements still ran (idempotent — the table /
     # indexes / schema may exist by name but with a different shape).
     assert len(db.unmanaged) == 5
+    # No-op result still records the SQL that ran — the operation
+    # was idempotent, not skipped.
+    assert result.setup_sql == tuple(db.unmanaged)
 
 
 # --- log_rerank_event validation -------------------------------------------
@@ -242,11 +277,9 @@ async def test_setup_rag_telemetry_registers_with_ddl_opt_in() -> None:
 
 
 from mcpg.rag_telemetry import (  # noqa: E402
-    EfficiencyObservationsSetupResult,
     RecordEfficiencyObservationResult,
     recommend_efficiency_thresholds,
     record_efficiency_observation,
-    setup_efficiency_observations,
 )
 
 
@@ -304,13 +337,12 @@ def test_percentile_implementations_match_across_modules() -> None:
 async def test_setup_efficiency_observations_first_run_creates_table_and_indexes() -> None:
     db = FakeDatabase(FakeRoutingDriver({}))  # type: ignore[arg-type]
     result = await setup_efficiency_observations(db)  # type: ignore[arg-type]
-    assert result == EfficiencyObservationsSetupResult(
-        schema_created=True,
-        table_created=True,
-        indexes_created=2,
-    )
+    assert result.schema_created is True
+    assert result.table_created is True
+    assert result.indexes_created == 2
     # Four run_unmanaged calls: schema + table + 2 indexes.
     assert len(db.unmanaged) == 4
+    assert result.setup_sql == tuple(db.unmanaged)
 
 
 async def test_setup_efficiency_observations_idempotent_when_exists() -> None:


### PR DESCRIPTION
## Summary

**PR-E of seven.** Three architecture P1s closed.

### `src/mcpg/rag_telemetry.py` — DDL-wrap + record-SQL

`setup_rag_telemetry` and `setup_efficiency_observations` called `database.run_unmanaged` **eight times total without a try/except wrap**. Any raw psycopg / `DatabaseError` leaked past the documented `RagTelemetryError` boundary, breaking the typed-error contract that the parallel `pg_search` / `turboquant` setup paths hold.

Fix: new `_run_setup_ddl(database, sql, executed)` helper — same pattern PR #92 established for turboquant DDL — that catches `Exception` and re-raises as `RagTelemetryError` with a short SQL preview in the message and the original cause attached on `__cause__`. As each DDL succeeds, its SQL is appended to a local list.

`RagTelemetrySetupResult` and `EfficiencyObservationsSetupResult` gained a `setup_sql: tuple[str, ...]` field. Same record-the-SQL invariant `CreateIndexResult.create_sql` / `ReindexResult.reindex_sql` already enforce on the pg_search / turboquant DDL surfaces.

### `src/mcpg/maintenance.py` — record-SQL

`MaintenanceResult` gained `maintenance_sql: str`. `run_maintenance` constructs the SQL once and threads it through both `run_unmanaged` and the result, so audit / change-review callers don't have to reach into a side-channel database double.

## What's not touched in this PR (deferred with reasoning)

- **`extensions.enable_extension`** runs DDL via `driver.execute_query(force_readonly=False)` instead of `database.run_unmanaged`. Pattern deviation, not a correctness bug — `CREATE EXTENSION` composes fine inside a transaction. Risk of changing the call shape > benefit; flagged for separate look.
- **`audit_trail._ensure_audit_table`** runs `ALTER TABLE` via the same pattern for the same reason. PR #98 (the chain_tip work) also added a `CREATE TABLE` call there. Best revisited once both PRs settle.

## Tests (+5, 1766 total)

- `test_setup_rag_telemetry_wraps_driver_failure_as_rag_telemetry_error` — `unmanaged_fail=True` FakeDatabase → expect `RagTelemetryError` with `setup DDL failed` prefix.
- `test_setup_rag_telemetry_preserves_cause_chain_on_failure` — pins `__cause__` is the original `RuntimeError`.
- `test_setup_efficiency_observations_wraps_driver_failure` — wrap regression on the sibling function.
- Existing first-run setup tests now also assert `setup_sql == tuple(db.unmanaged)` so the record-the-SQL invariant has regression pins on both result dataclasses.
- `test_run_maintenance_issues_vacuum_for_a_table` asserts `result.maintenance_sql` matches the executed SQL.

## Test plan

- [x] `ruff check .` + `ruff format` + `mypy src/mcpg` + `bandit` all clean
- [x] `uv run pytest tests/unit` — 1766 passed
- [x] CI matrix PG 14 / 15 / 16 / 17 / 18 — expected green; no SQL changes

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_