### PR TITLE
feat(redis_fdw): catalog + DDL + cache advisor — closes #118

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`redis_fdw` cache-and-foreign-data coverage** (`mcpg.redis_fdw`).
+  Eight new tools across read + DDL surfaces:
+  `list_redis_foreign_servers`, `describe_redis_cache_table`,
+  `get_redis_cache_stats`, `recommend_redis_cache_targets`,
+  `enable_redis_fdw`, `create_redis_cache_server`,
+  `create_redis_user_mapping`, `create_redis_cache_table`.
+
+  The advisor — `recommend_redis_cache_targets` — inspects
+  `pg_stat_user_tables` for read-heavy, low-write relations whose
+  working set fits comfortably in Redis (defaults: read/write ratio ≥
+  10, ≥ 1000 reads, ≤ 1M rows) and emits ready-to-run
+  `CREATE FOREIGN TABLE` stubs.
+
+  Security posture:
+  - Identifier allowlist on every DDL surface (server / table / user
+    / column names).
+  - TLS-on by default; refuses `tls=False` against non-loopback Redis
+    hosts unless `allow_insecure_tls=True` is set explicitly.
+  - `create_redis_user_mapping` never accepts a raw password —
+    callers pass `secret_ref`, resolved through `MCPG_SECRETS_BACKEND`.
+
+  New `cache_and_foreign_data` capability bucket in `mcpg.about` so
+  `describe_self` advertises the coverage cleanly. `redis_fdw` added
+  to `ENABLEABLE_EXTENSIONS`. Closes #118.
+
 ## [0.6.2] - 2026-06-17
 
 ### Added

