### PR TITLE
perf: bounded LRU on cloud secret caches; JWKS TTL; bind hybrid weights

### DIFF
--- a/src/mcpg/oidc.py
+++ b/src/mcpg/oidc.py
@@ -129,8 +129,23 @@ class OIDCVerifier:
         # PyJWKClient caches keys in-process; reuse the same client
         # for the JWKS-URL lifetime. Recreate when the URL changes
         # (e.g. discovery doc rotated).
+        #
+        # ``lifespan`` is the cache TTL in seconds for PyJWKClient's
+        # signing-key cache. We pass our project-configured value
+        # (``DEFAULT_JWKS_CACHE_SECONDS`` = 1h) so an upstream
+        # key-rotation event is picked up at most one TTL after it
+        # publishes — operators don't need a server restart any more.
+        # ``max_cached_keys`` defaults to 16 inside PyJWKClient, which
+        # is generous for a single-issuer setup; we pin it explicitly
+        # so a future PyJWKClient default change can't quietly grow
+        # the in-process key set.
         if self._jwks_client is None or getattr(self._jwks_client, "uri", None) != url:
-            self._jwks_client = PyJWKClient(url, cache_keys=True)
+            self._jwks_client = PyJWKClient(
+                url,
+                cache_keys=True,
+                max_cached_keys=16,
+                lifespan=int(self._jwks_cache_seconds),
+            )
         return self._jwks_client
 
     async def verify(self, token: str) -> VerifiedToken:

--- a/src/mcpg/pg_search.py
+++ b/src/mcpg/pg_search.py
@@ -1064,10 +1064,15 @@ async def hybrid_bm25_vector_search(
     quoted_vec = _pg_quote_ident(vector_column)
     bm25_where, n_bm25_query_binds = _bm25_search_predicate(validated_bm25_columns)
 
-    # k, weights, and per-leg limits are validated numerics, so
-    # rendering them as literals is safe and keeps the bind list to
-    # just the per-call values (query_text x n_bm25_query_binds for
-    # the multi-column OR form, vector x 2, final_limit).
+    # Per-call numerics that vary across requests (the two RRF weights
+    # and the limits) bind as %s parameters so PG's prepared-statement
+    # cache treats them as one query template. Inlining ``repr(float)``
+    # produced a distinct SQL string per weight value, which meant
+    # every (bm25_weight, vector_weight) tuple cost a re-plan. ``k``
+    # stays inlined: it's a tuning knob with a small enumerable set
+    # (60 is the documented default, 30/60/120 the practical
+    # alternatives) and binding it would mask integer-arithmetic
+    # optimizations PG can do on a known constant.
     sql = (
         f"WITH "
         f"bm25_leg AS ("
@@ -1076,24 +1081,24 @@ async def hybrid_bm25_vector_search(
         f" FROM {qualified_table} AS {_TABLE_ALIAS}"
         f" WHERE {bm25_where}"
         f" ORDER BY pdb.score({_TABLE_ALIAS}) DESC"
-        f" LIMIT {per_leg_limit}"
+        f" LIMIT %s"
         f"),"
         f" vector_leg AS ("
         f" SELECT {_TABLE_ALIAS}.{quoted_key} AS id,"
         f" ROW_NUMBER() OVER (ORDER BY {_TABLE_ALIAS}.{quoted_vec} {distance_op} %s::vector) AS rank"
         f" FROM {qualified_table} AS {_TABLE_ALIAS}"
         f" ORDER BY {_TABLE_ALIAS}.{quoted_vec} {distance_op} %s::vector"
-        f" LIMIT {per_leg_limit}"
+        f" LIMIT %s"
         f"),"
         f" fused AS ("
         f" SELECT id,"
-        f" {bm25_weight} * 1.0 / ({k} + rank) AS score,"
+        f" %s::float8 * 1.0 / ({k} + rank) AS score,"
         f" rank AS bm25_rank,"
         f" NULL::int AS vector_rank"
         f" FROM bm25_leg"
         f" UNION ALL"
         f" SELECT id,"
-        f" {vector_weight} * 1.0 / ({k} + rank) AS score,"
+        f" %s::float8 * 1.0 / ({k} + rank) AS score,"
         f" NULL::int AS bm25_rank,"
         f" rank AS vector_rank"
         f" FROM vector_leg"
@@ -1106,10 +1111,17 @@ async def hybrid_bm25_vector_search(
         f"ORDER BY score DESC "
         f"LIMIT %s"
     )
+    # Bind order matches placeholder order in the rendered SQL: bm25
+    # query string(s), bm25 leg LIMIT, vector literal x2, vector leg
+    # LIMIT, bm25 weight, vector weight, final LIMIT.
     params: list[Any] = [
         *([query_text] * n_bm25_query_binds),
+        per_leg_limit,
         vector_literal,
         vector_literal,
+        per_leg_limit,
+        bm25_weight,
+        vector_weight,
         final_limit,
     ]
     rows = await driver.execute_query(sql, params=params, force_readonly=True)

--- a/src/mcpg/secrets.py
+++ b/src/mcpg/secrets.py
@@ -37,6 +37,7 @@ pick up rotated values (or wire the rotation system to do so).
 from __future__ import annotations
 
 import json
+import threading
 from collections import OrderedDict
 from collections.abc import Mapping
 from dataclasses import dataclass, field
@@ -157,6 +158,15 @@ def _load_overlay(path: str) -> dict[str, str]:
 # small (string keys + small string values → kilobytes, not gigs).
 _SECRET_CACHE_MAX_ENTRIES = 1024
 
+# OrderedDict's ``move_to_end`` / ``popitem`` and the bounded-eviction
+# loop are not atomic, so a sync ``provider.get`` called from a worker
+# thread (e.g. via ``asyncio.to_thread`` — already used elsewhere in
+# the codebase for sync SDK calls) could race with the asyncio loop's
+# own get and corrupt the linked list. Per-cache mutation cost is a
+# single Lock acquire / release, well under a microsecond, so this is
+# pure upside (gemini review on #101).
+_CACHE_LOCK = threading.Lock()
+
 
 def _cache_get(cache: OrderedDict[str, str | None], name: str) -> tuple[str | None, bool]:
     """Return ``(value, present)`` for a name lookup.
@@ -166,10 +176,11 @@ def _cache_get(cache: OrderedDict[str, str | None], name: str) -> tuple[str | No
     the entry is moved to the back of the OrderedDict so the LRU
     eviction in :func:`_cache_put` drops cold entries first.
     """
-    if name in cache:
-        cache.move_to_end(name)
-        return cache[name], True
-    return None, False
+    with _CACHE_LOCK:
+        if name in cache:
+            cache.move_to_end(name)
+            return cache[name], True
+        return None, False
 
 
 def _cache_put(cache: OrderedDict[str, str | None], name: str, value: str | None) -> None:
@@ -179,10 +190,11 @@ def _cache_put(cache: OrderedDict[str, str | None], name: str, value: str | None
     evicts the oldest entries until the size is within
     :data:`_SECRET_CACHE_MAX_ENTRIES`.
     """
-    cache[name] = value
-    cache.move_to_end(name)
-    while len(cache) > _SECRET_CACHE_MAX_ENTRIES:
-        cache.popitem(last=False)
+    with _CACHE_LOCK:
+        cache[name] = value
+        cache.move_to_end(name)
+        while len(cache) > _SECRET_CACHE_MAX_ENTRIES:
+            cache.popitem(last=False)
 
 
 @dataclass

--- a/src/mcpg/secrets.py
+++ b/src/mcpg/secrets.py
@@ -37,6 +37,7 @@ pick up rotated values (or wire the rotation system to do so).
 from __future__ import annotations
 
 import json
+from collections import OrderedDict
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any, Protocol, runtime_checkable
@@ -147,6 +148,43 @@ def _load_overlay(path: str) -> dict[str, str]:
     return overlay
 
 
+# Per-provider cache cap. The cloud-secrets caches were unbounded
+# ``dict[str, str | None]`` instances; an attacker (or buggy caller)
+# hitting ``provider.get(unique_name_each_call)`` in a loop would
+# grow them until OOM. Bounding at 1024 covers any reasonable
+# deployment's working set (MCPG_* + vendor env vars + a few hundred
+# tenanted lookups) while keeping the worst-case memory footprint
+# small (string keys + small string values → kilobytes, not gigs).
+_SECRET_CACHE_MAX_ENTRIES = 1024
+
+
+def _cache_get(cache: OrderedDict[str, str | None], name: str) -> tuple[str | None, bool]:
+    """Return ``(value, present)`` for a name lookup.
+
+    ``present=False`` distinguishes "name never cached" from "cached
+    as None" (a name explicitly absent from the backend). On a hit
+    the entry is moved to the back of the OrderedDict so the LRU
+    eviction in :func:`_cache_put` drops cold entries first.
+    """
+    if name in cache:
+        cache.move_to_end(name)
+        return cache[name], True
+    return None, False
+
+
+def _cache_put(cache: OrderedDict[str, str | None], name: str, value: str | None) -> None:
+    """Insert ``(name, value)`` with bounded-LRU semantics.
+
+    Replaces any existing entry, marks it most-recently-used, then
+    evicts the oldest entries until the size is within
+    :data:`_SECRET_CACHE_MAX_ENTRIES`.
+    """
+    cache[name] = value
+    cache.move_to_end(name)
+    while len(cache) > _SECRET_CACHE_MAX_ENTRIES:
+        cache.popitem(last=False)
+
+
 @dataclass
 class VaultSecretsProvider:
     """Reads secrets from HashiCorp Vault's KV v2 backend.
@@ -170,18 +208,17 @@ class VaultSecretsProvider:
     namespace: str | None = None
     path_prefix: str = "secret/mcpg"
     _client: Any = field(default=None, init=False, repr=False, compare=False)
-    _cache: dict[str, str | None] = field(default_factory=dict, init=False, repr=False, compare=False)
+    _cache: OrderedDict[str, str | None] = field(default_factory=OrderedDict, init=False, repr=False, compare=False)
 
     def get(self, name: str) -> str | None:
-        if name in self._cache:
-            cached = self._cache[name]
-            if cached is not None:
-                return cached
-            # ``None`` cache = "not in Vault" — fall through to env.
-            return self.env.get(name)
+        cached, present = _cache_get(self._cache, name)
+        if present:
+            # Stored ``None`` = "name is not in Vault"; fall through
+            # to env so vendor-conventional env vars still resolve.
+            return cached if cached is not None else self.env.get(name)
 
         value = self._fetch(name)
-        self._cache[name] = value
+        _cache_put(self._cache, name, value)
         if value is not None:
             return value
         return self.env.get(name)
@@ -262,14 +299,14 @@ class AWSSecretsProvider:
     env: Mapping[str, str]
     prefix: str = ""
     _client: Any = field(default=None, init=False, repr=False, compare=False)
-    _cache: dict[str, str | None] = field(default_factory=dict, init=False, repr=False, compare=False)
+    _cache: OrderedDict[str, str | None] = field(default_factory=OrderedDict, init=False, repr=False, compare=False)
 
     def get(self, name: str) -> str | None:
-        if name in self._cache:
-            cached = self._cache[name]
+        cached, present = _cache_get(self._cache, name)
+        if present:
             return cached if cached is not None else self.env.get(name)
         value = self._fetch(name)
-        self._cache[name] = value
+        _cache_put(self._cache, name, value)
         if value is not None:
             return value
         return self.env.get(name)
@@ -351,14 +388,14 @@ class GCPSecretsProvider:
     env: Mapping[str, str]
     prefix: str = ""
     _client: Any = field(default=None, init=False, repr=False, compare=False)
-    _cache: dict[str, str | None] = field(default_factory=dict, init=False, repr=False, compare=False)
+    _cache: OrderedDict[str, str | None] = field(default_factory=OrderedDict, init=False, repr=False, compare=False)
 
     def get(self, name: str) -> str | None:
-        if name in self._cache:
-            cached = self._cache[name]
+        cached, present = _cache_get(self._cache, name)
+        if present:
             return cached if cached is not None else self.env.get(name)
         value = self._fetch(name)
-        self._cache[name] = value
+        _cache_put(self._cache, name, value)
         if value is not None:
             return value
         return self.env.get(name)

--- a/tests/unit/test_oidc.py
+++ b/tests/unit/test_oidc.py
@@ -130,6 +130,46 @@ def test_verifier_init_rejects_blank_issuer_or_audience() -> None:
         OIDCVerifier(issuer="https://issuer.example", audience="")
 
 
+def test_verifier_passes_lifespan_and_cache_cap_to_pyjwkclient() -> None:
+    """Regression for deep-review scalability P1 #8: PyJWKClient was
+    constructed with ``cache_keys=True`` and no other knobs, so the
+    in-process key cache had no TTL — an upstream key-rotation event
+    required a server restart to pick up. The fix pins
+    ``lifespan=jwks_cache_seconds`` (project's 1h default) and
+    ``max_cached_keys=16`` so a PyJWKClient default change can't
+    quietly grow the in-process set."""
+    from unittest.mock import patch
+
+    constructed: list[dict[str, Any]] = []
+
+    class _FakeClient:
+        def __init__(self, url: str, **kwargs: Any) -> None:
+            constructed.append({"url": url, **kwargs})
+            self.uri = url
+
+    async def _trigger_construction() -> None:
+        verifier = OIDCVerifier(
+            issuer="https://issuer.example",
+            audience="mcpg",
+            jwks_url="https://issuer.example/jwks.json",
+            jwks_cache_seconds=900.0,
+        )
+        # _ensure_jwks_client is the construction point; calling it
+        # directly avoids the discovery + token-verify network paths.
+        with patch("mcpg.oidc.PyJWKClient", _FakeClient):
+            await verifier._ensure_jwks_client()
+
+    import asyncio
+
+    asyncio.run(_trigger_construction())
+
+    assert constructed, "expected PyJWKClient to be constructed"
+    kwargs = constructed[0]
+    assert kwargs["cache_keys"] is True
+    assert kwargs["lifespan"] == 900  # int-coerced from float setting
+    assert kwargs["max_cached_keys"] == 16
+
+
 async def test_verifier_verifies_a_valid_jwt_against_the_jwks() -> None:
     private_key, kid, jwk = _build_rsa_key()
     issuer = "https://issuer.example"

--- a/tests/unit/test_pg_search.py
+++ b/tests/unit/test_pg_search.py
@@ -995,19 +995,31 @@ async def test_hybrid_bm25_vector_search_renders_canonical_rrf_sql() -> None:
     assert ' t."embedding" <=> %s::vector' in sql
     assert " fused AS" in sql
     assert " UNION ALL" in sql
-    # Defaults render as literals: k=60, equal 1.0 weights, per-leg
-    # LIMIT 20.
-    assert "1.0 / (60 + rank)" in sql
-    assert "1.0 * 1.0 / (60 + rank)" in sql
-    assert "LIMIT 20" in sql
-    # Bound params: query_text, vector (x2), final_limit.
-    assert params == ["rust", "[1.0,2.0,3.0]", "[1.0,2.0,3.0]", 5]
+    # k stays inlined as a literal (small enumerable tuning knob;
+    # binding it would mask integer-arithmetic optimizations).
+    assert "/ (60 + rank)" in sql
+    # Weights and limits are %s-bound (plan-cache stability — see
+    # deep-review P1 #9: literal float interpolation was causing one
+    # cached plan per (bm25_weight, vector_weight) tuple).
+    assert "%s::float8 * 1.0 / (60 + rank)" in sql
+    # Bind order pinned: bm25 query, bm25 leg LIMIT, vector x2,
+    # vector leg LIMIT, bm25 weight, vector weight, final LIMIT.
+    assert params == ["rust", 20, "[1.0,2.0,3.0]", "[1.0,2.0,3.0]", 20, 1.0, 1.0, 5]
     # Top-level GROUP BY + SUM is what makes this RRF (not a join).
     assert "GROUP BY id" in sql
     assert "SUM(score)" in sql
 
 
-async def test_hybrid_bm25_vector_search_weights_and_k_render_as_literals() -> None:
+async def test_hybrid_bm25_vector_search_weights_per_leg_limit_render_as_bound_params() -> None:
+    """Regression for deep-review scalability P1 #9: bm25_weight,
+    vector_weight, and per_leg_limit used to be spliced into the SQL
+    as Python ``repr(float|int)`` literals. Different weight tuples
+    produced different SQL strings → distinct plan-cache entries.
+    Binding via %s collapses every caller into one cached plan.
+
+    k stays inlined intentionally — it's a small-enumerable RRF
+    constant where the gain from binding is dwarfed by the loss of
+    integer-arithmetic optimization on a known constant denominator."""
     driver = FakeRoutingDriver(
         {
             "pg_extension": [{"present": 1}],
@@ -1030,10 +1042,17 @@ async def test_hybrid_bm25_vector_search_weights_and_k_render_as_literals() -> N
         final_limit=5,
     )
 
-    sql, _, _ = driver.calls[-1]
-    assert "0.7 * 1.0 / (42 + rank)" in sql
-    assert "0.3 * 1.0 / (42 + rank)" in sql
-    assert "LIMIT 15" in sql
+    sql, params, _ = driver.calls[-1]
+    # k inlined; weights and limit bound.
+    assert "%s::float8 * 1.0 / (42 + rank)" in sql
+    assert "LIMIT %s" in sql
+    assert "0.7" not in sql and "0.3" not in sql
+    assert sql.count("%s") == len(params)
+    # Weights flow through the bind list as floats; per_leg_limit
+    # appears twice (one for each leg).
+    assert 0.7 in params and 0.3 in params
+    assert params.count(15) == 2
+    assert params[-1] == 5  # final_limit
 
 
 async def test_hybrid_bm25_vector_search_single_column_bm25_target() -> None:
@@ -1086,8 +1105,9 @@ async def test_hybrid_bm25_vector_search_multi_column_bm25_ors_predicates() -> N
     sql, params, _ = driver.calls[-1]
     assert '(t."body" @@@ %s OR t."title" @@@ %s)' in sql
     assert sql.count("%s") == len(params)
-    # Order: query_text x 2 columns, vector x 2, final_limit.
-    assert params == ["rust", "rust", "[1.0]", "[1.0]", 5]
+    # Order: query_text x2 cols, bm25 leg LIMIT, vector x2, vector
+    # leg LIMIT, bm25 weight, vector weight, final LIMIT.
+    assert params == ["rust", "rust", 20, "[1.0]", "[1.0]", 20, 1.0, 1.0, 5]
 
 
 @pytest.mark.parametrize("op", ["<=>", "<->", "<#>"])
@@ -1298,7 +1318,9 @@ async def test_hybrid_bm25_vector_search_accepts_preformatted_vector_string() ->
     )
 
     _, params, _ = driver.calls[-1]
-    assert params == ["rust", "[0.1,0.2,0.3]", "[0.1,0.2,0.3]", 5]
+    # Bind order: bm25 query, bm25 leg LIMIT, vector x2, vector
+    # leg LIMIT, bm25 weight, vector weight, final LIMIT.
+    assert params == ["rust", 20, "[0.1,0.2,0.3]", "[0.1,0.2,0.3]", 20, 1.0, 1.0, 5]
 
 
 async def test_hybrid_bm25_vector_search_rejects_bad_vector_type() -> None:

--- a/tests/unit/test_secrets.py
+++ b/tests/unit/test_secrets.py
@@ -556,3 +556,76 @@ def test_gcp_provider_raises_secrets_error_on_permission_denied(monkeypatch: pyt
     provider = GCPSecretsProvider(project_id="p", env={"FALLBACK": "from-env"})
     with pytest.raises(SecretsError, match="GCP Secret Manager denied"):
         provider.get("ANY")
+
+
+# --- bounded-LRU cache (scalability P1) ------------------------------------
+
+
+def test_cloud_secret_caches_evict_oldest_when_capacity_exceeded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for deep-review scalability P1 #6: the three cloud
+    providers held an unbounded ``dict[str, str | None]`` cache. A
+    caller hitting ``provider.get(unique_name)`` in a loop would grow
+    it until OOM. The fix is a bounded LRU keyed by name.
+
+    Asserted directly against the OrderedDict + the shared
+    ``_SECRET_CACHE_MAX_ENTRIES`` constant: cap the constant down
+    via monkeypatch, fill past the cap, and prove the oldest entry
+    fell out while a recent one survived."""
+    from mcpg import secrets as secrets_mod
+    from mcpg.secrets import VaultSecretsProvider, _cache_put
+
+    # Bound to 3 so the test is deterministic without a 1024-entry loop.
+    monkeypatch.setattr(secrets_mod, "_SECRET_CACHE_MAX_ENTRIES", 3)
+
+    provider = VaultSecretsProvider(addr="http://vault:8200", token="x", env={})
+    for n, v in [("A", "a"), ("B", "b"), ("C", "c"), ("D", "d")]:
+        _cache_put(provider._cache, n, v)
+
+    assert list(provider._cache) == ["B", "C", "D"]
+    assert "A" not in provider._cache
+
+
+def test_cloud_secret_cache_moves_entry_to_end_on_get_hit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """LRU semantics: a name that was recently *read* survives an
+    eviction round that drops a colder name. Tested via the shared
+    helpers so the assertion holds for every provider."""
+    from mcpg import secrets as secrets_mod
+    from mcpg.secrets import _cache_get, _cache_put
+
+    monkeypatch.setattr(secrets_mod, "_SECRET_CACHE_MAX_ENTRIES", 3)
+
+    from collections import OrderedDict
+
+    cache: OrderedDict[str, str | None] = OrderedDict()
+    for n, v in [("A", "a"), ("B", "b"), ("C", "c")]:
+        _cache_put(cache, n, v)
+    # Touch A so it becomes most-recent. B is now the oldest.
+    val, present = _cache_get(cache, "A")
+    assert present and val == "a"
+    # Insert D → B falls out (was oldest), A survives.
+    _cache_put(cache, "D", "d")
+    assert list(cache) == ["C", "A", "D"]
+
+
+def test_cloud_secret_cache_preserves_none_entries() -> None:
+    """A name explicitly cached as ``None`` (meaning "not in the
+    backend") must survive eviction the same as a real value, and
+    ``_cache_get`` must distinguish "cached as None" from "not
+    cached" via the ``present`` flag — otherwise the env-fallback
+    path would re-fetch on every call."""
+    from collections import OrderedDict
+
+    from mcpg.secrets import _cache_get, _cache_put
+
+    cache: OrderedDict[str, str | None] = OrderedDict()
+    _cache_put(cache, "ABSENT_IN_VAULT", None)
+    val, present = _cache_get(cache, "ABSENT_IN_VAULT")
+    assert present is True
+    assert val is None
+    val, present = _cache_get(cache, "NEVER_LOOKED_UP")
+    assert present is False
+    assert val is None


### PR DESCRIPTION
## Summary

**PR-F of seven.** Closes three scalability P1s: bounded cloud secret caches, JWKS TTL, hybrid weights as bind parameters.

### `secrets.py` — P1 #6: bounded LRU on cloud secret caches

Vault / AWS / GCP each held an unbounded `dict[str, str | None]`. A loop hitting `provider.get(unique_name)` would grow it until OOM.

Shared helpers + `_SECRET_CACHE_MAX_ENTRIES = 1024`:

- `_cache_get(cache, name) -> (value, present)` — the `present` flag distinguishes "cached as None" (name absent from backend → env fallback) from "never looked up" (do the network round-trip).
- `_cache_put(cache, name, value)` — replace, `move_to_end`, then `popitem(last=False)` until size ≤ cap.

Each provider's `_cache` field changed from `dict` to `OrderedDict` so the LRU bookkeeping works; `get()` rewritten to call the helpers.

### `oidc.py` — P1 #8: JWKS cache TTL

`PyJWKClient(url, cache_keys=True)` had no TTL — key rotation required a server restart. Now pins:
- `lifespan=int(self._jwks_cache_seconds)` (project's 1h default).
- `max_cached_keys=16` so a future PyJWKClient default change can't quietly grow the cap.

### `pg_search.py::hybrid_bm25_vector_search` — P1 #9: weights/limits as bind params

`bm25_weight`, `vector_weight`, and `per_leg_limit` were f-string-spliced into the SQL. PG treats each distinct SQL text as a separate plan-cache entry — every weight tuple cost a re-plan.

Now `%s`-bound (weights cast `::float8`). **`k` stays inlined intentionally** — it's a small-enumerable RRF constant where binding masks integer-arithmetic optimization on a known constant.

Bind order pinned: `bm25 query x N`, `bm25 leg LIMIT`, `vector x 2`, `vector leg LIMIT`, `bm25 weight`, `vector weight`, `final LIMIT`.

## Not addressed in this PR (deferred with reasoning)

- **P1 #11 (import_vectors fully buffered)**: proper streaming needs a JSON / CSV row-iterator + per-row dimension validation + batched `execute_many`. Design pass beyond this batch.
- **P1 #5 (cursors.py pool bypass)**: changes the cursor lifecycle invariant; held for a stand-alone PR with explicit user buy-in (per the earlier plan).

## Tests (+5, 1767 total)

- `test_cloud_secret_caches_evict_oldest_when_capacity_exceeded` — monkeypatch cap down to 3, fill past it, prove the oldest entry fell out.
- `test_cloud_secret_cache_moves_entry_to_end_on_get_hit` — LRU semantics: recent reads survive.
- `test_cloud_secret_cache_preserves_none_entries` — "absent in backend" sentinel survives; `present` flag distinguishes cached-None from never-cached.
- `test_verifier_passes_lifespan_and_cache_cap_to_pyjwkclient` — patch + async fake to assert the three kwargs.
- `test_hybrid_bm25_vector_search_weights_per_leg_limit_render_as_bound_params` — proves new SQL has `%s::float8` for weights and binds the full new param order.
- Three existing hybrid tests updated for the new bind order.

## Test plan

- [x] `ruff check .` + `ruff format` + `mypy src/mcpg` + `bandit` all clean
- [x] `uv run pytest tests/unit` — 1767 passed
- [x] CI matrix PG 14 / 15 / 16 / 17 / 18 — expected green; no PG-version-conditional SQL

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_