### PR TITLE
docs(review): Phase A static fact pack + Phase B LLM observation harness

### DIFF
--- a/docs/reviews/phase-b-README.md
+++ b/docs/reviews/phase-b-README.md
@@ -1,0 +1,119 @@
+# Phase B — LLM behaviour observation pipeline
+
+A self-contained harness for measuring how an LLM actually behaves
+when it sees MCPg's tool catalogue. The output ties back to specific
+findings in `tool-surface-fact-pack.md` (Phase A) and
+`tool-overlap-report.md` (Phase A.0) so we can confirm — or refute —
+the static signals with measured behaviour before we touch any
+source code.
+
+## Files
+
+| File | Role |
+|---|---|
+| `phase-b-prompts.json` | The corpus — 22 prompts across 4 categories, each tagged with the Phase A finding it probes. Edit to add / remove / re-tune probes. |
+| `phase-b-observations.jsonl` | Generated. One JSONL row per (prompt × model × run). Append-only — keep across runs to compare provider/model behaviour. |
+| `phase-b-report.md` | Generated. Human-readable digest with run metadata, per-category hit rates, per-prompt detail, and a Phase A confirmation matrix. |
+| `../../tools/observe_llm_behaviour.py` | The harness. Reads the corpus + the v0.6.2 tool snapshot, calls Anthropic Messages API with the full tool catalogue, writes JSONL. |
+| `../../tools/summarise_llm_observations.py` | The reporter. Reads JSONL, writes Markdown. |
+
+## Prompt corpus structure
+
+Each prompt in `phase-b-prompts.json` has:
+
+```json
+{
+  "id": "od-01",
+  "category": "overlap_disambiguation",
+  "phase_a_reference": "tool-overlap-report.md #1 (score 4.99)",
+  "user_prompt": "I want to look at the individual WAL records ...",
+  "expected_tool": "read_pg_wal_records",
+  "rationale": "Records vs stats — 'individual' is the signal."
+}
+```
+
+Categories:
+
+1. **`overlap_disambiguation`** — 8 prompts probing the top pairs from
+   the overlap report. Tests whether the LLM picks the right tool when
+   two names look similar.
+2. **`list_family_picker`** — 4 prompts probing the 39-tool `list_*`
+   family. Tests whether the LLM disambiguates among same-prefix tools.
+3. **`return_shape`** — 5 prompts asking the LLM to describe what a
+   tool returns *without calling it*. Tests whether descriptions
+   convey return shape (Phase A flagged 75 tools missing this hint).
+4. **`self_introspection`** — 5 prompts asking high-level capability
+   questions ("What can mcpg do?"). Tests the gap Phase A flagged:
+   no MCP resources, no MCP prompts, no `about` tool.
+
+Each prompt either has an `expected_tool` (the right pick) **or**
+`expected_no_tool_call: true` (the right behaviour is to answer in
+text without calling a tool). The summariser uses these to compute
+hit rate per category and per Phase A finding.
+
+## Running
+
+```bash
+export ANTHROPIC_API_KEY=sk-...
+
+# Smoke test with 3 prompts before paying for a full run:
+python tools/observe_llm_behaviour.py --limit 3
+
+# Full corpus run, all 22 prompts, Sonnet:
+python tools/observe_llm_behaviour.py \
+    --model claude-sonnet-4-6 \
+    --output docs/reviews/phase-b-observations.jsonl
+
+# One category at a time when iterating:
+python tools/observe_llm_behaviour.py --category self_introspection
+
+# Then render the report:
+python tools/summarise_llm_observations.py \
+    > docs/reviews/phase-b-report.md
+```
+
+### Cost expectation per full run
+
+- **Input**: 22 prompts × ~30k tokens (catalogue + prompt + system) ≈ **660k input tokens**
+- **Output**: 22 × ~500 tokens ≈ **11k output tokens**
+- **At Sonnet 4.x list pricing** ($3/M in, $15/M out): **≈ $2.15** per cold run.
+- **With prompt caching** (Anthropic enables for `tools=` automatically on warm calls): typically **~$0.40** on the second+ run.
+
+If you want to evaluate cheaper models first, swap `--model` to
+`claude-haiku-4-5-20251001` (~10× cheaper). Halve the cost again with
+`--limit 10` while you iterate on the corpus.
+
+### Reproducibility
+
+The harness uses `temperature=0.0` and a stable system prompt. Two
+runs on the same model / corpus produce near-identical observations
+(Anthropic's tool-use sampling has minor non-determinism even at
+T=0, but tool picks are stable).
+
+## Interpreting the report
+
+The summariser's **§4 Phase A confirmation matrix** is the headline
+deliverable. It tells you, for each Phase A finding referenced by a
+prompt, whether Phase B's behaviour evidence:
+
+- **Confirmed** the static flag (LLM got it wrong)
+- **Refuted** it (LLM handled it fine despite the static signal)
+- Showed a **partial** pattern (LLM sometimes confused)
+
+That maps directly to what to fix. A "confirmed" finding with a 0%
+hit rate is a clear catalogue-improvement candidate; a "refuted"
+finding suggests the static flag was overcautious and we can ignore
+it. The §5 "Next steps" section is intentionally left empty for the
+reviewer to fill in based on the confirmation matrix.
+
+## When to re-run
+
+- After any non-trivial change to `register_tools` (rename, schema
+  shift, description rewrite). The contract test (PR #115) will tell
+  you the surface changed; this harness tells you whether the change
+  improved or regressed LLM behaviour.
+- When upgrading the target model (e.g. Sonnet 4.7 → Sonnet 4.8).
+- When considering a structural change (consolidating an ORM family,
+  adding an `about` tool, adding MCP resources).
+
+The corpus is the contract; the report is the evidence trail.

--- a/docs/reviews/phase-b-prompts.json
+++ b/docs/reviews/phase-b-prompts.json
@@ -1,0 +1,196 @@
+{
+  "_meta": {
+    "schema_version": 1,
+    "description": "Phase B prompt corpus. Each prompt probes a finding from the Phase A static report. Run via `tools/observe_llm_behaviour.py`.",
+    "prompt_count": 22,
+    "categories": ["overlap_disambiguation", "list_family_picker", "return_shape", "self_introspection"]
+  },
+  "prompts": [
+    {
+      "id": "od-01",
+      "category": "overlap_disambiguation",
+      "phase_a_reference": "tool-overlap-report.md #1 (score 4.99)",
+      "user_prompt": "I want to look at the individual Write-Ahead Log records that have been written since LSN 0/16B00000. Which mcpg tool should I call?",
+      "expected_tool": "read_pg_wal_records",
+      "rationale": "Records (the underlying entries) vs stats (aggregated by resource manager). Word 'individual' should be the signal."
+    },
+    {
+      "id": "od-02",
+      "category": "overlap_disambiguation",
+      "phase_a_reference": "tool-overlap-report.md #1 (score 4.99)",
+      "user_prompt": "I want a summary of WAL traffic by record-type and resource manager over the last hour. Which mcpg tool?",
+      "expected_tool": "read_pg_wal_stats",
+      "rationale": "Aggregated stats, not individual records. Word 'summary' should be the signal."
+    },
+    {
+      "id": "od-03",
+      "category": "overlap_disambiguation",
+      "phase_a_reference": "tool-overlap-report.md #2 (score 4.91)",
+      "user_prompt": "I just shipped a big batch of new documents and want to rebuild the BM25 search index on docs.content. Which tool?",
+      "expected_tool": "reindex_pg_search_index",
+      "rationale": "BM25 = pg_search index, not turboquant (which is vector/ANN). Should not pick reindex_turboquant_index."
+    },
+    {
+      "id": "od-04",
+      "category": "overlap_disambiguation",
+      "phase_a_reference": "tool-overlap-report.md #3 (score 4.62)",
+      "user_prompt": "I have a TimescaleDB hypertable called metrics.events and I want chunks older than 30 days to be dropped automatically. Which tool?",
+      "expected_tool": "add_retention_policy",
+      "rationale": "'Dropped' is the retention signal; should not pick add_compression_policy (which compresses, doesn't drop)."
+    },
+    {
+      "id": "od-05",
+      "category": "overlap_disambiguation",
+      "phase_a_reference": "tool-overlap-report.md #11 (score 3.58)",
+      "user_prompt": "I want to run an approximate-nearest-neighbour query against the turboquant index on documents.embedding. Which tool?",
+      "expected_tool": "turboquant_approx_candidates",
+      "rationale": "Approx candidates (initial retrieval) vs rerank candidates (re-scoring an existing candidate set). 'Approximate-nearest-neighbour query' is the initial retrieval phrase."
+    },
+    {
+      "id": "od-06",
+      "category": "overlap_disambiguation",
+      "phase_a_reference": "tool-overlap-report.md #13 (score 3.52)",
+      "user_prompt": "I'm doing semantic search and want results that are not only relevant but also diverse — no two near-duplicates in my top-10. Which mcpg tool?",
+      "expected_tool": "mmr_search",
+      "rationale": "Diversity / maximal marginal relevance is the MMR algorithm signal; plain vector_search returns top-K by similarity with no diversity penalty."
+    },
+    {
+      "id": "od-07",
+      "category": "overlap_disambiguation",
+      "phase_a_reference": "tool-overlap-report.md #6 (score 4.25)",
+      "user_prompt": "I want to see which PostgreSQL extensions I could install on this database — what's available in the server's library path, regardless of whether it's already enabled?",
+      "expected_tool": "list_available_extensions",
+      "rationale": "'Available' / 'could install' is the signal; list_extensions reports already-installed ones."
+    },
+    {
+      "id": "od-08",
+      "category": "overlap_disambiguation",
+      "phase_a_reference": "tool-overlap-report.md #17 (score 3.45)",
+      "user_prompt": "I have a migration file at /var/migrations/2026-06-add-orders-index.sql and I want mcpg to check whether running it would break anything before I actually run it. Which tool?",
+      "expected_tool": "validate_migration",
+      "rationale": "Validate the migration (operation safety) vs validate_migration_schema (the schema impact only). Depends on tool descriptions; both names sound identical."
+    },
+    {
+      "id": "lf-01",
+      "category": "list_family_picker",
+      "phase_a_reference": "fact-pack §1a (list_* dominates at 22.5%, 39 tools)",
+      "user_prompt": "I want to see which queries are currently running against the database and which one has been running the longest. Which mcpg tool?",
+      "expected_tool": "list_active_queries",
+      "rationale": "Tests whether the LLM picks the right list_* from 39 options when the cue is operational."
+    },
+    {
+      "id": "lf-02",
+      "category": "list_family_picker",
+      "phase_a_reference": "fact-pack §1a",
+      "user_prompt": "I'm cleaning up unused indexes and want to know what triggers exist on the orders table. Which tool?",
+      "expected_tool": "list_triggers",
+      "rationale": "Discriminator: list_triggers vs list_indexes vs list_foreign_keys all share 'list' + a database object name."
+    },
+    {
+      "id": "lf-03",
+      "category": "list_family_picker",
+      "phase_a_reference": "fact-pack §1a",
+      "user_prompt": "I'm doing a security review and want to see every role defined in the database, with the membership relationships between them. Which tool?",
+      "expected_tool": "list_roles",
+      "rationale": "Tests whether the LLM correctly disambiguates list_roles from similar admin tools."
+    },
+    {
+      "id": "lf-04",
+      "category": "list_family_picker",
+      "phase_a_reference": "fact-pack §1a",
+      "user_prompt": "I think a long-running transaction is holding locks and blocking app traffic. I want to see what locks are held right now and by whom.",
+      "expected_tool": "list_locks",
+      "rationale": "Operational cue (blocking app traffic) should help disambiguate from list_active_queries / walk_blocking_chains."
+    },
+    {
+      "id": "rs-01",
+      "category": "return_shape",
+      "phase_a_reference": "fact-pack §2e (75 tools with no return-shape hint)",
+      "user_prompt": "If I call `audit_database` with no arguments, what shape of data should I expect to come back? Describe the response structure without actually calling the tool.",
+      "expected_tool": null,
+      "expected_no_tool_call": true,
+      "rationale": "Tool description doesn't say what it returns. Measure whether LLM guesses or hedges."
+    },
+    {
+      "id": "rs-02",
+      "category": "return_shape",
+      "phase_a_reference": "fact-pack §2e",
+      "user_prompt": "What does `cluster_vectors` return when called with a table and a k value? Describe the response structure without actually calling the tool.",
+      "expected_tool": null,
+      "expected_no_tool_call": true,
+      "rationale": "No return-shape hint; clustering tools have wildly different return shapes (assignments vs centroids vs both)."
+    },
+    {
+      "id": "rs-03",
+      "category": "return_shape",
+      "phase_a_reference": "fact-pack §2e",
+      "user_prompt": "What does `find_sensitive_columns` return? Specifically: is it just column names, or does it also include the matching reason / classification?",
+      "expected_tool": null,
+      "expected_no_tool_call": true,
+      "rationale": "The user's mental model (with reason / without reason) drives whether they pick this tool or write a custom query."
+    },
+    {
+      "id": "rs-04",
+      "category": "return_shape",
+      "phase_a_reference": "fact-pack §2e",
+      "user_prompt": "What does `full_text_search` return? Just matching IDs, or matching rows with ranking scores?",
+      "expected_tool": null,
+      "expected_no_tool_call": true,
+      "rationale": "Score vs no-score is a real picker decision."
+    },
+    {
+      "id": "rs-05",
+      "category": "return_shape",
+      "phase_a_reference": "fact-pack §2e",
+      "user_prompt": "If I run `analyze_hnsw_recall`, what does the result look like? Will it tell me a single recall number, or a per-k recall curve?",
+      "expected_tool": null,
+      "expected_no_tool_call": true,
+      "rationale": "Single-value vs curve is a meaningful difference for downstream code."
+    },
+    {
+      "id": "si-01",
+      "category": "self_introspection",
+      "phase_a_reference": "fact-pack §4 (no resources, no prompts, no `about` tool)",
+      "user_prompt": "What can mcpg do? Give me a high-level summary of its capabilities — I'm new to this server.",
+      "expected_tool": null,
+      "expected_no_tool_call": true,
+      "rationale": "The big test. Does the LLM produce a useful summary? Is it accurate? Does it miss whole capability buckets?"
+    },
+    {
+      "id": "si-02",
+      "category": "self_introspection",
+      "phase_a_reference": "fact-pack §4",
+      "user_prompt": "Does mcpg support vector / semantic search? If yes, what's available?",
+      "expected_tool": null,
+      "expected_no_tool_call": true,
+      "rationale": "Targeted capability question. Should mention pgvector, mmr_search, vector_search, turboquant, BM25 hybrid."
+    },
+    {
+      "id": "si-03",
+      "category": "self_introspection",
+      "phase_a_reference": "fact-pack §4",
+      "user_prompt": "I'm thinking of using mcpg for a multi-tenant SaaS app. Does it support per-tenant role isolation, audit trails, and rate limiting?",
+      "expected_tool": null,
+      "expected_no_tool_call": true,
+      "rationale": "Three-part capability question; tests whether the LLM can piece together capabilities from the tool catalog."
+    },
+    {
+      "id": "si-04",
+      "category": "self_introspection",
+      "phase_a_reference": "fact-pack §4",
+      "user_prompt": "Can mcpg help me migrate data between two PostgreSQL databases? What's the recommended approach?",
+      "expected_tool": null,
+      "expected_no_tool_call": true,
+      "rationale": "Tests whether the LLM finds the data_movement / dump_database / restore_database tools and recommends them coherently."
+    },
+    {
+      "id": "si-05",
+      "category": "self_introspection",
+      "phase_a_reference": "fact-pack §4",
+      "user_prompt": "Does mcpg support graph operations on top of PostgreSQL? I'm thinking of using it for a recommendation system.",
+      "expected_tool": null,
+      "expected_no_tool_call": true,
+      "rationale": "Tests whether the LLM finds the graph tools (create_graph / cypher / walk_blocking_chains-style) and contextualises them appropriately."
+    }
+  ]
+}

--- a/docs/reviews/tool-surface-fact-pack.md
+++ b/docs/reviews/tool-surface-fact-pack.md
@@ -1,0 +1,269 @@
+# MCPg tool-surface fact pack (Phase A — static observation)
+
+_Generated from `tests/contract/tool_surface.snapshot.json` (173 tools) and the v0.6.2 source tree. Read-only; no MCPg code changes. Token counts are char/4 estimates (±~15% vs tiktoken)._
+
+---
+
+## 1. Catalog shape
+
+- Total tools registered: **173**
+- Distinct verb prefixes: **65**
+- Description length — median **288 chars**, p90 **669**, max **1156**, min **42**
+- Parameter count — median **2**, p90 **7**, max **18**
+- Required parameter count — median **1**, p90 **4**, max **14**
+- Schema depth (0 = no params; 1 = flat) — median **1**, max **1**
+
+### 1a. Verb-prefix breakdown
+
+| Verb prefix | Tool count | % of catalog |
+|---|---:|---:|
+| `list_*` | 39 | 22.5% |
+| `generate_*` | 13 | 7.5% |
+| `analyze_*` | 9 | 5.2% |
+| `recommend_*` | 8 | 4.6% |
+| `get_*` | 7 | 4.0% |
+| `run_*` | 7 | 4.0% |
+| `read_*` | 6 | 3.5% |
+| `create_*` | 4 | 2.3% |
+| `find_*` | 3 | 1.7% |
+| `import_*` | 3 | 1.7% |
+| `partman_*` | 3 | 1.7% |
+| `pg_*` | 3 | 1.7% |
+| `vector_*` | 3 | 1.7% |
+| `add_*` | 2 | 1.2% |
+| `cancel_*` | 2 | 1.2% |
+| `describe_*` | 2 | 1.2% |
+| `detect_*` | 2 | 1.2% |
+| `export_*` | 2 | 1.2% |
+| `hybrid_*` | 2 | 1.2% |
+| `monitor_*` | 2 | 1.2% |
+| `reindex_*` | 2 | 1.2% |
+| `schedule_*` | 2 | 1.2% |
+| `setup_*` | 2 | 1.2% |
+| `turboquant_*` | 2 | 1.2% |
+| `validate_*` | 2 | 1.2% |
+| `verify_*` | 2 | 1.2% |
+| `audit_*` | 1 | 0.6% |
+| `check_*` | 1 | 0.6% |
+| `close_*` | 1 | 0.6% |
+| `cluster_*` | 1 | 0.6% |
+| `compare_*` | 1 | 0.6% |
+| `complete_*` | 1 | 0.6% |
+| `copy_*` | 1 | 0.6% |
+| `cross_*` | 1 | 0.6% |
+| `drop_*` | 1 | 0.6% |
+| `dump_*` | 1 | 0.6% |
+| `enable_*` | 1 | 0.6% |
+| `explain_*` | 1 | 0.6% |
+| `fetch_*` | 1 | 0.6% |
+| `full_*` | 1 | 0.6% |
+| `fuzzy_*` | 1 | 0.6% |
+| `geo_*` | 1 | 0.6% |
+| `lint_*` | 1 | 0.6% |
+| `log_*` | 1 | 0.6% |
+| `maintain_*` | 1 | 0.6% |
+| `migrate_*` | 1 | 0.6% |
+| `mmr_*` | 1 | 0.6% |
+| `open_*` | 1 | 0.6% |
+| `optimize_*` | 1 | 0.6% |
+| `poll_*` | 1 | 0.6% |
+| `prepare_*` | 1 | 0.6% |
+| `prune_*` | 1 | 0.6% |
+| `record_*` | 1 | 0.6% |
+| `restore_*` | 1 | 0.6% |
+| `seed_*` | 1 | 0.6% |
+| `subscribe_*` | 1 | 0.6% |
+| `summarize_*` | 1 | 0.6% |
+| `terminate_*` | 1 | 0.6% |
+| `test_*` | 1 | 0.6% |
+| `translate_*` | 1 | 0.6% |
+| `tune_*` | 1 | 0.6% |
+| `unschedule_*` | 1 | 0.6% |
+| `unsubscribe_*` | 1 | 0.6% |
+| `walk_*` | 1 | 0.6% |
+| `why_*` | 1 | 0.6% |
+
+### 1b. Description-length histogram
+
+| Length (chars) | Tools |
+|---|---:|
+| 0..0 | 0 |
+| 1..50 | 2 |
+| 51..100 | 21 |
+| 101..200 | 42 |
+| 201..400 | 56 |
+| 401..800 | 44 |
+| 801+ | 8 |
+
+### 1c. Parameter-count histogram
+
+| Parameters | Tools |
+|---|---:|
+| 0..0 | 30 |
+| 1..1 | 49 |
+| 2..2 | 28 |
+| 3..3 | 22 |
+| 4..5 | 17 |
+| 6..8 | 11 |
+| 9+ | 16 |
+
+## 2. Description quality heuristics
+
+- **Empty descriptions:** 0 / 173 (0.0%)
+- **Very short (<50 chars, non-empty):** 2 / 173 (1.2%)
+- **Name-restating (description adds <3 novel content words):** 2 / 173 (1.2%)
+- **Gated tools missing security caveat in description:** 0 / 173 (0.0%)
+- **No return-shape hint in description:** 75 / 173 (43.4%)
+
+### 2b. Tools with very short descriptions (<50 chars)
+
+- `list_extensions` — _List the extensions installed in the database._
+- `list_triggers` — _List the user-defined triggers on a table._
+
+### 2c. Tools whose description appears to just restate the name
+
+_Flagged when the description contains <3 distinct content words beyond what's already in the tool name. Low-signal descriptions cost the LLM tokens without adding picking signal._
+
+- `list_extensions` — _List the extensions installed in the database._
+- `list_foreign_data_wrappers` — _List the foreign-data wrappers installed in the database._
+
+### 2e. Tools with no return-shape hint
+
+_75 tools whose description never says what they return (no 'returns', 'yields', 'list of', 'object with', 'rows', etc.). An LLM picker often needs to know the shape to decide whether to call this tool or another that returns a more directly-usable shape._
+
+Top 20 by alphabetical order (full list elided to keep the report readable):
+
+- `add_compression_policy`
+- `analyze_hnsw_recall`
+- `analyze_rerank_score_distribution`
+- `audit_database`
+- `cancel_query`
+- `check_database_health`
+- `create_graph`
+- `create_hypertable`
+- `describe_graph`
+- `describe_table`
+- `drop_graph`
+- `enable_extension`
+- `export_table`
+- `find_sensitive_columns`
+- `find_unused_objects`
+- `full_text_search`
+- `fuzzy_search`
+- `generate_drizzle_schema`
+- `generate_fk_cascade_graph`
+- `generate_graph_diagram`
+- _…and 55 more._
+
+## 3. Token-budget cost
+
+Total catalogue cost when surfaced to an LLM (single `tools/list` response, approximate): **~28,071 tokens**.
+
+Per-component breakdown:
+
+| Component | Tokens | % of total |
+|---|---:|---:|
+| Names | 816 | 2.9% |
+| Descriptions | 14,166 | 50.5% |
+| Input schemas | 13,089 | 46.6% |
+| **Total** | **28,071** | 100% |
+
+### 3a. Top 15 most-expensive tools (token budget)
+
+| Tool | Total | Name | Desc | Schema |
+|---|---:|---:|---:|---:|
+| `create_pg_search_index` | 749 | 6 | 220 | 523 |
+| `record_efficiency_observation` | 558 | 7 | 176 | 375 |
+| `pg_search_more_like_this` | 518 | 6 | 145 | 367 |
+| `monitor_embedding_drift` | 510 | 6 | 289 | 215 |
+| `hybrid_bm25_vector_search` | 483 | 6 | 191 | 286 |
+| `detect_vector_outliers` | 463 | 6 | 232 | 225 |
+| `pg_search_run` | 458 | 3 | 211 | 244 |
+| `log_rerank_event` | 450 | 4 | 132 | 314 |
+| `translate_nl_to_sql` | 429 | 5 | 276 | 148 |
+| `cross_table_similarity` | 402 | 6 | 170 | 226 |
+| `analyze_vector_search_efficiency` | 399 | 8 | 190 | 201 |
+| `schedule_logical_backup` | 399 | 6 | 214 | 179 |
+| `hybrid_search` | 384 | 3 | 176 | 205 |
+| `create_turboquant_index` | 379 | 6 | 154 | 219 |
+| `cluster_vectors` | 372 | 4 | 188 | 180 |
+
+### 3b. Bottom 15 cheapest tools
+
+| Tool | Total |
+|---|---:|
+| `list_views` | 55 |
+| `list_functions` | 54 |
+| `list_active_queries` | 53 |
+| `list_enums` | 53 |
+| `list_cron_jobs` | 48 |
+| `list_available_extensions` | 46 |
+| `verify_audit_chain` | 45 |
+| `get_server_info` | 44 |
+| `list_foreign_servers` | 44 |
+| `list_publications` | 43 |
+| `list_subscriptions` | 42 |
+| `list_user_mappings` | 42 |
+| `list_foreign_data_wrappers` | 41 |
+| `list_graphs` | 35 |
+| `list_extensions` | 34 |
+
+### 3c. Context-window context
+
+At ~28,071 tokens, the full mcpg catalogue is 14.0% of a Claude 200k context window, 21.9% of a 128k window, and 87.7% of a 32k window. The cost is fixed per turn — every conversation pays it for every request as long as the LLM holds the catalogue in context.
+
+## 4. Self-introspection inventory
+
+What an MCP client (Claude Desktop, Cursor, an automation agent) sees when it first connects to mcpg, *beyond* the `tools/list` response covered by sections 1–3.
+
+- **MCP resources exposed:** 0
+
+- **MCP prompts exposed:** 0
+
+- **Dedicated self-description tool present** (`about` / `capabilities` / `describe_self`): no
+
+- **`get_server_info` tool body (current implementation):**
+
+```python
+async def get_server_info(ctx: _Ctx) -> dict[str, Any]:
+        return asdict(build_server_info(ctx.request_context.lifespan_context))
+
+    @server.tool(
+        name="get_metrics_exposition",
+        description=(
+            "Return the in-process Prometheus-format metrics for this MCPg "
+            "server. Three series: mcpg_tool_calls_total (counter by tool / "
+            "status), mcpg_tool_duration_seconds (histogram by tool with "
+            "sum and count). Useful when the HTTP transport's /metrics "
+            "endpoint is unreachable (e.g. running over stdio) or to fetch "
+            "via the MCP protocol itself."
+        ),
+    )
+    async def get_metrics_exposition(ctx: _Ctx) -> str:
+        del ctx  # context unused; tool reads from process-wide singleton
+        from mcpg.observability import render_prometheus
+
+        return render_prometheus()
+```
+
+---
+
+## 5. Cross-cutting observations
+
+Interpretations the raw stats above point at — not verdicts, just leads worth Phase-B verification.
+
+- 43% of tools never describe what they return. The LLM has to call them speculatively to find out, which wastes turns when the return shape is wrong for the task.
+- mcpg exposes **zero MCP resources and zero MCP prompts**. When Claude Chat or Cursor asks 'what is this server / what can it do' beyond just listing tools, there is no structured answer to surface. Self-introspection currently relies on the client reading every tool description and synthesising.
+- No dedicated `about` / `capabilities` / `describe_self` tool. The closest is `get_server_info`, which mostly returns server config / version. There is no tool an LLM can call to get a human-readable answer to 'what does mcpg do?' without ingesting the full 173-tool catalogue.
+
+---
+
+## 6. Hand-off to Phase B
+
+Phase A surfaces leads; Phase B (LLM behaviour observation) confirms or refutes them. The Phase-B prompt corpus should include at least:
+
+1. **Picker-confusion probes** for the top-scoring overlap pairs from `tool-overlap-report.md` (Phase A.0). Ask the LLM to disambiguate them; if it can't, the static flag is real.
+2. **Permission-denial probes** for the `missing security caveat` list. Simulate a denial; see whether the LLM can suggest the right `MCPG_*` flag.
+3. **Return-shape probes** for the `no return hint` list. Ask the LLM what it expects the tool to return; compare to reality.
+4. **Self-introspection probes** — 'What can this MCP server do?' / 'List mcpg's capabilities' / 'Can mcpg do X?' Measure whether the response is accurate, complete, and useful.
+

--- a/tools/observe_llm_behaviour.py
+++ b/tools/observe_llm_behaviour.py
@@ -1,0 +1,359 @@
+"""Phase B — LLM behaviour observation harness.
+
+For each prompt in `docs/reviews/phase-b-prompts.json`, this harness:
+
+1. Loads the MCPg tool catalogue from the contract snapshot.
+2. Sends it as the `tools=` parameter on an Anthropic Messages API
+   call (using native MCP-style tool calling — the same surface a
+   real Claude Desktop session sees).
+3. Records exactly what the LLM did: which tool it picked, what
+   arguments it proposed, what text it generated, how many tokens
+   it cost.
+4. Appends a JSONL line to the output file (default
+   `docs/reviews/phase-b-observations.jsonl`).
+
+Why Anthropic specifically: the conversation has been Claude-centric
+and Claude is the primary MCPg target. The harness is structured so
+adding OpenAI / Gemini providers is a one-class swap if you ever
+want a comparison run, but for our first cut we want Claude's
+behaviour because that's what users will see.
+
+Usage::
+
+    export ANTHROPIC_API_KEY=...
+    python tools/observe_llm_behaviour.py \\
+        --model claude-sonnet-4-6 \\
+        --output docs/reviews/phase-b-observations.jsonl
+
+    # Filter to one category if iterating:
+    python tools/observe_llm_behaviour.py \\
+        --category self_introspection
+
+    # Reduce scope while validating the harness:
+    python tools/observe_llm_behaviour.py --limit 3
+
+The harness is deterministic per prompt id (uses temperature=0 +
+stable system prompt). Re-running on the same corpus produces the
+same observations within Anthropic's tool-use sampling tolerance.
+
+**Cost estimate**: 22 prompts x ~28k tokens of tools + ~300 tokens
+of prompt + ~500 tokens of response ≈ ~640k input tokens + ~11k
+output tokens per full run. At Sonnet 4.x pricing (~$3/M input,
+~$15/M output) that's roughly $2.10 per run before prompt caching
+(which Anthropic enables automatically on tools — bringing input
+cost down to ~10% on warm runs).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SNAPSHOT_PATH = _REPO_ROOT / "tests" / "contract" / "tool_surface.snapshot.json"
+_CORPUS_PATH = _REPO_ROOT / "docs" / "reviews" / "phase-b-prompts.json"
+_DEFAULT_OUTPUT = _REPO_ROOT / "docs" / "reviews" / "phase-b-observations.jsonl"
+
+_SYSTEM_PROMPT = (
+    "You are an AI agent connected to mcpg — a Model Context Protocol "
+    "(MCP) server that exposes PostgreSQL capabilities to LLMs. You "
+    "have access to mcpg's full tool catalogue via the `tools=` parameter "
+    "on this conversation.\n\n"
+    "For each user request, decide whether to call a tool, ask a "
+    "clarifying question, or answer from your own knowledge of the "
+    "tool catalogue. When the user asks 'what can mcpg do?' or similar "
+    "introspection questions, answer in plain prose based on the "
+    "available tools — do not just dump the tool list."
+)
+
+
+# ---------------------------------------------------------------------------
+# Tool catalogue → Anthropic tool-use format
+# ---------------------------------------------------------------------------
+
+
+def _load_tool_catalogue() -> list[dict[str, Any]]:
+    """Map the snapshot record shape into Anthropic's tool-use shape.
+
+    Snapshot has: ``name``, ``description``, ``inputSchema``.
+    Anthropic wants: ``name``, ``description``, ``input_schema``.
+    """
+    snapshot = json.loads(_SNAPSHOT_PATH.read_text(encoding="utf-8"))
+    return [
+        {
+            "name": t["name"],
+            "description": t["description"],
+            "input_schema": t["inputSchema"],
+        }
+        for t in snapshot["tools"]
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Anthropic API call
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Observation:
+    """One row of evidence for the report."""
+
+    prompt_id: str
+    category: str
+    phase_a_reference: str
+    user_prompt: str
+    expected_tool: str | None
+    expected_no_tool_call: bool
+    rationale: str
+    # Captured response:
+    picked_tool: str | None
+    picked_args: dict[str, Any] | None
+    text_response: str
+    stop_reason: str
+    input_tokens: int
+    output_tokens: int
+    latency_ms: int
+    # Derived correctness:
+    matched_expected: bool | None
+    # Provider plumbing
+    provider: str
+    model: str
+    timestamp: str
+    raw_error: str | None = None
+    raw_blocks: list[dict[str, Any]] = field(default_factory=list)
+
+
+async def _call_anthropic(
+    *,
+    api_key: str,
+    base_url: str,
+    model: str,
+    system_prompt: str,
+    user_prompt: str,
+    tools: list[dict[str, Any]],
+    max_tokens: int,
+    timeout: float,
+) -> tuple[dict[str, Any], int]:
+    """Single Messages API call. Returns ``(response_json, latency_ms)``."""
+    started = time.monotonic()
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        response = await client.post(
+            f"{base_url.rstrip('/')}/v1/messages",
+            headers={
+                "x-api-key": api_key,
+                "anthropic-version": "2023-06-01",
+                "content-type": "application/json",
+            },
+            json={
+                "model": model,
+                "max_tokens": max_tokens,
+                "temperature": 0.0,
+                "system": system_prompt,
+                "tools": tools,
+                "messages": [{"role": "user", "content": user_prompt}],
+            },
+        )
+    latency_ms = int((time.monotonic() - started) * 1000)
+    response.raise_for_status()
+    return response.json(), latency_ms
+
+
+def _parse_response(body: dict[str, Any]) -> tuple[str | None, dict[str, Any] | None, str, list[dict[str, Any]]]:
+    """Extract (picked_tool_name, picked_args, text, raw_blocks) from
+    the Anthropic Messages response."""
+    picked_tool: str | None = None
+    picked_args: dict[str, Any] | None = None
+    text_parts: list[str] = []
+    raw_blocks: list[dict[str, Any]] = []
+    for block in body.get("content") or []:
+        raw_blocks.append(block)
+        if block.get("type") == "tool_use":
+            # First tool_use wins for the observation; multi-call chains
+            # are interesting but rare on these single-turn probes.
+            if picked_tool is None:
+                picked_tool = block.get("name")
+                picked_args = block.get("input")
+        elif block.get("type") == "text":
+            text_parts.append(block.get("text", ""))
+    return picked_tool, picked_args, "\n\n".join(text_parts).strip(), raw_blocks
+
+
+def _judge_match(prompt: dict[str, Any], picked_tool: str | None) -> bool | None:
+    """Has the LLM produced the expected behaviour?
+
+    * For tool-picker prompts (``expected_tool`` set): must pick that tool.
+    * For "no tool call expected" prompts (``expected_no_tool_call`` true):
+      must NOT pick any tool.
+    * Otherwise: undecidable (return None).
+    """
+    expected_tool = prompt.get("expected_tool")
+    expected_no_call = prompt.get("expected_no_tool_call", False)
+    if expected_tool is not None:
+        return picked_tool == expected_tool
+    if expected_no_call:
+        return picked_tool is None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Top-level driver
+# ---------------------------------------------------------------------------
+
+
+async def _run(
+    *,
+    api_key: str,
+    base_url: str,
+    model: str,
+    output_path: Path,
+    category_filter: str | None,
+    limit: int | None,
+    max_tokens: int,
+    timeout: float,
+) -> int:
+    corpus = json.loads(_CORPUS_PATH.read_text(encoding="utf-8"))
+    prompts = corpus["prompts"]
+    if category_filter:
+        prompts = [p for p in prompts if p["category"] == category_filter]
+    if limit is not None:
+        prompts = prompts[:limit]
+
+    tools = _load_tool_catalogue()
+    print(f"[harness] {len(prompts)} prompts queued, {len(tools)} tools in catalogue, model={model}", file=sys.stderr)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    successes = 0
+    failures = 0
+    with output_path.open("a", encoding="utf-8") as f:
+        for prompt in prompts:
+            try:
+                body, latency_ms = await _call_anthropic(
+                    api_key=api_key,
+                    base_url=base_url,
+                    model=model,
+                    system_prompt=_SYSTEM_PROMPT,
+                    user_prompt=prompt["user_prompt"],
+                    tools=tools,
+                    max_tokens=max_tokens,
+                    timeout=timeout,
+                )
+            except httpx.HTTPError as exc:
+                obs = Observation(
+                    prompt_id=prompt["id"],
+                    category=prompt["category"],
+                    phase_a_reference=prompt.get("phase_a_reference", ""),
+                    user_prompt=prompt["user_prompt"],
+                    expected_tool=prompt.get("expected_tool"),
+                    expected_no_tool_call=prompt.get("expected_no_tool_call", False),
+                    rationale=prompt.get("rationale", ""),
+                    picked_tool=None,
+                    picked_args=None,
+                    text_response="",
+                    stop_reason="",
+                    input_tokens=0,
+                    output_tokens=0,
+                    latency_ms=0,
+                    matched_expected=None,
+                    provider="anthropic",
+                    model=model,
+                    timestamp=datetime.now(UTC).isoformat(),
+                    raw_error=str(exc),
+                )
+                failures += 1
+            else:
+                picked, args, text, blocks = _parse_response(body)
+                usage = body.get("usage") or {}
+                obs = Observation(
+                    prompt_id=prompt["id"],
+                    category=prompt["category"],
+                    phase_a_reference=prompt.get("phase_a_reference", ""),
+                    user_prompt=prompt["user_prompt"],
+                    expected_tool=prompt.get("expected_tool"),
+                    expected_no_tool_call=prompt.get("expected_no_tool_call", False),
+                    rationale=prompt.get("rationale", ""),
+                    picked_tool=picked,
+                    picked_args=args,
+                    text_response=text,
+                    stop_reason=body.get("stop_reason", ""),
+                    input_tokens=int(usage.get("input_tokens", 0)),
+                    output_tokens=int(usage.get("output_tokens", 0)),
+                    latency_ms=latency_ms,
+                    matched_expected=_judge_match(prompt, picked),
+                    provider="anthropic",
+                    model=model,
+                    timestamp=datetime.now(UTC).isoformat(),
+                    raw_blocks=blocks,
+                )
+                successes += 1
+
+            f.write(json.dumps(obs.__dict__, default=str) + "\n")
+            f.flush()
+            verdict = "?" if obs.matched_expected is None else ("OK" if obs.matched_expected else "MISS")
+            print(
+                f"[{prompt['id']}] {verdict}  "
+                f"picked={picked if successes else 'ERR'}  "
+                f"in={obs.input_tokens}  out={obs.output_tokens}  "
+                f"lat={obs.latency_ms}ms",
+                file=sys.stderr,
+            )
+
+    print(f"[harness] done. {successes} success, {failures} failure.", file=sys.stderr)
+    return 0 if failures == 0 else 1
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--model", default="claude-sonnet-4-6", help="Anthropic model id.")
+    parser.add_argument(
+        "--base-url", default="https://api.anthropic.com", help="Override the API base URL (proxy / mock)."
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=_DEFAULT_OUTPUT,
+        help="JSONL output path. Appended (not overwritten) so you can run iteratively.",
+    )
+    parser.add_argument(
+        "--category",
+        choices=["overlap_disambiguation", "list_family_picker", "return_shape", "self_introspection"],
+        help="Run only one category.",
+    )
+    parser.add_argument("--limit", type=int, help="Run only the first N prompts (after category filter).")
+    parser.add_argument("--max-tokens", type=int, default=1024, help="Anthropic max_tokens per response.")
+    parser.add_argument("--timeout", type=float, default=120.0, help="HTTP timeout per call (seconds).")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    import asyncio
+
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        print("ANTHROPIC_API_KEY not set in environment.", file=sys.stderr)
+        return 2
+    return asyncio.run(
+        _run(
+            api_key=api_key,
+            base_url=args.base_url,
+            model=args.model,
+            output_path=args.output,
+            category_filter=args.category,
+            limit=args.limit,
+            max_tokens=args.max_tokens,
+            timeout=args.timeout,
+        )
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/static_tool_facts.py
+++ b/tools/static_tool_facts.py
@@ -1,0 +1,645 @@
+"""Tool-surface fact-pack generator (Phase A — static observation).
+
+Produces a single Markdown report covering everything we can know
+about MCPg's tool surface *without* talking to an LLM:
+
+* Catalog shape — counts by verb prefix, description-length and
+  parameter-count distributions, schema depth and required-vs-optional
+  split.
+* Description quality heuristics — empty / short / name-restating /
+  missing-security-caveat / missing-return-hint descriptions.
+* Token-budget cost — char-based estimate of how much of an LLM's
+  context window the catalogue eats, per-tool and aggregate.
+* Self-introspection inventory — what an MCP client sees on
+  first connect *beyond* ``tools/list``: server info, MCP
+  resources, MCP prompts, the ``get_server_info`` tool's output
+  shape.
+
+The report is the input for Phase B (LLM behaviour observation).
+Where Phase A flags "this description is just the name in English,"
+Phase B should ask the LLM to disambiguate that tool from its
+siblings and see whether the LLM can — that's how we tie the static
+facts to actual observed behaviour.
+
+Run with:
+
+    python tools/static_tool_facts.py > docs/reviews/tool-surface-fact-pack.md
+
+The analyser is read-only — it never mutates the snapshot or
+source tree. The cost approximation (char_count / 4) is a coarse
+proxy for tokens; ratios between tools are reliable, absolute
+numbers are within ~15% of tiktoken-cl100k for English content.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import statistics
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SNAPSHOT_PATH = _REPO_ROOT / "tests" / "contract" / "tool_surface.snapshot.json"
+_TOOLS_SOURCE = _REPO_ROOT / "src" / "mcpg" / "tools.py"
+_SERVER_SOURCE = _REPO_ROOT / "src" / "mcpg" / "server.py"
+
+# ---------------------------------------------------------------------------
+# Token estimation
+# ---------------------------------------------------------------------------
+
+
+def _approx_tokens(text: str) -> int:
+    """Character-count heuristic. Within ~15% of tiktoken for English
+    prose; ratios between tools are reliable. Avoids adding a tiktoken
+    dev dep.
+    """
+    if not text:
+        return 0
+    return max(1, round(len(text) / 4))
+
+
+def _tool_token_cost(tool: dict[str, Any]) -> dict[str, int]:
+    """Per-tool token budget, broken into name / description / schema
+    so we can see where the cost lives."""
+    name_t = _approx_tokens(tool["name"])
+    desc_t = _approx_tokens(tool.get("description") or "")
+    schema_t = _approx_tokens(json.dumps(tool.get("inputSchema") or {}))
+    return {
+        "name": name_t,
+        "description": desc_t,
+        "schema": schema_t,
+        "total": name_t + desc_t + schema_t,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Catalog shape
+# ---------------------------------------------------------------------------
+
+
+def _verb_prefix(name: str) -> str:
+    """First underscore-separated token; the operational verb."""
+    return name.split("_", 1)[0] if "_" in name else name
+
+
+def _schema_param_summary(schema: dict[str, Any]) -> dict[str, Any]:
+    """Per-tool input-schema descriptive stats."""
+    props = schema.get("properties") or {}
+    required = set(schema.get("required") or [])
+    optional = set(props) - required
+
+    # Schema "depth" — how many levels of nested objects appear.
+    # A flat shape is depth=1; one level of nesting = depth=2; etc.
+    def _depth(node: Any) -> int:
+        if not isinstance(node, dict):
+            return 0
+        if "properties" in node:
+            kids = node.get("properties") or {}
+            child_max = max((_depth(v) for v in kids.values()), default=0)
+            return 1 + child_max
+        if "items" in node:
+            return _depth(node.get("items"))
+        return 0
+
+    depth = _depth(schema)
+    return {
+        "param_count": len(props),
+        "required_count": len(required),
+        "optional_count": len(optional),
+        "depth": depth,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Description quality heuristics
+# ---------------------------------------------------------------------------
+
+
+# Recognises "<verb> the <name fragments>" patterns where the
+# description is just the tool name rephrased. e.g. name=list_tables,
+# desc="List the tables." → flagged.
+def _name_restates_check(name: str, description: str) -> bool:
+    """Approximate: does the description add ≥2 distinct content
+    words beyond what's in the name?"""
+    if not description:
+        return False  # empty is its own bucket
+    desc_lower = description.lower()
+    name_words = {w for w in re.split(r"[_\-]+", name.lower()) if len(w) > 2}
+    # Stop-word filter for description side.
+    desc_words = {w for w in re.findall(r"[a-z][a-z0-9]+", desc_lower) if len(w) > 2}
+    novel = (
+        desc_words
+        - name_words
+        - {
+            "the",
+            "and",
+            "for",
+            "with",
+            "this",
+            "from",
+            "into",
+            "all",
+            "any",
+            "via",
+            "use",
+            "uses",
+            "used",
+            "you",
+            "your",
+            "tool",
+        }
+    )
+    return len(novel) < 3
+
+
+# Tools that touch a gated surface should say so in their description
+# so the LLM knows when to suggest the operator enable a flag.
+_GATED_NAME_PATTERNS = [
+    ("write", "MCPG_ACCESS_MODE"),
+    ("update", "MCPG_ACCESS_MODE"),
+    ("delete", "MCPG_ACCESS_MODE"),
+    ("create_", "DDL"),
+    ("drop_", "DDL"),
+    ("alter_", "DDL"),
+    ("reindex", "DDL"),
+    ("vacuum", "MCPG_ACCESS_MODE"),
+    ("dump", "shell"),
+    ("restore", "shell"),
+    ("psql", "shell"),
+    ("listen", "MCPG_ALLOW_LISTEN"),
+]
+
+
+def _missing_security_caveat(name: str, description: str) -> str | None:
+    """Return the security-flag name a tool *should* mention given
+    its name, or ``None`` if no caveat is expected (or one is present)."""
+    desc_lower = (description or "").lower()
+    for needle, flag in _GATED_NAME_PATTERNS:
+        if needle not in name:
+            continue
+        # Loose presence check — variants of how we mention the flag.
+        if any(
+            token in desc_lower
+            for token in (
+                flag.lower(),
+                "unrestricted",
+                "allow_ddl",
+                "allow_shell",
+                "allow_listen",
+                "ddl",
+            )
+        ):
+            return None
+        return flag
+    return None
+
+
+_RETURN_HINT_KEYWORDS = (
+    "return",
+    "returns",
+    "yields",
+    "emits",
+    "produces",
+    "list of",
+    "list with",
+    "object with",
+    "dict with",
+    "rows",
+    "result",
+    "output",
+    "responds with",
+    "writes",
+    "drops",
+    "creates",
+)
+
+
+def _has_return_hint(description: str) -> bool:
+    """Does the description say *anything* about what the tool returns?"""
+    if not description:
+        return False
+    lower = description.lower()
+    return any(k in lower for k in _RETURN_HINT_KEYWORDS)
+
+
+# ---------------------------------------------------------------------------
+# Self-introspection inventory (source-code probe)
+# ---------------------------------------------------------------------------
+
+
+def _find_get_server_info_body() -> str:
+    """Read the get_server_info tool's body from tools.py so we can
+    see what an MCP client gets when it asks 'what is this server'."""
+    if not _TOOLS_SOURCE.exists():
+        return "(source not found)"
+    text = _TOOLS_SOURCE.read_text(encoding="utf-8")
+    match = re.search(
+        r"async def get_server_info[^\n]*\n((?:    [^\n]*\n|\n)+)",
+        text,
+    )
+    return match.group(0).rstrip() if match else "(get_server_info not found)"
+
+
+def _list_mcp_resource_decorators() -> list[str]:
+    """Find any ``@server.resource(...)`` registrations in the server
+    source. MCP servers can expose resources alongside tools; if mcpg
+    doesn't expose any, that's a data point."""
+    if not _SERVER_SOURCE.exists():
+        return []
+    text = _SERVER_SOURCE.read_text(encoding="utf-8")
+    return re.findall(r"@\w+\.resource\([^)]*\)", text)
+
+
+def _list_mcp_prompt_decorators() -> list[str]:
+    if not _SERVER_SOURCE.exists():
+        return []
+    text = _SERVER_SOURCE.read_text(encoding="utf-8")
+    return re.findall(r"@\w+\.prompt\([^)]*\)", text)
+
+
+# ---------------------------------------------------------------------------
+# Report rendering
+# ---------------------------------------------------------------------------
+
+
+def _hist_bins(values: list[int], edges: list[int]) -> list[tuple[str, int]]:
+    """Render a histogram for an int distribution against operator-friendly
+    bin edges. Returns list of (label, count)."""
+    counts: list[int] = [0] * (len(edges) + 1)
+    for v in values:
+        placed = False
+        for i, edge in enumerate(edges):
+            if v <= edge:
+                counts[i] += 1
+                placed = True
+                break
+        if not placed:
+            counts[-1] += 1
+    labels = []
+    last = -1
+    for edge in edges:
+        labels.append(f"{last + 1}..{edge}")
+        last = edge
+    labels.append(f"{last + 1}+")
+    return list(zip(labels, counts, strict=True))
+
+
+def main() -> int:
+    snapshot = json.loads(_SNAPSHOT_PATH.read_text(encoding="utf-8"))
+    tools: list[dict[str, Any]] = snapshot["tools"]
+    n = len(tools)
+
+    # ---- catalog shape -----------------------------------------------------
+    verb_counts: Counter[str] = Counter(_verb_prefix(t["name"]) for t in tools)
+    desc_lengths = [len(t.get("description") or "") for t in tools]
+    param_summaries = [_schema_param_summary(t.get("inputSchema") or {}) for t in tools]
+    param_counts = [p["param_count"] for p in param_summaries]
+    required_counts = [p["required_count"] for p in param_summaries]
+    depths = [p["depth"] for p in param_summaries]
+
+    # ---- description quality ----------------------------------------------
+    empty_desc = [t["name"] for t in tools if not (t.get("description") or "").strip()]
+    short_desc = [t["name"] for t in tools if 0 < len(t.get("description") or "") < 50]
+    name_restating = [t["name"] for t in tools if _name_restates_check(t["name"], t.get("description") or "")]
+    missing_caveat = [(t["name"], _missing_security_caveat(t["name"], t.get("description") or "")) for t in tools]
+    missing_caveat = [(n, f) for (n, f) in missing_caveat if f is not None]
+    no_return_hint = [t["name"] for t in tools if not _has_return_hint(t.get("description") or "")]
+
+    # ---- token cost -------------------------------------------------------
+    per_tool_tokens = []
+    for t in tools:
+        cost = _tool_token_cost(t)
+        per_tool_tokens.append((t["name"], cost))
+    per_tool_tokens.sort(key=lambda x: -x[1]["total"])
+    total_tokens = sum(c[1]["total"] for c in per_tool_tokens)
+    total_name = sum(c[1]["name"] for c in per_tool_tokens)
+    total_desc = sum(c[1]["description"] for c in per_tool_tokens)
+    total_schema = sum(c[1]["schema"] for c in per_tool_tokens)
+
+    # ---- self-introspection inventory -------------------------------------
+    server_info_body = _find_get_server_info_body()
+    resource_decorators = _list_mcp_resource_decorators()
+    prompt_decorators = _list_mcp_prompt_decorators()
+
+    # ---- render -----------------------------------------------------------
+    out: list[str] = []
+    out.append("# MCPg tool-surface fact pack (Phase A — static observation)")
+    out.append("")
+    out.append(
+        "_Generated from `tests/contract/tool_surface.snapshot.json` "
+        f"({n} tools) and the v0.6.2 source tree. Read-only; "
+        "no MCPg code changes. Token counts are char/4 estimates "
+        "(±~15% vs tiktoken)._"
+    )
+    out.append("")
+    out.append("---")
+    out.append("")
+
+    # --- catalog shape -----------------------------------------------------
+    out.append("## 1. Catalog shape")
+    out.append("")
+    out.append(f"- Total tools registered: **{n}**")
+    out.append(f"- Distinct verb prefixes: **{len(verb_counts)}**")
+    out.append(
+        f"- Description length — median **{statistics.median(desc_lengths)} chars**, "
+        f"p90 **{int(statistics.quantiles(desc_lengths, n=10)[-1])}**, "
+        f"max **{max(desc_lengths)}**, min **{min(desc_lengths)}**"
+    )
+    out.append(
+        f"- Parameter count — median **{statistics.median(param_counts)}**, "
+        f"p90 **{int(statistics.quantiles(param_counts, n=10)[-1])}**, "
+        f"max **{max(param_counts)}**"
+    )
+    out.append(
+        f"- Required parameter count — median **{statistics.median(required_counts)}**, "
+        f"p90 **{int(statistics.quantiles(required_counts, n=10)[-1])}**, "
+        f"max **{max(required_counts)}**"
+    )
+    out.append(
+        f"- Schema depth (0 = no params; 1 = flat) — median **{statistics.median(depths)}**, max **{max(depths)}**"
+    )
+    out.append("")
+
+    out.append("### 1a. Verb-prefix breakdown")
+    out.append("")
+    out.append("| Verb prefix | Tool count | % of catalog |")
+    out.append("|---|---:|---:|")
+    for verb, count in verb_counts.most_common():
+        out.append(f"| `{verb}_*` | {count} | {100 * count / n:.1f}% |")
+    out.append("")
+
+    out.append("### 1b. Description-length histogram")
+    out.append("")
+    out.append("| Length (chars) | Tools |")
+    out.append("|---|---:|")
+    for label, count in _hist_bins(desc_lengths, [0, 50, 100, 200, 400, 800]):
+        out.append(f"| {label} | {count} |")
+    out.append("")
+
+    out.append("### 1c. Parameter-count histogram")
+    out.append("")
+    out.append("| Parameters | Tools |")
+    out.append("|---|---:|")
+    for label, count in _hist_bins(param_counts, [0, 1, 2, 3, 5, 8]):
+        out.append(f"| {label} | {count} |")
+    out.append("")
+
+    # --- description quality ----------------------------------------------
+    out.append("## 2. Description quality heuristics")
+    out.append("")
+    out.append(f"- **Empty descriptions:** {len(empty_desc)} / {n} ({100 * len(empty_desc) / n:.1f}%)")
+    out.append(f"- **Very short (<50 chars, non-empty):** {len(short_desc)} / {n} ({100 * len(short_desc) / n:.1f}%)")
+    out.append(
+        f"- **Name-restating (description adds <3 novel content words):** "
+        f"{len(name_restating)} / {n} ({100 * len(name_restating) / n:.1f}%)"
+    )
+    out.append(
+        f"- **Gated tools missing security caveat in description:** "
+        f"{len(missing_caveat)} / {n} ({100 * len(missing_caveat) / n:.1f}%)"
+    )
+    out.append(
+        f"- **No return-shape hint in description:** {len(no_return_hint)} / {n} ({100 * len(no_return_hint) / n:.1f}%)"
+    )
+    out.append("")
+
+    if empty_desc:
+        out.append("### 2a. Tools with empty descriptions")
+        out.append("")
+        for name in sorted(empty_desc):
+            out.append(f"- `{name}`")
+        out.append("")
+
+    if short_desc:
+        out.append("### 2b. Tools with very short descriptions (<50 chars)")
+        out.append("")
+        for name in sorted(short_desc):
+            tool = next(t for t in tools if t["name"] == name)
+            out.append(f"- `{name}` — _{(tool.get('description') or '').strip()}_")
+        out.append("")
+
+    if name_restating:
+        out.append("### 2c. Tools whose description appears to just restate the name")
+        out.append("")
+        out.append(
+            "_Flagged when the description contains <3 distinct content "
+            "words beyond what's already in the tool name. Low-signal "
+            "descriptions cost the LLM tokens without adding picking signal._"
+        )
+        out.append("")
+        for name in sorted(name_restating):
+            tool = next(t for t in tools if t["name"] == name)
+            desc = (tool.get("description") or "").strip()
+            out.append(f"- `{name}` — _{desc[:160]}{'…' if len(desc) > 160 else ''}_")
+        out.append("")
+
+    if missing_caveat:
+        out.append("### 2d. Gated tools without a security caveat")
+        out.append("")
+        out.append(
+            "_Tools whose name implies a gated operation (write / DDL / "
+            "shell / listen) but whose description doesn't mention which "
+            "MCPG_ACCESS_MODE or MCPG_ALLOW_* flag is required. An LLM "
+            "that can't see this from the description can't suggest "
+            "'ask the operator to enable allow_ddl' when the call fails._"
+        )
+        out.append("")
+        for name, flag in sorted(missing_caveat):
+            out.append(f"- `{name}` — expected flag mention: **{flag}**")
+        out.append("")
+
+    out.append("### 2e. Tools with no return-shape hint")
+    out.append("")
+    out.append(
+        f"_{len(no_return_hint)} tools whose description never says what they return "
+        "(no 'returns', 'yields', 'list of', 'object with', 'rows', etc.). "
+        "An LLM picker often needs to know the shape to decide whether to "
+        "call this tool or another that returns a more directly-usable shape._"
+    )
+    out.append("")
+    out.append("Top 20 by alphabetical order (full list elided to keep the report readable):")
+    out.append("")
+    for name in sorted(no_return_hint)[:20]:
+        out.append(f"- `{name}`")
+    if len(no_return_hint) > 20:
+        out.append(f"- _…and {len(no_return_hint) - 20} more._")
+    out.append("")
+
+    # --- token cost -------------------------------------------------------
+    out.append("## 3. Token-budget cost")
+    out.append("")
+    out.append(
+        f"Total catalogue cost when surfaced to an LLM (single `tools/list` "
+        f"response, approximate): **~{total_tokens:,} tokens**."
+    )
+    out.append("")
+    out.append("Per-component breakdown:")
+    out.append("")
+    out.append("| Component | Tokens | % of total |")
+    out.append("|---|---:|---:|")
+    out.append(f"| Names | {total_name:,} | {100 * total_name / total_tokens:.1f}% |")
+    out.append(f"| Descriptions | {total_desc:,} | {100 * total_desc / total_tokens:.1f}% |")
+    out.append(f"| Input schemas | {total_schema:,} | {100 * total_schema / total_tokens:.1f}% |")
+    out.append(f"| **Total** | **{total_tokens:,}** | 100% |")
+    out.append("")
+
+    out.append("### 3a. Top 15 most-expensive tools (token budget)")
+    out.append("")
+    out.append("| Tool | Total | Name | Desc | Schema |")
+    out.append("|---|---:|---:|---:|---:|")
+    for name, cost in per_tool_tokens[:15]:
+        out.append(f"| `{name}` | {cost['total']} | {cost['name']} | {cost['description']} | {cost['schema']} |")
+    out.append("")
+
+    out.append("### 3b. Bottom 15 cheapest tools")
+    out.append("")
+    out.append("| Tool | Total |")
+    out.append("|---|---:|")
+    for name, cost in per_tool_tokens[-15:]:
+        out.append(f"| `{name}` | {cost['total']} |")
+    out.append("")
+
+    out.append("### 3c. Context-window context")
+    out.append("")
+    out.append(
+        f"At ~{total_tokens:,} tokens, the full mcpg catalogue is "
+        f"{100 * total_tokens / 200_000:.1f}% of a Claude 200k context window, "
+        f"{100 * total_tokens / 128_000:.1f}% of a 128k window, and "
+        f"{100 * total_tokens / 32_000:.1f}% of a 32k window. The cost is fixed "
+        f"per turn — every conversation pays it for every request as long as "
+        f"the LLM holds the catalogue in context."
+    )
+    out.append("")
+
+    # --- self-introspection inventory --------------------------------------
+    out.append("## 4. Self-introspection inventory")
+    out.append("")
+    out.append(
+        "What an MCP client (Claude Desktop, Cursor, an automation agent) "
+        "sees when it first connects to mcpg, *beyond* the `tools/list` "
+        "response covered by sections 1-3."
+    )
+    out.append("")
+
+    out.append(f"- **MCP resources exposed:** {len(resource_decorators)}")
+    if resource_decorators:
+        out.append("")
+        for d in resource_decorators:
+            out.append(f"  - `{d}`")
+    out.append("")
+    out.append(f"- **MCP prompts exposed:** {len(prompt_decorators)}")
+    if prompt_decorators:
+        out.append("")
+        for d in prompt_decorators:
+            out.append(f"  - `{d}`")
+    out.append("")
+
+    has_about_tool = any(t["name"] in {"about", "describe_self", "capabilities", "mcpg_about"} for t in tools)
+    out.append(
+        f"- **Dedicated self-description tool present** "
+        f"(`about` / `capabilities` / `describe_self`): "
+        f"{'yes' if has_about_tool else 'no'}"
+    )
+    out.append("")
+    out.append("- **`get_server_info` tool body (current implementation):**")
+    out.append("")
+    out.append("```python")
+    out.append(server_info_body)
+    out.append("```")
+    out.append("")
+
+    # --- crosscutting summary ---------------------------------------------
+    out.append("---")
+    out.append("")
+    out.append("## 5. Cross-cutting observations")
+    out.append("")
+    out.append("Interpretations the raw stats above point at — not verdicts, just leads worth Phase-B verification.")
+    out.append("")
+    obs: list[str] = []
+
+    pct_empty = 100 * len(empty_desc) / n
+    pct_short = 100 * len(short_desc) / n
+    pct_restate = 100 * len(name_restating) / n
+    if pct_empty + pct_short + pct_restate > 25:
+        obs.append(
+            f"Description quality is the biggest static lever: "
+            f"{pct_empty + pct_short + pct_restate:.0f}% of tools have descriptions "
+            "that are empty, very short, or essentially restate the name. "
+            "An LLM picker treats these as low-signal noise."
+        )
+    pct_no_return = 100 * len(no_return_hint) / n
+    if pct_no_return > 30:
+        obs.append(
+            f"{pct_no_return:.0f}% of tools never describe what they return. "
+            "The LLM has to call them speculatively to find out, which wastes "
+            "turns when the return shape is wrong for the task."
+        )
+    if missing_caveat:
+        obs.append(
+            f"{len(missing_caveat)} gated tools (write / DDL / shell / listen) "
+            "don't mention their required MCPG_ACCESS_MODE / MCPG_ALLOW_* flag "
+            "in the description. An LLM seeing a permission denial can't tell "
+            "the operator which flag to flip."
+        )
+    if not resource_decorators and not prompt_decorators:
+        obs.append(
+            "mcpg exposes **zero MCP resources and zero MCP prompts**. "
+            "When Claude Chat or Cursor asks 'what is this server / what can "
+            "it do' beyond just listing tools, there is no structured "
+            "answer to surface. Self-introspection currently relies on the "
+            "client reading every tool description and synthesising."
+        )
+    if not has_about_tool:
+        obs.append(
+            "No dedicated `about` / `capabilities` / `describe_self` tool. "
+            "The closest is `get_server_info`, which mostly returns server "
+            "config / version. There is no tool an LLM can call to get "
+            "a human-readable answer to 'what does mcpg do?' without "
+            "ingesting the full 173-tool catalogue."
+        )
+
+    if obs:
+        for line in obs:
+            out.append(f"- {line}")
+    else:
+        out.append("_(none — the static signal is clean.)_")
+    out.append("")
+    out.append("---")
+    out.append("")
+    out.append("## 6. Hand-off to Phase B")
+    out.append("")
+    out.append(
+        "Phase A surfaces leads; Phase B (LLM behaviour observation) "
+        "confirms or refutes them. The Phase-B prompt corpus should "
+        "include at least:"
+    )
+    out.append("")
+    out.append(
+        "1. **Picker-confusion probes** for the top-scoring overlap pairs "
+        "from `tool-overlap-report.md` (Phase A.0). Ask the LLM to "
+        "disambiguate them; if it can't, the static flag is real."
+    )
+    out.append(
+        "2. **Permission-denial probes** for the `missing security caveat` "
+        "list. Simulate a denial; see whether the LLM can suggest the "
+        "right `MCPG_*` flag."
+    )
+    out.append(
+        "3. **Return-shape probes** for the `no return hint` list. Ask "
+        "the LLM what it expects the tool to return; compare to reality."
+    )
+    out.append(
+        "4. **Self-introspection probes** — 'What can this MCP server do?' "
+        "/ 'List mcpg's capabilities' / 'Can mcpg do X?' Measure whether "
+        "the response is accurate, complete, and useful."
+    )
+    out.append("")
+
+    print("\n".join(out))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/summarise_llm_observations.py
+++ b/tools/summarise_llm_observations.py
@@ -1,0 +1,249 @@
+"""Phase B — summarise LLM observation JSONL into a Markdown report.
+
+Reads ``docs/reviews/phase-b-observations.jsonl`` (whatever
+``observe_llm_behaviour.py`` produced) and renders a single Markdown
+report. The report ties each LLM observation back to its Phase A
+finding so the reader can see, finding-by-finding, whether the
+static signal was actually born out in behaviour.
+
+Sections:
+
+1. **Run metadata** — provider, model, prompt count, hit rate,
+   token totals, total cost estimate, latency stats.
+2. **Per-category results** — hit rate, miss list, and a digest of
+   the model's text response so we can see whether the misses were
+   confusion or genuine alternatives.
+3. **Per-prompt details** — full transcript-style entry for each
+   prompt: expected, picked, text response, args proposed.
+4. **Confirmed Phase A findings** — auto-derived list of which
+   static flags Phase B confirmed, refuted, or left undecided.
+
+Run with::
+
+    python tools/summarise_llm_observations.py \\
+        > docs/reviews/phase-b-report.md
+
+The summariser is read-only; the JSONL is the source of truth.
+"""
+
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_JSONL_PATH = _REPO_ROOT / "docs" / "reviews" / "phase-b-observations.jsonl"
+
+# Anthropic Sonnet 4.x list pricing as of the corpus run (USD per 1M
+# tokens). The constants are intentionally inline so the cost number
+# in the report is self-documenting; bump when prices change.
+_INPUT_USD_PER_M = 3.00
+_OUTPUT_USD_PER_M = 15.00
+
+
+def _load_observations() -> list[dict[str, Any]]:
+    if not _JSONL_PATH.exists():
+        print(
+            f"ERROR: no observations found at {_JSONL_PATH}.\nRun `python tools/observe_llm_behaviour.py` first.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    return [json.loads(line) for line in _JSONL_PATH.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def _format_args(args: dict[str, Any] | None) -> str:
+    if not args:
+        return "_(none)_"
+    return "`" + ", ".join(f"{k}={json.dumps(v)}" for k, v in args.items()) + "`"
+
+
+def _truncate(text: str, limit: int = 280) -> str:
+    text = text.strip().replace("\n", " ")
+    return text if len(text) <= limit else text[: limit - 1] + "…"
+
+
+def main() -> int:
+    rows = _load_observations()
+    if not rows:
+        print("ERROR: observation file is empty.", file=sys.stderr)
+        return 2
+
+    # ---- run metadata -------------------------------------------------
+    n = len(rows)
+    providers = sorted({r["provider"] for r in rows})
+    models = sorted({r["model"] for r in rows})
+    total_in = sum(int(r.get("input_tokens", 0)) for r in rows)
+    total_out = sum(int(r.get("output_tokens", 0)) for r in rows)
+    cost_in = total_in / 1_000_000 * _INPUT_USD_PER_M
+    cost_out = total_out / 1_000_000 * _OUTPUT_USD_PER_M
+    latencies = [int(r.get("latency_ms", 0)) for r in rows if r.get("latency_ms")]
+    errors = [r for r in rows if r.get("raw_error")]
+    judged = [r for r in rows if r.get("matched_expected") is not None]
+    hits = [r for r in judged if r.get("matched_expected") is True]
+    misses = [r for r in judged if r.get("matched_expected") is False]
+
+    out: list[str] = []
+    out.append("# MCPg tool-surface fact pack — Phase B (LLM behaviour observation)")
+    out.append("")
+    out.append(
+        f"_Generated from `docs/reviews/phase-b-observations.jsonl` "
+        f"({n} prompts). Provider(s): {', '.join(providers)}. "
+        f"Model(s): {', '.join(models)}. Phase A findings referenced as "
+        f"`fact-pack §X` ←→ `tool-overlap-report.md #N`._"
+    )
+    out.append("")
+
+    out.append("## 1. Run metadata")
+    out.append("")
+    out.append(f"- Prompts run: **{n}**  (errors: {len(errors)})")
+    out.append(f"- Judgable prompts: **{len(judged)}**  (`expected_tool` set or `expected_no_tool_call=true`)")
+    if judged:
+        pct_hit = 100 * len(hits) / len(judged)
+        out.append(f"- Hit rate: **{len(hits)} / {len(judged)}** (**{pct_hit:.0f}%**)")
+    out.append(
+        f"- Token totals: **{total_in:,} input + {total_out:,} output**  "
+        f"≈ **${cost_in + cost_out:.2f}** at "
+        f"${_INPUT_USD_PER_M:.2f}/M in + ${_OUTPUT_USD_PER_M:.2f}/M out"
+    )
+    if latencies:
+        out.append(
+            f"- Latency — median **{int(statistics.median(latencies))} ms**, "
+            f"p90 **{int(statistics.quantiles(latencies, n=10)[-1])} ms**, "
+            f"max **{max(latencies)} ms**"
+        )
+    out.append("")
+
+    # ---- per-category --------------------------------------------------
+    by_cat: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for r in rows:
+        by_cat[r["category"]].append(r)
+
+    out.append("## 2. Per-category results")
+    out.append("")
+    out.append("| Category | Prompts | Judged | Hits | Hit rate |")
+    out.append("|---|---:|---:|---:|---:|")
+    for cat in sorted(by_cat):
+        cat_rows = by_cat[cat]
+        cat_judged = [r for r in cat_rows if r.get("matched_expected") is not None]
+        cat_hits = [r for r in cat_judged if r.get("matched_expected") is True]
+        rate = f"{100 * len(cat_hits) / len(cat_judged):.0f}%" if cat_judged else "n/a"
+        out.append(f"| `{cat}` | {len(cat_rows)} | {len(cat_judged)} | {len(cat_hits)} | {rate} |")
+    out.append("")
+
+    if misses:
+        out.append("### 2a. Misses (LLM picked something other than expected)")
+        out.append("")
+        for r in misses:
+            out.append(
+                f"- **`{r['prompt_id']}`** _(category: `{r['category']}`)_ — "
+                f"expected `{r['expected_tool']}`, got "
+                f"`{r['picked_tool'] or '(no tool)'}`"
+            )
+            out.append(f"  - User prompt: _{_truncate(r['user_prompt'])}_")
+            if r.get("text_response"):
+                out.append(f"  - Text response (first line): _{_truncate(r['text_response'], 200)}_")
+            out.append(f"  - Phase A reference: {r.get('phase_a_reference', '—')}")
+        out.append("")
+
+    # ---- per-prompt --------------------------------------------------
+    out.append("## 3. Per-prompt details")
+    out.append("")
+    out.append(
+        "_Every observation, ordered by category then prompt id._ "
+        "Use this section when reviewing a category's behaviour in depth."
+    )
+    out.append("")
+    for cat in sorted(by_cat):
+        out.append(f"### Category — `{cat}`")
+        out.append("")
+        for r in sorted(by_cat[cat], key=lambda x: x["prompt_id"]):
+            verdict = (
+                "✅ matched expected"
+                if r.get("matched_expected") is True
+                else "❌ did not match expected"
+                if r.get("matched_expected") is False
+                else "— undecidable"
+            )
+            out.append(f"#### `{r['prompt_id']}` — {verdict}")
+            out.append("")
+            out.append(f"**Phase A reference:** `{r.get('phase_a_reference', '—')}`  ")
+            out.append(f"**User prompt:** _{r['user_prompt']}_  ")
+            if r.get("expected_tool"):
+                out.append(f"**Expected tool:** `{r['expected_tool']}`  ")
+            if r.get("expected_no_tool_call"):
+                out.append("**Expected:** no tool call (text-only answer)  ")
+            out.append(f"**Picked tool:** `{r.get('picked_tool') or '(no tool)'}`  ")
+            if r.get("picked_args"):
+                out.append(f"**Picked args:** {_format_args(r['picked_args'])}  ")
+            out.append(f"**Stop reason:** `{r.get('stop_reason') or 'n/a'}`")
+            out.append("")
+            if r.get("text_response"):
+                out.append("**Text response:**")
+                out.append("")
+                out.append("> " + r["text_response"].replace("\n", "\n> "))
+                out.append("")
+            if r.get("raw_error"):
+                out.append(f"**Error:** `{r['raw_error']}`")
+                out.append("")
+            out.append("---")
+            out.append("")
+
+    # ---- Phase A confirmation matrix -----------------------------------
+    out.append("## 4. Phase A finding confirmation")
+    out.append("")
+    out.append(
+        "Each Phase A finding mapped against what Phase B actually saw. "
+        "A finding is **confirmed** if the relevant probes missed the "
+        "expected pick or the LLM hallucinated capabilities; **refuted** "
+        "if all probes passed cleanly."
+    )
+    out.append("")
+
+    # Group by Phase A reference and report hit rate per group.
+    by_ref: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for r in rows:
+        by_ref[r.get("phase_a_reference", "—")].append(r)
+
+    out.append("| Phase A reference | Prompts | Judged | Hits | Hit rate | Verdict |")
+    out.append("|---|---:|---:|---:|---:|---|")
+    for ref, ref_rows in sorted(by_ref.items()):
+        judged_rows = [r for r in ref_rows if r.get("matched_expected") is not None]
+        hits_rows = [r for r in judged_rows if r.get("matched_expected") is True]
+        rate_str = f"{100 * len(hits_rows) / len(judged_rows):.0f}%" if judged_rows else "n/a"
+        if not judged_rows:
+            verdict = "_undecidable_"
+        elif len(hits_rows) == len(judged_rows):
+            verdict = "**refuted** _(LLM handled cleanly)_"
+        elif len(hits_rows) == 0:
+            verdict = "**confirmed** _(LLM always wrong)_"
+        else:
+            verdict = "**partial** _(LLM sometimes confused)_"
+        out.append(f"| {ref} | {len(ref_rows)} | {len(judged_rows)} | {len(hits_rows)} | {rate_str} | {verdict} |")
+    out.append("")
+
+    out.append("---")
+    out.append("")
+    out.append("## 5. Next steps")
+    out.append("")
+    out.append(
+        "Based on the **confirmed** Phase A findings above, here is "
+        "the prioritised list of catalogue improvements the data "
+        "supports. The hit rate per finding is the quantitative "
+        "argument: lower rate = stronger case for a tactical fix."
+    )
+    out.append("")
+    out.append(
+        "_(This section is hand-curated after the run — the summariser reports the data; the reviewer interprets it.)_"
+    )
+    out.append("")
+
+    print("\n".join(out))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Phase A (static) + Phase B (LLM behaviour) fact-finding for the 173-tool MCPg catalogue. The objective stated upthread: **collect all factual information before any tactical fixes, and observe LLM behaviour as part of the evidence**. This PR delivers both.

No source changes to mcpg. Everything is analyser scripts, generated reports, and an LLM observation harness the user runs on their own time with their own API key.

## What landed

### Phase A — static analysis (already runnable, report committed)

- `tools/static_tool_facts.py` — single-pass analyser
- `docs/reviews/tool-surface-fact-pack.md` — generated report (173 tools, v0.6.2)
- `tools/analyse_tool_overlap.py` + `docs/reviews/tool-overlap-report.md` — kept from the earlier overlap sweep

### Phase B — LLM behaviour observation (set up, ready to run)

- `docs/reviews/phase-b-prompts.json` — 22-prompt corpus, 4 categories
- `tools/observe_llm_behaviour.py` — Anthropic Messages API harness
- `tools/summarise_llm_observations.py` — JSONL → Markdown report
- `docs/reviews/phase-b-README.md` — operator guide

## Phase A headline findings

| Finding | Number | What it means |
|---|---|---|
| Tools registered | **173** | (under maximal-flag config) |
| Tools with empty descriptions | 0 (0%) | ✅ |
| Gated tools missing security caveat | 0 (0%) | ✅ — every write/DDL/shell/listen tool tells the LLM what flag to flip |
| Tools with no return-shape hint | **75 (43%)** | LLM has to call them speculatively to learn what they emit |
| Catalogue token cost per turn | **~28,000 tokens** | 14% of Claude 200k window, 22% of 128k, 88% of 32k |
| MCP resources exposed | **0** | |
| MCP prompts exposed | **0** | |
| `about`/`capabilities`/`describe_self` tool | **absent** | The only answer to "what does mcpg do?" today is the 173-tool list |

Detail tables (verb-prefix breakdown, description-length histogram, parameter-count histogram, top-15 most-expensive tools, etc.) are in `tool-surface-fact-pack.md`.

## Phase B — what the corpus probes

Each prompt is tagged with the Phase A finding it tests, so the report's §4 confirmation matrix maps directly back to "this static signal was real" vs "static signal was overcautious."

| Category | Prompts | Tests |
|---|---|---|
| `overlap_disambiguation` | 8 | Top pairs from `tool-overlap-report.md` (e.g. `read_pg_wal_records` vs `read_pg_wal_stats`; `mmr_search` vs `vector_search`; `add_compression_policy` vs `add_retention_policy`) |
| `list_family_picker` | 4 | The 39-tool `list_*` family — does the LLM pick the right one? |
| `return_shape` | 5 | The 75 tools missing return hints — can the LLM guess what they return? |
| `self_introspection` | 5 | "What can mcpg do?" / "Does mcpg support X?" — directly tests the no-resources / no-prompts / no-about gap |

## Cost expectations for the Phase B run

Sonnet 4.x, list pricing, 22 prompts:

- Cold run: ~$2.15 (~640k input + ~11k output tokens)
- Warm run with prompt caching: ~$0.40 (`tools=` is cached automatically)

Smoke test: `python tools/observe_llm_behaviour.py --limit 3` ≈ $0.30

## What I expect Phase B to confirm

Predictions, to be measured rather than assumed:

1. **`self_introspection` will be the worst category** — the LLM will answer "what can mcpg do?" by partially hallucinating capabilities or by missing whole capability buckets, because there's no structured surface to introspect.
2. **`return_shape` will produce hedged answers** — without a hint in the description, the LLM either guesses generically ("returns a list of results") or explicitly says it doesn't know.
3. **`overlap_disambiguation` will mostly pass** — Claude is good at picking from similar tools when the user prompt has a distinguishing phrase, so most of the 8 will likely match expected.
4. **`list_family_picker` will mostly pass for the same reason** — but might show 1-2 misses if descriptions are weak.

If the data lines up with these predictions, the prioritised tactical work is clear: **(a) ship an `about`/`describe_self` tool and/or MCP resources** to fix introspection; **(b) add return-shape sentences** to the 75 flagged tools. Both are mechanical, low-risk, ship in small PRs.

If the data contradicts the predictions (e.g. introspection works surprisingly well, or overlap pairs miss badly), the tactical priorities shift — and we'll have the evidence to justify it.

## Workflow once merged

1. Merge this (no source changes; can land anytime).
2. When ready, you run the harness with `ANTHROPIC_API_KEY` set.
3. Run `tools/summarise_llm_observations.py > docs/reviews/phase-b-report.md` to render the report.
4. Decide tactical priorities from the §4 confirmation matrix.
5. The §5 "Next steps" section is intentionally blank for you to fill in based on the data.

## Test plan

- [x] Both analysers run clean against v0.6.2 snapshot
- [x] Both modules import without error
- [x] Phase B corpus validates as JSON
- [x] All pre-commit hooks pass (lint / format / mypy / bandit)
- [ ] Full Phase B run pending your `ANTHROPIC_API_KEY` + go-ahead

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Add a two-phase analysis pipeline to study MCPg’s tool catalogue via static inspection and LLM behaviour, producing human-readable review reports without changing core server code.

New Features:
- Introduce a static analysis script that generates a comprehensive Markdown fact pack for the MCPg tool surface from the existing contract snapshot.
- Add an Anthropic-based harness to observe LLM behaviour against the full MCPg tool catalogue using a tagged prompt corpus.
- Provide a summariser that converts recorded LLM observations into a structured Markdown report with per-category and per-finding metrics.

Enhancements:
- Document Phase B’s behaviour-observation workflow, including corpus structure, run instructions, cost expectations, and interpretation guidance.
- Check MCP self-introspection surfaces (resources, prompts, about-style tools) and token budget characteristics to inform future catalogue improvements.

Documentation:
- Add the Phase A tool-surface fact pack report describing catalogue shape, description quality, token costs, and self-introspection inventory.
- Add Phase B operator documentation and a JSON prompt corpus defining the LLM behaviour probes and their links back to Phase A findings.

Tests:
- Leverage the existing tool_surface snapshot as a stable contract input for analysis and behaviour experiments without modifying runtime code.