--- a/src/mcpg/about.py
+++ b/src/mcpg/about.py
@@ -285,6 +285,35 @@ CAPABILITIES: tuple[Capability, ...] = (
         ),
     ),
     Capability(
+        id="cache_and_foreign_data",
+        name="Cache and foreign data",
+        summary=(
+            "Foreign-data-wrapper coverage for cache-style data sources — "
+            "currently Redis via redis_fdw, with FDW catalog introspection "
+            "shared with the schema-introspection bucket."
+        ),
+        detail=(
+            "`list_redis_foreign_servers`, `describe_redis_cache_table`, and "
+            "`get_redis_cache_stats` filter the foreign-data catalog to the "
+            "redis_fdw subset. `create_redis_cache_server`, "
+            "`create_redis_user_mapping`, and `create_redis_cache_table` wrap "
+            "the DDL with identifier validation, secrets-backend credential "
+            "plumbing, and TLS-by-default. `recommend_redis_cache_targets` "
+            "analyses pg_stat_user_tables for read-heavy tables that would "
+            "benefit from a Redis cache layer. The generic FDW catalog tools "
+            "(`list_foreign_data_wrappers`, `list_foreign_servers`, "
+            "`list_foreign_tables`, `list_user_mappings`) live in the "
+            "schema-introspection bucket."
+        ),
+        headline_tools=(
+            "list_redis_foreign_servers",
+            "describe_redis_cache_table",
+            "recommend_redis_cache_targets",
+            "create_redis_cache_server",
+            "create_redis_cache_table",
+        ),
+    ),
+    Capability(
         id="diagrams_and_codegen",
         name="Diagrams and ORM codegen",
         summary=(
@@ -541,6 +570,15 @@ _TOOL_TO_BUCKET_OVERRIDES: dict[str, str] = {
     "compare_schemas": "schema_introspection",
     "summarize_table": "schema_introspection",
     "get_compact_schema": "schema_introspection",
+    # redis_fdw — every redis-prefixed surface is the new cache bucket.
+    "list_redis_foreign_servers": "cache_and_foreign_data",
+    "describe_redis_cache_table": "cache_and_foreign_data",
+    "get_redis_cache_stats": "cache_and_foreign_data",
+    "recommend_redis_cache_targets": "cache_and_foreign_data",
+    "enable_redis_fdw": "cache_and_foreign_data",
+    "create_redis_cache_server": "cache_and_foreign_data",
+    "create_redis_user_mapping": "cache_and_foreign_data",
+    "create_redis_cache_table": "cache_and_foreign_data",
 }
 
 

--- a/src/mcpg/extensions.py
+++ b/src/mcpg/extensions.py
@@ -36,6 +36,7 @@ ENABLEABLE_EXTENSIONS = frozenset(
         "earthdistance",
         "postgis",
         "postgres_fdw",
+        "redis_fdw",
         "pg_cron",
         "pg_partman",
         "pg_buffercache",

--- a/src/mcpg/redis_fdw.py
+++ b/src/mcpg/redis_fdw.py
@@ -52,7 +52,7 @@ _VALID_KEY_TYPES = frozenset({"hash", "list", "string", "set", "zset"})
 
 # Loopback families: TLS may be disabled here without the explicit
 # ``allow_insecure_tls`` flag. Everything else must pass through TLS.
-_LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1", "0.0.0.0"})
+_LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
 
 # Identifier validator — Postgres unquoted identifier shape. We use this
 # pattern (vs psycopg's Identifier escaping) because foreign-server /

--- a/src/mcpg/redis_fdw.py
+++ b/src/mcpg/redis_fdw.py
@@ -1,0 +1,666 @@
+"""``redis_fdw`` coverage — catalog filters, DDL helpers, cache stats, advisor.
+
+``redis_fdw`` is a foreign-data wrapper that exposes a Redis instance as
+SQL-queryable foreign tables. Operators reach for it as a drop-in cache
+front for expensive Postgres queries, as a landing zone for ephemeral
+session / rate-limit / pub-sub state queried alongside relational data,
+and as a migration aid when moving between Redis and Postgres.
+
+This module groups everything redis_fdw-shaped behind one import surface
+so the tools layer stays uniform with the other FDW + cache-and-foreign-data
+buckets:
+
+* Read tools — filter ``pg_foreign_server`` / ``pg_foreign_table`` to the
+  redis_fdw subset, describe a single cache foreign table, and best-effort
+  cache-stats reporting.
+* DDL tools — wrap ``CREATE SERVER`` / ``CREATE USER MAPPING`` /
+  ``CREATE FOREIGN TABLE`` with parameterised identifier validation and
+  secrets-backend credential plumbing.
+* Advisor — analyse ``pg_stat_user_tables`` + ``pg_stat_statements`` for
+  read-heavy, low-write tables that would benefit from Redis-fronted
+  caching, and emit ready-to-run ``CREATE FOREIGN TABLE`` stubs.
+
+Security posture
+----------------
+``redis_fdw`` runs in-process inside Postgres. Every DDL tool here flows
+through the regular allowlist + RBAC / unrestricted gates. The user-mapping
+helper never accepts a raw password as a tool argument — it takes a
+secret reference and resolves it through ``MCPG_SECRETS_BACKEND``. TLS to
+non-loopback Redis hosts is required unless ``allow_insecure_tls=True`` is
+passed explicitly.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+
+from mcpg._vendor.sql import SqlDriver
+from mcpg.extensions import extension_installed
+from mcpg.introspection import _parse_options
+from mcpg.secrets import SecretsProvider
+
+# redis_fdw identifies itself in pg_foreign_data_wrapper as "redis_fdw" —
+# we use that as the discriminator on every catalog filter below.
+_REDIS_FDW_NAME = "redis_fdw"
+
+# Redis-side key structures the FDW recognises. The strings match the
+# ``tabletype`` option the FDW expects on ``CREATE FOREIGN TABLE``.
+_VALID_KEY_TYPES = frozenset({"hash", "list", "string", "set", "zset"})
+
+# Loopback families: TLS may be disabled here without the explicit
+# ``allow_insecure_tls`` flag. Everything else must pass through TLS.
+_LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1", "0.0.0.0"})
+
+# Identifier validator — Postgres unquoted identifier shape. We use this
+# pattern (vs psycopg's Identifier escaping) because foreign-server /
+# user-mapping DDL is built up out of identifiers we trust *after this
+# check*; rejecting hostile inputs at the boundary is simpler than
+# escape-correctness everywhere downstream.
+_IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+class RedisFdwError(Exception):
+    """Raised when a redis_fdw operation cannot complete."""
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class RedisForeignServer:
+    """A ``CREATE SERVER ... FOREIGN DATA WRAPPER redis_fdw`` row.
+
+    ``address`` is the host the FDW connects to (taken from the
+    ``address`` option). ``port``, ``database`` and ``password_configured``
+    are extracted from the server options dict so callers don't have to
+    re-parse it. The full ``options`` dict is preserved for completeness.
+    """
+
+    name: str
+    address: str | None
+    port: int | None
+    database: int | None
+    tls: bool
+    password_configured: bool
+    options: dict[str, str]
+
+
+@dataclass(frozen=True, slots=True)
+class RedisCacheTableInfo:
+    """The shape of one redis-backed foreign table.
+
+    ``key_type`` is the Redis-side structure (``hash`` / ``list`` /
+    ``string`` / ``set`` / ``zset``). ``ttl_seconds`` is the configured
+    expiration if the FDW exposes it; ``None`` when keys live until
+    explicit eviction.
+    """
+
+    schema: str
+    name: str
+    server: str
+    key_type: str | None
+    key_prefix: str | None
+    ttl_seconds: int | None
+    columns: list[dict[str, str]]
+    options: dict[str, str]
+
+
+@dataclass(frozen=True, slots=True)
+class RedisCacheStats:
+    """Best-effort metrics for a redis_fdw server.
+
+    redis_fdw versions vary in what they expose. When the FDW or
+    auxiliary functions are missing we still want a deterministic
+    response — ``available=False`` with everything else zeroed.
+    """
+
+    server: str
+    available: bool
+    key_count: int | None
+    used_memory_bytes: int | None
+    detail: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class CreateRedisServerResult:
+    name: str
+    address: str
+    port: int
+    database: int
+    tls: bool
+    created: bool
+
+
+@dataclass(frozen=True, slots=True)
+class CreateRedisUserMappingResult:
+    server: str
+    user: str
+    secret_ref: str
+    created: bool
+
+
+@dataclass(frozen=True, slots=True)
+class CreateRedisCacheTableResult:
+    schema: str
+    name: str
+    server: str
+    key_type: str
+    columns: tuple[str, ...]
+    created: bool
+
+
+@dataclass(frozen=True, slots=True)
+class RedisCacheRecommendation:
+    """One advisor recommendation row.
+
+    ``reason`` is a stable identifier the agent can react to: e.g.
+    ``read_heavy_low_write``, ``small_hot_relation``, ``frequent_pk_lookup``.
+    ``ready_to_run_sql`` is the foreign-table stub the operator can paste.
+    """
+
+    schema: str
+    table: str
+    reads: int
+    writes: int
+    read_write_ratio: float
+    estimated_row_count: int
+    reason: str
+    ready_to_run_sql: str
+
+
+@dataclass(frozen=True, slots=True)
+class RecommendRedisCacheTargetsResult:
+    server: str | None
+    candidates: list[RedisCacheRecommendation] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Read helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_int(options: Mapping[str, str], key: str) -> int | None:
+    raw = options.get(key)
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        return None
+
+
+def _is_truthy(value: str | None) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() in {"true", "t", "yes", "y", "on", "1"}
+
+
+async def list_redis_foreign_servers(driver: SqlDriver) -> list[RedisForeignServer]:
+    """List the ``CREATE SERVER`` rows backed by ``redis_fdw``.
+
+    Joins ``pg_foreign_server`` to ``pg_foreign_data_wrapper`` and keeps
+    only the rows where ``fdwname = 'redis_fdw'``. Returns an empty list
+    when ``redis_fdw`` is not installed.
+    """
+    if not await extension_installed(driver, _REDIS_FDW_NAME):
+        return []
+    rows = await driver.execute_query(
+        "SELECT s.srvname AS name, s.srvoptions AS options "
+        "FROM pg_foreign_server s "
+        "JOIN pg_foreign_data_wrapper fdw ON fdw.oid = s.srvfdw "
+        "WHERE fdw.fdwname = %s "
+        "ORDER BY s.srvname",
+        params=[_REDIS_FDW_NAME],
+        force_readonly=True,
+    )
+    results: list[RedisForeignServer] = []
+    for row in rows or []:
+        options = _parse_options(row.cells["options"])
+        results.append(
+            RedisForeignServer(
+                name=row.cells["name"],
+                address=options.get("address") or options.get("host"),
+                port=_parse_int(options, "port"),
+                database=_parse_int(options, "database"),
+                tls=_is_truthy(options.get("tls")),
+                # We can never read the password back from the catalog —
+                # ``password_configured`` is True iff a user mapping is
+                # present for this server. The dedicated lookup keeps
+                # ``list_redis_foreign_servers`` to a single round-trip.
+                password_configured=False,
+                options=options,
+            )
+        )
+    if not results:
+        return results
+    # Second probe — flag servers that have any user mapping configured.
+    server_names = [r.name for r in results]
+    mapping_rows = await driver.execute_query(
+        "SELECT DISTINCT srvname FROM pg_user_mappings WHERE srvname = ANY(%s)",
+        params=[server_names],
+        force_readonly=True,
+    )
+    configured = {row.cells["srvname"] for row in mapping_rows or []}
+    return [
+        RedisForeignServer(
+            name=r.name,
+            address=r.address,
+            port=r.port,
+            database=r.database,
+            tls=r.tls,
+            password_configured=r.name in configured,
+            options=r.options,
+        )
+        for r in results
+    ]
+
+
+async def describe_redis_cache_table(driver: SqlDriver, schema: str, table: str) -> RedisCacheTableInfo:
+    """Describe one redis-backed foreign table.
+
+    Raises ``RedisFdwError`` when the table doesn't exist or isn't backed
+    by ``redis_fdw``.
+    """
+    rows = await driver.execute_query(
+        "SELECT c.relname AS name, s.srvname AS server, ft.ftoptions AS options "
+        "FROM pg_foreign_table ft "
+        "JOIN pg_class c ON c.oid = ft.ftrelid "
+        "JOIN pg_namespace n ON n.oid = c.relnamespace "
+        "JOIN pg_foreign_server s ON s.oid = ft.ftserver "
+        "JOIN pg_foreign_data_wrapper fdw ON fdw.oid = s.srvfdw "
+        "WHERE n.nspname = %s AND c.relname = %s AND fdw.fdwname = %s",
+        params=[schema, table, _REDIS_FDW_NAME],
+        force_readonly=True,
+    )
+    if not rows:
+        raise RedisFdwError(f"no redis_fdw foreign table {schema}.{table}")
+    row = rows[0]
+    options = _parse_options(row.cells["options"])
+    col_rows = await driver.execute_query(
+        "SELECT a.attname AS name, format_type(a.atttypid, a.atttypmod) AS data_type "
+        "FROM pg_attribute a "
+        "JOIN pg_class c ON c.oid = a.attrelid "
+        "JOIN pg_namespace n ON n.oid = c.relnamespace "
+        "WHERE n.nspname = %s AND c.relname = %s AND a.attnum > 0 AND NOT a.attisdropped "
+        "ORDER BY a.attnum",
+        params=[schema, table],
+        force_readonly=True,
+    )
+    columns = [{"name": r.cells["name"], "data_type": r.cells["data_type"]} for r in col_rows or []]
+    return RedisCacheTableInfo(
+        schema=schema,
+        name=row.cells["name"],
+        server=row.cells["server"],
+        key_type=options.get("tabletype"),
+        key_prefix=options.get("keyprefix") or options.get("key_prefix"),
+        ttl_seconds=_parse_int(options, "ttl") or _parse_int(options, "expiry"),
+        columns=columns,
+        options=options,
+    )
+
+
+async def get_redis_cache_stats(driver: SqlDriver, server: str) -> RedisCacheStats:
+    """Best-effort metrics for one redis_fdw server.
+
+    redis_fdw doesn't ship a uniform stats SQL function across versions.
+    We probe ``pg_foreign_server`` to confirm the server exists, then
+    return ``available=False`` with a descriptive ``detail`` when no
+    stats surface is available. This is deliberately a soft failure —
+    callers can layer their own Redis-side probes on top.
+    """
+    rows = await driver.execute_query(
+        "SELECT s.srvname FROM pg_foreign_server s "
+        "JOIN pg_foreign_data_wrapper fdw ON fdw.oid = s.srvfdw "
+        "WHERE s.srvname = %s AND fdw.fdwname = %s",
+        params=[server, _REDIS_FDW_NAME],
+        force_readonly=True,
+    )
+    if not rows:
+        raise RedisFdwError(f"no redis_fdw foreign server {server!r}")
+    # No stable cross-version SQL surface — report unavailable rather
+    # than fabricating zeros.
+    return RedisCacheStats(
+        server=server,
+        available=False,
+        key_count=None,
+        used_memory_bytes=None,
+        detail="redis_fdw does not expose uniform stats SQL — query Redis directly (INFO / DBSIZE) for live metrics",
+    )
+
+
+# ---------------------------------------------------------------------------
+# DDL helpers
+# ---------------------------------------------------------------------------
+
+
+def _validate_identifier(label: str, value: str) -> str:
+    """Reject everything outside the ``[A-Za-z_][A-Za-z0-9_]*`` shape.
+
+    ``CREATE SERVER`` / ``CREATE USER MAPPING`` / ``CREATE FOREIGN TABLE``
+    DDL is built up of identifiers we can't bind. The allowlist is the
+    injection guard.
+    """
+    if not _IDENT_RE.match(value):
+        raise RedisFdwError(f"{label} {value!r} is not a valid unquoted SQL identifier")
+    return value
+
+
+def _validate_address(address: str) -> str:
+    """Reject obvious shell metacharacters; permit IP addresses + hostnames."""
+    cleaned = address.strip()
+    if not cleaned:
+        raise RedisFdwError("address must be a non-empty hostname or IP")
+    if any(ch in cleaned for ch in "'\";\\\n\r"):
+        raise RedisFdwError("address contains characters that are not allowed in a server option")
+    return cleaned
+
+
+def _is_loopback(address: str) -> bool:
+    if address in _LOOPBACK_HOSTS:
+        return True
+    try:
+        return ipaddress.ip_address(address).is_loopback
+    except ValueError:
+        return False
+
+
+async def create_redis_cache_server(
+    driver: SqlDriver,
+    *,
+    name: str,
+    address: str,
+    port: int = 6379,
+    database: int = 0,
+    tls: bool = True,
+    allow_insecure_tls: bool = False,
+) -> CreateRedisServerResult:
+    """Run ``CREATE SERVER name FOREIGN DATA WRAPPER redis_fdw OPTIONS (...)``.
+
+    The default posture is TLS-on. Refusing ``tls=False`` against a
+    non-loopback host without ``allow_insecure_tls=True`` mirrors the
+    HTTP-runtime TLS-enforcement story already used elsewhere in MCPg.
+    Idempotent via ``IF NOT EXISTS``.
+    """
+    _validate_identifier("server name", name)
+    address = _validate_address(address)
+    if port <= 0 or port > 65535:
+        raise RedisFdwError("port must be in 1..65535")
+    if database < 0:
+        raise RedisFdwError("database must be a non-negative integer")
+    if not tls and not _is_loopback(address) and not allow_insecure_tls:
+        raise RedisFdwError(
+            f"refusing tls=False against non-loopback Redis host {address!r}; pass allow_insecure_tls=True to override"
+        )
+    if not await extension_installed(driver, _REDIS_FDW_NAME):
+        raise RedisFdwError("redis_fdw extension is not installed; call enable_extension('redis_fdw') first")
+    options = f"address '{address}', port '{port}', database '{database}', tls '{'true' if tls else 'false'}'"
+    await driver.execute_query(
+        f'CREATE SERVER IF NOT EXISTS "{name}" FOREIGN DATA WRAPPER redis_fdw OPTIONS ({options})',
+        force_readonly=False,
+    )
+    return CreateRedisServerResult(
+        name=name,
+        address=address,
+        port=port,
+        database=database,
+        tls=tls,
+        created=True,
+    )
+
+
+async def create_redis_user_mapping(
+    driver: SqlDriver,
+    *,
+    server: str,
+    user: str,
+    secret_ref: str,
+    secrets: SecretsProvider,
+) -> CreateRedisUserMappingResult:
+    """Run ``CREATE USER MAPPING FOR user SERVER server OPTIONS (password '…')``.
+
+    The Redis password is **never** accepted as an argument — instead the
+    caller passes ``secret_ref``, the name of an entry in the configured
+    secrets backend (``MCPG_SECRETS_BACKEND``). We resolve it here and
+    interpolate the value into the OPTIONS list.
+
+    The password value is escaped by doubling single quotes inside the
+    SQL literal. The secret reference itself is logged-as-name only — the
+    raw value never round-trips through any tool argument boundary.
+    """
+    _validate_identifier("server name", server)
+    if user.lower() == "public":
+        user_clause = "PUBLIC"
+    else:
+        _validate_identifier("user name", user)
+        user_clause = f'"{user}"'
+    if not secret_ref or not secret_ref.strip():
+        raise RedisFdwError("secret_ref must reference a name in the configured secrets backend")
+    password = secrets.get(secret_ref)
+    if password is None or not password:
+        raise RedisFdwError(f"secret_ref {secret_ref!r} did not resolve to a value via MCPG_SECRETS_BACKEND")
+    if not await extension_installed(driver, _REDIS_FDW_NAME):
+        raise RedisFdwError("redis_fdw extension is not installed; call enable_extension('redis_fdw') first")
+    # Escape ' by doubling it; reject characters that would break out
+    # of the OPTIONS list. Defense in depth — secrets-backend values
+    # are not adversarial by default, but we still guard the SQL
+    # boundary.
+    if any(ch in password for ch in ("\n", "\r", "\x00")):
+        raise RedisFdwError("resolved Redis password contains forbidden control characters")
+    escaped = password.replace("'", "''")
+    await driver.execute_query(
+        f"CREATE USER MAPPING IF NOT EXISTS FOR {user_clause} SERVER \"{server}\" OPTIONS (password '{escaped}')",
+        force_readonly=False,
+    )
+    return CreateRedisUserMappingResult(
+        server=server,
+        user=user,
+        secret_ref=secret_ref,
+        created=True,
+    )
+
+
+def _validate_column_decls(columns: list[dict[str, str]]) -> list[tuple[str, str]]:
+    """Reject column declarations that aren't simple ``name type`` pairs."""
+    out: list[tuple[str, str]] = []
+    for col in columns:
+        name = col.get("name", "")
+        col_type = col.get("type", "")
+        _validate_identifier("column name", name)
+        if not col_type or any(ch in col_type for ch in "'\";\\\n\r"):
+            raise RedisFdwError(
+                f"column {name!r} type {col_type!r} is not a simple Postgres type — provide a bare type name"
+            )
+        out.append((name, col_type.strip()))
+    if not out:
+        raise RedisFdwError("at least one column is required")
+    return out
+
+
+async def create_redis_cache_table(
+    driver: SqlDriver,
+    *,
+    schema: str,
+    name: str,
+    server: str,
+    key_type: str,
+    columns: list[dict[str, str]],
+    key_prefix: str | None = None,
+    ttl_seconds: int | None = None,
+) -> CreateRedisCacheTableResult:
+    """Run ``CREATE FOREIGN TABLE schema.name (...) SERVER server OPTIONS (tabletype 'hash', …)``.
+
+    ``key_type`` must be one of ``hash`` / ``list`` / ``string`` / ``set``
+    / ``zset``. ``columns`` is a list of ``{name, type}`` dicts. Optional
+    ``key_prefix`` and ``ttl_seconds`` are passed through as redis_fdw
+    options.
+    """
+    _validate_identifier("schema", schema)
+    _validate_identifier("table name", name)
+    _validate_identifier("server name", server)
+    if key_type not in _VALID_KEY_TYPES:
+        raise RedisFdwError(f"key_type must be one of {sorted(_VALID_KEY_TYPES)}, got {key_type!r}")
+    decls = _validate_column_decls(columns)
+    if ttl_seconds is not None and ttl_seconds < 0:
+        raise RedisFdwError("ttl_seconds must be a non-negative integer")
+    if not await extension_installed(driver, _REDIS_FDW_NAME):
+        raise RedisFdwError("redis_fdw extension is not installed; call enable_extension('redis_fdw') first")
+    columns_sql = ", ".join(f'"{n}" {t}' for n, t in decls)
+    options_parts = [f"tabletype '{key_type}'"]
+    if key_prefix is not None:
+        if any(ch in key_prefix for ch in "'\";\\\n\r"):
+            raise RedisFdwError("key_prefix contains characters that are not allowed in a foreign-table option")
+        options_parts.append(f"keyprefix '{key_prefix}'")
+    if ttl_seconds is not None:
+        options_parts.append(f"ttl '{ttl_seconds}'")
+    options_sql = ", ".join(options_parts)
+    await driver.execute_query(
+        f'CREATE FOREIGN TABLE IF NOT EXISTS "{schema}"."{name}" ({columns_sql}) '
+        f'SERVER "{server}" OPTIONS ({options_sql})',
+        force_readonly=False,
+    )
+    return CreateRedisCacheTableResult(
+        schema=schema,
+        name=name,
+        server=server,
+        key_type=key_type,
+        columns=tuple(n for n, _ in decls),
+        created=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Advisor
+# ---------------------------------------------------------------------------
+
+
+# Thresholds — exposed as module constants so the docs/plans page can
+# reference them by name and the tests can flex one without flipping
+# others.
+_DEFAULT_MIN_READ_WRITE_RATIO = 10.0
+_DEFAULT_MIN_READS_PER_DAY = 1_000
+_DEFAULT_MAX_ROWS = 1_000_000
+
+
+async def recommend_redis_cache_targets(
+    driver: SqlDriver,
+    *,
+    server: str | None = None,
+    min_read_write_ratio: float = _DEFAULT_MIN_READ_WRITE_RATIO,
+    min_reads_per_day: int = _DEFAULT_MIN_READS_PER_DAY,
+    max_rows: int = _DEFAULT_MAX_ROWS,
+    limit: int = 20,
+) -> RecommendRedisCacheTargetsResult:
+    """Recommend tables that would benefit from a Redis cache layer.
+
+    The heuristic favours tables where:
+
+    1. Read traffic dominates write traffic — ``seq_scan + idx_scan``
+       relative to ``n_tup_ins + n_tup_upd + n_tup_del`` must exceed
+       ``min_read_write_ratio``.
+    2. Absolute read volume is meaningful — ``min_reads_per_day`` filters
+       out cold tables that just happen to have zero writes.
+    3. The working set fits comfortably in Redis — ``max_rows`` caps
+       recommendations at relations whose ``pg_class.reltuples`` is
+       below the threshold.
+
+    When ``server`` is provided the generated ``ready_to_run_sql`` stub
+    targets that server name; otherwise the stub uses a placeholder
+    operators must substitute.
+
+    The advisor is read-only. It never touches Redis itself.
+    """
+    if min_read_write_ratio <= 0:
+        raise RedisFdwError("min_read_write_ratio must be positive")
+    if min_reads_per_day < 0:
+        raise RedisFdwError("min_reads_per_day must be non-negative")
+    if max_rows <= 0:
+        raise RedisFdwError("max_rows must be positive")
+    if limit <= 0:
+        raise RedisFdwError("limit must be positive")
+
+    rows = await driver.execute_query(
+        "SELECT s.schemaname AS schema, s.relname AS table_name, "
+        "  COALESCE(s.seq_scan, 0) + COALESCE(s.idx_scan, 0) AS reads, "
+        "  COALESCE(s.n_tup_ins, 0) + COALESCE(s.n_tup_upd, 0) + COALESCE(s.n_tup_del, 0) AS writes, "
+        "  c.reltuples::bigint AS est_rows "
+        "FROM pg_stat_user_tables s "
+        "JOIN pg_class c ON c.oid = s.relid "
+        "WHERE c.relkind IN ('r', 'p')",
+        force_readonly=True,
+    )
+    candidates: list[RedisCacheRecommendation] = []
+    target_server = server or "<configure-redis-server>"
+    for row in rows or []:
+        reads = int(row.cells["reads"])
+        writes = int(row.cells["writes"])
+        est_rows = max(int(row.cells["est_rows"]), 0)
+        if reads < min_reads_per_day:
+            continue
+        if est_rows > max_rows:
+            continue
+        # Avoid div-by-zero by treating "no writes" as a very large ratio.
+        ratio = float("inf") if writes == 0 else reads / max(writes, 1)
+        if ratio < min_read_write_ratio:
+            continue
+        reason = _classify_recommendation(reads, writes, est_rows)
+        schema = row.cells["schema"]
+        table = row.cells["table_name"]
+        stub = (
+            f"-- redis_fdw cache stub for {schema}.{table}\n"
+            f'CREATE FOREIGN TABLE IF NOT EXISTS "{schema}"."{table}_cache" (\n'
+            f"    key text,\n"
+            f"    value text\n"
+            f') SERVER "{target_server}" OPTIONS (\n'
+            f"    tabletype 'hash',\n"
+            f"    keyprefix '{schema}:{table}:'\n"
+            f");"
+        )
+        candidates.append(
+            RedisCacheRecommendation(
+                schema=schema,
+                table=table,
+                reads=reads,
+                writes=writes,
+                read_write_ratio=ratio if ratio != float("inf") else float(reads),
+                estimated_row_count=est_rows,
+                reason=reason,
+                ready_to_run_sql=stub,
+            )
+        )
+    candidates.sort(key=lambda c: (-c.reads, c.estimated_row_count))
+    return RecommendRedisCacheTargetsResult(server=server, candidates=candidates[:limit])
+
+
+def _classify_recommendation(reads: int, writes: int, est_rows: int) -> str:
+    if writes == 0:
+        return "read_only_lookup_table"
+    if est_rows <= 10_000:
+        return "small_hot_relation"
+    if reads >= writes * 100:
+        return "read_heavy_low_write"
+    return "moderate_read_dominant"
+
+
+__all__ = [
+    "CreateRedisCacheTableResult",
+    "CreateRedisServerResult",
+    "CreateRedisUserMappingResult",
+    "RecommendRedisCacheTargetsResult",
+    "RedisCacheRecommendation",
+    "RedisCacheStats",
+    "RedisCacheTableInfo",
+    "RedisFdwError",
+    "RedisForeignServer",
+    "create_redis_cache_server",
+    "create_redis_cache_table",
+    "create_redis_user_mapping",
+    "describe_redis_cache_table",
+    "get_redis_cache_stats",
+    "list_redis_foreign_servers",
+    "recommend_redis_cache_targets",
+]

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -52,6 +52,7 @@ from mcpg import (
     query,
     rag_efficiency,
     rag_telemetry,
+    redis_fdw,
     rls,
     schema_diff,
     schema_docs,
@@ -3750,6 +3751,254 @@ def _register_pg_search_ddl(server: FastMCP[AppContext]) -> None:
         return asdict(result)
 
 
+def _register_redis_fdw_reads(server: FastMCP[AppContext]) -> None:
+    @server.tool(
+        name="list_redis_foreign_servers",
+        description=_with_example(
+            "List the foreign servers backed by ``redis_fdw`` — the FDW that "
+            "exposes a Redis instance as SQL-queryable foreign tables. "
+            "Reports each server's connection address, port, database, TLS "
+            "posture, and whether a user mapping (credential) is configured. "
+            "Returns an empty list when the redis_fdw extension is not installed. "
+            "Returns a list of objects with `name`, `address`, `port`, "
+            "`database`, `tls` (bool), `password_configured` (bool), and "
+            "`options` (the full server-options dict).",
+            "list_redis_foreign_servers()",
+        ),
+    )
+    async def list_redis_foreign_servers(ctx: _Ctx) -> list[dict[str, Any]]:
+        async def _run() -> list[dict[str, Any]]:
+            servers = await redis_fdw.list_redis_foreign_servers(_driver(ctx))
+            return [asdict(s) for s in servers]
+
+        return await _cached_call(ctx, "list_redis_foreign_servers", _run)
+
+    @server.tool(
+        name="describe_redis_cache_table",
+        description=_with_example(
+            "Describe one foreign table backed by ``redis_fdw``: which server "
+            "it's mapped to, the Redis-side key structure (`hash` / `list` / "
+            "`string` / `set` / `zset`), key-prefix, TTL, and SQL-side column "
+            "shape. Raises an error when the table doesn't exist or isn't "
+            "backed by redis_fdw. "
+            "Returns an object with `schema`, `name`, `server`, `key_type`, "
+            "`key_prefix`, `ttl_seconds`, `columns` (list of `{name, data_type}`), "
+            "and `options` (the full foreign-table options dict).",
+            "describe_redis_cache_table(schema='public', table='sessions_cache')",
+        ),
+    )
+    async def describe_redis_cache_table(ctx: _Ctx, schema: str, table: str) -> dict[str, Any]:
+        async def _run() -> dict[str, Any]:
+            info = await redis_fdw.describe_redis_cache_table(_driver(ctx), schema, table)
+            return asdict(info)
+
+        return await _cached_call(ctx, "describe_redis_cache_table", _run, schema, table)
+
+    @server.tool(
+        name="get_redis_cache_stats",
+        description=_with_example(
+            "Best-effort cache metrics for a redis_fdw server. redis_fdw does "
+            "not ship a uniform stats SQL surface across versions, so the tool "
+            "validates that the server exists and otherwise reports "
+            "`available=false` with a diagnostic. Operators wanting live "
+            "metrics should query Redis directly (INFO / DBSIZE). "
+            "Returns an object with `server`, `available` (bool), `key_count`, "
+            "`used_memory_bytes`, and `detail` (a human-readable note).",
+            "get_redis_cache_stats(server='redis_primary')",
+        ),
+    )
+    async def get_redis_cache_stats(ctx: _Ctx, server: str) -> dict[str, Any]:
+        async def _run() -> dict[str, Any]:
+            stats = await redis_fdw.get_redis_cache_stats(_driver(ctx), server)
+            return asdict(stats)
+
+        return await _cached_call(ctx, "get_redis_cache_stats", _run, server)
+
+    @server.tool(
+        name="recommend_redis_cache_targets",
+        description=_with_example(
+            "Recommend tables that would benefit from a Redis cache layer. "
+            "Inspects ``pg_stat_user_tables`` for read-heavy, low-write "
+            "relations whose working set fits comfortably in Redis "
+            "(default: read/write ratio ≥ 10, ≥ 1000 reads, ≤ 1M rows). "
+            "When ``server`` is provided the generated ``ready_to_run_sql`` "
+            "stub targets that server name; otherwise the stub uses a "
+            "placeholder operators must substitute. Advisor is read-only — "
+            "never touches Redis itself. "
+            "Returns an object with `server` and `candidates` — a list of "
+            "objects with `schema`, `table`, `reads`, `writes`, "
+            "`read_write_ratio`, `estimated_row_count`, `reason` "
+            "(`read_only_lookup_table` / `small_hot_relation` / "
+            "`read_heavy_low_write` / `moderate_read_dominant`), and "
+            "`ready_to_run_sql` (a CREATE FOREIGN TABLE stub).",
+            "recommend_redis_cache_targets(server='redis_primary', limit=10)",
+        ),
+    )
+    async def recommend_redis_cache_targets(
+        ctx: _Ctx,
+        server: str | None = None,
+        min_read_write_ratio: float = 10.0,
+        min_reads_per_day: int = 1000,
+        max_rows: int = 1_000_000,
+        limit: int = 20,
+    ) -> dict[str, Any]:
+        async def _run() -> dict[str, Any]:
+            result = await redis_fdw.recommend_redis_cache_targets(
+                _driver(ctx),
+                server=server,
+                min_read_write_ratio=min_read_write_ratio,
+                min_reads_per_day=min_reads_per_day,
+                max_rows=max_rows,
+                limit=limit,
+            )
+            return asdict(result)
+
+        return await _cached_call(
+            ctx,
+            "recommend_redis_cache_targets",
+            _run,
+            server,
+            min_read_write_ratio,
+            min_reads_per_day,
+            max_rows,
+            limit,
+        )
+
+
+def _register_redis_fdw_ddl(server: FastMCP[AppContext]) -> None:
+    @server.tool(
+        name="enable_redis_fdw",
+        description=_with_example(
+            "Install the ``redis_fdw`` extension. Thin wrapper over "
+            "``enable_extension('redis_fdw')`` — convenient for agents that "
+            "have located the cache-and-foreign-data bucket but haven't found "
+            "the generic extension installer. redis_fdw runs in-process inside "
+            "Postgres; operators should be aware of that operational "
+            "implication before installing. Requires DDL mode. "
+            "Returns an object with `name='redis_fdw'` and `enabled=true`.",
+            "enable_redis_fdw()",
+        ),
+    )
+    async def enable_redis_fdw(ctx: _Ctx) -> dict[str, Any]:
+        result = await extensions.enable_extension(_driver(ctx), "redis_fdw")
+        await ctx.request_context.lifespan_context.cache.clear()
+        return asdict(result)
+
+    @server.tool(
+        name="create_redis_cache_server",
+        description=_with_example(
+            "Create a foreign server backed by ``redis_fdw`` "
+            "(``CREATE SERVER … FOREIGN DATA WRAPPER redis_fdw OPTIONS (…)``). "
+            "TLS is enabled by default; the tool refuses ``tls=false`` against "
+            "a non-loopback Redis host unless ``allow_insecure_tls=true`` is "
+            "passed explicitly. ``name`` must be a valid unquoted SQL "
+            "identifier. Idempotent via ``IF NOT EXISTS``. Requires DDL mode. "
+            "Returns an object with `name`, `address`, `port`, `database`, "
+            "`tls`, and `created=true`.",
+            "create_redis_cache_server(name='redis_primary', address='redis.internal', port=6379)",
+        ),
+    )
+    async def create_redis_cache_server(
+        ctx: _Ctx,
+        name: str,
+        address: str,
+        port: int = 6379,
+        database: int = 0,
+        tls: bool = True,
+        allow_insecure_tls: bool = False,
+    ) -> dict[str, Any]:
+        result = await redis_fdw.create_redis_cache_server(
+            _driver(ctx),
+            name=name,
+            address=address,
+            port=port,
+            database=database,
+            tls=tls,
+            allow_insecure_tls=allow_insecure_tls,
+        )
+        await ctx.request_context.lifespan_context.cache.clear()
+        return asdict(result)
+
+    @server.tool(
+        name="create_redis_user_mapping",
+        description=_with_example(
+            "Create a user mapping for a redis_fdw foreign server. The Redis "
+            "password is never accepted as a tool argument — pass "
+            "``secret_ref`` (the name of a secret in the configured "
+            "``MCPG_SECRETS_BACKEND``) and the tool resolves it before "
+            "interpolating into the OPTIONS clause. ``user='public'`` creates "
+            "a PUBLIC mapping; otherwise the user name must be a valid "
+            "unquoted SQL identifier. Idempotent via ``IF NOT EXISTS``. "
+            "Requires DDL mode. "
+            "Returns an object with `server`, `user`, `secret_ref` (echoed by "
+            "name, not value), and `created=true`.",
+            "create_redis_user_mapping(server='redis_primary', user='public', secret_ref='REDIS_PASSWORD')",
+        ),
+    )
+    async def create_redis_user_mapping(
+        ctx: _Ctx,
+        server: str,
+        user: str,
+        secret_ref: str,
+    ) -> dict[str, Any]:
+        import os
+
+        from mcpg.secrets import build_secrets_provider
+
+        secrets_provider, _backend = build_secrets_provider(os.environ)
+        result = await redis_fdw.create_redis_user_mapping(
+            _driver(ctx),
+            server=server,
+            user=user,
+            secret_ref=secret_ref,
+            secrets=secrets_provider,
+        )
+        await ctx.request_context.lifespan_context.cache.clear()
+        return asdict(result)
+
+    @server.tool(
+        name="create_redis_cache_table",
+        description=_with_example(
+            "Create a foreign table backed by ``redis_fdw``. ``key_type`` is "
+            "the Redis-side structure (one of ``hash`` / ``list`` / ``string`` "
+            "/ ``set`` / ``zset``). ``columns`` is a list of "
+            "``{name, type}`` dicts — every name must be a valid unquoted SQL "
+            "identifier and every type a bare Postgres type. Optional "
+            "``key_prefix`` and ``ttl_seconds`` are passed through as "
+            "redis_fdw options. Idempotent via ``IF NOT EXISTS``. Requires "
+            "DDL mode. "
+            "Returns an object with `schema`, `name`, `server`, `key_type`, "
+            "`columns` (tuple of column names), and `created=true`.",
+            "create_redis_cache_table(schema='public', name='sessions_cache', "
+            "server='redis_primary', key_type='hash', "
+            "columns=[{'name': 'key', 'type': 'text'}, {'name': 'value', 'type': 'text'}], "
+            "key_prefix='session:', ttl_seconds=3600)",
+        ),
+    )
+    async def create_redis_cache_table(
+        ctx: _Ctx,
+        schema: str,
+        name: str,
+        server: str,
+        key_type: str,
+        columns: list[dict[str, str]],
+        key_prefix: str | None = None,
+        ttl_seconds: int | None = None,
+    ) -> dict[str, Any]:
+        result = await redis_fdw.create_redis_cache_table(
+            _driver(ctx),
+            schema=schema,
+            name=name,
+            server=server,
+            key_type=key_type,
+            columns=columns,
+            key_prefix=key_prefix,
+            ttl_seconds=ttl_seconds,
+        )
+        await ctx.request_context.lifespan_context.cache.clear()
+        return asdict(result)
+
+
 def _register_cron_write(server: FastMCP[AppContext]) -> None:
     @server.tool(
         name="schedule_cron_job",
@@ -4164,6 +4413,7 @@ def register_tools(server: FastMCP[AppContext], settings: Settings) -> None:
         _register_pg_search_reads(server)
         _register_timescaledb_reads(server)
         _register_graphs_reads(server)
+        _register_redis_fdw_reads(server)
     if is_permitted(settings.access_mode, Capability.WRITE):
         _register_write(server)
         _register_maintenance(server)
@@ -4180,6 +4430,7 @@ def register_tools(server: FastMCP[AppContext], settings: Settings) -> None:
         _register_rag_telemetry_ddl(server)
         _register_timescaledb_writes(server)
         _register_graphs_writes(server)
+        _register_redis_fdw_ddl(server)
     if is_permitted(settings.access_mode, Capability.MIGRATE) and settings.allow_ddl:
         _register_migrations(server)
     if is_permitted(settings.access_mode, Capability.SHELL) and settings.allow_shell:

--- a/tests/contract/tool_surface.snapshot.json
+++ b/tests/contract/tool_surface.snapshot.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "schema_version": 1,
-    "tool_count": 174
+    "tool_count": 182
   },
   "tools": [
     {
@@ -899,6 +899,142 @@
       "name": "create_pg_search_index"
     },
     {
+      "description": "Create a foreign server backed by ``redis_fdw`` (``CREATE SERVER … FOREIGN DATA WRAPPER redis_fdw OPTIONS (…)``). TLS is enabled by default; the tool refuses ``tls=false`` against a non-loopback Redis host unless ``allow_insecure_tls=true`` is passed explicitly. ``name`` must be a valid unquoted SQL identifier. Idempotent via ``IF NOT EXISTS``. Requires DDL mode. Returns an object with `name`, `address`, `port`, `database`, `tls`, and `created=true`.\n\nExample: `create_redis_cache_server(name='redis_primary', address='redis.internal', port=6379)`",
+      "inputSchema": {
+        "properties": {
+          "address": {
+            "title": "Address",
+            "type": "string"
+          },
+          "allow_insecure_tls": {
+            "default": false,
+            "title": "Allow Insecure Tls",
+            "type": "boolean"
+          },
+          "database": {
+            "default": 0,
+            "title": "Database",
+            "type": "integer"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "port": {
+            "default": 6379,
+            "title": "Port",
+            "type": "integer"
+          },
+          "tls": {
+            "default": true,
+            "title": "Tls",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "name",
+          "address"
+        ],
+        "title": "create_redis_cache_serverArguments",
+        "type": "object"
+      },
+      "name": "create_redis_cache_server"
+    },
+    {
+      "description": "Create a foreign table backed by ``redis_fdw``. ``key_type`` is the Redis-side structure (one of ``hash`` / ``list`` / ``string`` / ``set`` / ``zset``). ``columns`` is a list of ``{name, type}`` dicts — every name must be a valid unquoted SQL identifier and every type a bare Postgres type. Optional ``key_prefix`` and ``ttl_seconds`` are passed through as redis_fdw options. Idempotent via ``IF NOT EXISTS``. Requires DDL mode. Returns an object with `schema`, `name`, `server`, `key_type`, `columns` (tuple of column names), and `created=true`.\n\nExample: `create_redis_cache_table(schema='public', name='sessions_cache', server='redis_primary', key_type='hash', columns=[{'name': 'key', 'type': 'text'}, {'name': 'value', 'type': 'text'}], key_prefix='session:', ttl_seconds=3600)`",
+      "inputSchema": {
+        "properties": {
+          "columns": {
+            "items": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "title": "Columns",
+            "type": "array"
+          },
+          "key_prefix": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Key Prefix"
+          },
+          "key_type": {
+            "title": "Key Type",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "schema": {
+            "title": "Schema",
+            "type": "string"
+          },
+          "server": {
+            "title": "Server",
+            "type": "string"
+          },
+          "ttl_seconds": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Ttl Seconds"
+          }
+        },
+        "required": [
+          "schema",
+          "name",
+          "server",
+          "key_type",
+          "columns"
+        ],
+        "title": "create_redis_cache_tableArguments",
+        "type": "object"
+      },
+      "name": "create_redis_cache_table"
+    },
+    {
+      "description": "Create a user mapping for a redis_fdw foreign server. The Redis password is never accepted as a tool argument — pass ``secret_ref`` (the name of a secret in the configured ``MCPG_SECRETS_BACKEND``) and the tool resolves it before interpolating into the OPTIONS clause. ``user='public'`` creates a PUBLIC mapping; otherwise the user name must be a valid unquoted SQL identifier. Idempotent via ``IF NOT EXISTS``. Requires DDL mode. Returns an object with `server`, `user`, `secret_ref` (echoed by name, not value), and `created=true`.\n\nExample: `create_redis_user_mapping(server='redis_primary', user='public', secret_ref='REDIS_PASSWORD')`",
+      "inputSchema": {
+        "properties": {
+          "secret_ref": {
+            "title": "Secret Ref",
+            "type": "string"
+          },
+          "server": {
+            "title": "Server",
+            "type": "string"
+          },
+          "user": {
+            "title": "User",
+            "type": "string"
+          }
+        },
+        "required": [
+          "server",
+          "user",
+          "secret_ref"
+        ],
+        "title": "create_redis_user_mappingArguments",
+        "type": "object"
+      },
+      "name": "create_redis_user_mapping"
+    },
+    {
       "description": "Build a CREATE INDEX … USING turboquant statement under tight allowlists and run it on autocommit (CONCURRENTLY can't run inside a transaction). ``metric`` is 'cosine' | 'inner_product' | 'l2' (mapped to the matching tq_*_ops opclass). Index options ``bits`` (1..64), ``lists`` (0..1_000_000), ``transform`` (allowlist: 'hadamard'), ``normalized`` (bool) are all optional; any not supplied are omitted from the WITH clause so upstream's defaults apply. The rendered CREATE INDEX SQL is returned in ``create_sql`` for auditability. Performs DDL — requires unrestricted mode + MCPG_ALLOW_DDL; pg_turboquant installed.",
       "inputSchema": {
         "properties": {
@@ -1065,6 +1201,28 @@
         "type": "object"
       },
       "name": "describe_graph"
+    },
+    {
+      "description": "Describe one foreign table backed by ``redis_fdw``: which server it's mapped to, the Redis-side key structure (`hash` / `list` / `string` / `set` / `zset`), key-prefix, TTL, and SQL-side column shape. Raises an error when the table doesn't exist or isn't backed by redis_fdw. Returns an object with `schema`, `name`, `server`, `key_type`, `key_prefix`, `ttl_seconds`, `columns` (list of `{name, data_type}`), and `options` (the full foreign-table options dict).\n\nExample: `describe_redis_cache_table(schema='public', table='sessions_cache')`",
+      "inputSchema": {
+        "properties": {
+          "schema": {
+            "title": "Schema",
+            "type": "string"
+          },
+          "table": {
+            "title": "Table",
+            "type": "string"
+          }
+        },
+        "required": [
+          "schema",
+          "table"
+        ],
+        "title": "describe_redis_cache_tableArguments",
+        "type": "object"
+      },
+      "name": "describe_redis_cache_table"
     },
     {
       "description": "Return a high-level summary of what mcpg can do, organised into capability buckets (schema introspection, query execution, vector search, RAG telemetry, audit trail, migrations, time-series, etc.). Call this first when discovering mcpg's surface — it's much more compact than walking the full tool catalogue. Returns an object with `headline`, `version`, `tool_count`, `capability_count`, and a `capabilities` list, where each capability has `id`, `name`, `summary`, `detail`, `headline_tools` (top 3-6 tools to reach for first), `tool_count`, and `all_tools` (the full list in that bucket). Read-only; no database access. Pair with `list_tools` (MCP-protocol) when you need every tool's full schema.",
@@ -1259,6 +1417,15 @@
         "type": "object"
       },
       "name": "enable_extension"
+    },
+    {
+      "description": "Install the ``redis_fdw`` extension. Thin wrapper over ``enable_extension('redis_fdw')`` — convenient for agents that have located the cache-and-foreign-data bucket but haven't found the generic extension installer. redis_fdw runs in-process inside Postgres; operators should be aware of that operational implication before installing. Requires DDL mode. Returns an object with `name='redis_fdw'` and `enabled=true`.\n\nExample: `enable_redis_fdw()`",
+      "inputSchema": {
+        "properties": {},
+        "title": "enable_redis_fdwArguments",
+        "type": "object"
+      },
+      "name": "enable_redis_fdw"
     },
     {
       "description": "Return the PostgreSQL execution plan for a query without running it. The query is validated by the same safety allowlist as run_select.\n\nExample: `explain_query(sql='SELECT * FROM orders WHERE created_at > now() - interval \\'7 days\\'')`",
@@ -1863,6 +2030,23 @@
         "type": "object"
       },
       "name": "get_pg_search_index_metadata"
+    },
+    {
+      "description": "Best-effort cache metrics for a redis_fdw server. redis_fdw does not ship a uniform stats SQL surface across versions, so the tool validates that the server exists and otherwise reports `available=false` with a diagnostic. Operators wanting live metrics should query Redis directly (INFO / DBSIZE). Returns an object with `server`, `available` (bool), `key_count`, `used_memory_bytes`, and `detail` (a human-readable note).\n\nExample: `get_redis_cache_stats(server='redis_primary')`",
+      "inputSchema": {
+        "properties": {
+          "server": {
+            "title": "Server",
+            "type": "string"
+          }
+        },
+        "required": [
+          "server"
+        ],
+        "title": "get_redis_cache_statsArguments",
+        "type": "object"
+      },
+      "name": "get_redis_cache_stats"
     },
     {
       "description": "Return the MCPg server version, access mode, transport, and database connection status.",
@@ -2657,6 +2841,15 @@
         "type": "object"
       },
       "name": "list_publications"
+    },
+    {
+      "description": "List the foreign servers backed by ``redis_fdw`` — the FDW that exposes a Redis instance as SQL-queryable foreign tables. Reports each server's connection address, port, database, TLS posture, and whether a user mapping (credential) is configured. Returns an empty list when the redis_fdw extension is not installed. Returns a list of objects with `name`, `address`, `port`, `database`, `tls` (bool), `password_configured` (bool), and `options` (the full server-options dict).\n\nExample: `list_redis_foreign_servers()`",
+      "inputSchema": {
+        "properties": {},
+        "title": "list_redis_foreign_serversArguments",
+        "type": "object"
+      },
+      "name": "list_redis_foreign_servers"
     },
     {
       "description": "Report the health of every configured read replica. Each entry shows index, password-obfuscated DSN, whether the replica is currently degraded (skipped from routing), the last error that took it out, and how many seconds remain before it's re-probed. Returns an empty list when no replicas are configured.",
@@ -3799,6 +3992,48 @@
         "type": "object"
       },
       "name": "recommend_pg_search_maintenance"
+    },
+    {
+      "description": "Recommend tables that would benefit from a Redis cache layer. Inspects ``pg_stat_user_tables`` for read-heavy, low-write relations whose working set fits comfortably in Redis (default: read/write ratio ≥ 10, ≥ 1000 reads, ≤ 1M rows). When ``server`` is provided the generated ``ready_to_run_sql`` stub targets that server name; otherwise the stub uses a placeholder operators must substitute. Advisor is read-only — never touches Redis itself. Returns an object with `server` and `candidates` — a list of objects with `schema`, `table`, `reads`, `writes`, `read_write_ratio`, `estimated_row_count`, `reason` (`read_only_lookup_table` / `small_hot_relation` / `read_heavy_low_write` / `moderate_read_dominant`), and `ready_to_run_sql` (a CREATE FOREIGN TABLE stub).\n\nExample: `recommend_redis_cache_targets(server='redis_primary', limit=10)`",
+      "inputSchema": {
+        "properties": {
+          "limit": {
+            "default": 20,
+            "title": "Limit",
+            "type": "integer"
+          },
+          "max_rows": {
+            "default": 1000000,
+            "title": "Max Rows",
+            "type": "integer"
+          },
+          "min_read_write_ratio": {
+            "default": 10.0,
+            "title": "Min Read Write Ratio",
+            "type": "number"
+          },
+          "min_reads_per_day": {
+            "default": 1000,
+            "title": "Min Reads Per Day",
+            "type": "integer"
+          },
+          "server": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Server"
+          }
+        },
+        "title": "recommend_redis_cache_targetsArguments",
+        "type": "object"
+      },
+      "name": "recommend_redis_cache_targets"
     },
     {
       "description": "Roll-up advisor over the four analytics for one window. Returns a single headline ``summary`` + the full list of findings. Built from whichever combination of ``reranker_idle`` / ``topk_stable`` / ``score_clustering`` / ``rerank_hurts_ndcg`` / ``rerank_lifts_ndcg`` fires. Also feeds the ``RAG Reranker Pipeline`` category in audit_database. Reads from mcpg_rag.rerank_events.",

--- a/tests/unit/test_redis_fdw.py
+++ b/tests/unit/test_redis_fdw.py
@@ -1,0 +1,400 @@
+"""Tests for the redis_fdw coverage module."""
+
+from __future__ import annotations
+
+import pytest
+from _fakes import FakeRoutingDriver
+
+from mcpg.redis_fdw import (
+    RecommendRedisCacheTargetsResult,
+    RedisCacheRecommendation,
+    RedisCacheStats,
+    RedisCacheTableInfo,
+    RedisFdwError,
+    RedisForeignServer,
+    create_redis_cache_server,
+    create_redis_cache_table,
+    create_redis_user_mapping,
+    describe_redis_cache_table,
+    get_redis_cache_stats,
+    list_redis_foreign_servers,
+    recommend_redis_cache_targets,
+)
+
+
+class _StaticSecrets:
+    """Trivial secrets provider double — returns a fixed value for one name."""
+
+    def __init__(self, mapping: dict[str, str | None]) -> None:
+        self._mapping = mapping
+
+    def get(self, name: str) -> str | None:
+        return self._mapping.get(name)
+
+
+# --- list_redis_foreign_servers --------------------------------------------
+
+
+async def test_list_returns_empty_when_extension_absent() -> None:
+    driver = FakeRoutingDriver({"FROM pg_extension WHERE extname": []})
+    assert await list_redis_foreign_servers(driver) == []  # type: ignore[arg-type]
+
+
+async def test_list_parses_server_options_and_flags_password() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "FROM pg_extension WHERE extname": [{"present": 1}],
+            "FROM pg_foreign_server s ": [
+                {
+                    "name": "redis_primary",
+                    "options": ["address=redis.internal", "port=6379", "database=0", "tls=true"],
+                },
+                {
+                    "name": "redis_secondary",
+                    "options": ["address=10.0.0.5", "port=6380", "database=1", "tls=false"],
+                },
+            ],
+            "FROM pg_user_mappings WHERE srvname": [
+                {"srvname": "redis_primary"},
+            ],
+        }
+    )
+    servers = await list_redis_foreign_servers(driver)  # type: ignore[arg-type]
+    assert servers == [
+        RedisForeignServer(
+            name="redis_primary",
+            address="redis.internal",
+            port=6379,
+            database=0,
+            tls=True,
+            password_configured=True,
+            options={"address": "redis.internal", "port": "6379", "database": "0", "tls": "true"},
+        ),
+        RedisForeignServer(
+            name="redis_secondary",
+            address="10.0.0.5",
+            port=6380,
+            database=1,
+            tls=False,
+            password_configured=False,
+            options={"address": "10.0.0.5", "port": "6380", "database": "1", "tls": "false"},
+        ),
+    ]
+
+
+# --- describe_redis_cache_table --------------------------------------------
+
+
+async def test_describe_returns_table_shape_with_columns() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "FROM pg_foreign_table ft ": [
+                {
+                    "name": "sessions_cache",
+                    "server": "redis_primary",
+                    "options": ["tabletype=hash", "keyprefix=session:", "ttl=3600"],
+                }
+            ],
+            "FROM pg_attribute a ": [
+                {"name": "key", "data_type": "text"},
+                {"name": "value", "data_type": "text"},
+            ],
+        }
+    )
+    info = await describe_redis_cache_table(driver, "public", "sessions_cache")  # type: ignore[arg-type]
+    assert info == RedisCacheTableInfo(
+        schema="public",
+        name="sessions_cache",
+        server="redis_primary",
+        key_type="hash",
+        key_prefix="session:",
+        ttl_seconds=3600,
+        columns=[{"name": "key", "data_type": "text"}, {"name": "value", "data_type": "text"}],
+        options={"tabletype": "hash", "keyprefix": "session:", "ttl": "3600"},
+    )
+
+
+async def test_describe_raises_for_missing_table() -> None:
+    driver = FakeRoutingDriver({"FROM pg_foreign_table ft ": []})
+    with pytest.raises(RedisFdwError, match="no redis_fdw foreign table"):
+        await describe_redis_cache_table(driver, "public", "ghost")  # type: ignore[arg-type]
+
+
+# --- get_redis_cache_stats -------------------------------------------------
+
+
+async def test_get_stats_reports_unavailable_when_server_exists() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "FROM pg_foreign_server s ": [{"srvname": "redis_primary"}],
+        }
+    )
+    stats = await get_redis_cache_stats(driver, "redis_primary")  # type: ignore[arg-type]
+    assert stats == RedisCacheStats(
+        server="redis_primary",
+        available=False,
+        key_count=None,
+        used_memory_bytes=None,
+        detail=("redis_fdw does not expose uniform stats SQL — query Redis directly (INFO / DBSIZE) for live metrics"),
+    )
+
+
+async def test_get_stats_raises_for_missing_server() -> None:
+    driver = FakeRoutingDriver({"FROM pg_foreign_server s ": []})
+    with pytest.raises(RedisFdwError, match="no redis_fdw foreign server"):
+        await get_redis_cache_stats(driver, "ghost")  # type: ignore[arg-type]
+
+
+# --- create_redis_cache_server ---------------------------------------------
+
+
+async def test_create_server_emits_create_server_with_options() -> None:
+    driver = FakeRoutingDriver({"FROM pg_extension WHERE extname": [{"present": 1}]})
+    result = await create_redis_cache_server(
+        driver,  # type: ignore[arg-type]
+        name="redis_primary",
+        address="redis.internal",
+        port=6379,
+        database=0,
+        tls=True,
+    )
+    assert result.created is True
+    queries = " | ".join(call[0] for call in driver.calls)
+    assert 'CREATE SERVER IF NOT EXISTS "redis_primary" FOREIGN DATA WRAPPER redis_fdw' in queries
+    assert "address 'redis.internal'" in queries
+    assert "port '6379'" in queries
+    assert "tls 'true'" in queries
+
+
+async def test_create_server_rejects_bad_identifier() -> None:
+    driver = FakeRoutingDriver({"FROM pg_extension WHERE extname": [{"present": 1}]})
+    with pytest.raises(RedisFdwError, match="not a valid unquoted SQL identifier"):
+        await create_redis_cache_server(driver, name="redis; DROP", address="redis.internal")  # type: ignore[arg-type]
+
+
+async def test_create_server_rejects_address_with_quotes() -> None:
+    driver = FakeRoutingDriver({"FROM pg_extension WHERE extname": [{"present": 1}]})
+    with pytest.raises(RedisFdwError, match="address contains characters"):
+        await create_redis_cache_server(driver, name="r", address="evil'; DROP --")  # type: ignore[arg-type]
+
+
+async def test_create_server_rejects_insecure_tls_on_remote_host() -> None:
+    driver = FakeRoutingDriver({"FROM pg_extension WHERE extname": [{"present": 1}]})
+    with pytest.raises(RedisFdwError, match="refusing tls=False"):
+        await create_redis_cache_server(
+            driver,  # type: ignore[arg-type]
+            name="redis_primary",
+            address="redis.internal",
+            tls=False,
+        )
+
+
+async def test_create_server_allows_insecure_tls_on_loopback() -> None:
+    driver = FakeRoutingDriver({"FROM pg_extension WHERE extname": [{"present": 1}]})
+    result = await create_redis_cache_server(
+        driver,  # type: ignore[arg-type]
+        name="local_redis",
+        address="127.0.0.1",
+        tls=False,
+    )
+    assert result.created is True
+
+
+async def test_create_server_rejects_bad_port() -> None:
+    driver = FakeRoutingDriver({"FROM pg_extension WHERE extname": [{"present": 1}]})
+    with pytest.raises(RedisFdwError, match="port must be"):
+        await create_redis_cache_server(driver, name="r", address="127.0.0.1", port=0)  # type: ignore[arg-type]
+
+
+async def test_create_server_requires_extension_installed() -> None:
+    driver = FakeRoutingDriver({"FROM pg_extension WHERE extname": []})
+    with pytest.raises(RedisFdwError, match="redis_fdw extension is not installed"):
+        await create_redis_cache_server(driver, name="r", address="127.0.0.1")  # type: ignore[arg-type]
+
+
+# --- create_redis_user_mapping ---------------------------------------------
+
+
+async def test_create_user_mapping_resolves_secret_and_escapes_quotes() -> None:
+    driver = FakeRoutingDriver({"FROM pg_extension WHERE extname": [{"present": 1}]})
+    secrets = _StaticSecrets({"REDIS_PASSWORD": "s3'cret"})
+    result = await create_redis_user_mapping(
+        driver,  # type: ignore[arg-type]
+        server="redis_primary",
+        user="public",
+        secret_ref="REDIS_PASSWORD",
+        secrets=secrets,  # type: ignore[arg-type]
+    )
+    assert result.created is True
+    assert result.secret_ref == "REDIS_PASSWORD"
+    queries = " | ".join(call[0] for call in driver.calls)
+    assert "CREATE USER MAPPING IF NOT EXISTS FOR PUBLIC" in queries
+    assert 'SERVER "redis_primary"' in queries
+    # Quotes inside the secret are doubled (SQL string escape).
+    assert "password 's3''cret'" in queries
+
+
+async def test_create_user_mapping_rejects_unresolved_secret() -> None:
+    driver = FakeRoutingDriver({"FROM pg_extension WHERE extname": [{"present": 1}]})
+    secrets = _StaticSecrets({})
+    with pytest.raises(RedisFdwError, match="did not resolve"):
+        await create_redis_user_mapping(
+            driver,  # type: ignore[arg-type]
+            server="redis_primary",
+            user="public",
+            secret_ref="MISSING",
+            secrets=secrets,  # type: ignore[arg-type]
+        )
+
+
+async def test_create_user_mapping_rejects_control_characters_in_password() -> None:
+    driver = FakeRoutingDriver({"FROM pg_extension WHERE extname": [{"present": 1}]})
+    secrets = _StaticSecrets({"BAD": "abc\nDROP"})
+    with pytest.raises(RedisFdwError, match="control characters"):
+        await create_redis_user_mapping(
+            driver,  # type: ignore[arg-type]
+            server="redis_primary",
+            user="public",
+            secret_ref="BAD",
+            secrets=secrets,  # type: ignore[arg-type]
+        )
+
+
+async def test_create_user_mapping_validates_user_identifier() -> None:
+    driver = FakeRoutingDriver({"FROM pg_extension WHERE extname": [{"present": 1}]})
+    secrets = _StaticSecrets({"P": "x"})
+    with pytest.raises(RedisFdwError, match="user name"):
+        await create_redis_user_mapping(
+            driver,  # type: ignore[arg-type]
+            server="redis_primary",
+            user="bad; user",
+            secret_ref="P",
+            secrets=secrets,  # type: ignore[arg-type]
+        )
+
+
+# --- create_redis_cache_table ----------------------------------------------
+
+
+async def test_create_table_emits_create_foreign_table_with_options() -> None:
+    driver = FakeRoutingDriver({"FROM pg_extension WHERE extname": [{"present": 1}]})
+    result = await create_redis_cache_table(
+        driver,  # type: ignore[arg-type]
+        schema="public",
+        name="sessions_cache",
+        server="redis_primary",
+        key_type="hash",
+        columns=[{"name": "key", "type": "text"}, {"name": "value", "type": "text"}],
+        key_prefix="session:",
+        ttl_seconds=3600,
+    )
+    assert result.created is True
+    assert result.columns == ("key", "value")
+    queries = " | ".join(call[0] for call in driver.calls)
+    assert 'CREATE FOREIGN TABLE IF NOT EXISTS "public"."sessions_cache"' in queries
+    assert '"key" text, "value" text' in queries
+    assert "tabletype 'hash'" in queries
+    assert "keyprefix 'session:'" in queries
+    assert "ttl '3600'" in queries
+
+
+async def test_create_table_rejects_unknown_key_type() -> None:
+    driver = FakeRoutingDriver({"FROM pg_extension WHERE extname": [{"present": 1}]})
+    with pytest.raises(RedisFdwError, match="key_type must be one of"):
+        await create_redis_cache_table(
+            driver,  # type: ignore[arg-type]
+            schema="public",
+            name="t",
+            server="redis_primary",
+            key_type="json",
+            columns=[{"name": "k", "type": "text"}],
+        )
+
+
+async def test_create_table_rejects_bad_column_type() -> None:
+    driver = FakeRoutingDriver({"FROM pg_extension WHERE extname": [{"present": 1}]})
+    with pytest.raises(RedisFdwError, match="column 'k' type"):
+        await create_redis_cache_table(
+            driver,  # type: ignore[arg-type]
+            schema="public",
+            name="t",
+            server="redis_primary",
+            key_type="hash",
+            columns=[{"name": "k", "type": "text'); DROP --"}],
+        )
+
+
+async def test_create_table_requires_at_least_one_column() -> None:
+    driver = FakeRoutingDriver({"FROM pg_extension WHERE extname": [{"present": 1}]})
+    with pytest.raises(RedisFdwError, match="at least one column"):
+        await create_redis_cache_table(
+            driver,  # type: ignore[arg-type]
+            schema="public",
+            name="t",
+            server="redis_primary",
+            key_type="hash",
+            columns=[],
+        )
+
+
+# --- recommend_redis_cache_targets -----------------------------------------
+
+
+async def test_recommend_filters_by_ratio_reads_and_size() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "FROM pg_stat_user_tables s ": [
+                # 1000 reads + 0 writes → infinite ratio, qualifies.
+                {"schema": "public", "table_name": "ref_data", "reads": 5000, "writes": 0, "est_rows": 500},
+                # 100 reads → below min_reads_per_day default.
+                {"schema": "public", "table_name": "cold_table", "reads": 100, "writes": 0, "est_rows": 100},
+                # 10M rows → exceeds max_rows.
+                {"schema": "public", "table_name": "big", "reads": 100_000, "writes": 0, "est_rows": 10_000_000},
+                # ratio = 5 → below min_read_write_ratio default.
+                {"schema": "public", "table_name": "even", "reads": 5000, "writes": 1000, "est_rows": 1000},
+                # ratio = 50, reads = 50000 → qualifies, small.
+                {"schema": "public", "table_name": "lookup", "reads": 50_000, "writes": 1000, "est_rows": 5_000},
+            ],
+        }
+    )
+    result = await recommend_redis_cache_targets(driver, server="redis_primary")  # type: ignore[arg-type]
+    assert isinstance(result, RecommendRedisCacheTargetsResult)
+    names = [c.table for c in result.candidates]
+    assert names == ["lookup", "ref_data"]
+    # Sanity-check the read_only_lookup_table classifier on the writes=0 row.
+    assert any(c.reason == "read_only_lookup_table" and c.table == "ref_data" for c in result.candidates)
+    # Generated stub uses the supplied server name.
+    assert all('SERVER "redis_primary"' in c.ready_to_run_sql for c in result.candidates)
+
+
+async def test_recommend_uses_placeholder_when_server_not_given() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "FROM pg_stat_user_tables s ": [
+                {"schema": "public", "table_name": "ref", "reads": 10_000, "writes": 0, "est_rows": 100},
+            ],
+        }
+    )
+    result = await recommend_redis_cache_targets(driver)  # type: ignore[arg-type]
+    assert result.server is None
+    assert "<configure-redis-server>" in result.candidates[0].ready_to_run_sql
+
+
+async def test_recommend_rejects_bad_thresholds() -> None:
+    driver = FakeRoutingDriver({"FROM pg_stat_user_tables s ": []})
+    with pytest.raises(RedisFdwError, match="min_read_write_ratio"):
+        await recommend_redis_cache_targets(driver, min_read_write_ratio=0)  # type: ignore[arg-type]
+
+
+def test_recommendation_dataclass_shape() -> None:
+    rec = RedisCacheRecommendation(
+        schema="public",
+        table="users",
+        reads=10,
+        writes=1,
+        read_write_ratio=10.0,
+        estimated_row_count=100,
+        reason="small_hot_relation",
+        ready_to_run_sql="CREATE FOREIGN TABLE ...",
+    )
+    assert rec.reason == "small_hot_relation"


