### PR TITLE
refactor: typed errors across graph/cypher/locks; relocate nl2sql wrapper logic

### DIFF
--- a/src/mcpg/cypher.py
+++ b/src/mcpg/cypher.py
@@ -13,7 +13,7 @@ from typing import Any, TypedDict
 
 from mcpg.context import AppContext
 from mcpg.database import DatabaseError
-from mcpg.graph import parse_agtype
+from mcpg.graph import GraphError, parse_agtype
 from mcpg.policy import Capability, check_permission
 
 logger = logging.getLogger(__name__)
@@ -82,7 +82,7 @@ async def run_cypher(
     """
     # 1. Defensive validation of graph_name
     if not graph_name.replace("_", "").isalnum() or graph_name[0].isdigit():
-        raise ValueError(f"invalid graph name: {graph_name!r}")
+        raise GraphError(f"invalid graph name: {graph_name!r}")
 
     # 2. Safety / Write checks: Cypher statements can modify graph state.
     # We inspect if the Cypher query contains modifying keywords as single words.
@@ -106,7 +106,7 @@ async def run_cypher(
         raise DatabaseError("could not verify graph existence") from exc
 
     if not graph_rows:
-        raise ValueError(f"graph {graph_name!r} does not exist")
+        raise GraphError(f"graph {graph_name!r} does not exist")
 
     # 4. Parse return columns and run the cypher() call on a DEDICATED
     #    pool checkout so ``SET LOCAL search_path`` auto-resets at the

--- a/src/mcpg/graph.py
+++ b/src/mcpg/graph.py
@@ -15,6 +15,20 @@ from mcpg.context import AppContext
 from mcpg.database import DatabaseError
 
 
+class GraphError(Exception):
+    """Raised on invalid input or invariant violations across the
+    Apache AGE graph integration.
+
+    Shared by :mod:`mcpg.graph`, :mod:`mcpg.cypher`,
+    :mod:`mcpg.graph_mgmt`, and :mod:`mcpg.graph_diagram` — every
+    public-facing wrapper raises this rather than a bare
+    :class:`ValueError`, so callers get one consistent error class
+    to catch (matches the ``*Error``-per-module convention every
+    other surface follows: PgSearchError, TurboQuantError,
+    SecretsError, …).
+    """
+
+
 class GraphInfo(TypedDict):
     """Structured information about an Apache AGE graph."""
 
@@ -99,7 +113,7 @@ async def describe_graph(context: AppContext, graph_name: str) -> GraphDescripti
     """
     # Defensive quoting validation
     if not graph_name.replace("_", "").isalnum() or graph_name[0].isdigit():
-        raise ValueError(f"invalid graph name: {graph_name!r}")
+        raise GraphError(f"invalid graph name: {graph_name!r}")
 
     driver = context.database.driver()
 
@@ -113,7 +127,7 @@ async def describe_graph(context: AppContext, graph_name: str) -> GraphDescripti
         raise DatabaseError("could not query graph metadata") from exc
 
     if not graph_rows:
-        raise ValueError(f"graph {graph_name!r} does not exist")
+        raise GraphError(f"graph {graph_name!r} does not exist")
 
     # Load age to ensure graph functions are visible
     await driver.execute_query("LOAD 'age';")

--- a/src/mcpg/graph_diagram.py
+++ b/src/mcpg/graph_diagram.py
@@ -12,6 +12,7 @@ from typing import Any, TypedDict
 
 from mcpg.context import AppContext
 from mcpg.database import DatabaseError
+from mcpg.graph import GraphError
 from mcpg.policy import Capability, check_permission
 
 logger = logging.getLogger(__name__)
@@ -37,7 +38,7 @@ async def generate_graph_diagram(
     """
     # 1. Validate name
     if not graph_name.replace("_", "").isalnum() or graph_name[0].isdigit():
-        raise ValueError(f"invalid graph name: {graph_name!r}")
+        raise GraphError(f"invalid graph name: {graph_name!r}")
 
     # 2. Check read permission
     check_permission(Capability.READ, context.settings.access_mode)
@@ -54,7 +55,7 @@ async def generate_graph_diagram(
         raise DatabaseError("could not query graph metadata") from exc
 
     if not graph_rows:
-        raise ValueError(f"graph {graph_name!r} does not exist")
+        raise GraphError(f"graph {graph_name!r} does not exist")
 
     await driver.execute_query("LOAD 'age';")
     await driver.execute_query(f"SET search_path = {graph_name}, ag_catalog, public;")

--- a/src/mcpg/graph_mgmt.py
+++ b/src/mcpg/graph_mgmt.py
@@ -11,6 +11,7 @@ from typing import TypedDict
 
 from mcpg.context import AppContext
 from mcpg.database import DatabaseError
+from mcpg.graph import GraphError
 from mcpg.policy import Capability, check_permission
 
 logger = logging.getLogger(__name__)
@@ -32,7 +33,7 @@ async def create_graph(context: AppContext, graph_name: str) -> GraphMgmtResult:
     """
     # 1. Validate name
     if not graph_name.replace("_", "").isalnum() or graph_name[0].isdigit():
-        raise ValueError(f"invalid graph name: {graph_name!r}")
+        raise GraphError(f"invalid graph name: {graph_name!r}")
 
     # 2. Gate under DDL permission
     check_permission(Capability.DDL, context.settings.access_mode)
@@ -78,7 +79,7 @@ async def drop_graph(context: AppContext, graph_name: str, cascade: bool = True)
     """
     # 1. Validate name
     if not graph_name.replace("_", "").isalnum() or graph_name[0].isdigit():
-        raise ValueError(f"invalid graph name: {graph_name!r}")
+        raise GraphError(f"invalid graph name: {graph_name!r}")
 
     # 2. Gate under DDL permission
     check_permission(Capability.DDL, context.settings.access_mode)

--- a/src/mcpg/locks.py
+++ b/src/mcpg/locks.py
@@ -19,6 +19,16 @@ from typing import Any
 
 from mcpg._vendor.sql import SqlDriver
 
+
+class LocksError(Exception):
+    """Raised on invalid input to a lock-inspection function.
+
+    Matches the ``*Error``-per-module convention every other surface
+    follows (PgSearchError, TurboQuantError, GraphError, …) rather
+    than the bare ``ValueError`` the lock helpers used to raise.
+    """
+
+
 DEFAULT_LOCK_LIMIT = 100
 DEFAULT_BLOCKING_LIMIT = 50
 
@@ -73,7 +83,7 @@ async def list_locks(driver: SqlDriver, *, limit: int = DEFAULT_LOCK_LIMIT) -> l
     — the entries most likely to need agent attention.
     """
     if limit < 1:
-        raise ValueError("limit must be >= 1")
+        raise LocksError("limit must be >= 1")
     rows = await driver.execute_query(
         "SELECT l.pid, l.locktype, l.mode, l.granted, "
         "       CASE WHEN l.relation IS NOT NULL "
@@ -121,7 +131,7 @@ async def find_blocking_chains(driver: SqlDriver, *, limit: int = DEFAULT_BLOCKI
     becomes one row.
     """
     if limit < 1:
-        raise ValueError("limit must be >= 1")
+        raise LocksError("limit must be >= 1")
     rows = await driver.execute_query(
         "SELECT blocked.pid AS blocked_pid, "
         "       LEFT(blocked.query, 200) AS blocked_query, "
@@ -390,7 +400,7 @@ async def walk_blocking_chains(driver: SqlDriver, *, limit: int = DEFAULT_BLOCKI
     and renders a Mermaid flowchart representing the lock dependency graph.
     """
     if limit < 1:
-        raise ValueError("limit must be >= 1")
+        raise LocksError("limit must be >= 1")
 
     rows = await driver.execute_query(
         "SELECT blocked.pid AS blocked_pid, "

--- a/src/mcpg/nl2sql.py
+++ b/src/mcpg/nl2sql.py
@@ -314,7 +314,15 @@ def resolve_provider_call_params(settings: Settings, requested_provider: str | N
     base_url override.
     """
     api_keys = dict(settings.nl2sql_api_keys)
-    chosen = (requested_provider or settings.nl2sql_provider or "").strip().lower() or None
+    # Normalize each candidate *individually* and only then pick the
+    # first non-empty one. A bare ``(a or b or "").strip().lower()``
+    # would let a whitespace-only ``requested_provider`` short-circuit
+    # the chain (``"   "`` is truthy) and bury a perfectly-valid
+    # operator default behind a misleading "no provider configured"
+    # error (gemini review on #102).
+    requested_norm = (requested_provider or "").strip().lower() or None
+    default_norm = (settings.nl2sql_provider or "").strip().lower() or None
+    chosen = requested_norm or default_norm
     if chosen is None:
         # No provider arg AND no default configured AND no vendor keys
         # in the env — provider= alone can't fix this, the operator
@@ -339,7 +347,16 @@ def resolve_provider_call_params(settings: Settings, requested_provider: str | N
             "provider= argument."
         )
 
-    is_default = chosen == settings.nl2sql_provider
+    # Compare against the normalized form of the configured default —
+    # ``chosen`` is already strip()ped + lower()ed and
+    # ``settings.nl2sql_provider`` can carry mixed casing or stray
+    # whitespace from the env. Without normalization here, a default
+    # like ``"Anthropic\n"`` would silently disable the operator's
+    # ``MCPG_NL2SQL_MODEL`` / ``MCPG_NL2SQL_BASE_URL`` overrides and
+    # route traffic at the public endpoint — gemini review on #102
+    # called this out as security-critical (the base_url path is
+    # often a private proxy / regional gateway).
+    is_default = chosen == default_norm
     model = settings.nl2sql_model if (is_default and settings.nl2sql_model) else DEFAULT_MODELS[chosen]
     base_url = settings.nl2sql_base_url if is_default else None
     return ProviderCallParams(

--- a/src/mcpg/nl2sql.py
+++ b/src/mcpg/nl2sql.py
@@ -31,13 +31,16 @@ import json
 import logging
 import re
 from dataclasses import dataclass
-from typing import Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 import httpx
 
 from mcpg._vendor.sql import SqlDriver
 from mcpg.introspection import describe_table, list_foreign_keys, list_tables
 from mcpg.query import DEFAULT_MAX_ROWS, QueryError, run_select
+
+if TYPE_CHECKING:
+    from mcpg.config import Settings
 
 logger = logging.getLogger(__name__)
 
@@ -272,6 +275,79 @@ class GeminiProvider:
 def is_valid_provider(name: str) -> bool:
     """Return ``True`` for any name :func:`build_provider` will accept."""
     return name in _SUPPORTED_PROVIDERS
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderCallParams:
+    """The fully-resolved set of inputs needed to call one provider.
+
+    Produced by :func:`resolve_provider_call_params` so the tool
+    wrapper layer in :mod:`mcpg.tools` doesn't carry provider-
+    selection / API-key dispatch / model-override logic. The tool
+    wrapper becomes a thin pass-through: build a provider with the
+    constructor args here, then call :func:`translate_nl_to_sql`.
+    """
+
+    provider_name: str
+    api_key: str
+    model: str
+    base_url: str | None
+
+
+def resolve_provider_call_params(settings: Settings, requested_provider: str | None) -> ProviderCallParams:
+    """Pick the provider for this call and resolve its full call shape.
+
+    Threads three signals together:
+
+    1. ``requested_provider`` from the caller (``provider=`` arg on
+       ``translate_nl_to_sql``) — highest precedence.
+    2. ``settings.nl2sql_provider`` (``MCPG_NL2SQL_PROVIDER``) — the
+       operator-configured default.
+    3. Whatever vendor keys are present in the operator-supplied
+       credentials. If neither (1) nor (2) is set, fail fast — this
+       is a configuration issue the caller can't solve.
+
+    Overrides for ``model`` / ``base_url`` only apply when the chosen
+    provider IS the configured default. Forwarding an Anthropic-shaped
+    model id to an OpenAI call (or vice versa) would just break, so
+    non-default calls always use the upstream default model + no
+    base_url override.
+    """
+    api_keys = dict(settings.nl2sql_api_keys)
+    chosen = (requested_provider or settings.nl2sql_provider or "").strip().lower() or None
+    if chosen is None:
+        # No provider arg AND no default configured AND no vendor keys
+        # in the env — provider= alone can't fix this, the operator
+        # needs to set at least one vendor API key.
+        raise NL2SQLError(
+            "translate_nl_to_sql has no provider configured. Set at "
+            "least one of ANTHROPIC_API_KEY / OPENAI_API_KEY / "
+            "GEMINI_API_KEY (or GOOGLE_API_KEY) in the server's "
+            "environment. The tool's provider= argument selects "
+            "between providers that are already configured — it can't "
+            "supply credentials on its own."
+        )
+    if not is_valid_provider(chosen):
+        raise NL2SQLError(f"unknown NL→SQL provider {chosen!r}; supported: anthropic, openai, gemini")
+    api_key = api_keys.get(chosen)
+    if api_key is None:
+        configured = sorted(api_keys) or ["(none)"]
+        raise NL2SQLError(
+            f"provider {chosen!r} is not configured (currently configured: "
+            f"{', '.join(configured)}). Set {VENDOR_ENV_VAR_HINT[chosen]} "
+            "in the environment, or pick a configured provider via the "
+            "provider= argument."
+        )
+
+    is_default = chosen == settings.nl2sql_provider
+    model = settings.nl2sql_model if (is_default and settings.nl2sql_model) else DEFAULT_MODELS[chosen]
+    base_url = settings.nl2sql_base_url if is_default else None
+    return ProviderCallParams(
+        provider_name=chosen,
+        api_key=api_key,
+        model=model,
+        base_url=base_url,
+    )
 
 
 def build_provider(

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -2299,46 +2299,17 @@ def _register_query(server: FastMCP[AppContext]) -> None:
         table_filter: list[str] | None = None,
         max_rows: int = query.DEFAULT_MAX_ROWS,
     ) -> dict[str, Any]:
+        # All NL→SQL business logic — provider selection from request
+        # arg / env default / configured keys, model + base_url override
+        # rules, error shaping for misconfig — lives in mcpg.nl2sql so
+        # this wrapper can stay a thin driver + asdict pass-through.
         settings = ctx.request_context.lifespan_context.settings
-        api_keys = dict(settings.nl2sql_api_keys)
-
-        chosen = (provider or settings.nl2sql_provider or "").strip().lower() or None
-        if chosen is None:
-            # No provider arg AND no default configured AND no vendor keys
-            # in the env — provider= alone can't fix this, the operator
-            # needs to set at least one vendor API key.
-            raise nl2sql.NL2SQLError(
-                "translate_nl_to_sql has no provider configured. Set at "
-                "least one of ANTHROPIC_API_KEY / OPENAI_API_KEY / "
-                "GEMINI_API_KEY (or GOOGLE_API_KEY) in the server's "
-                "environment. The tool's provider= argument selects "
-                "between providers that are already configured — it can't "
-                "supply credentials on its own."
-            )
-        if not nl2sql.is_valid_provider(chosen):
-            raise nl2sql.NL2SQLError(f"unknown NL→SQL provider {chosen!r}; supported: anthropic, openai, gemini")
-        api_key = api_keys.get(chosen)
-        if api_key is None:
-            configured = sorted(api_keys) or ["(none)"]
-            raise nl2sql.NL2SQLError(
-                f"provider {chosen!r} is not configured (currently configured: "
-                f"{', '.join(configured)}). Set {nl2sql.VENDOR_ENV_VAR_HINT[chosen]} "
-                "in the environment, or pick a configured provider via the "
-                "provider= argument."
-            )
-
-        # The operator's MCPG_NL2SQL_MODEL / MCPG_NL2SQL_BASE_URL overrides
-        # only apply when this call uses the default provider — overriding
-        # an Anthropic-shaped model id on an OpenAI call would just break.
-        is_default = chosen == settings.nl2sql_provider
-        model = settings.nl2sql_model if (is_default and settings.nl2sql_model) else nl2sql.DEFAULT_MODELS[chosen]
-        base_url = settings.nl2sql_base_url if is_default else None
-
-        llm = nl2sql.build_provider(chosen, api_key, base_url=base_url)
+        params = nl2sql.resolve_provider_call_params(settings, provider)
+        llm = nl2sql.build_provider(params.provider_name, params.api_key, base_url=params.base_url)
         result = await nl2sql.translate_nl_to_sql(
             _driver(ctx),
             provider=llm,
-            model=model,
+            model=params.model,
             question=question,
             schema=schema,
             execute=execute,

--- a/tests/unit/test_cypher.py
+++ b/tests/unit/test_cypher.py
@@ -9,6 +9,7 @@ from mcpg.config import AccessMode, Settings
 from mcpg.context import AppContext
 from mcpg.cursors import CursorManager
 from mcpg.cypher import parse_return_columns, run_cypher
+from mcpg.graph import GraphError
 from mcpg.listen import ListenManager
 from mcpg.policy import PermissionError
 
@@ -35,7 +36,7 @@ async def test_run_cypher_validates_inputs() -> None:
         cursor_manager=CursorManager(url),
     )
 
-    with pytest.raises(ValueError, match="invalid graph name"):
+    with pytest.raises(GraphError, match="invalid graph name"):
         await run_cypher(context, "my-graph-with-dashes", "MATCH (n) RETURN n")
 
 
@@ -51,7 +52,7 @@ async def test_run_cypher_checks_graph_existence() -> None:
         cursor_manager=CursorManager(url),
     )
 
-    with pytest.raises(ValueError, match="graph 'my_graph' does not exist"):
+    with pytest.raises(GraphError, match="graph 'my_graph' does not exist"):
         await run_cypher(context, "my_graph", "MATCH (n) RETURN n")
 
 

--- a/tests/unit/test_graph.py
+++ b/tests/unit/test_graph.py
@@ -9,7 +9,7 @@ from mcpg.config import Settings
 from mcpg.context import AppContext
 from mcpg.cursors import CursorManager
 from mcpg.database import DatabaseError
-from mcpg.graph import describe_graph, list_graphs, parse_agtype
+from mcpg.graph import GraphError, describe_graph, list_graphs, parse_agtype
 from mcpg.listen import ListenManager
 
 
@@ -107,10 +107,10 @@ async def test_describe_graph_validates_inputs() -> None:
         cursor_manager=CursorManager(url),
     )
 
-    with pytest.raises(ValueError, match="invalid graph name"):
+    with pytest.raises(GraphError, match="invalid graph name"):
         await describe_graph(context, "my-graph-with-dashes")
 
-    with pytest.raises(ValueError, match="invalid graph name"):
+    with pytest.raises(GraphError, match="invalid graph name"):
         await describe_graph(context, "1startwithdigit")
 
 
@@ -127,7 +127,7 @@ async def test_describe_graph_raises_error_if_not_exists() -> None:
         cursor_manager=CursorManager(url),
     )
 
-    with pytest.raises(ValueError, match="graph 'my_graph' does not exist"):
+    with pytest.raises(GraphError, match="graph 'my_graph' does not exist"):
         await describe_graph(context, "my_graph")
 
 

--- a/tests/unit/test_graph_diagram.py
+++ b/tests/unit/test_graph_diagram.py
@@ -8,6 +8,7 @@ from _fakes import FakeDatabase, FakeRoutingDriver
 from mcpg.config import Settings
 from mcpg.context import AppContext
 from mcpg.cursors import CursorManager
+from mcpg.graph import GraphError
 from mcpg.graph_diagram import generate_graph_diagram
 from mcpg.listen import ListenManager
 
@@ -24,7 +25,7 @@ async def test_generate_graph_diagram_validates_inputs() -> None:
         cursor_manager=CursorManager(url),
     )
 
-    with pytest.raises(ValueError, match="invalid graph name"):
+    with pytest.raises(GraphError, match="invalid graph name"):
         await generate_graph_diagram(context, "my-graph-with-dashes")
 
 
@@ -40,7 +41,7 @@ async def test_generate_graph_diagram_raises_error_if_not_exists() -> None:
         cursor_manager=CursorManager(url),
     )
 
-    with pytest.raises(ValueError, match="graph 'my_graph' does not exist"):
+    with pytest.raises(GraphError, match="graph 'my_graph' does not exist"):
         await generate_graph_diagram(context, "my_graph")
 
 

--- a/tests/unit/test_graph_mgmt.py
+++ b/tests/unit/test_graph_mgmt.py
@@ -8,6 +8,7 @@ from _fakes import FakeDatabase, FakeRoutingDriver
 from mcpg.config import AccessMode, Settings
 from mcpg.context import AppContext
 from mcpg.cursors import CursorManager
+from mcpg.graph import GraphError
 from mcpg.graph_mgmt import create_graph, drop_graph
 from mcpg.listen import ListenManager
 from mcpg.policy import PermissionError
@@ -25,7 +26,7 @@ async def test_create_graph_validates_inputs() -> None:
         cursor_manager=CursorManager(url),
     )
 
-    with pytest.raises(ValueError, match="invalid graph name"):
+    with pytest.raises(GraphError, match="invalid graph name"):
         await create_graph(context, "my-graph-with-dashes")
 
 

--- a/tests/unit/test_locks.py
+++ b/tests/unit/test_locks.py
@@ -10,6 +10,7 @@ from mcpg.locks import (
     BlockingGraphReport,
     BlockingPair,
     LockInfo,
+    LocksError,
     find_blocking_chains,
     list_locks,
     walk_blocking_chains,
@@ -69,7 +70,7 @@ async def test_list_locks_returns_empty_list_when_no_locks_held() -> None:
 
 
 async def test_list_locks_rejects_zero_limit() -> None:
-    with pytest.raises(ValueError, match="limit"):
+    with pytest.raises(LocksError, match="limit"):
         await list_locks(FakeRoutingDriver({}), limit=0)  # type: ignore[arg-type]
 
 
@@ -108,7 +109,7 @@ async def test_find_blocking_chains_returns_empty_list_when_nothing_blocked() ->
 
 
 async def test_find_blocking_chains_rejects_zero_limit() -> None:
-    with pytest.raises(ValueError, match="limit"):
+    with pytest.raises(LocksError, match="limit"):
         await find_blocking_chains(FakeRoutingDriver({}), limit=0)  # type: ignore[arg-type]
 
 
@@ -223,5 +224,5 @@ async def test_walk_blocking_chains_deadlock_cycle() -> None:
 
 
 async def test_walk_blocking_chains_rejects_zero_limit() -> None:
-    with pytest.raises(ValueError, match="limit"):
+    with pytest.raises(LocksError, match="limit"):
         await walk_blocking_chains(FakeRoutingDriver({}), limit=0)  # type: ignore[arg-type]

--- a/tests/unit/test_nl2sql.py
+++ b/tests/unit/test_nl2sql.py
@@ -369,3 +369,42 @@ def test_resolve_provider_call_params_errors_when_caller_picks_unconfigured() ->
     settings = _settings(ANTHROPIC_API_KEY="ant-1", MCPG_NL2SQL_PROVIDER="anthropic")
     with pytest.raises(NL2SQLError, match="provider 'openai' is not configured"):
         resolve_provider_call_params(settings, "openai")
+
+
+def test_resolve_falls_back_to_default_when_request_arg_is_whitespace_only() -> None:
+    """Regression for gemini review on #102: ``(req or default or "")``
+    short-circuits on a truthy whitespace string, which then strips
+    to empty, which then ``or None``s back to nothing — burying a
+    perfectly-valid operator default behind a misleading "no provider
+    configured" error. Each candidate is now normalized individually."""
+    settings = _settings(ANTHROPIC_API_KEY="ant-1", MCPG_NL2SQL_PROVIDER="anthropic")
+    params = resolve_provider_call_params(settings, "   ")
+    assert params.provider_name == "anthropic"
+    assert params.api_key == "ant-1"
+
+
+def test_resolve_compares_against_normalized_default_for_override_decision() -> None:
+    """Defence-in-depth check raised on the gemini review on #102.
+
+    ``load_settings`` already strips + lowercases ``MCPG_NL2SQL_PROVIDER``
+    (config.py:544), so the env path can't carry stray casing into
+    ``settings.nl2sql_provider`` — meaning the agent's "private-proxy
+    traffic leaks to a public endpoint" scenario doesn't fire through
+    the documented config path. But code that constructs ``Settings``
+    directly (test fixtures, Python-only bootstraps) can. Normalizing
+    the default before the equality check in
+    ``resolve_provider_call_params`` keeps the override logic robust
+    regardless of how ``Settings`` got built.
+
+    Asserted via the load_settings path: when the operator's default
+    matches the chosen call, both overrides must apply."""
+    settings = _settings(
+        ANTHROPIC_API_KEY="ant-1",
+        MCPG_NL2SQL_PROVIDER="anthropic",
+        MCPG_NL2SQL_MODEL="claude-sonnet-X",
+        MCPG_NL2SQL_BASE_URL="https://proxy.example",
+    )
+    params = resolve_provider_call_params(settings, None)
+    assert params.provider_name == "anthropic"
+    assert params.model == "claude-sonnet-X"
+    assert params.base_url == "https://proxy.example"

--- a/tests/unit/test_nl2sql.py
+++ b/tests/unit/test_nl2sql.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 import pytest
 from _fakes import FakeRoutingDriver
 
+from mcpg.config import load_settings
 from mcpg.nl2sql import (
     DEFAULT_MODELS,
     HARD_MAX_TOKENS,
@@ -15,9 +16,11 @@ from mcpg.nl2sql import (
     LLMProvider,
     NL2SQLError,
     OpenAIProvider,
+    ProviderCallParams,
     _parse_response,
     build_provider,
     is_valid_provider,
+    resolve_provider_call_params,
     translate_nl_to_sql,
 )
 
@@ -296,3 +299,73 @@ async def test_translate_nl_to_sql_handles_curly_braces_in_the_question() -> Non
     assert result.sql == "SELECT 1"
     assert '{"k": 1}' in provider.captured_user
     assert "{empty: braces}" in provider.captured_user
+
+
+# --- resolve_provider_call_params (PR-G: business logic relocated
+# from the tools.py wrapper). The tool wrapper now just calls this
+# helper, builds the provider, and forwards to translate_nl_to_sql,
+# so the resolution rules need direct test coverage here. -----------
+
+_DB_URL = "postgresql://u:p@localhost/db"
+
+
+def _settings(**extra: str):
+    env = {"MCPG_DATABASE_URL": _DB_URL}
+    env.update(extra)
+    return load_settings(env)
+
+
+def test_resolve_provider_call_params_uses_explicit_request_arg_over_default() -> None:
+    settings = _settings(
+        ANTHROPIC_API_KEY="ant-1",
+        OPENAI_API_KEY="oai-1",
+        MCPG_NL2SQL_PROVIDER="anthropic",
+    )
+    params = resolve_provider_call_params(settings, "openai")
+    assert isinstance(params, ProviderCallParams)
+    assert params.provider_name == "openai"
+    assert params.api_key == "oai-1"
+    # ``model`` falls back to the upstream default when this call
+    # ISN'T using the configured default provider — operator's
+    # MCPG_NL2SQL_MODEL would be Anthropic-shaped here.
+    assert params.model == DEFAULT_MODELS["openai"]
+    assert params.base_url is None
+
+
+def test_resolve_provider_call_params_applies_overrides_only_on_default_call() -> None:
+    settings = _settings(
+        ANTHROPIC_API_KEY="ant-1",
+        MCPG_NL2SQL_PROVIDER="anthropic",
+        MCPG_NL2SQL_MODEL="claude-sonnet-X",
+        MCPG_NL2SQL_BASE_URL="https://proxy.example",
+    )
+    # No explicit provider arg → uses the configured default → the
+    # operator's model + base_url overrides ALSO apply.
+    params = resolve_provider_call_params(settings, None)
+    assert params.provider_name == "anthropic"
+    assert params.model == "claude-sonnet-X"
+    assert params.base_url == "https://proxy.example"
+
+
+def test_resolve_provider_call_params_normalises_case_and_whitespace() -> None:
+    settings = _settings(ANTHROPIC_API_KEY="ant-1", MCPG_NL2SQL_PROVIDER="anthropic")
+    params = resolve_provider_call_params(settings, "  ANTHROPIC  ")
+    assert params.provider_name == "anthropic"
+
+
+def test_resolve_provider_call_params_errors_when_nothing_configured() -> None:
+    settings = _settings()  # no vendor keys, no MCPG_NL2SQL_PROVIDER
+    with pytest.raises(NL2SQLError, match="has no provider configured"):
+        resolve_provider_call_params(settings, None)
+
+
+def test_resolve_provider_call_params_errors_on_unknown_provider() -> None:
+    settings = _settings(ANTHROPIC_API_KEY="ant-1", MCPG_NL2SQL_PROVIDER="anthropic")
+    with pytest.raises(NL2SQLError, match="unknown NL"):
+        resolve_provider_call_params(settings, "azure")
+
+
+def test_resolve_provider_call_params_errors_when_caller_picks_unconfigured() -> None:
+    settings = _settings(ANTHROPIC_API_KEY="ant-1", MCPG_NL2SQL_PROVIDER="anthropic")
+    with pytest.raises(NL2SQLError, match="provider 'openai' is not configured"):
+        resolve_provider_call_params(settings, "openai")


### PR DESCRIPTION
## Summary

**PR-G of seven.** Closes the remaining architecture P1s from the deep review.

### (1) `ValueError` → typed `*Error` sweep

The deep-review noted: *"ValueError used for boundary validation despite no typed error existing: graph.py:102,116, graph_mgmt.py:35,81, graph_diagram.py:40,57, cypher.py:85,109, locks.py:76,124,393. Inconsistent with the *Error convention every other module uses."*

- **`src/mcpg/graph.py`** — new `GraphError` shared across all four AGE-graph modules (one domain → one error class; matches how `pg_search.py`'s `PgSearchAdvisorFinding` etc. are domain-shared).
- **`cypher.py`, `graph_mgmt.py`, `graph_diagram.py`** — import `GraphError`, raise it from previously bare `ValueError` sites (invalid graph name; graph does not exist).
- **`src/mcpg/locks.py`** — new `LocksError`. Three `limit must be >= 1` sites updated.
- Eleven test-site updates across five test files. Mechanical (substring matchers unchanged).

**Backwards-incompat note**: code that caught `ValueError` from these surfaces will need `GraphError` / `LocksError` (or `Exception`). Worth the change — every other surface in the codebase uses typed errors, and tooling (incl. the deep-review agent) keys off them.

### (2) `translate_nl_to_sql` wrapper: business logic relocated

The tool wrapper in `tools.py` carried provider selection + model override + API-key dispatch (~45 lines of business logic). Moved to `mcpg.nl2sql`:

- New `ProviderCallParams` dataclass + **`resolve_provider_call_params(settings, requested_provider)`** in `mcpg.nl2sql`. Threads the three signals (caller's `provider=` arg → `MCPG_NL2SQL_PROVIDER` default → vendor keys present) and resolves the `(name, key, model, base_url)` tuple, with the documented rule that `MCPG_NL2SQL_MODEL` / `MCPG_NL2SQL_BASE_URL` only apply when the call uses the configured default provider.
- `from mcpg.config import Settings` lives under `TYPE_CHECKING` so the module stays import-light.
- Tool wrapper shrinks from ~45 lines to ~5: `params = resolve_provider_call_params(...); llm = build_provider(...); return asdict(await translate_nl_to_sql(...))`.

## Tests (+6, 1769 total)

Direct `ProviderCallParams` unit coverage for the resolution rules:

- Explicit-arg precedence over operator default.
- Override application only when the call uses the configured default.
- Whitespace/case normalisation.
- The three error paths (nothing configured, unknown provider, unconfigured provider).

The pre-existing 13 routing tests in `test_nl2sql_routing.py` still exercise the same code paths through the wrapper end-to-end — these direct tests pin the helper so a future wrapper refactor can't silently lose a branch.

## Test plan

- [x] `ruff check .` + `ruff format` + `mypy src/mcpg` + `bandit` all clean
- [x] `uv run pytest tests/unit` — 1769 passed
- [x] CI matrix PG 14 / 15 / 16 / 17 / 18 — expected green; no SQL touched

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_