### PR TITLE
release: cut 0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-06-17
+
 ### Added
 
 - **`mcpg_rag.rerank_events` + `mcpg_rag.efficiency_observations`
@@ -322,6 +324,26 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 - **Stale `mcpg --version` output bumped 0.5.1 → 0.6.1 in
   `docs/installation.md`** (#95).
+
+### Dependencies
+
+- **Transitive bumps to close 7 Dependabot security alerts** (#113).
+  Lockfile-only refresh (`uv.lock`); no `pyproject.toml` change since
+  every flagged package reaches the project transitively under loose
+  constraints, so downstream PyPI installs already resolve to the
+  patched versions.
+
+  - `cryptography` 48.0.0 → 49.0.0 — OpenSSL CVE in statically-linked
+    wheels (alert #5).
+  - `python-multipart` 0.0.29 → 0.0.32 — closes four alerts:
+    Content-Disposition RFC 2231/5987 parameter smuggling (#1),
+    `application/x-www-form-urlencoded` `;` separator differential
+    (#2), negative `Content-Length` unbounded read in `parse_form`
+    (#3), quadratic-time `;` separator scan DoS (#4).
+  - `starlette` 1.2.0 → 1.3.1 — closes two alerts: unvalidated
+    request path poisons `request.url.hostname` (#6),
+    `request.form()` limits silently ignored on
+    `application/x-www-form-urlencoded` (#7, DoS).
 
 ## [0.6.1] - 2026-06-09
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -45,7 +45,7 @@ Verify the install:
 
 ```bash
 mcpg --version
-# → mcpg 0.6.1
+# → mcpg 0.6.2
 ```
 
 ### Option 2 — Docker

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcpg"
-version = "0.6.1"
+version = "0.6.2"
 description = "A production-grade PostgreSQL Model Context Protocol (MCP) server."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

Patch bump rolling up everything merged since v0.6.1.

## What's in the release

13 substantive commits since `v0.6.1`, grouped:

### NL→SQL remediation arc (security-critical)
- **#106** — Closes two P0 prompt-injection paths (stored DEFAULT, schema-name verbatim into prompt)
- **#107** — New `mcpg_audit.nl2sql_events` time-series table (partitioned/compressed/RLS)
- **#108** — Hardening sweep: brief char cap, single-statement assertion, `QueryError` redaction, robust fence handling, vendor-egress warning
- **#109** — `mcpg_audit.events` HMAC-aware migration onto the same stack
- **#110** — `mcpg_rag.rerank_events` + `mcpg_rag.efficiency_observations` migration
- **#111** — Bundle migration DDL into one `execute_query` so `ACCESS EXCLUSIVE` lock actually holds

### Earlier security / perf / fixes
- **#96** — Redact error messages + secret provider repr at every leak edge
- **#97** — Pin TLS minimum + AEAD cipher allowlist + reject HTTP JWKS
- **#99** — Bound four scalability P0 cliffs in `vector_ops` / `mmr_search` / `verify_audit_chain`
- **#100** — Wrap DDL + record-the-SQL across `rag_telemetry` / `maintenance` setup paths
- **#101** — Bounded LRU on cloud secret caches; JWKS TTL; bind hybrid weights
- **#102** — Typed errors across `graph` / `cypher` / `locks`; relocate `nl2sql` wrapper logic
- **#104** — Replace `ORDER BY RANDOM()` with probability-based sampling
- **#105** — Anchor audit HMAC chain against tail-truncation attack

### Dependency hygiene
- **#113** — Bump `cryptography` 48.0.0 → 49.0.0, `python-multipart` 0.0.29 → 0.0.32, `starlette` 1.2.0 → 1.3.1; closes 7 Dependabot security alerts. **Lockfile-only** — `pyproject.toml`'s loose constraints already let downstream PyPI installers resolve to the patched versions, so this benefits dev / CI reproducibility rather than end users.

## Why patch (0.6.2) rather than minor (0.7.0)

The net effect on the public API is additive only — new env vars (`MCPG_NL2SQL_AUDIT_*`, `MCPG_AUDIT_EVENTS_*`, `MCPG_RAG_TELEMETRY_*`), new functions (`migrate_audit_events_to_partitioned`, `migrate_rag_telemetry_to_partitioned`), no removals, no signature changes. The headline change for existing users is **security fixes**, which fit the patch-bump cadence.

## Files touched

| File | Change |
|---|---|
| `pyproject.toml` | `version = "0.6.1"` → `"0.6.2"` |
| `CHANGELOG.md` | Promote `[Unreleased]` → `[0.6.2] - 2026-06-17`; add a Dependencies block summarising #113 |
| `docs/installation.md` | Sample `mcpg --version` output refresh |

Per project convention (only minor releases get a dedicated `release-notes-0.X.0.md` page), no new release-notes file — patch lives in CHANGELOG.

## Test plan

- [x] Pre-commit hooks pass (lint/format/mypy/bandit) on the version-bump-only change
- [x] All upstream merged work already CI-verified before landing
- [ ] CI matrix PG 14 / 15 / 16 / 17 / 18 — expected green (no code changes)

## After merge

- Tag `v0.6.2` against the merge commit
- Push tag → triggers PyPI publish per existing release workflow

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Bump the project to release version 0.6.2 and document the changes since 0.6.1.

Build:
- Update project version metadata from 0.6.1 to 0.6.2 in pyproject configuration.

Documentation:
- Update installation documentation to reflect the new 0.6.2 version in sample CLI output.

Chores:
- Promote the unreleased changelog section to 0.6.2 with added dependency upgrade notes addressing multiple security alerts.