### PR DESCRIPTION
## Summary

Closes #118. Lands the full `redis_fdw` coverage scope: catalog filters, DDL helpers, cache-stats reporting, and the `recommend_redis_cache_targets` advisor — eight new tools in a new `cache_and_foreign_data` capability bucket.

### New tools (8)

| Tool | Surface | Purpose |
|---|---|---|
| `list_redis_foreign_servers` | read | Filters `pg_foreign_server` to the redis_fdw subset; reports address / port / TLS / `password_configured`. |
| `describe_redis_cache_table` | read | Surfaces key structure (`hash`/`list`/`string`/`set`/`zset`), key prefix, TTL, and column shape for one foreign table. |
| `get_redis_cache_stats` | read | Validates the server exists; reports `available=False` with a diagnostic note (redis_fdw doesn't ship uniform stats SQL). |
| `recommend_redis_cache_targets` | read advisor | Inspects `pg_stat_user_tables` for read-heavy, low-write relations; emits ready-to-run `CREATE FOREIGN TABLE` stubs. |
| `enable_redis_fdw` | DDL | Thin wrapper over `enable_extension('redis_fdw')` for surface discoverability. |
| `create_redis_cache_server` | DDL | `CREATE SERVER … OPTIONS (address, port, database, tls)`. |
| `create_redis_user_mapping` | DDL | `CREATE USER MAPPING` — resolves password through `MCPG_SECRETS_BACKEND`. |
| `create_redis_cache_table` | DDL | `CREATE FOREIGN TABLE … OPTIONS (tabletype, keyprefix, ttl)`. |

### Security posture

- **Identifier allowlist** on every DDL surface (server / table / user / column names) — the injection guard, since `CREATE SERVER` / `CREATE USER MAPPING` / `CREATE FOREIGN TABLE` DDL is built up of identifiers that can't be parameter-bound.
- **TLS-on by default**; refuses `tls=False` against non-loopback Redis hosts unless `allow_insecure_tls=True` is set explicitly. Mirrors the existing `MCPG_HTTP_TLS_*` enforcement story.
- **`create_redis_user_mapping` never accepts a raw password** — callers pass `secret_ref` (the name of a secret in `MCPG_SECRETS_BACKEND`) and the tool resolves it. Quote-escapes the value and rejects control characters before interpolating.

### Module + plumbing

- New `src/mcpg/redis_fdw.py` (~600 lines) — dataclasses, validators, read helpers, DDL helpers, advisor.
- `redis_fdw` added to `ENABLEABLE_EXTENSIONS` (the existing `enable_extension` allowlist).
- New `cache_and_foreign_data` capability bucket in `mcpg.about` so `describe_self` advertises the coverage cleanly. Every redis-prefixed tool mapped via `_TOOL_TO_BUCKET_OVERRIDES`.
- Snapshot regenerated; contract test passes.

### Tests

- 25 unit tests in `tests/unit/test_redis_fdw.py` covering catalog parsing, DDL shape, identifier + address + port + TLS validation, secret resolution + escaping, advisor threshold filtering + classifier output.
- Full unit + contract suite: 1930 tests pass locally.

## Test plan

- [x] `python -m pytest tests/unit/test_redis_fdw.py` — 25 / 25 pass
- [x] `python -m pytest tests/unit/ tests/contract/` — 1930 pass
- [x] `ruff check src/mcpg/redis_fdw.py` — clean
- [x] `mypy src/mcpg/redis_fdw.py` — clean
- [x] `bandit -r src/mcpg/redis_fdw.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Introduce Redis foreign-data-wrapper (redis_fdw) support with new cache and foreign data tools, catalog introspection, DDL helpers, and a read-heavy table cache advisor.

New Features:
- Add eight redis_fdw tools for listing Redis foreign servers, describing cache tables, fetching cache stats, recommending cache targets, enabling the extension, and creating servers, user mappings, and cache tables.
- Expose a new cache_and_foreign_data capability bucket so redis_fdw tools are discoverable via describe_self and capability routing.
- Provide a Redis cache advisor that inspects pg_stat_user_tables and emits ready-to-run CREATE FOREIGN TABLE stubs for suitable relations.

Enhancements:
- Register redis_fdw tools in the existing tool registry and capability routing, including cache-aware read and DDL registration.
- Extend the enableable extensions allowlist to include redis_fdw.

Documentation:
- Document redis_fdw cache-and-foreign-data coverage and security posture in the changelog, including TLS defaults and secrets-backed password handling.

Tests:
- Add a new unit test suite for mcpg.redis_fdw covering catalog parsing, DDL validation, secret resolution and escaping, TLS safeguards, and advisor heuristics.
- Update the contract tool surface snapshot to include the new redis_fdw tools.