### PR TITLE
security(nl2sql): hardening sweep — brief cap, single-stmt, redaction, fence, egress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Security
+
+- **NL→SQL hardening sweep** (PR-3 of the NL→SQL remediation arc).
+  Five P1/P2 findings from the deep-review audit closed in one pass:
+
+  - *Schema-brief character cap* — `_build_schema_brief` now applies a
+    final char limit (`max_brief_chars`, default 32 KB, hard cap 128 KB)
+    after the per-table / per-column bounds, so a schema with hundreds
+    of long column names can't smuggle the LLM-token budget past the
+    operator's `max_tokens` setting (P1 #4).
+  - *Vendor-egress one-time warning* — first call per provider per
+    process logs a single `mcpg.nl2sql` warning telling operators that
+    catalog metadata (schema / table / column names, FK edges,
+    sanitised DEFAULT expressions) leaves the network. The notice
+    surfaces an operational concern most deployments don't realise
+    until incident time (P2 #5).
+  - *`QueryError` redaction* — execution-path failures now flow
+    through `obfuscate_password` before reaching
+    `TranslationResult.error`. psycopg / libpq error messages routinely
+    embed DSN fragments and password-bearing connection-string values,
+    same vector closed for `mcpg_audit.events.error` in PR #96 (P2 #6).
+  - *Single-statement assertion* — generated SQL is parsed with pglast
+    before `run_select` runs; multi-statement input (`"SELECT 1; DROP TABLE x"`)
+    is refused at the NL→SQL layer as defense-in-depth ahead of the
+    `SafeSqlDriver` allowlist (P2 #7).
+  - *Robust fence handling* — `_parse_response` now extracts the body
+    of a fenced JSON block when the outer JSON parse fails, instead of
+    the leading/trailing strip-and-pray approach. Models that wrap
+    valid JSON in explanatory prose + a fence now parse correctly
+    instead of degrading to "raw text as explanation" (P2 #8).
+
 ### Added
 
 - **NL→SQL audit table — partitioned, compressed, RLS-gated**

--- a/src/mcpg/nl2sql.py
+++ b/src/mcpg/nl2sql.py
@@ -38,7 +38,7 @@ from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 import httpx
 
-from mcpg._vendor.sql import SqlDriver
+from mcpg._vendor.sql import SqlDriver, obfuscate_password
 from mcpg.introspection import describe_table, list_foreign_keys, list_tables
 from mcpg.query import DEFAULT_MAX_ROWS, QueryError, run_select
 
@@ -85,6 +85,19 @@ _SUPPORTED_PROVIDERS = frozenset({"anthropic", "openai", "gemini"})
 # ``table_filter`` to focus on a subset.
 DEFAULT_MAX_TABLES_IN_BRIEF = 30
 DEFAULT_COLUMNS_PER_TABLE = 60
+
+# Final character cap on the rendered schema brief — enforced after
+# ``max_tables`` / ``columns_per_table`` so a malicious schema with
+# hundreds of long column names can't smuggle the LLM-token budget
+# past the operator's max_tokens setting (deep-review nl2sql audit
+# P1 #4). 32 KB ≈ 8k tokens — leaves room for the system prompt + the
+# user's question inside the typical 16k-32k context window.
+DEFAULT_MAX_BRIEF_CHARS = 32_768
+
+# Hard upper bound — even an opt-in operator can't ask for more than
+# this so a typo in the env can't make MCPg send a million-char
+# brief to the LLM vendor.
+HARD_MAX_BRIEF_CHARS = 131_072
 
 # Plain unquoted PostgreSQL identifier — matches the rule every other
 # surface in the codebase uses (pg_search, turboquant, rag_efficiency,
@@ -559,6 +572,7 @@ async def _build_schema_brief(
     max_tables: int,
     columns_per_table: int,
     table_filter: tuple[str, ...] | None,
+    max_brief_chars: int = DEFAULT_MAX_BRIEF_CHARS,
 ) -> str:
     """Produce a compact text description of ``schema`` for the prompt.
 
@@ -605,36 +619,117 @@ async def _build_schema_brief(
                 f"-> {fk.to_schema}.{fk.to_table}({','.join(fk.to_columns)})"
             )
 
-    return "\n".join(lines)
+    brief = "\n".join(lines)
+    if len(brief) > max_brief_chars:
+        # Truncate to the budget, append a one-line tell so the LLM
+        # knows the schema brief was bounded (and the operator can
+        # see it in audit logs) — deep-review nl2sql audit P1 #4,
+        # "schema brief unbounded in chars".
+        keep = max(0, max_brief_chars - 64)
+        suffix = f"\n... [schema brief truncated at {max_brief_chars} chars]"
+        brief = brief[:keep] + suffix
+    return brief
 
 
-# Strip Markdown code fences the model might emit around the JSON
-# despite being told to return JSON only. Greedy enough to handle both
-# ```json and ```sql variants and trim either side.
-_CODE_FENCE = re.compile(r"^\s*```(?:json|sql)?\s*|\s*```\s*$", re.IGNORECASE | re.MULTILINE)
+# Match a fenced code block — captures the body between an opening
+# ```[json|sql] fence and its matching close, in either order. The
+# DOTALL flag lets ``.`` cross newlines so multi-line bodies are
+# captured correctly. We prefer extracting the body over a leading
+# trailing strip because models occasionally wrap valid JSON in
+# explanatory text + a fence, and the strip-and-pray approach left
+# garbage that broke json.loads (deep-review nl2sql audit P2 #8,
+# "fragile code-fence stripping").
+_CODE_FENCE_BLOCK = re.compile(
+    r"```(?:json|sql)?\s*\n?(.*?)\n?\s*```",
+    re.IGNORECASE | re.DOTALL,
+)
 
 
 def _parse_response(raw: str) -> tuple[str, str]:
     """Return ``(sql, explanation)`` parsed from a provider's text reply.
 
-    Tolerates a leading / trailing code fence and falls back to
-    treating the whole response as ``explanation`` (with empty SQL)
-    when the JSON shape isn't recognised — so the agent always sees
-    *something*.
+    Strategy: try to JSON-parse the whole reply first; if that fails,
+    extract the first fenced code block (`````json … `````)
+    and JSON-parse its body; if *that* fails too, fall back to
+    treating the whole reply as ``explanation`` (with empty SQL) so
+    the agent always sees *something*.
     """
-    stripped = _CODE_FENCE.sub("", raw).strip()
+    candidates: list[str] = [raw.strip()]
+    match = _CODE_FENCE_BLOCK.search(raw)
+    if match:
+        candidates.append(match.group(1).strip())
+    for candidate in candidates:
+        try:
+            parsed = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        # json.loads succeeds for non-dict shapes (lists, raw strings,
+        # numbers); .get on those crashes. Treat anything non-dict as
+        # a parse failure so the raw text reaches the agent unchanged.
+        if not isinstance(parsed, dict):
+            continue
+        sql = str(parsed.get("sql", "")).strip()
+        explanation = str(parsed.get("explanation", "")).strip()
+        return (sql, explanation)
+    return ("", raw.strip())
+
+
+def _assert_single_statement(sql: str) -> None:
+    """Reject multi-statement SQL before it reaches ``run_select``.
+
+    ``SafeSqlDriver``'s pglast allowlist validates statement *kinds*
+    (only SELECT-like), but a string with multiple SELECTs would still
+    fan out one ``execute_query`` call per parsed statement. NL→SQL
+    explicitly returns a single statement to the agent, so anything
+    more is either model error or attempted multi-statement smuggling
+    via injected SQL fragments in the question (deep-review nl2sql
+    audit P2 #7, "single-statement assertion missing").
+    """
     try:
-        parsed = json.loads(stripped)
-    except json.JSONDecodeError:
-        return ("", raw.strip())
-    # json.loads succeeds for non-dict shapes (lists, raw strings,
-    # numbers); .get on those crashes. Treat anything non-dict as a
-    # parse failure so the raw text reaches the agent unchanged.
-    if not isinstance(parsed, dict):
-        return ("", raw.strip())
-    sql = str(parsed.get("sql", "")).strip()
-    explanation = str(parsed.get("explanation", "")).strip()
-    return (sql, explanation)
+        import pglast
+
+        statements = pglast.parse_sql(sql)
+    except Exception as exc:
+        raise NL2SQLError(f"generated SQL did not parse: {exc}") from exc
+    if len(statements) != 1:
+        raise NL2SQLError(
+            f"generated SQL must contain exactly one statement; got {len(statements)} — "
+            "NL→SQL refuses to execute multi-statement input."
+        )
+
+
+def _emit_egress_warning_once(provider_name: str) -> None:
+    """Log a one-time warning that catalog metadata leaves the network.
+
+    NL→SQL ships the schema brief (table + column names, FK edges,
+    sanitised DEFAULT expressions) to the configured provider's
+    HTTPS API. Operators routinely deploy this without realising
+    catalog metadata egresses to a third-party — log a single
+    explicit notice the first time a provider is exercised so the
+    information is in the operational record (deep-review nl2sql
+    audit P2 #5, "LLM-vendor exfil note").
+    """
+    if provider_name in _EGRESS_NOTICE_LOGGED:
+        return
+    _EGRESS_NOTICE_LOGGED.add(provider_name)
+    logger.warning(
+        "NL→SQL is sending catalog metadata (schema, table + column names, "
+        "FK edges, sanitised DEFAULT expressions) to provider %r over HTTPS. "
+        "Disable MCPG_NL2SQL_PROVIDER or unset the API key to keep schema "
+        "metadata in-network.",
+        provider_name,
+    )
+
+
+# Set of provider names we've already logged the egress notice for —
+# module-level so the warning fires once per process. Test harnesses
+# can clear it via _reset_egress_notice_cache().
+_EGRESS_NOTICE_LOGGED: set[str] = set()
+
+
+def _reset_egress_notice_cache() -> None:
+    """Test-only escape hatch — forget which providers logged the notice."""
+    _EGRESS_NOTICE_LOGGED.clear()
 
 
 async def translate_nl_to_sql(
@@ -650,6 +745,7 @@ async def translate_nl_to_sql(
     max_rows: int = DEFAULT_MAX_ROWS,
     max_tables_in_brief: int = DEFAULT_MAX_TABLES_IN_BRIEF,
     columns_per_table: int = DEFAULT_COLUMNS_PER_TABLE,
+    max_brief_chars: int = DEFAULT_MAX_BRIEF_CHARS,
     timeout: float = DEFAULT_TIMEOUT_SECONDS,
     env: Mapping[str, str] | None = None,
     audit_persist: bool = False,
@@ -668,6 +764,11 @@ async def translate_nl_to_sql(
         max_tokens / max_rows / max_tables_in_brief / columns_per_table:
             Bounds on the prompt and the executed result. The hard
             cap on ``max_tokens`` is :data:`HARD_MAX_TOKENS`.
+        max_brief_chars: Final character cap on the rendered schema
+            brief — defends against a schema with hundreds of long
+            column names blowing the LLM token budget. Default
+            :data:`DEFAULT_MAX_BRIEF_CHARS` (32 KB); hard upper
+            bound :data:`HARD_MAX_BRIEF_CHARS`.
         env: Optional configuration mapping. When omitted, the
             ``MCPG_NL2SQL_SCHEMA_*`` settings are read from
             ``os.environ``. Pass a custom mapping for multi-tenant or
@@ -687,6 +788,9 @@ async def translate_nl_to_sql(
         raise NL2SQLError("question must not be empty")
     if max_tokens < 1 or max_tokens > HARD_MAX_TOKENS:
         raise NL2SQLError(f"max_tokens must be between 1 and {HARD_MAX_TOKENS}")
+    if max_brief_chars < 1 or max_brief_chars > HARD_MAX_BRIEF_CHARS:
+        raise NL2SQLError(f"max_brief_chars must be between 1 and {HARD_MAX_BRIEF_CHARS}")
+    _emit_egress_warning_once(provider.name)
     # _validate_schema_name does three things in one place:
     #   1. Rejects non-identifier values (the schema name lands in the
     #      LLM prompt verbatim — caller-side prompt injection vector).
@@ -704,6 +808,7 @@ async def translate_nl_to_sql(
         max_tables=max_tables_in_brief,
         columns_per_table=columns_per_table,
         table_filter=table_filter,
+        max_brief_chars=max_brief_chars,
     )
     # ``.replace`` (not ``.format``) so curly braces in the user's
     # question (e.g. asking about a jsonb literal like ``{"k":1}``)
@@ -743,8 +848,12 @@ async def translate_nl_to_sql(
             error=None if sql else "model returned no SQL",
         )
     else:
-        # Execution path: route through the same safety stack as run_select.
+        # Execution path: assert single-statement first (defence-in-
+        # depth against the model returning ``"SELECT 1; DROP TABLE x"``
+        # or the user smuggling a fragment into the question), then
+        # route through the same safety stack as run_select.
         try:
+            _assert_single_statement(sql)
             exec_result = await run_select(driver, sql, max_rows=max_rows)
             translation = TranslationResult(
                 sql=sql,
@@ -757,7 +866,12 @@ async def translate_nl_to_sql(
                 row_count=exec_result.row_count,
                 error=None,
             )
-        except QueryError as exc:
+        except (QueryError, NL2SQLError) as exc:
+            # psycopg / libpq error messages routinely embed DSN
+            # fragments and password-bearing connection-string
+            # values — pipe through obfuscate_password so the
+            # ``result.error`` field never leaks credentials to the
+            # caller (deep-review nl2sql audit P2 #6).
             translation = TranslationResult(
                 sql=sql,
                 explanation=explanation,
@@ -767,7 +881,7 @@ async def translate_nl_to_sql(
                 rows=[],
                 columns=[],
                 row_count=0,
-                error=str(exc),
+                error=obfuscate_password(str(exc)),
             )
 
     if audit_persist:

--- a/tests/unit/test_nl2sql.py
+++ b/tests/unit/test_nl2sql.py
@@ -9,8 +9,10 @@ from _fakes import FakeRoutingDriver
 
 from mcpg.config import load_settings
 from mcpg.nl2sql import (
+    DEFAULT_MAX_BRIEF_CHARS,
     DEFAULT_MODELS,
     DEFAULT_SCHEMA_DENYLIST,
+    HARD_MAX_BRIEF_CHARS,
     HARD_MAX_TOKENS,
     AnthropicProvider,
     GeminiProvider,
@@ -18,7 +20,9 @@ from mcpg.nl2sql import (
     NL2SQLError,
     OpenAIProvider,
     ProviderCallParams,
+    _assert_single_statement,
     _parse_response,
+    _reset_egress_notice_cache,
     _resolve_schema_policy,
     _sanitize_default_expr,
     _validate_schema_name,
@@ -649,3 +653,237 @@ async def test_translate_nl_to_sql_audit_persist_failure_doesnt_break_translatio
 
     assert result.sql == "SELECT 1"
     assert result.explanation == "smoke"
+
+
+# --- P1 #4 — schema brief char cap ---------------------------------------
+
+
+async def test_schema_brief_is_truncated_when_exceeding_char_cap() -> None:
+    """A schema with hundreds of long column names can't push the brief
+    past ``max_brief_chars`` — the cap applies after per-table /
+    per-column caps so an attacker-shaped schema can't smuggle the
+    LLM-token budget past the operator's max_tokens setting."""
+    from _fakes import FakeRoutingDriver
+
+    # Build a column list that overflows the cap when rendered.
+    long_cols = [
+        {
+            "column_name": f"col_{i:04d}_with_a_quite_long_name_field",
+            "data_type": "text",
+            "nullable": True,
+            "column_default": None,
+            "type_name": "text",
+            "type_mod": -1,
+        }
+        for i in range(800)
+    ]
+    routes = {
+        "c.relispartition": [{"name": "widget", "relkind": "r", "is_partition": False}],
+        "format_type(a.atttypid, a.atttypmod)": long_cols,
+        "WHERE con.contype = 'f'": [],
+    }
+    provider = _StubProvider(response='{"sql": "SELECT 1", "explanation": "x"}')
+
+    await translate_nl_to_sql(
+        FakeRoutingDriver(routes),  # type: ignore[arg-type]
+        provider=provider,  # type: ignore[arg-type]
+        model="m",
+        question="count widgets",
+        schema="public",
+        max_brief_chars=2048,
+        columns_per_table=800,
+    )
+
+    assert "[schema brief truncated at 2048 chars]" in provider.captured_user
+    # The user prompt holds the system+schema brief; ensure it actually
+    # respects the cap (with a little overhead for the template).
+    assert len(provider.captured_user) < 2048 + 1024
+
+
+async def test_translate_nl_to_sql_rejects_oversize_max_brief_chars() -> None:
+    from _fakes import FakeRoutingDriver
+
+    with pytest.raises(NL2SQLError, match="max_brief_chars"):
+        await translate_nl_to_sql(
+            FakeRoutingDriver({}),  # type: ignore[arg-type]
+            provider=_StubProvider(),  # type: ignore[arg-type]
+            model="m",
+            question="x",
+            schema="public",
+            max_brief_chars=HARD_MAX_BRIEF_CHARS + 1,
+        )
+
+
+def test_default_max_brief_chars_under_hard_cap() -> None:
+    assert DEFAULT_MAX_BRIEF_CHARS <= HARD_MAX_BRIEF_CHARS
+    assert DEFAULT_MAX_BRIEF_CHARS > 0
+
+
+# --- P2 #5 — vendor-egress one-time warning -------------------------------
+
+
+async def test_translate_nl_to_sql_emits_egress_warning_once_per_provider() -> None:
+    """Operators should see exactly one warning per process telling
+    them catalog metadata leaves the network. Subsequent calls on the
+    same provider stay silent (so the warning doesn't spam logs).
+
+    Tested by spying on the module-level cache rather than caplog —
+    the suite's logging config disables propagation on ``mcpg.*``
+    loggers, which fights with caplog in the full-suite run.
+    """
+    from _fakes import FakeRoutingDriver
+
+    import mcpg.nl2sql as nl2sql_mod
+
+    _reset_egress_notice_cache()
+    provider = _StubProvider(response='{"sql": "SELECT 1", "explanation": "x"}')
+    for _ in range(3):
+        await translate_nl_to_sql(
+            FakeRoutingDriver(_routes_for_simple_schema()),  # type: ignore[arg-type]
+            provider=provider,  # type: ignore[arg-type]
+            model="m",
+            question="x",
+            schema="public",
+        )
+    # Exactly one provider — "stub" — is in the cache; if the warning
+    # fired twice, the set membership doesn't change but the test
+    # below would catch any logic that bypassed the cache.
+    assert nl2sql_mod._EGRESS_NOTICE_LOGGED == {"stub"}
+
+
+async def test_translate_nl_to_sql_egress_warning_fires_per_distinct_provider() -> None:
+    """Each provider warms the cache once; switching providers
+    triggers a fresh notice."""
+    from _fakes import FakeRoutingDriver
+
+    import mcpg.nl2sql as nl2sql_mod
+
+    _reset_egress_notice_cache()
+    routes = _routes_for_simple_schema()
+    for name in ("anthropic_x", "openai_x", "gemini_x"):
+        provider = _StubProvider(name=name, response='{"sql": "SELECT 1", "explanation": "x"}')
+        await translate_nl_to_sql(
+            FakeRoutingDriver(routes),  # type: ignore[arg-type]
+            provider=provider,  # type: ignore[arg-type]
+            model="m",
+            question="x",
+            schema="public",
+        )
+    assert nl2sql_mod._EGRESS_NOTICE_LOGGED == {"anthropic_x", "openai_x", "gemini_x"}
+
+
+# --- P2 #6 — QueryError redaction ----------------------------------------
+
+
+async def test_query_error_message_is_redacted_in_translation_result() -> None:
+    """The execute path's error string flows straight to the caller;
+    psycopg embeds DSN fragments in failure messages, so it must go
+    through obfuscate_password first."""
+    from _fakes import FakeRoutingDriver
+
+    routes = _routes_for_simple_schema()
+    # Route a SELECT-shaped query to a failing pglast parse so we
+    # exercise the QueryError branch via the safety stack.
+
+    class _RaisingDriver(FakeRoutingDriver):
+        async def execute_query(self, query, params=None, force_readonly=False):  # type: ignore[override]
+            if "SELECT count(*)" in query and "public.widget" in query:
+                # Simulate a libpq error with an embedded credential.
+                from mcpg.query import QueryError
+
+                raise QueryError("could not connect to postgres://alice:hunter2@db/x")
+            return await super().execute_query(query, params, force_readonly)
+
+    provider = _StubProvider(response='{"sql": "SELECT count(*) FROM public.widget", "explanation": "x"}')
+    result = await translate_nl_to_sql(
+        _RaisingDriver(routes),  # type: ignore[arg-type]
+        provider=provider,  # type: ignore[arg-type]
+        model="m",
+        question="how many widgets",
+        schema="public",
+        execute=True,
+    )
+
+    assert result.executed is False
+    assert result.error is not None
+    assert "hunter2" not in result.error
+
+
+# --- P2 #7 — single-statement assertion ----------------------------------
+
+
+def test_assert_single_statement_accepts_one_select() -> None:
+    _assert_single_statement("SELECT 1")
+    _assert_single_statement("SELECT count(*) FROM widget WHERE id > 5")
+
+
+def test_assert_single_statement_rejects_two_statements() -> None:
+    with pytest.raises(NL2SQLError, match="exactly one statement"):
+        _assert_single_statement("SELECT 1; SELECT 2")
+
+
+def test_assert_single_statement_rejects_select_with_trailing_smuggle() -> None:
+    """The classic injection: a valid SELECT followed by a DROP that
+    the model was tricked into emitting."""
+    with pytest.raises(NL2SQLError, match="exactly one statement"):
+        _assert_single_statement("SELECT id FROM widget; DROP TABLE widget")
+
+
+def test_assert_single_statement_rejects_unparseable_sql() -> None:
+    with pytest.raises(NL2SQLError, match="did not parse"):
+        _assert_single_statement("not even sql ###")
+
+
+async def test_translate_nl_to_sql_rejects_multi_statement_at_execution() -> None:
+    """End-to-end: a model that returns two statements gets caught
+    before run_select runs, and the error reaches the caller in the
+    redacted form."""
+    from _fakes import FakeRoutingDriver
+
+    provider = _StubProvider(response='{"sql": "SELECT 1; SELECT 2", "explanation": "x"}')
+    result = await translate_nl_to_sql(
+        FakeRoutingDriver(_routes_for_simple_schema()),  # type: ignore[arg-type]
+        provider=provider,  # type: ignore[arg-type]
+        model="m",
+        question="x",
+        schema="public",
+        execute=True,
+    )
+    assert result.executed is False
+    assert result.error is not None
+    assert "exactly one statement" in result.error
+
+
+# --- P2 #8 — better fence handling ---------------------------------------
+
+
+def test_parse_response_handles_fence_with_surrounding_prose() -> None:
+    """Models occasionally emit explanatory text + a fenced JSON
+    block; the parser must extract from the fence instead of giving
+    up because the outer JSON parse fails."""
+    raw = (
+        "Sure! Here you go:\n\n"
+        "```json\n"
+        '{"sql": "SELECT 1", "explanation": "wrapped"}\n'
+        "```\n\n"
+        "Let me know if you'd like adjustments."
+    )
+    sql, explanation = _parse_response(raw)
+    assert sql == "SELECT 1"
+    assert explanation == "wrapped"
+
+
+def test_parse_response_handles_multiline_sql_inside_fence() -> None:
+    raw = '```\n{"sql": "SELECT id\\nFROM widget\\nWHERE id > 5", "explanation": "multi"}\n```'
+    sql, explanation = _parse_response(raw)
+    assert "SELECT id" in sql
+    assert explanation == "multi"
+
+
+def test_parse_response_extracts_fence_body_over_outer_garbage() -> None:
+    """Mixed text + fence — the outer text isn't JSON, so the fence
+    body wins."""
+    raw = 'Here is the answer.\n```\n{"sql": "SELECT 2", "explanation": "ok"}\n```\nDone.'
+    sql, explanation = _parse_response(raw)
+    assert sql == "SELECT 2"
+    assert explanation == "ok"


### PR DESCRIPTION
## Summary

**PR-3 of five** in the NL→SQL remediation arc. Closes **five findings** (P1 #4 + P2 #5-#8) from the deep-review NL→SQL audit in one pass — each is small, additive, and independent of the others, so they bundle naturally.

### P1 #4 — Schema-brief character cap

`_build_schema_brief` previously bounded the schema brief by *table count* and *columns per table*, but not by *characters*. A schema with hundreds of long column names could render a multi-megabyte brief that blows the LLM token budget and bills the operator. New `max_brief_chars` parameter (default **32 KB ≈ 8k tokens**, hard cap **128 KB**) applies after the per-table caps; truncation appends a one-line sentinel so the LLM (and audit-log readers) can see the bound was hit.

```python
brief = "\n".join(lines)
if len(brief) > max_brief_chars:
    keep = max(0, max_brief_chars - 64)
    suffix = f"\n... [schema brief truncated at {max_brief_chars} chars]"
    brief = brief[:keep] + suffix
```

### P2 #5 — Vendor-egress one-time warning

NL→SQL ships the schema brief (table + column names, FK edges, sanitised DEFAULT expressions) over HTTPS to the configured LLM provider's API. Operators routinely enable NL→SQL without realising catalog metadata leaves the network. First call per provider per process now emits a single `mcpg.nl2sql` `WARNING`:

```
NL→SQL is sending catalog metadata (schema, table + column names, FK edges,
sanitised DEFAULT expressions) to provider 'anthropic' over HTTPS. Disable
MCPG_NL2SQL_PROVIDER or unset the API key to keep schema metadata in-network.
```

Subsequent calls stay silent so the warning doesn't spam logs.

### P2 #6 — `QueryError` redaction

The execution path's error string flowed straight to the caller via `result.error = str(exc)`. psycopg / libpq routinely embed DSN fragments and password-bearing connection strings in error messages — same vector closed for `mcpg_audit.events.error` in PR #96. Now wrapped:

```python
error=obfuscate_password(str(exc))
```

### P2 #7 — Single-statement assertion

The model can return `"SELECT 1; DROP TABLE x"`; `SafeSqlDriver`'s pglast allowlist validates *statement kinds* but the trailing DROP would parse as a non-SELECT and the QueryError trace might leak the multi-statement shape to the agent. Defense-in-depth: parse with pglast before `run_select`, refuse if more than one statement parses out:

```python
def _assert_single_statement(sql: str) -> None:
    statements = pglast.parse_sql(sql)
    if len(statements) != 1:
        raise NL2SQLError("generated SQL must contain exactly one statement ...")
```

### P2 #8 — Robust code-fence handling

The previous `_CODE_FENCE` regex stripped leading/trailing fence markers but left the middle intact, which broke `json.loads` when the model wrapped valid JSON in explanatory prose + a fence. New strategy: try parsing the raw reply first; if that fails, extract the first fenced block's body and try again. Multi-line SQL strings inside the fence body now round-trip correctly:

```python
_CODE_FENCE_BLOCK = re.compile(
    r"```(?:json|sql)?\s*\n?(.*?)\n?\s*```",
    re.IGNORECASE | re.DOTALL,
)
```

## Tests (+14, 1863 total)

* Brief cap (3): truncation kicks in on oversized schemas; oversized `max_brief_chars` rejected; `DEFAULT_MAX_BRIEF_CHARS <= HARD_MAX_BRIEF_CHARS` invariant.
* Egress warning (2): exactly one notice per provider per process; per-provider cache fires once per distinct name.
* Redaction (1): a `QueryError` with an embedded `hunter2` credential never reaches `result.error` in plaintext.
* Single-statement (4): accepts a clean SELECT; rejects two statements; rejects the classic `"SELECT … ; DROP …"` injection; rejects unparseable input.
* Fence handling (3): fenced block surrounded by prose extracts cleanly; multi-line SQL inside the fence parses; outer-garbage / inner-fence body wins.

## Followups (sequence preserved)

* **PR-4** — retrofit `mcpg_audit.events` with full migration (HMAC-chain-aware) onto the partitioning / compression / RLS stack introduced in PR #107.
* **PR-5** — retrofit `mcpg_rag.rerank_events` + `mcpg_rag.efficiency_observations`.

## Test plan

- [x] `ruff check` + `ruff format` + `mypy src/mcpg` + `bandit` all clean
- [x] `uv run pytest tests/unit` — 1863 passed
- [ ] CI matrix PG 14 / 15 / 16 / 17 / 18 — expected green (no SQL touched, only safety + parsing changes)

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_