### PR TITLE
feat(pg_prewarm): advisor + autowarm + add-tools skill — closes #119

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **`pg_prewarm` cache-warming coverage** (`mcpg.pg_prewarm`). Eight
+  new tools: `get_prewarm_extension_status`,
+  `list_prewarmed_relations`, `recommend_prewarm_targets`,
+  `prewarm_relation`, `prewarm_recommended`, `schedule_autowarm`,
+  `unschedule_autowarm`, `list_autowarm_jobs`.
+
+  The headline advisor — `recommend_prewarm_targets` — inspects
+  `pg_stat_user_tables` + `pg_statio_user_tables` for relations whose
+  first-query latency would benefit from pg_prewarm. Caps the cumulative
+  cost at `shared_buffers_budget_pct` * `shared_buffers` (default 60%)
+  so the recommendation never silently exceeds the buffer pool. Ranks
+  candidates by miss-volume descending and emits stable reason codes
+  (`seq_scan_dominant` / `high_cold_miss_rate` /
+  `small_hot_relation_uncached` / `index_in_critical_path`) plus a
+  ready-to-run `SELECT pg_prewarm(...)` stub per row.
+
+  `schedule_autowarm` / `unschedule_autowarm` drive a pg_cron-backed
+  "warm after restart" loop — the canonical missing piece for DBAs
+  running clusters with frequent restarts.
+
+  `pg_prewarm` added to `ENABLEABLE_EXTENSIONS`. New `cache_warming`
+  capability bucket in `mcpg.about`. Closes #119.
+
+- **Contributing playbook for new tools**
+  (`docs/contributing/adding-tools.md`). Captures the consistent
+  end-to-end shape every new MCPg capability follows: module layout,
+  identifier validation, tool registration, description conventions
+  (the "Returns ..." sentence), naming conventions, capability bucket
+  overrides, test patterns, snapshot regen, quality gates, commit
+  cadence. Also installed as a `mcpg-add-tool` Claude Code skill.
+
 - **`redis_fdw` cache-and-foreign-data coverage** (`mcpg.redis_fdw`).
   Eight new tools across read + DDL surfaces:
   `list_redis_foreign_servers`, `describe_redis_cache_table`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,19 @@ uv run mypy src/mcpg       # type-check
 
 Install the git hooks once: `uv run pre-commit install`.
 
+## Adding new tools / capabilities
+
+The canonical playbook for adding a new MCPg capability — module layout, naming
+conventions, validation patterns, tool registration, capability bucket, tests,
+snapshot regen, commit cadence — lives in
+[`docs/contributing/adding-tools.md`](docs/contributing/adding-tools.md). Read
+it before opening a PR that touches `src/mcpg/tools.py` or adds a new module
+under `src/mcpg/`.
+
+Claude Code users: the same playbook is installed as a `mcpg-add-tool` skill
+and auto-triggers when you ask to add a new tool or expose a new extension's
+surface.
+
 ## Test-Driven Development
 
 MCPg is a TDD project. For all **authored** code:

--- a/docs/contributing/adding-tools.md
+++ b/docs/contributing/adding-tools.md
@@ -1,0 +1,455 @@
+# Adding a new tool / capability to MCPg
+
+Every new capability in MCPg follows the same shape. Don't reinvent — this guide documents the conventions so the surface stays uniform for LLM agents and the codebase stays readable. Follow each section in order.
+
+> Claude Code users: this playbook is also installed as a [`mcpg-add-tool`](../../) skill at `~/.claude/skills/mcpg-add-tool/SKILL.md`. The skill auto-triggers when the user asks to add a new tool or expose a new extension's surface, and reads the same content as this file.
+
+## 0. Branch and commit cadence
+
+- Branch off `main`: `git checkout -b claude/<feature>-coverage`.
+- **Commit and push after every logical slice** — module, tool registrations, bucket, tests, snapshot regen, changelog. The prior context-loss incident was caused by trying to land a 5-batch refactor in one shot. Smaller commits survive context resets.
+- Run the full lint / type / test gate before every commit.
+
+## 1. Module layout — `src/mcpg/<feature>.py`
+
+Pattern from `src/mcpg/redis_fdw.py`, `src/mcpg/pg_prewarm.py`, `src/mcpg/cron.py`:
+
+```python
+"""<Feature> coverage — <one-line summary of read/write/advisor surface>.
+
+<2-4 paragraph context: what the feature is, why operators reach for it,
+what gap MCPg fills. End with a 'Security posture' block if the feature
+is DDL-touching or credentials-touching.>
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from mcpg._vendor.sql import SqlDriver
+from mcpg.extensions import extension_installed
+
+# Module-level constants (mode allowlists, defaults). Inline so the
+# tool descriptions and the validator share the same source of truth.
+_VALID_MODES = frozenset({"a", "b"})
+_DEFAULT_LIMIT = 20
+
+
+class <Feature>Error(Exception):
+    """Raised when a <feature> operation cannot complete."""
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses — one per return shape. ALL frozen=True, slots=True.
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True, slots=True)
+class <Thing>:
+    """Short docstring explaining the shape."""
+    field_a: str
+    field_b: int | None
+    items: list[dict[str, str]] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Read helpers — return dataclasses; deterministic fallback when feature absent.
+# ---------------------------------------------------------------------------
+
+async def list_<thing>(driver: SqlDriver) -> list[<Thing>]:
+    if not await extension_installed(driver, "<extension_name>"):
+        return []
+    rows = await driver.execute_query("SELECT ... FROM ...", force_readonly=True)
+    return [<Thing>(field_a=row.cells["a"], ...) for row in rows or []]
+
+
+# ---------------------------------------------------------------------------
+# DDL/write helpers — validate identifiers, then parameter-bind.
+# ---------------------------------------------------------------------------
+
+def _validate_identifier(label: str, value: str) -> str:
+    if not _IDENT_RE.match(value):
+        raise <Feature>Error(f"{label} {value!r} is not a valid unquoted SQL identifier")
+    return value
+
+async def create_<thing>(driver: SqlDriver, *, name: str, ...) -> CreateResult:
+    _validate_identifier("name", name)
+    if not await extension_installed(driver, "<extension_name>"):
+        raise <Feature>Error("<extension> is not installed; call enable_extension('<extension>') first")
+    await driver.execute_query(
+        f'CREATE ... "{name}" ...',
+        force_readonly=False,
+    )
+    return CreateResult(name=name, ..., created=True)
+
+
+# ---------------------------------------------------------------------------
+# Advisor (when applicable) — read-only; sorts by impact; respects budget.
+# ---------------------------------------------------------------------------
+
+async def recommend_<thing>(
+    driver: SqlDriver,
+    *,
+    limit: int = _DEFAULT_LIMIT,
+    budget_pct: float = 60.0,
+) -> RecommendResult:
+    ...
+
+
+__all__ = [
+    "<Feature>Error",
+    "<Thing>",
+    "list_<thing>",
+    "create_<thing>",
+    "recommend_<thing>",
+]
+```
+
+### Rules
+
+- **Every public return shape is a `@dataclass(frozen=True, slots=True)`** — never raw dicts. The tool layer calls `asdict()` on the dataclass to produce the MCP response.
+- **Reads return empty + are silent when the extension is absent**; writes raise a descriptive `<Feature>Error` saying to call `enable_extension('<name>')` first.
+- **Parameter-bind every value** (`%s` placeholders). Where an identifier can't be bound (e.g. `CREATE SERVER name`, `CREATE EXTENSION name`), validate against an allowlist or `^[A-Za-z_][A-Za-z0-9_]*$` regex first — that's the injection guard.
+- **Never f-string a value into a SQL string** unless you've already validated against an allowlist. bandit B608 will flag it; the validator at the boundary is the answer.
+- **Secrets are always indirection**: write tools that need a password / token take a `secret_ref` arg and resolve it through `mcpg.secrets.build_secrets_provider(env)`. Never accept the raw value at the tool boundary.
+
+## 2. Identifier / SQL-injection patterns
+
+Where a value can be bound: use `%s`.
+
+Where it can't (DDL identifier slots):
+- Validate against `_IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")` for names.
+- Validate against `frozenset({"a", "b", ...})` for enum-like fields (modes, key types, etc).
+- For string options inside `OPTIONS (...)`: reject `'`, `"`, `;`, `\`, `\n`, `\r` at the boundary, then double-escape `'` -> `''`.
+- For schema-filter parameters that can be NULL: use `(%s::text IS NULL OR n.nspname = %s)` not f-string concatenation. Keeps bandit happy.
+
+## 3. Tool registration — `src/mcpg/tools.py`
+
+### Import the module
+
+Add to the alphabetical import block at the top of `src/mcpg/tools.py`:
+
+```python
+from mcpg import (
+    ...,
+    <feature>,
+    ...,
+)
+```
+
+### Add `_register_*` functions
+
+Two or three functions per feature:
+- `_register_<feature>_reads(server)` — registered under `Capability.READ`.
+- `_register_<feature>_writes(server)` — registered under `Capability.WRITE`.
+- `_register_<feature>_ddl(server)` — registered under `Capability.DDL` + `settings.allow_ddl`.
+
+### Tool decoration shape
+
+```python
+@server.tool(
+    name="list_<thing>",
+    description=_with_example(
+        "<One-paragraph description of what the tool does. End with: "
+        "Returns a list of objects with `field_a` (description), `field_b` (description), ...>",
+        "list_<thing>(arg='value')",
+    ),
+)
+async def list_<thing>(ctx: _Ctx, arg: str) -> list[dict[str, Any]]:
+    async def _run() -> list[dict[str, Any]]:
+        items = await <feature>.list_<thing>(_driver(ctx), arg)
+        return [asdict(i) for i in items]
+    return await _cached_call(ctx, "list_<thing>", _run, arg)
+```
+
+Write/DDL tools clear the cache after running:
+
+```python
+@server.tool(name="create_<thing>", description=_with_example("...", "..."))
+async def create_<thing>(ctx: _Ctx, name: str, ...) -> dict[str, Any]:
+    result = await <feature>.create_<thing>(_driver(ctx), name=name, ...)
+    await ctx.request_context.lifespan_context.cache.clear()
+    return asdict(result)
+```
+
+### Wire into the dispatch block at the bottom of `tools.py`
+
+```python
+if is_permitted(settings.access_mode, Capability.READ):
+    ...
+    _register_<feature>_reads(server)
+if is_permitted(settings.access_mode, Capability.WRITE):
+    ...
+    _register_<feature>_writes(server)
+if is_permitted(settings.access_mode, Capability.DDL) and settings.allow_ddl:
+    ...
+    _register_<feature>_ddl(server)
+```
+
+## 4. Description conventions — the "Returns ..." sentence
+
+This is the headline fix from PR #121 (Phase A finding #2). Every tool description ends with a `Returns ...` sentence that lists the **actual** dataclass fields (not generic "an object").
+
+```
+Returns an object with `name`, `address`, `port`, `database`, `tls` (bool),
+`password_configured` (bool), and `options` (the full server-options dict).
+```
+
+For lists:
+
+```
+Returns a list of objects with `name` (the index name), `method`
+(btree / gin / gist / brin / hash / spgist / hnsw / ivfflat / …),
+`definition`, and `partitioned`.
+```
+
+For nested shapes, say so explicitly:
+
+```
+Returns an object with `candidates` — a list of objects with `schema`,
+`relation`, `reason` (one of `read_only_lookup_table` / `small_hot_relation` /
+`read_heavy_low_write` / `moderate_read_dominant`), and `ready_to_run_sql`.
+```
+
+### Why this matters
+
+The Phase B LLM observation harness measured how often Claude correctly inferred return shape from description. Tools without the Returns sentence had hit rates ~40% lower than tools with it. The sentence is the single biggest lever on agent reliability.
+
+## 5. Naming conventions
+
+| Pattern | Use for | Examples |
+|---|---|---|
+| `list_<thing>` | Catalog enumeration | `list_redis_foreign_servers`, `list_prewarmed_relations`, `list_indexes` |
+| `describe_<thing>` | Single-object detail | `describe_redis_cache_table`, `describe_table` |
+| `get_<thing>` | One-shot status / metric | `get_prewarm_extension_status`, `get_server_info` |
+| `recommend_<thing>` | Advisor output | `recommend_redis_cache_targets`, `recommend_prewarm_targets`, `recommend_indexes` |
+| `analyze_<thing>` | Analytical computation | `analyze_query_plan`, `analyze_reranker_lift` |
+| `enable_<extension>` | Wrap CREATE EXTENSION | `enable_redis_fdw` |
+| `create_<thing>` | DDL writes | `create_redis_cache_server`, `create_hypertable` |
+| `schedule_<thing>` / `unschedule_<thing>` | pg_cron registration pairs | `schedule_autowarm`, `schedule_cron_job` |
+| `prewarm_<thing>` / `dump_<thing>` | Action verbs | `prewarm_relation`, `dump_database` |
+
+Avoid generic verbs like `do_*`, `process_*`, `handle_*` — they don't help an LLM pick. Prefer specific verbs tied to the operation.
+
+snake_case everywhere. No leading underscores on tool names (they're public API).
+
+## 6. Capability bucket — `src/mcpg/about.py`
+
+If the feature is a distinct operational area, add a new `Capability(...)` entry in the `CAPABILITIES` tuple. Otherwise map the new tools into an existing bucket via `_TOOL_TO_BUCKET_OVERRIDES`.
+
+### New bucket pattern
+
+```python
+Capability(
+    id="<bucket_id>",                          # snake_case, stable forever
+    name="<Display name>",                     # title case
+    summary=(
+        "<One sentence (≤140 chars), agent-friendly summary of what the "
+        "bucket covers.>"
+    ),
+    detail=(
+        "<2-3 sentences with concrete tool names called out. This is what "
+        "an LLM sees when it expands the bucket.>"
+    ),
+    headline_tools=(
+        "<the 3-6 tools an agent should reach for first>",
+    ),
+),
+```
+
+### Override every new tool name
+
+Even if the tool name *would* be classified by a `_TOOL_TO_BUCKET_PATTERNS` regex, add an explicit override row in `_TOOL_TO_BUCKET_OVERRIDES`. This makes the mapping audit-friendly and prevents pattern-match drift.
+
+```python
+_TOOL_TO_BUCKET_OVERRIDES: dict[str, str] = {
+    ...
+    "list_<thing>": "<bucket_id>",
+    "describe_<thing>": "<bucket_id>",
+    "recommend_<thing>": "<bucket_id>",
+    "create_<thing>": "<bucket_id>",
+    ...
+}
+```
+
+The contract test `tests/unit/test_about.py::test_every_registered_tool_classifies_into_a_bucket` will fail loudly if you miss one.
+
+## 7. Tests — `tests/unit/test_<feature>.py`
+
+Use `FakeRoutingDriver({substring: rows})` from `tests/unit/_fakes.py`. Pattern:
+
+```python
+"""Tests for the <feature> coverage module."""
+
+from __future__ import annotations
+
+import pytest
+from _fakes import FakeRoutingDriver
+
+from mcpg.<feature> import (
+    <Feature>Error,
+    <Thing>,
+    list_<thing>,
+    create_<thing>,
+    recommend_<thing>,
+)
+
+
+async def test_list_returns_empty_when_extension_absent() -> None:
+    driver = FakeRoutingDriver({"FROM pg_extension WHERE extname": []})
+    assert await list_<thing>(driver) == []  # type: ignore[arg-type]
+
+
+async def test_list_parses_rows() -> None:
+    driver = FakeRoutingDriver({
+        "FROM pg_extension WHERE extname": [{"present": 1}],
+        "FROM <main_table>": [{"name": "a", ...}],
+    })
+    result = await list_<thing>(driver)  # type: ignore[arg-type]
+    assert result == [<Thing>(name="a", ...)]
+
+
+async def test_create_emits_expected_ddl() -> None:
+    driver = FakeRoutingDriver({"FROM pg_extension WHERE extname": [{"present": 1}]})
+    await create_<thing>(driver, name="x", ...)  # type: ignore[arg-type]
+    queries = " | ".join(call[0] for call in driver.calls)
+    assert 'CREATE ... "x"' in queries
+
+
+async def test_create_rejects_bad_identifier() -> None:
+    driver = FakeRoutingDriver({"FROM pg_extension WHERE extname": [{"present": 1}]})
+    with pytest.raises(<Feature>Error, match="identifier"):
+        await create_<thing>(driver, name="bad; DROP")  # type: ignore[arg-type]
+
+
+async def test_recommend_classifies_correctly() -> None:
+    # One row per classifier branch — verify each `reason` code is emitted.
+    ...
+```
+
+### Coverage targets
+
+For every public function:
+- **Happy path** — happy input, expected output.
+- **Extension-absent path** — confirms graceful fallback (empty list for reads, error for writes).
+- **Validation rejection** — confirms each `<Feature>Error` raise path.
+- **Edge cases** — empty input, zero-size relation (div-by-zero), boundary values.
+
+For every advisor:
+- **All classifier branches** — one input row that exercises each `reason` code.
+- **Budget / threshold enforcement** — confirm filtering boundaries.
+- **Sort order** — confirm the documented ranking.
+
+For every DDL helper:
+- **SQL shape** — assert specific substrings in `driver.calls`.
+- **Injection guard** — confirm `'`, `"`, `;`, etc are rejected.
+- **Idempotency** — `IF NOT EXISTS` / parameterized re-run safe.
+
+Aim for 20-30 tests per medium-sized module (redis_fdw shipped 25, pg_prewarm shipped 24).
+
+`# type: ignore[arg-type]` after passing a fake driver is the existing convention — mypy doesn't follow our SqlDriver protocol perfectly, but mypy runs only on `src/mcpg` in CI so the unused-ignore warnings on tests don't gate anything.
+
+## 8. Snapshot regen + contract test
+
+After registering tools, regenerate the snapshot:
+
+```bash
+MCPG_REGENERATE_TOOL_SNAPSHOT=1 python -m pytest tests/contract/test_tool_surface_snapshot.py
+```
+
+Then run the contract test without regen to confirm a clean diff:
+
+```bash
+python -m pytest tests/contract/ tests/unit/test_about.py
+```
+
+If `test_tool_surface_matches_snapshot` fails after a Gemini review suggestion edited `src/mcpg/tools.py`, regenerate again — the pattern from PR #121.
+
+## 9. Quality gate before every commit
+
+```bash
+source .venv/bin/activate
+ruff check src/mcpg/<feature>.py tests/unit/test_<feature>.py
+ruff format src/mcpg/<feature>.py tests/unit/test_<feature>.py
+mypy src/mcpg/<feature>.py
+bandit -q -r src/mcpg/<feature>.py
+python -m pytest tests/unit/test_<feature>.py tests/contract/
+```
+
+All five must be green. Bandit medium+ findings are blockers — the redis_fdw branch tripped on `0.0.0.0` in a loopback-host set (B104) and on a schema-filter f-string (B608); both were quickly fixed at validation boundaries.
+
+## 10. CHANGELOG.md
+
+Add a feature entry under `## [Unreleased]`:
+
+```markdown
+### Added
+
+- **`<feature>` coverage** (`mcpg.<feature>`). N new tools across read +
+  write surfaces: `list_<thing>`, `describe_<thing>`, ...
+
+  <Paragraph on the headline advisor / why this matters.>
+
+  Security posture:
+  - <validation guard>
+  - <credential plumbing>
+
+  New `<bucket_id>` capability bucket in `mcpg.about` so `describe_self`
+  advertises the coverage cleanly. `<extension>` added to
+  `ENABLEABLE_EXTENSIONS`. Closes #N.
+```
+
+## 11. PR body shape
+
+Markdown structure that has reviewed cleanly:
+
+```
+## Summary
+
+Closes #N. <One-sentence description.>
+
+### New tools (N)
+
+<table | bullet list with surface column + purpose>
+
+### Security posture
+
+- <bullet per guard>
+
+### Module + plumbing
+
+- New `src/mcpg/<feature>.py` (~N lines) — <breakdown>.
+- <extension> added to `ENABLEABLE_EXTENSIONS`.
+- New `<bucket_id>` capability bucket in `mcpg.about`; every tool mapped via `_TOOL_TO_BUCKET_OVERRIDES`.
+- Snapshot regenerated; contract test passes.
+
+### Tests
+
+- N unit tests in `tests/unit/test_<feature>.py` covering ...
+- Full unit + contract suite: <N> tests pass locally.
+
+## Test plan
+
+- [x] `python -m pytest tests/unit/test_<feature>.py` — N / N pass
+- [x] `python -m pytest tests/unit/ tests/contract/` — <total> pass
+- [x] `ruff check` / `mypy` / `bandit` — clean
+```
+
+## 12. Recurring gotchas
+
+- **Snapshot drift after Gemini review**: Gemini suggestions touch tool descriptions directly via GitHub UI, which desyncs the snapshot. Pull the branch, run snapshot regen, push the diff.
+- **Cron job names need a `mcpg_` prefix**: so `list_autowarm_jobs` / similar can filter them deterministically.
+- **`pg_cron` returns booleans as `True`/`False` not 1/0**: use `bool(rows[0].cells["removed"])` not `rows[0].cells["removed"] == 1`.
+- **`pg_buffercache` joins use `pg_relation_filenode(c.oid)` not `c.relfilenode`** — the latter is 0 for partitioned parents.
+- **`shared_buffers` is human-readable** (`"128MB"`) — convert via `pg_size_bytes(current_setting('shared_buffers')) / current_setting('block_size')::int`.
+- **`extension_installed()` is a single round-trip** — call it once per function, not in a loop.
+
+## 13. Cross-references
+
+- Real-world worked examples to copy from:
+  - `src/mcpg/redis_fdw.py` + `tests/unit/test_redis_fdw.py` (PR #122) — FDW + DDL + advisor + secrets backend
+  - `src/mcpg/pg_prewarm.py` + `tests/unit/test_pg_prewarm.py` (PR pending) — extension status + buffer reads + advisor + cron scheduler
+  - `src/mcpg/cron.py` + `tests/unit/test_cron.py` — pg_cron pattern, write tools
+  - `src/mcpg/extensions.py` — allowlist guard for `CREATE EXTENSION`
+  - `src/mcpg/about.py` — capability buckets + overrides
+- Style: `CONTRIBUTING.md`
+- Phase A static analyser (helps spot tools whose descriptions still need a Returns sentence): `tools/static_tool_facts.py`

--- a/src/mcpg/about.py
+++ b/src/mcpg/about.py
@@ -314,6 +314,33 @@ CAPABILITIES: tuple[Capability, ...] = (
         ),
     ),
     Capability(
+        id="cache_warming",
+        name="Cache warming and pg_prewarm",
+        summary=(
+            "Inspect shared-buffer residency, recommend prewarm targets "
+            "against a shared_buffers budget, and schedule pg_cron-backed "
+            "autowarm jobs."
+        ),
+        detail=(
+            "`get_prewarm_extension_status` reports whether ``pg_prewarm`` "
+            "and ``pg_buffercache`` are installed and whether pg_prewarm is "
+            "registered in shared_preload_libraries. `list_prewarmed_relations` "
+            "surfaces current shared-buffer residency. The headline advisor "
+            "`recommend_prewarm_targets` ranks relations by miss-volume and "
+            "caps the cumulative cost at a shared_buffers budget. Pair with "
+            "`prewarm_recommended` to act on its output. "
+            "`schedule_autowarm` / `unschedule_autowarm` / `list_autowarm_jobs` "
+            "drive a pg_cron-backed loop for the 'warm after restart' pattern."
+        ),
+        headline_tools=(
+            "recommend_prewarm_targets",
+            "prewarm_recommended",
+            "list_prewarmed_relations",
+            "schedule_autowarm",
+            "get_prewarm_extension_status",
+        ),
+    ),
+    Capability(
         id="diagrams_and_codegen",
         name="Diagrams and ORM codegen",
         summary=(
@@ -570,7 +597,7 @@ _TOOL_TO_BUCKET_OVERRIDES: dict[str, str] = {
     "compare_schemas": "schema_introspection",
     "summarize_table": "schema_introspection",
     "get_compact_schema": "schema_introspection",
-    # redis_fdw — every redis-prefixed surface is the new cache bucket.
+    # redis_fdw — every redis-prefixed surface is the cache_and_foreign_data bucket.
     "list_redis_foreign_servers": "cache_and_foreign_data",
     "describe_redis_cache_table": "cache_and_foreign_data",
     "get_redis_cache_stats": "cache_and_foreign_data",
@@ -579,6 +606,15 @@ _TOOL_TO_BUCKET_OVERRIDES: dict[str, str] = {
     "create_redis_cache_server": "cache_and_foreign_data",
     "create_redis_user_mapping": "cache_and_foreign_data",
     "create_redis_cache_table": "cache_and_foreign_data",
+    # pg_prewarm — every prewarm / autowarm surface is the cache_warming bucket.
+    "get_prewarm_extension_status": "cache_warming",
+    "list_prewarmed_relations": "cache_warming",
+    "recommend_prewarm_targets": "cache_warming",
+    "prewarm_relation": "cache_warming",
+    "prewarm_recommended": "cache_warming",
+    "schedule_autowarm": "cache_warming",
+    "unschedule_autowarm": "cache_warming",
+    "list_autowarm_jobs": "cache_warming",
 }
 
 

--- a/src/mcpg/extensions.py
+++ b/src/mcpg/extensions.py
@@ -40,6 +40,7 @@ ENABLEABLE_EXTENSIONS = frozenset(
         "pg_cron",
         "pg_partman",
         "pg_buffercache",
+        "pg_prewarm",
         "pg_walinspect",
         "pg_turboquant",
         "pg_search",

--- a/src/mcpg/pg_prewarm.py
+++ b/src/mcpg/pg_prewarm.py
@@ -1,0 +1,688 @@
+"""``pg_prewarm`` coverage — extension status, buffer-cache reads, advisor, autowarm.
+
+``pg_prewarm`` is a contrib extension that loads relation pages into shared
+buffers / OS page cache *before* they are queried, so the first query
+doesn't pay the cold-cache penalty. It's a well-known operational tool
+that is genuinely under-used because:
+
+1. Operators don't always know *which* tables would benefit most.
+2. The "do this every restart" loop is manual — there is no shipped
+   autowarm policy.
+
+This module collapses both gaps into the MCPg tool surface:
+
+* Read tools — buffer-cache residency (``pg_buffercache`` join) and
+  extension status (presence + ``shared_preload_libraries`` hint).
+* Advisor — ``recommend_prewarm_targets`` scores tables by cold-miss
+  rate, sequential-scan ratio, and current shared-buffer residency,
+  respects a ``shared_buffers_budget_pct`` cap, and emits ready-to-run
+  ``SELECT pg_prewarm(...)`` statements.
+* Write tools — single-relation invocation, bulk "apply recommended"
+  with budget enforcement.
+* Autowarm scheduler — a pg_cron job that calls the bulk advisor at a
+  chosen cadence.
+
+The whole module is opt-in via ``pg_prewarm`` (and, for residency
+visibility, ``pg_buffercache``) being installed. Every helper degrades
+to a deterministic "not available" result rather than raising when the
+extension is missing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from mcpg._vendor.sql import SqlDriver
+from mcpg.extensions import extension_installed
+
+# pg_prewarm modes (matches the upstream signature: pg_prewarm(regclass,
+# mode text, fork text, first_block, last_block)). We don't expose ``fork``
+# / block-range tuning at the tool surface — the common case is "warm the
+# whole main fork" and operators who need range control are already past
+# the LLM-agent layer.
+_VALID_PREWARM_MODES = frozenset({"prefetch", "read", "buffer"})
+
+# Default safeguards for the advisor. Operators can lift them per call.
+_DEFAULT_BUDGET_PCT = 60.0
+_DEFAULT_MIN_HEAP_BLKS_READ = 1_000
+_DEFAULT_LIMIT = 20
+
+# The default autowarm job name. Picked so list_autowarm_jobs has a
+# stable substring to filter cron jobs on.
+_AUTOWARM_JOB_NAME = "mcpg_autowarm"
+
+
+class PrewarmError(Exception):
+    """Raised when a pg_prewarm operation cannot complete."""
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class PrewarmExtensionStatus:
+    """Whether the prewarm-related extensions are usable.
+
+    ``pg_prewarm`` is the headline; ``pg_buffercache`` is the
+    supporting cast — without it, residency visibility tools degrade
+    to "not available". ``autoprewarm_libraries_present`` reports
+    whether ``pg_prewarm`` is listed in ``shared_preload_libraries``
+    (the autoprewarm background worker requires it).
+    """
+
+    pg_prewarm_installed: bool
+    pg_buffercache_installed: bool
+    autoprewarm_libraries_present: bool
+    shared_preload_libraries: str
+
+
+@dataclass(frozen=True, slots=True)
+class PrewarmedRelation:
+    """Current shared-buffer residency for one relation.
+
+    ``blocks_cached`` is the number of 8 KiB blocks of this relation
+    currently in shared buffers; ``total_blocks`` is its on-disk size
+    in the same unit. ``pct_cached`` is the convenient ratio.
+    """
+
+    schema: str
+    table: str
+    blocks_cached: int
+    total_blocks: int
+    pct_cached: float
+    dirty_blocks: int
+
+
+@dataclass(frozen=True, slots=True)
+class PrewarmRecommendation:
+    """One advisor recommendation.
+
+    ``reason`` is one of:
+
+    * ``high_cold_miss_rate`` — heap_blks_read >> heap_blks_hit.
+    * ``small_hot_relation_uncached`` — small table, hot in stats but
+      cold in shared buffers.
+    * ``seq_scan_dominant`` — significant seq_scan with low cache
+      residency.
+    * ``index_in_critical_path`` — index whose blocks are missed often.
+
+    ``prewarm_mode`` is ``buffer`` (shared buffers) / ``prefetch`` (OS
+    page cache) / ``read`` (blocking read). ``estimated_buffer_cost``
+    is in 8 KiB blocks against ``shared_buffers``.
+    """
+
+    schema: str
+    relation: str
+    reason: str
+    prewarm_mode: str
+    estimated_buffer_cost: int
+    heap_blks_read: int
+    heap_blks_hit: int
+    cache_miss_ratio: float
+    ready_to_run_sql: str
+
+
+@dataclass(frozen=True, slots=True)
+class RecommendPrewarmTargetsResult:
+    """Advisor output rolled up with the budget context.
+
+    ``shared_buffers_blocks`` is the configured ``shared_buffers`` in
+    8 KiB pages. ``budget_blocks`` is the cap derived from
+    ``shared_buffers_budget_pct``. ``total_cost_blocks`` sums the
+    recommendations actually returned (after the cap was applied).
+    """
+
+    shared_buffers_blocks: int
+    budget_blocks: int
+    total_cost_blocks: int
+    candidates: list[PrewarmRecommendation] = field(default_factory=list)
+
+
+@dataclass(frozen=True, slots=True)
+class PrewarmResult:
+    """The outcome of a single ``pg_prewarm(...)`` call."""
+
+    schema: str
+    relation: str
+    mode: str
+    blocks_prewarmed: int
+
+
+@dataclass(frozen=True, slots=True)
+class BulkPrewarmOutcome:
+    """One row in :class:`BulkPrewarmResult`."""
+
+    schema: str
+    relation: str
+    mode: str
+    blocks_prewarmed: int
+    error: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class BulkPrewarmResult:
+    """Result of ``prewarm_recommended``."""
+
+    dry_run: bool
+    total_blocks: int
+    outcomes: list[BulkPrewarmOutcome] = field(default_factory=list)
+
+
+@dataclass(frozen=True, slots=True)
+class AutowarmJob:
+    """A pg_cron job MCPg owns for autowarm."""
+
+    jobid: int
+    jobname: str
+    schedule: str
+    command: str
+
+
+@dataclass(frozen=True, slots=True)
+class ScheduleAutowarmResult:
+    """Outcome of registering an autowarm cron job."""
+
+    jobid: int
+    name: str
+    schedule: str
+
+
+@dataclass(frozen=True, slots=True)
+class UnscheduleAutowarmResult:
+    """Outcome of removing an autowarm cron job."""
+
+    name: str
+    removed: bool
+
+
+# ---------------------------------------------------------------------------
+# Status helpers
+# ---------------------------------------------------------------------------
+
+
+async def get_prewarm_extension_status(driver: SqlDriver) -> PrewarmExtensionStatus:
+    """Report whether ``pg_prewarm`` (+ optional ``pg_buffercache``) are usable.
+
+    Also surfaces the current ``shared_preload_libraries`` setting so
+    operators can spot the missing autoprewarm worker registration in
+    one glance.
+    """
+    has_prewarm = await extension_installed(driver, "pg_prewarm")
+    has_buffercache = await extension_installed(driver, "pg_buffercache")
+    rows = await driver.execute_query(
+        "SELECT current_setting('shared_preload_libraries', true) AS spl",
+        force_readonly=True,
+    )
+    spl = (rows[0].cells.get("spl") if rows else None) or ""
+    libs = [piece.strip() for piece in spl.split(",") if piece.strip()]
+    return PrewarmExtensionStatus(
+        pg_prewarm_installed=has_prewarm,
+        pg_buffercache_installed=has_buffercache,
+        autoprewarm_libraries_present="pg_prewarm" in libs,
+        shared_preload_libraries=spl,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Buffer-cache residency reads
+# ---------------------------------------------------------------------------
+
+
+async def list_prewarmed_relations(
+    driver: SqlDriver,
+    *,
+    schema: str | None = None,
+    limit: int = 100,
+) -> list[PrewarmedRelation]:
+    """Report current shared-buffer residency per relation.
+
+    Requires ``pg_buffercache``. Returns an empty list when the extension
+    is missing (deterministic for callers — they treat absence as "no
+    visibility" rather than a hard error).
+
+    ``limit`` defends against very wide databases — a 10k-relation join
+    against ``pg_buffercache`` is cheap but ranking the top-N is what
+    operators typically want.
+    """
+    if not await extension_installed(driver, "pg_buffercache"):
+        return []
+    if limit <= 0:
+        raise PrewarmError("limit must be positive")
+    # Pass schema as a bound parameter; NULL means "no schema filter".
+    # Using `(%s::text IS NULL OR n.nspname = %s)` keeps the SQL static
+    # (no string interpolation) so bandit B608 isn't tripped.
+    rows = await driver.execute_query(
+        "SELECT n.nspname AS schema, c.relname AS table_name, "
+        "  count(*) FILTER (WHERE b.relfilenode IS NOT NULL) AS blocks_cached, "
+        "  count(*) FILTER (WHERE b.isdirty) AS dirty_blocks, "
+        "  pg_relation_size(c.oid) / current_setting('block_size')::int AS total_blocks "
+        "FROM pg_class c "
+        "JOIN pg_namespace n ON n.oid = c.relnamespace "
+        "LEFT JOIN pg_buffercache b ON b.relfilenode = pg_relation_filenode(c.oid) "
+        "WHERE c.relkind IN ('r', 'p') "
+        "  AND n.nspname NOT IN ('pg_catalog', 'information_schema') "
+        "  AND (%s::text IS NULL OR n.nspname = %s) "
+        "GROUP BY n.nspname, c.relname, c.oid "
+        "HAVING count(*) FILTER (WHERE b.relfilenode IS NOT NULL) > 0 "
+        "ORDER BY blocks_cached DESC "
+        "LIMIT %s",
+        params=[schema, schema, limit],
+        force_readonly=True,
+    )
+    results: list[PrewarmedRelation] = []
+    for row in rows or []:
+        cached = int(row.cells["blocks_cached"])
+        total = int(row.cells["total_blocks"] or 0)
+        pct = (100.0 * cached / total) if total > 0 else 0.0
+        results.append(
+            PrewarmedRelation(
+                schema=row.cells["schema"],
+                table=row.cells["table_name"],
+                blocks_cached=cached,
+                total_blocks=total,
+                pct_cached=round(pct, 2),
+                dirty_blocks=int(row.cells["dirty_blocks"]),
+            )
+        )
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Advisor — recommend_prewarm_targets
+# ---------------------------------------------------------------------------
+
+
+async def _shared_buffers_blocks(driver: SqlDriver) -> int:
+    """Return ``shared_buffers`` in 8 KiB blocks (the unit pg_prewarm uses).
+
+    ``current_setting('shared_buffers')`` returns a human-readable value
+    like ``"128MB"`` or ``"16384"``; ``pg_size_bytes`` normalises that
+    to bytes and we divide by ``block_size``.
+    """
+    rows = await driver.execute_query(
+        "SELECT pg_size_bytes(current_setting('shared_buffers')) /   current_setting('block_size')::int AS blocks",
+        force_readonly=True,
+    )
+    if not rows:
+        return 0
+    return int(rows[0].cells.get("blocks") or 0)
+
+
+def _classify_prewarm_reason(*, seq_scans: int, idx_scans: int, miss_ratio: float, est_blocks: int) -> str:
+    """Pick the stable reason code for one candidate."""
+    if seq_scans > idx_scans and miss_ratio >= 0.5:
+        return "seq_scan_dominant"
+    if miss_ratio >= 0.5:
+        return "high_cold_miss_rate"
+    if est_blocks <= 256:
+        return "small_hot_relation_uncached"
+    return "index_in_critical_path"
+
+
+def _prewarm_sql(schema: str, relation: str, mode: str) -> str:
+    """The ``SELECT pg_prewarm(...)`` statement for one relation."""
+    return f"SELECT pg_prewarm('{schema}.{relation}'::regclass, '{mode}');"
+
+
+async def recommend_prewarm_targets(
+    driver: SqlDriver,
+    *,
+    shared_buffers_budget_pct: float = _DEFAULT_BUDGET_PCT,
+    min_heap_blks_read: int = _DEFAULT_MIN_HEAP_BLKS_READ,
+    limit: int = _DEFAULT_LIMIT,
+    prewarm_mode: str = "buffer",
+) -> RecommendPrewarmTargetsResult:
+    """Recommend tables / indexes whose first-query latency would benefit from prewarm.
+
+    Heuristic (per relation):
+
+    1. From ``pg_statio_user_tables`` get ``heap_blks_read`` (cache
+       miss) and ``heap_blks_hit`` (cache hit). High miss-ratio relations
+       are good prewarm targets.
+    2. From ``pg_stat_user_tables`` get ``seq_scan`` vs ``idx_scan`` to
+       distinguish "sequential-scan dominant" from "index-scan critical
+       path" — the recommendation carries the right ``reason``.
+    3. From ``pg_class.reltuples`` * ``current_setting('block_size')``
+       compute the estimated cost in 8 KiB blocks. We sort recommendations
+       by descending miss-volume and stop adding once the cumulative cost
+       would exceed ``shared_buffers_budget_pct`` * ``shared_buffers``.
+
+    ``prewarm_mode`` propagates into the generated SQL stubs and the
+    recommendation rows.
+
+    The advisor is read-only — it never invokes ``pg_prewarm``. Pair
+    it with ``prewarm_recommended`` when you want to act on its output.
+    """
+    if prewarm_mode not in _VALID_PREWARM_MODES:
+        raise PrewarmError(f"prewarm_mode must be one of {sorted(_VALID_PREWARM_MODES)}, got {prewarm_mode!r}")
+    if shared_buffers_budget_pct <= 0 or shared_buffers_budget_pct > 100:
+        raise PrewarmError("shared_buffers_budget_pct must be in (0, 100]")
+    if min_heap_blks_read < 0:
+        raise PrewarmError("min_heap_blks_read must be non-negative")
+    if limit <= 0:
+        raise PrewarmError("limit must be positive")
+
+    sb_blocks = await _shared_buffers_blocks(driver)
+    budget_blocks = int(sb_blocks * shared_buffers_budget_pct / 100)
+
+    # The advisor relies only on the stats views — it never touches
+    # pg_buffercache, so it works even when buffercache isn't installed.
+    rows = await driver.execute_query(
+        "SELECT s.schemaname AS schema, s.relname AS relation, "
+        "  COALESCE(io.heap_blks_read, 0) AS heap_blks_read, "
+        "  COALESCE(io.heap_blks_hit, 0) AS heap_blks_hit, "
+        "  COALESCE(s.seq_scan, 0) AS seq_scans, "
+        "  COALESCE(s.idx_scan, 0) AS idx_scans, "
+        "  pg_relation_size(s.relid) / current_setting('block_size')::int AS est_blocks "
+        "FROM pg_stat_user_tables s "
+        "LEFT JOIN pg_statio_user_tables io ON io.relid = s.relid",
+        force_readonly=True,
+    )
+
+    raw: list[tuple[int, PrewarmRecommendation]] = []
+    for row in rows or []:
+        heap_read = int(row.cells["heap_blks_read"])
+        heap_hit = int(row.cells["heap_blks_hit"])
+        if heap_read < min_heap_blks_read:
+            continue
+        seq_scans = int(row.cells["seq_scans"])
+        idx_scans = int(row.cells["idx_scans"])
+        est_blocks = max(int(row.cells["est_blocks"] or 0), 1)
+        miss_ratio = heap_read / max(heap_read + heap_hit, 1)
+        reason = _classify_prewarm_reason(
+            seq_scans=seq_scans,
+            idx_scans=idx_scans,
+            miss_ratio=miss_ratio,
+            est_blocks=est_blocks,
+        )
+        schema = row.cells["schema"]
+        relation = row.cells["relation"]
+        rec = PrewarmRecommendation(
+            schema=schema,
+            relation=relation,
+            reason=reason,
+            prewarm_mode=prewarm_mode,
+            estimated_buffer_cost=est_blocks,
+            heap_blks_read=heap_read,
+            heap_blks_hit=heap_hit,
+            cache_miss_ratio=round(miss_ratio, 3),
+            ready_to_run_sql=_prewarm_sql(schema, relation, prewarm_mode),
+        )
+        raw.append((heap_read, rec))
+    # Rank by miss-volume descending (the bigger the absolute pain, the
+    # higher the payoff from prewarming).
+    raw.sort(key=lambda pair: -pair[0])
+
+    chosen: list[PrewarmRecommendation] = []
+    running = 0
+    for _, rec in raw:
+        if len(chosen) >= limit:
+            break
+        if budget_blocks > 0 and running + rec.estimated_buffer_cost > budget_blocks:
+            # Skip this candidate but keep checking — a smaller one
+            # might still fit. Honest cost reporting beats "everything
+            # fit silently".
+            continue
+        chosen.append(rec)
+        running += rec.estimated_buffer_cost
+    return RecommendPrewarmTargetsResult(
+        shared_buffers_blocks=sb_blocks,
+        budget_blocks=budget_blocks,
+        total_cost_blocks=running,
+        candidates=chosen,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Write helpers — pg_prewarm() invocation
+# ---------------------------------------------------------------------------
+
+
+def _validate_relation(schema: str, relation: str) -> None:
+    """Reject identifiers with characters that would break out of a literal."""
+    for label, value in (("schema", schema), ("relation", relation)):
+        if not value:
+            raise PrewarmError(f"{label} must be non-empty")
+        if any(ch in value for ch in "'\";\\\n\r"):
+            raise PrewarmError(f"{label} {value!r} contains characters that aren't allowed in a regclass literal")
+
+
+async def prewarm_relation(
+    driver: SqlDriver,
+    *,
+    schema: str,
+    relation: str,
+    mode: str = "buffer",
+) -> PrewarmResult:
+    """Run ``SELECT pg_prewarm('schema.relation'::regclass, mode);`` once."""
+    if mode not in _VALID_PREWARM_MODES:
+        raise PrewarmError(f"mode must be one of {sorted(_VALID_PREWARM_MODES)}, got {mode!r}")
+    _validate_relation(schema, relation)
+    if not await extension_installed(driver, "pg_prewarm"):
+        raise PrewarmError("pg_prewarm extension is not installed; call enable_extension('pg_prewarm') first")
+    rows = await driver.execute_query(
+        f"SELECT pg_prewarm('{schema}.{relation}'::regclass, '{mode}') AS blocks",
+        force_readonly=False,
+    )
+    blocks = int(rows[0].cells["blocks"]) if rows else 0
+    return PrewarmResult(schema=schema, relation=relation, mode=mode, blocks_prewarmed=blocks)
+
+
+async def prewarm_recommended(
+    driver: SqlDriver,
+    *,
+    shared_buffers_budget_pct: float = _DEFAULT_BUDGET_PCT,
+    min_heap_blks_read: int = _DEFAULT_MIN_HEAP_BLKS_READ,
+    limit: int = _DEFAULT_LIMIT,
+    prewarm_mode: str = "buffer",
+    dry_run: bool = False,
+) -> BulkPrewarmResult:
+    """Run ``recommend_prewarm_targets`` and prewarm every candidate.
+
+    ``dry_run=True`` reports what *would* be prewarmed without invoking
+    pg_prewarm. Errors per-relation are captured and reported in the
+    ``outcomes`` list so a single bad relation doesn't fail the whole
+    bulk pass.
+    """
+    if not dry_run and not await extension_installed(driver, "pg_prewarm"):
+        raise PrewarmError("pg_prewarm extension is not installed; call enable_extension('pg_prewarm') first")
+    recommendations = await recommend_prewarm_targets(
+        driver,
+        shared_buffers_budget_pct=shared_buffers_budget_pct,
+        min_heap_blks_read=min_heap_blks_read,
+        limit=limit,
+        prewarm_mode=prewarm_mode,
+    )
+    outcomes: list[BulkPrewarmOutcome] = []
+    total = 0
+    for rec in recommendations.candidates:
+        if dry_run:
+            outcomes.append(
+                BulkPrewarmOutcome(
+                    schema=rec.schema,
+                    relation=rec.relation,
+                    mode=rec.prewarm_mode,
+                    blocks_prewarmed=0,
+                    error=None,
+                )
+            )
+            continue
+        try:
+            result = await prewarm_relation(
+                driver,
+                schema=rec.schema,
+                relation=rec.relation,
+                mode=rec.prewarm_mode,
+            )
+        except Exception as exc:
+            outcomes.append(
+                BulkPrewarmOutcome(
+                    schema=rec.schema,
+                    relation=rec.relation,
+                    mode=rec.prewarm_mode,
+                    blocks_prewarmed=0,
+                    error=str(exc),
+                )
+            )
+            continue
+        outcomes.append(
+            BulkPrewarmOutcome(
+                schema=rec.schema,
+                relation=rec.relation,
+                mode=rec.prewarm_mode,
+                blocks_prewarmed=result.blocks_prewarmed,
+                error=None,
+            )
+        )
+        total += result.blocks_prewarmed
+    return BulkPrewarmResult(dry_run=dry_run, total_blocks=total, outcomes=outcomes)
+
+
+# ---------------------------------------------------------------------------
+# Autowarm — pg_cron-backed scheduler
+# ---------------------------------------------------------------------------
+
+
+def _validate_cron_schedule(schedule: str) -> str:
+    """Reject schedules with characters that would break out of the literal."""
+    if not schedule or not schedule.strip():
+        raise PrewarmError("schedule must be non-empty")
+    if any(ch in schedule for ch in "'\";\\\n\r"):
+        raise PrewarmError("schedule contains characters that aren't allowed in a cron expression")
+    return schedule.strip()
+
+
+def _autowarm_command(
+    *,
+    shared_buffers_budget_pct: float,
+    min_heap_blks_read: int,
+    limit: int,
+    prewarm_mode: str,
+) -> str:
+    """Build the SELECT statement the cron job will run.
+
+    We embed the parameters directly because pg_cron stores commands as
+    text and reads them later in a fresh session. The parameters have
+    already been validated (numeric / known-enum) so embedding is safe.
+    """
+    return (
+        "SELECT mcpg.prewarm_recommended_cron("
+        f"{float(shared_buffers_budget_pct)}, "
+        f"{int(min_heap_blks_read)}, "
+        f"{int(limit)}, "
+        f"'{prewarm_mode}');"
+    )
+
+
+async def schedule_autowarm(
+    driver: SqlDriver,
+    *,
+    name: str = _AUTOWARM_JOB_NAME,
+    schedule: str = "@reboot",
+    shared_buffers_budget_pct: float = _DEFAULT_BUDGET_PCT,
+    min_heap_blks_read: int = _DEFAULT_MIN_HEAP_BLKS_READ,
+    limit: int = _DEFAULT_LIMIT,
+    prewarm_mode: str = "buffer",
+) -> ScheduleAutowarmResult:
+    """Register a pg_cron job that calls the bulk-prewarm helper at ``schedule``.
+
+    ``schedule`` accepts a cron expression (``"0 4 * * *"``) or pg_cron
+    interval shortcut (``"@reboot"`` / ``"30 seconds"`` / etc.). The
+    default ``@reboot`` plus an operator-supplied daily refresh covers
+    the "warm after restart" + "warm again before traffic" pattern most
+    teams want.
+
+    The command embeds the budget / limit / mode arguments as numeric
+    literals — the receiver function must be installed separately
+    (operators paste the helper into their database; the standard
+    template is documented in ``docs/plans/pg-prewarm-advisor.md``).
+    """
+    if prewarm_mode not in _VALID_PREWARM_MODES:
+        raise PrewarmError(f"prewarm_mode must be one of {sorted(_VALID_PREWARM_MODES)}, got {prewarm_mode!r}")
+    if shared_buffers_budget_pct <= 0 or shared_buffers_budget_pct > 100:
+        raise PrewarmError("shared_buffers_budget_pct must be in (0, 100]")
+    if min_heap_blks_read < 0:
+        raise PrewarmError("min_heap_blks_read must be non-negative")
+    if limit <= 0:
+        raise PrewarmError("limit must be positive")
+    schedule = _validate_cron_schedule(schedule)
+    if not name or any(ch in name for ch in "'\";\\\n\r"):
+        raise PrewarmError("name must be a simple identifier")
+    if not await extension_installed(driver, "pg_cron"):
+        raise PrewarmError("pg_cron extension is not installed; install it before scheduling an autowarm job")
+    command = _autowarm_command(
+        shared_buffers_budget_pct=shared_buffers_budget_pct,
+        min_heap_blks_read=min_heap_blks_read,
+        limit=limit,
+        prewarm_mode=prewarm_mode,
+    )
+    rows = await driver.execute_query(
+        "SELECT cron.schedule(%s, %s, %s) AS jobid",
+        params=[name, schedule, command],
+        force_readonly=False,
+    )
+    jobid = int(rows[0].cells["jobid"]) if rows else 0
+    return ScheduleAutowarmResult(jobid=jobid, name=name, schedule=schedule)
+
+
+async def unschedule_autowarm(
+    driver: SqlDriver,
+    *,
+    name: str = _AUTOWARM_JOB_NAME,
+) -> UnscheduleAutowarmResult:
+    """Remove the autowarm pg_cron job by name (idempotent)."""
+    if not name or any(ch in name for ch in "'\";\\\n\r"):
+        raise PrewarmError("name must be a simple identifier")
+    if not await extension_installed(driver, "pg_cron"):
+        return UnscheduleAutowarmResult(name=name, removed=False)
+    rows = await driver.execute_query(
+        "SELECT cron.unschedule(%s) AS removed",
+        params=[name],
+        force_readonly=False,
+    )
+    removed = bool(rows[0].cells["removed"]) if rows else False
+    return UnscheduleAutowarmResult(name=name, removed=removed)
+
+
+async def list_autowarm_jobs(driver: SqlDriver) -> list[AutowarmJob]:
+    """List the pg_cron jobs whose name starts with ``mcpg_autowarm``."""
+    if not await extension_installed(driver, "pg_cron"):
+        return []
+    rows = await driver.execute_query(
+        "SELECT jobid, jobname, schedule, command FROM cron.job WHERE jobname LIKE 'mcpg_autowarm%' ORDER BY jobid",
+        force_readonly=True,
+    )
+    return [
+        AutowarmJob(
+            jobid=int(row.cells["jobid"]),
+            jobname=row.cells["jobname"],
+            schedule=row.cells["schedule"],
+            command=row.cells["command"],
+        )
+        for row in rows or []
+    ]
+
+
+__all__ = [
+    "AutowarmJob",
+    "BulkPrewarmOutcome",
+    "BulkPrewarmResult",
+    "PrewarmError",
+    "PrewarmExtensionStatus",
+    "PrewarmRecommendation",
+    "PrewarmResult",
+    "PrewarmedRelation",
+    "RecommendPrewarmTargetsResult",
+    "ScheduleAutowarmResult",
+    "UnscheduleAutowarmResult",
+    "get_prewarm_extension_status",
+    "list_autowarm_jobs",
+    "list_prewarmed_relations",
+    "prewarm_recommended",
+    "prewarm_relation",
+    "recommend_prewarm_targets",
+    "schedule_autowarm",
+    "unschedule_autowarm",
+]

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -47,6 +47,7 @@ from mcpg import (
     naming,
     nl2sql,
     partman,
+    pg_prewarm,
     pg_search,
     prisma,
     query,
@@ -4074,6 +4075,227 @@ def _register_cron_write(server: FastMCP[AppContext]) -> None:
         return asdict(result)
 
 
+def _register_pg_prewarm_reads(server: FastMCP[AppContext]) -> None:
+    @server.tool(
+        name="get_prewarm_extension_status",
+        description=_with_example(
+            "Report whether ``pg_prewarm`` (and the supporting "
+            "``pg_buffercache``) are installed, and whether ``pg_prewarm`` is "
+            "listed in ``shared_preload_libraries`` (the autoprewarm worker "
+            "requires it). "
+            "Returns an object with `pg_prewarm_installed` (bool), "
+            "`pg_buffercache_installed` (bool), `autoprewarm_libraries_present` "
+            "(bool), and `shared_preload_libraries` (the raw setting).",
+            "get_prewarm_extension_status()",
+        ),
+    )
+    async def get_prewarm_extension_status(ctx: _Ctx) -> dict[str, Any]:
+        async def _run() -> dict[str, Any]:
+            status = await pg_prewarm.get_prewarm_extension_status(_driver(ctx))
+            return asdict(status)
+
+        return await _cached_call(ctx, "get_prewarm_extension_status", _run)
+
+    @server.tool(
+        name="list_prewarmed_relations",
+        description=_with_example(
+            "Report current shared-buffer residency per relation, ranked by "
+            "blocks-cached descending. Requires the ``pg_buffercache`` "
+            "extension; returns an empty list when it's missing. "
+            "Returns a list of objects with `schema`, `table`, "
+            "`blocks_cached` (8 KiB pages currently in shared buffers), "
+            "`total_blocks` (the relation's on-disk size in the same unit), "
+            "`pct_cached` (the residency ratio rounded to 2 decimals), and "
+            "`dirty_blocks` (pages with pending writes).",
+            "list_prewarmed_relations(schema='public', limit=50)",
+        ),
+    )
+    async def list_prewarmed_relations(
+        ctx: _Ctx,
+        schema: str | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        async def _run() -> list[dict[str, Any]]:
+            relations = await pg_prewarm.list_prewarmed_relations(_driver(ctx), schema=schema, limit=limit)
+            return [asdict(r) for r in relations]
+
+        return await _cached_call(ctx, "list_prewarmed_relations", _run, schema, limit)
+
+    @server.tool(
+        name="recommend_prewarm_targets",
+        description=_with_example(
+            "Recommend relations whose first-query latency would benefit from "
+            "``pg_prewarm``. Inspects ``pg_stat_user_tables`` + "
+            "``pg_statio_user_tables`` to find high cold-miss-rate / "
+            "seq_scan-dominant relations, and caps the cumulative cost at "
+            "``shared_buffers_budget_pct`` * ``shared_buffers`` so the "
+            "recommendation never silently exceeds shared_buffers. The "
+            "advisor is read-only — never invokes pg_prewarm itself. "
+            "Returns an object with `shared_buffers_blocks` (configured "
+            "shared_buffers in 8 KiB pages), `budget_blocks` (the cap), "
+            "`total_cost_blocks` (sum of recommendations actually returned), "
+            "and `candidates` — a list of objects with `schema`, `relation`, "
+            "`reason` (`seq_scan_dominant` / `high_cold_miss_rate` / "
+            "`small_hot_relation_uncached` / `index_in_critical_path`), "
+            "`prewarm_mode`, `estimated_buffer_cost`, `heap_blks_read`, "
+            "`heap_blks_hit`, `cache_miss_ratio`, and `ready_to_run_sql`.",
+            "recommend_prewarm_targets(shared_buffers_budget_pct=60.0, limit=10)",
+        ),
+    )
+    async def recommend_prewarm_targets(
+        ctx: _Ctx,
+        shared_buffers_budget_pct: float = 60.0,
+        min_heap_blks_read: int = 1000,
+        limit: int = 20,
+        prewarm_mode: str = "buffer",
+    ) -> dict[str, Any]:
+        async def _run() -> dict[str, Any]:
+            result = await pg_prewarm.recommend_prewarm_targets(
+                _driver(ctx),
+                shared_buffers_budget_pct=shared_buffers_budget_pct,
+                min_heap_blks_read=min_heap_blks_read,
+                limit=limit,
+                prewarm_mode=prewarm_mode,
+            )
+            return asdict(result)
+
+        return await _cached_call(
+            ctx,
+            "recommend_prewarm_targets",
+            _run,
+            shared_buffers_budget_pct,
+            min_heap_blks_read,
+            limit,
+            prewarm_mode,
+        )
+
+    @server.tool(
+        name="list_autowarm_jobs",
+        description=_with_example(
+            "List the pg_cron jobs MCPg registered for autowarm "
+            "(``jobname LIKE 'mcpg_autowarm%'``). Returns an empty list when "
+            "``pg_cron`` is not installed. "
+            "Returns a list of objects with `jobid`, `jobname`, `schedule` "
+            "(the cron expression), and `command` (the SELECT the job runs).",
+            "list_autowarm_jobs()",
+        ),
+    )
+    async def list_autowarm_jobs(ctx: _Ctx) -> list[dict[str, Any]]:
+        async def _run() -> list[dict[str, Any]]:
+            jobs = await pg_prewarm.list_autowarm_jobs(_driver(ctx))
+            return [asdict(j) for j in jobs]
+
+        return await _cached_call(ctx, "list_autowarm_jobs", _run)
+
+
+def _register_pg_prewarm_writes(server: FastMCP[AppContext]) -> None:
+    @server.tool(
+        name="prewarm_relation",
+        description=_with_example(
+            "Run ``SELECT pg_prewarm('schema.relation'::regclass, mode)`` "
+            "once. ``mode`` is one of ``buffer`` (load into shared buffers), "
+            "``prefetch`` (OS page cache), or ``read`` (blocking read). "
+            "Requires pg_prewarm installed. "
+            "Returns an object with `schema`, `relation`, `mode`, and "
+            "`blocks_prewarmed`.",
+            "prewarm_relation(schema='public', relation='orders', mode='buffer')",
+        ),
+    )
+    async def prewarm_relation(
+        ctx: _Ctx,
+        schema: str,
+        relation: str,
+        mode: str = "buffer",
+    ) -> dict[str, Any]:
+        result = await pg_prewarm.prewarm_relation(_driver(ctx), schema=schema, relation=relation, mode=mode)
+        await ctx.request_context.lifespan_context.cache.clear()
+        return asdict(result)
+
+    @server.tool(
+        name="prewarm_recommended",
+        description=_with_example(
+            "Invoke ``recommend_prewarm_targets`` and prewarm every "
+            "recommendation in order. ``dry_run=true`` reports what would be "
+            "prewarmed without invoking pg_prewarm. Per-relation errors are "
+            "captured and reported in the ``outcomes`` list so one bad "
+            "relation doesn't fail the whole bulk pass. "
+            "Returns an object with `dry_run` (bool), `total_blocks` (sum of "
+            "blocks_prewarmed across successful outcomes), and `outcomes` — "
+            "a list of objects with `schema`, `relation`, `mode`, "
+            "`blocks_prewarmed`, and `error` (null on success).",
+            "prewarm_recommended(shared_buffers_budget_pct=60.0, dry_run=False)",
+        ),
+    )
+    async def prewarm_recommended(
+        ctx: _Ctx,
+        shared_buffers_budget_pct: float = 60.0,
+        min_heap_blks_read: int = 1000,
+        limit: int = 20,
+        prewarm_mode: str = "buffer",
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        result = await pg_prewarm.prewarm_recommended(
+            _driver(ctx),
+            shared_buffers_budget_pct=shared_buffers_budget_pct,
+            min_heap_blks_read=min_heap_blks_read,
+            limit=limit,
+            prewarm_mode=prewarm_mode,
+            dry_run=dry_run,
+        )
+        await ctx.request_context.lifespan_context.cache.clear()
+        return asdict(result)
+
+    @server.tool(
+        name="schedule_autowarm",
+        description=_with_example(
+            "Register a pg_cron job that calls the bulk prewarm helper at "
+            "``schedule``. Default schedule is ``@reboot`` — the canonical "
+            "'warm after restart' loop. Requires pg_cron installed. The "
+            "cron command embeds the budget / limit / mode arguments and "
+            "calls a `mcpg.prewarm_recommended_cron(...)` SQL function the "
+            "operator must install separately (template in "
+            "``docs/plans/pg-prewarm-advisor.md``). "
+            "Returns an object with `jobid`, `name`, and `schedule`.",
+            "schedule_autowarm(name='mcpg_autowarm', schedule='@reboot')",
+        ),
+    )
+    async def schedule_autowarm(
+        ctx: _Ctx,
+        name: str = "mcpg_autowarm",
+        schedule: str = "@reboot",
+        shared_buffers_budget_pct: float = 60.0,
+        min_heap_blks_read: int = 1000,
+        limit: int = 20,
+        prewarm_mode: str = "buffer",
+    ) -> dict[str, Any]:
+        result = await pg_prewarm.schedule_autowarm(
+            _driver(ctx),
+            name=name,
+            schedule=schedule,
+            shared_buffers_budget_pct=shared_buffers_budget_pct,
+            min_heap_blks_read=min_heap_blks_read,
+            limit=limit,
+            prewarm_mode=prewarm_mode,
+        )
+        await ctx.request_context.lifespan_context.cache.clear()
+        return asdict(result)
+
+    @server.tool(
+        name="unschedule_autowarm",
+        description=_with_example(
+            "Remove an autowarm pg_cron job by name. Idempotent — returns "
+            "``removed=false`` when the job didn't exist (or pg_cron isn't "
+            "installed). "
+            "Returns an object with `name` and `removed` (bool).",
+            "unschedule_autowarm(name='mcpg_autowarm')",
+        ),
+    )
+    async def unschedule_autowarm(ctx: _Ctx, name: str = "mcpg_autowarm") -> dict[str, Any]:
+        result = await pg_prewarm.unschedule_autowarm(_driver(ctx), name=name)
+        await ctx.request_context.lifespan_context.cache.clear()
+        return asdict(result)
+
+
 def _register_partman(server: FastMCP[AppContext]) -> None:
     @server.tool(
         name="partman_create_parent",
@@ -4414,6 +4636,7 @@ def register_tools(server: FastMCP[AppContext], settings: Settings) -> None:
         _register_timescaledb_reads(server)
         _register_graphs_reads(server)
         _register_redis_fdw_reads(server)
+        _register_pg_prewarm_reads(server)
     if is_permitted(settings.access_mode, Capability.WRITE):
         _register_write(server)
         _register_maintenance(server)
@@ -4422,6 +4645,7 @@ def register_tools(server: FastMCP[AppContext], settings: Settings) -> None:
         _register_turboquant_writes(server)
         _register_rag_telemetry_write(server)
         _register_data_movement_writes(server)
+        _register_pg_prewarm_writes(server)
     if is_permitted(settings.access_mode, Capability.DDL) and settings.allow_ddl:
         _register_ddl(server)
         _register_partman(server)

--- a/tests/contract/tool_surface.snapshot.json
+++ b/tests/contract/tool_surface.snapshot.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "schema_version": 1,
-    "tool_count": 182
+    "tool_count": 190
   },
   "tools": [
     {
@@ -2032,6 +2032,15 @@
       "name": "get_pg_search_index_metadata"
     },
     {
+      "description": "Report whether ``pg_prewarm`` (and the supporting ``pg_buffercache``) are installed, and whether ``pg_prewarm`` is listed in ``shared_preload_libraries`` (the autoprewarm worker requires it). Returns an object with `pg_prewarm_installed` (bool), `pg_buffercache_installed` (bool), `autoprewarm_libraries_present` (bool), and `shared_preload_libraries` (the raw setting).\n\nExample: `get_prewarm_extension_status()`",
+      "inputSchema": {
+        "properties": {},
+        "title": "get_prewarm_extension_statusArguments",
+        "type": "object"
+      },
+      "name": "get_prewarm_extension_status"
+    },
+    {
       "description": "Best-effort cache metrics for a redis_fdw server. redis_fdw does not ship a uniform stats SQL surface across versions, so the tool validates that the server exists and otherwise reports `available=false` with a diagnostic. Operators wanting live metrics should query Redis directly (INFO / DBSIZE). Returns an object with `server`, `available` (bool), `key_count`, `used_memory_bytes`, and `detail` (a human-readable note).\n\nExample: `get_redis_cache_stats(server='redis_primary')`",
       "inputSchema": {
         "properties": {
@@ -2469,6 +2478,15 @@
       "name": "list_audit_events"
     },
     {
+      "description": "List the pg_cron jobs MCPg registered for autowarm (``jobname LIKE 'mcpg_autowarm%'``). Returns an empty list when ``pg_cron`` is not installed. Returns a list of objects with `jobid`, `jobname`, `schedule` (the cron expression), and `command` (the SELECT the job runs).\n\nExample: `list_autowarm_jobs()`",
+      "inputSchema": {
+        "properties": {},
+        "title": "list_autowarm_jobsArguments",
+        "type": "object"
+      },
+      "name": "list_autowarm_jobs"
+    },
+    {
       "description": "List every extension available to the database, with whether it is installed. Returns a list of objects with `name`, `default_version`, `installed_version` (null when not installed), and `installed` (bool).",
       "inputSchema": {
         "properties": {},
@@ -2832,6 +2850,33 @@
         "type": "object"
       },
       "name": "list_policies"
+    },
+    {
+      "description": "Report current shared-buffer residency per relation, ranked by blocks-cached descending. Requires the ``pg_buffercache`` extension; returns an empty list when it's missing. Returns a list of objects with `schema`, `table`, `blocks_cached` (8 KiB pages currently in shared buffers), `total_blocks` (the relation's on-disk size in the same unit), `pct_cached` (the residency ratio rounded to 2 decimals), and `dirty_blocks` (pages with pending writes).\n\nExample: `list_prewarmed_relations(schema='public', limit=50)`",
+      "inputSchema": {
+        "properties": {
+          "limit": {
+            "default": 100,
+            "title": "Limit",
+            "type": "integer"
+          },
+          "schema": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Schema"
+          }
+        },
+        "title": "list_prewarmed_relationsArguments",
+        "type": "object"
+      },
+      "name": "list_prewarmed_relations"
     },
     {
       "description": "List logical-replication publications with the tables and operations they include. Returns a list of objects with `name`, `owner`, `all_tables` (bool), `publishes_insert` / `publishes_update` / `publishes_delete` / `publishes_truncate` (bools), and `tables` (list of `schema.table` strings).",
@@ -3735,6 +3780,68 @@
       "name": "prepare_migration"
     },
     {
+      "description": "Invoke ``recommend_prewarm_targets`` and prewarm every recommendation in order. ``dry_run=true`` reports what would be prewarmed without invoking pg_prewarm. Per-relation errors are captured and reported in the ``outcomes`` list so one bad relation doesn't fail the whole bulk pass. Returns an object with `dry_run` (bool), `total_blocks` (sum of blocks_prewarmed across successful outcomes), and `outcomes` — a list of objects with `schema`, `relation`, `mode`, `blocks_prewarmed`, and `error` (null on success).\n\nExample: `prewarm_recommended(shared_buffers_budget_pct=60.0, dry_run=False)`",
+      "inputSchema": {
+        "properties": {
+          "dry_run": {
+            "default": false,
+            "title": "Dry Run",
+            "type": "boolean"
+          },
+          "limit": {
+            "default": 20,
+            "title": "Limit",
+            "type": "integer"
+          },
+          "min_heap_blks_read": {
+            "default": 1000,
+            "title": "Min Heap Blks Read",
+            "type": "integer"
+          },
+          "prewarm_mode": {
+            "default": "buffer",
+            "title": "Prewarm Mode",
+            "type": "string"
+          },
+          "shared_buffers_budget_pct": {
+            "default": 60.0,
+            "title": "Shared Buffers Budget Pct",
+            "type": "number"
+          }
+        },
+        "title": "prewarm_recommendedArguments",
+        "type": "object"
+      },
+      "name": "prewarm_recommended"
+    },
+    {
+      "description": "Run ``SELECT pg_prewarm('schema.relation'::regclass, mode)`` once. ``mode`` is one of ``buffer`` (load into shared buffers), ``prefetch`` (OS page cache), or ``read`` (blocking read). Requires pg_prewarm installed. Returns an object with `schema`, `relation`, `mode`, and `blocks_prewarmed`.\n\nExample: `prewarm_relation(schema='public', relation='orders', mode='buffer')`",
+      "inputSchema": {
+        "properties": {
+          "mode": {
+            "default": "buffer",
+            "title": "Mode",
+            "type": "string"
+          },
+          "relation": {
+            "title": "Relation",
+            "type": "string"
+          },
+          "schema": {
+            "title": "Schema",
+            "type": "string"
+          }
+        },
+        "required": [
+          "schema",
+          "relation"
+        ],
+        "title": "prewarm_relationArguments",
+        "type": "object"
+      },
+      "name": "prewarm_relation"
+    },
+    {
       "description": "Delete persisted audit events older than older_than_days from mcpg_audit.events — a cron-friendly retention helper for the otherwise-unbounded audit table. Returns the number deleted, the cutoff timestamp, and the rows remaining. Refuses to run when MCPG_AUDIT_INTEGRITY is enabled (pruning would break the HMAC signature chain). Available only in unrestricted mode.",
       "inputSchema": {
         "properties": {
@@ -3992,6 +4099,36 @@
         "type": "object"
       },
       "name": "recommend_pg_search_maintenance"
+    },
+    {
+      "description": "Recommend relations whose first-query latency would benefit from ``pg_prewarm``. Inspects ``pg_stat_user_tables`` + ``pg_statio_user_tables`` to find high cold-miss-rate / seq_scan-dominant relations, and caps the cumulative cost at ``shared_buffers_budget_pct`` * ``shared_buffers`` so the recommendation never silently exceeds shared_buffers. The advisor is read-only — never invokes pg_prewarm itself. Returns an object with `shared_buffers_blocks` (configured shared_buffers in 8 KiB pages), `budget_blocks` (the cap), `total_cost_blocks` (sum of recommendations actually returned), and `candidates` — a list of objects with `schema`, `relation`, `reason` (`seq_scan_dominant` / `high_cold_miss_rate` / `small_hot_relation_uncached` / `index_in_critical_path`), `prewarm_mode`, `estimated_buffer_cost`, `heap_blks_read`, `heap_blks_hit`, `cache_miss_ratio`, and `ready_to_run_sql`.\n\nExample: `recommend_prewarm_targets(shared_buffers_budget_pct=60.0, limit=10)`",
+      "inputSchema": {
+        "properties": {
+          "limit": {
+            "default": 20,
+            "title": "Limit",
+            "type": "integer"
+          },
+          "min_heap_blks_read": {
+            "default": 1000,
+            "title": "Min Heap Blks Read",
+            "type": "integer"
+          },
+          "prewarm_mode": {
+            "default": "buffer",
+            "title": "Prewarm Mode",
+            "type": "string"
+          },
+          "shared_buffers_budget_pct": {
+            "default": 60.0,
+            "title": "Shared Buffers Budget Pct",
+            "type": "number"
+          }
+        },
+        "title": "recommend_prewarm_targetsArguments",
+        "type": "object"
+      },
+      "name": "recommend_prewarm_targets"
     },
     {
       "description": "Recommend tables that would benefit from a Redis cache layer. Inspects ``pg_stat_user_tables`` for read-heavy, low-write relations whose working set fits comfortably in Redis (default: read/write ratio ≥ 10, ≥ 1000 reads, ≤ 1M rows). When ``server`` is provided the generated ``ready_to_run_sql`` stub targets that server name; otherwise the stub uses a placeholder operators must substitute. Advisor is read-only — never touches Redis itself. Returns an object with `server` and `candidates` — a list of objects with `schema`, `table`, `reads`, `writes`, `read_write_ratio`, `estimated_row_count`, `reason` (`read_only_lookup_table` / `small_hot_relation` / `read_heavy_low_write` / `moderate_read_dominant`), and `ready_to_run_sql` (a CREATE FOREIGN TABLE stub).\n\nExample: `recommend_redis_cache_targets(server='redis_primary', limit=10)`",
@@ -4547,6 +4684,46 @@
       "name": "run_write"
     },
     {
+      "description": "Register a pg_cron job that calls the bulk prewarm helper at ``schedule``. Default schedule is ``@reboot`` — the canonical 'warm after restart' loop. Requires pg_cron installed. The cron command embeds the budget / limit / mode arguments and calls a `mcpg.prewarm_recommended_cron(...)` SQL function the operator must install separately (template in ``docs/plans/pg-prewarm-advisor.md``). Returns an object with `jobid`, `name`, and `schedule`.\n\nExample: `schedule_autowarm(name='mcpg_autowarm', schedule='@reboot')`",
+      "inputSchema": {
+        "properties": {
+          "limit": {
+            "default": 20,
+            "title": "Limit",
+            "type": "integer"
+          },
+          "min_heap_blks_read": {
+            "default": 1000,
+            "title": "Min Heap Blks Read",
+            "type": "integer"
+          },
+          "name": {
+            "default": "mcpg_autowarm",
+            "title": "Name",
+            "type": "string"
+          },
+          "prewarm_mode": {
+            "default": "buffer",
+            "title": "Prewarm Mode",
+            "type": "string"
+          },
+          "schedule": {
+            "default": "@reboot",
+            "title": "Schedule",
+            "type": "string"
+          },
+          "shared_buffers_budget_pct": {
+            "default": 60.0,
+            "title": "Shared Buffers Budget Pct",
+            "type": "number"
+          }
+        },
+        "title": "schedule_autowarmArguments",
+        "type": "object"
+      },
+      "name": "schedule_autowarm"
+    },
+    {
       "description": "Register a pg_cron job. ``schedule`` is a cron expression or pg_cron interval shortcut (e.g. '30 seconds'). Available only in unrestricted mode; requires pg_cron installed. Returns an object with `jobid` (the pg_cron job id), `name`, and `schedule`.",
       "inputSchema": {
         "properties": {
@@ -5052,6 +5229,21 @@
         "type": "object"
       },
       "name": "turboquant_rerank_candidates"
+    },
+    {
+      "description": "Remove an autowarm pg_cron job by name. Idempotent — returns ``removed=false`` when the job didn't exist (or pg_cron isn't installed). Returns an object with `name` and `removed` (bool).\n\nExample: `unschedule_autowarm(name='mcpg_autowarm')`",
+      "inputSchema": {
+        "properties": {
+          "name": {
+            "default": "mcpg_autowarm",
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "title": "unschedule_autowarmArguments",
+        "type": "object"
+      },
+      "name": "unschedule_autowarm"
     },
     {
       "description": "Unschedule a pg_cron job by name. Returns ``removed=true`` when the job existed. Available only in unrestricted mode.",

--- a/tests/unit/test_pg_prewarm.py
+++ b/tests/unit/test_pg_prewarm.py
@@ -1,0 +1,421 @@
+"""Tests for the pg_prewarm coverage module."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from _fakes import FakeRoutingDriver
+
+from mcpg.pg_prewarm import (
+    AutowarmJob,
+    BulkPrewarmResult,
+    PrewarmedRelation,
+    PrewarmError,
+    PrewarmExtensionStatus,
+    PrewarmRecommendation,
+    PrewarmResult,
+    RecommendPrewarmTargetsResult,
+    ScheduleAutowarmResult,
+    UnscheduleAutowarmResult,
+    get_prewarm_extension_status,
+    list_autowarm_jobs,
+    list_prewarmed_relations,
+    prewarm_recommended,
+    prewarm_relation,
+    recommend_prewarm_targets,
+    schedule_autowarm,
+    unschedule_autowarm,
+)
+
+
+def _shared_buffers_route(blocks: int = 16384) -> dict[str, list[dict[str, Any]]]:
+    """Stat helper for the shared_buffers / block_size probe."""
+    return {"pg_size_bytes(current_setting('shared_buffers'))": [{"blocks": blocks}]}
+
+
+# --- get_prewarm_extension_status ------------------------------------------
+
+
+async def test_status_reports_missing_extensions() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "FROM pg_extension WHERE extname": [],
+            "current_setting('shared_preload_libraries'": [{"spl": ""}],
+        }
+    )
+    status = await get_prewarm_extension_status(driver)  # type: ignore[arg-type]
+    assert status == PrewarmExtensionStatus(
+        pg_prewarm_installed=False,
+        pg_buffercache_installed=False,
+        autoprewarm_libraries_present=False,
+        shared_preload_libraries="",
+    )
+
+
+async def test_status_detects_autoprewarm_library_in_spl() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "FROM pg_extension WHERE extname": [{"present": 1}],
+            "current_setting('shared_preload_libraries'": [{"spl": "pg_stat_statements, pg_prewarm , pg_cron"}],
+        }
+    )
+    status = await get_prewarm_extension_status(driver)  # type: ignore[arg-type]
+    assert status.pg_prewarm_installed is True
+    assert status.pg_buffercache_installed is True
+    assert status.autoprewarm_libraries_present is True
+
+
+# --- list_prewarmed_relations ----------------------------------------------
+
+
+async def test_list_prewarmed_returns_empty_when_buffercache_absent() -> None:
+    driver = FakeRoutingDriver({"FROM pg_extension WHERE extname": []})
+    assert await list_prewarmed_relations(driver) == []  # type: ignore[arg-type]
+
+
+async def test_list_prewarmed_maps_rows_and_computes_pct() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "FROM pg_extension WHERE extname": [{"present": 1}],
+            "FROM pg_class c ": [
+                {
+                    "schema": "public",
+                    "table_name": "orders",
+                    "blocks_cached": 200,
+                    "dirty_blocks": 5,
+                    "total_blocks": 1000,
+                },
+                {"schema": "public", "table_name": "users", "blocks_cached": 50, "dirty_blocks": 0, "total_blocks": 0},
+            ],
+        }
+    )
+    rels = await list_prewarmed_relations(driver)  # type: ignore[arg-type]
+    assert rels == [
+        PrewarmedRelation("public", "orders", 200, 1000, 20.0, 5),
+        PrewarmedRelation("public", "users", 50, 0, 0.0, 0),
+    ]
+
+
+async def test_list_prewarmed_rejects_bad_limit() -> None:
+    driver = FakeRoutingDriver({"FROM pg_extension WHERE extname": [{"present": 1}]})
+    with pytest.raises(PrewarmError, match="limit must be positive"):
+        await list_prewarmed_relations(driver, limit=0)  # type: ignore[arg-type]
+
+
+# --- recommend_prewarm_targets ---------------------------------------------
+
+
+async def test_recommend_filters_and_classifies() -> None:
+    routes = {
+        "FROM pg_stat_user_tables s ": [
+            # seq_scan dominant + high miss → seq_scan_dominant.
+            {
+                "schema": "public",
+                "relation": "events",
+                "heap_blks_read": 50_000,
+                "heap_blks_hit": 5_000,
+                "seq_scans": 100,
+                "idx_scans": 10,
+                "est_blocks": 100,
+            },
+            # high miss but idx_scan dominant → high_cold_miss_rate.
+            {
+                "schema": "public",
+                "relation": "logs",
+                "heap_blks_read": 30_000,
+                "heap_blks_hit": 5_000,
+                "seq_scans": 5,
+                "idx_scans": 100,
+                "est_blocks": 200,
+            },
+            # small hot relation uncached.
+            {
+                "schema": "public",
+                "relation": "lookup",
+                "heap_blks_read": 5_000,
+                "heap_blks_hit": 50_000,
+                "seq_scans": 100,
+                "idx_scans": 100,
+                "est_blocks": 10,
+            },
+            # filtered: low absolute reads.
+            {
+                "schema": "public",
+                "relation": "cold",
+                "heap_blks_read": 50,
+                "heap_blks_hit": 5,
+                "seq_scans": 5,
+                "idx_scans": 0,
+                "est_blocks": 100,
+            },
+        ],
+    }
+    routes.update(_shared_buffers_route(16384))
+    driver = FakeRoutingDriver(routes)
+    result = await recommend_prewarm_targets(driver)  # type: ignore[arg-type]
+    names = [c.relation for c in result.candidates]
+    assert "events" in names and "logs" in names and "lookup" in names
+    assert "cold" not in names
+    reasons = {c.relation: c.reason for c in result.candidates}
+    assert reasons["events"] == "seq_scan_dominant"
+    assert reasons["logs"] == "high_cold_miss_rate"
+    assert reasons["lookup"] == "small_hot_relation_uncached"
+    # Ready-to-run SQL is the canonical pg_prewarm signature.
+    for c in result.candidates:
+        assert c.ready_to_run_sql.startswith("SELECT pg_prewarm('")
+        assert c.prewarm_mode == "buffer"
+
+
+async def test_recommend_respects_shared_buffers_budget() -> None:
+    routes = {
+        "FROM pg_stat_user_tables s ": [
+            # Each row is 600 blocks; budget 1000 → only first two fit.
+            {
+                "schema": "public",
+                "relation": "a",
+                "heap_blks_read": 50_000,
+                "heap_blks_hit": 0,
+                "seq_scans": 0,
+                "idx_scans": 100,
+                "est_blocks": 600,
+            },
+            {
+                "schema": "public",
+                "relation": "b",
+                "heap_blks_read": 40_000,
+                "heap_blks_hit": 0,
+                "seq_scans": 0,
+                "idx_scans": 100,
+                "est_blocks": 400,
+            },
+            {
+                "schema": "public",
+                "relation": "c",
+                "heap_blks_read": 30_000,
+                "heap_blks_hit": 0,
+                "seq_scans": 0,
+                "idx_scans": 100,
+                "est_blocks": 600,
+            },
+        ],
+    }
+    # shared_buffers = 1666 blocks * 60% = 999 → first two fit (600 + 400 = 1000 exceeds, so b alone keeps room).
+    # Set shared_buffers to 1667 blocks: 60% = 1000, so a(600)+b(400)=1000 fits, c(600) doesn't.
+    routes.update(_shared_buffers_route(1667))
+    driver = FakeRoutingDriver(routes)
+    result = await recommend_prewarm_targets(driver, shared_buffers_budget_pct=60.0)  # type: ignore[arg-type]
+    names = [c.relation for c in result.candidates]
+    assert names == ["a", "b"]
+    assert result.total_cost_blocks == 1000
+    assert result.budget_blocks == 1000
+    assert result.shared_buffers_blocks == 1667
+
+
+async def test_recommend_rejects_bad_inputs() -> None:
+    driver = FakeRoutingDriver({"FROM pg_stat_user_tables s ": []})
+    with pytest.raises(PrewarmError, match="prewarm_mode"):
+        await recommend_prewarm_targets(driver, prewarm_mode="invalid")  # type: ignore[arg-type]
+    with pytest.raises(PrewarmError, match="shared_buffers_budget_pct"):
+        await recommend_prewarm_targets(driver, shared_buffers_budget_pct=0)  # type: ignore[arg-type]
+    with pytest.raises(PrewarmError, match="limit"):
+        await recommend_prewarm_targets(driver, limit=0)  # type: ignore[arg-type]
+
+
+# --- prewarm_relation -------------------------------------------------------
+
+
+async def test_prewarm_relation_emits_select_with_regclass_cast() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "FROM pg_extension WHERE extname": [{"present": 1}],
+            "SELECT pg_prewarm(": [{"blocks": 1024}],
+        }
+    )
+    result = await prewarm_relation(driver, schema="public", relation="orders")  # type: ignore[arg-type]
+    assert result == PrewarmResult("public", "orders", "buffer", 1024)
+    queries = " | ".join(call[0] for call in driver.calls)
+    assert "pg_prewarm('public.orders'::regclass, 'buffer')" in queries
+
+
+async def test_prewarm_relation_rejects_bad_mode() -> None:
+    driver = FakeRoutingDriver({"FROM pg_extension WHERE extname": [{"present": 1}]})
+    with pytest.raises(PrewarmError, match="mode must be"):
+        await prewarm_relation(driver, schema="public", relation="orders", mode="bogus")  # type: ignore[arg-type]
+
+
+async def test_prewarm_relation_rejects_quotes_in_relation() -> None:
+    driver = FakeRoutingDriver({"FROM pg_extension WHERE extname": [{"present": 1}]})
+    with pytest.raises(PrewarmError, match="characters"):
+        await prewarm_relation(driver, schema="public", relation="orders'; DROP --")  # type: ignore[arg-type]
+
+
+async def test_prewarm_relation_requires_extension() -> None:
+    driver = FakeRoutingDriver({"FROM pg_extension WHERE extname": []})
+    with pytest.raises(PrewarmError, match="pg_prewarm extension"):
+        await prewarm_relation(driver, schema="public", relation="orders")  # type: ignore[arg-type]
+
+
+# --- prewarm_recommended ----------------------------------------------------
+
+
+async def test_bulk_dry_run_does_not_call_pg_prewarm() -> None:
+    routes = {
+        "FROM pg_extension WHERE extname": [{"present": 1}],
+        "FROM pg_stat_user_tables s ": [
+            {
+                "schema": "public",
+                "relation": "a",
+                "heap_blks_read": 50_000,
+                "heap_blks_hit": 0,
+                "seq_scans": 0,
+                "idx_scans": 100,
+                "est_blocks": 100,
+            },
+        ],
+    }
+    routes.update(_shared_buffers_route(16384))
+    driver = FakeRoutingDriver(routes)
+    result = await prewarm_recommended(driver, dry_run=True)  # type: ignore[arg-type]
+    assert isinstance(result, BulkPrewarmResult)
+    assert result.dry_run is True
+    assert result.total_blocks == 0
+    assert len(result.outcomes) == 1
+    queries = " | ".join(call[0] for call in driver.calls)
+    # The dry-run path never executes the actual pg_prewarm call.
+    assert "SELECT pg_prewarm('public.a'" not in queries
+
+
+async def test_bulk_apply_invokes_pg_prewarm_per_candidate() -> None:
+    routes = {
+        "FROM pg_extension WHERE extname": [{"present": 1}],
+        "FROM pg_stat_user_tables s ": [
+            {
+                "schema": "public",
+                "relation": "a",
+                "heap_blks_read": 50_000,
+                "heap_blks_hit": 0,
+                "seq_scans": 0,
+                "idx_scans": 100,
+                "est_blocks": 100,
+            },
+            {
+                "schema": "public",
+                "relation": "b",
+                "heap_blks_read": 30_000,
+                "heap_blks_hit": 0,
+                "seq_scans": 0,
+                "idx_scans": 100,
+                "est_blocks": 100,
+            },
+        ],
+        "SELECT pg_prewarm(": [{"blocks": 500}],
+    }
+    routes.update(_shared_buffers_route(16384))
+    driver = FakeRoutingDriver(routes)
+    result = await prewarm_recommended(driver)  # type: ignore[arg-type]
+    assert result.dry_run is False
+    # Both outcomes succeed with 500 blocks each.
+    assert all(o.error is None for o in result.outcomes)
+    assert result.total_blocks == 1000
+
+
+# --- autowarm scheduling ----------------------------------------------------
+
+
+async def test_schedule_autowarm_calls_cron_schedule() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "FROM pg_extension WHERE extname": [{"present": 1}],
+            "SELECT cron.schedule(": [{"jobid": 42}],
+        }
+    )
+    result = await schedule_autowarm(driver)  # type: ignore[arg-type]
+    assert result == ScheduleAutowarmResult(jobid=42, name="mcpg_autowarm", schedule="@reboot")
+    schedule_calls = [c for c in driver.calls if "cron.schedule" in c[0]]
+    assert len(schedule_calls) == 1
+    sql, params, _ = schedule_calls[0]
+    assert "cron.schedule(%s, %s, %s)" in sql
+    assert params is not None
+    assert params[0] == "mcpg_autowarm"
+    assert params[1] == "@reboot"
+    assert "prewarm_recommended_cron" in params[2]
+
+
+async def test_schedule_autowarm_rejects_pg_cron_absent() -> None:
+    driver = FakeRoutingDriver({"FROM pg_extension WHERE extname": []})
+    with pytest.raises(PrewarmError, match="pg_cron extension"):
+        await schedule_autowarm(driver)  # type: ignore[arg-type]
+
+
+async def test_schedule_autowarm_rejects_bad_schedule() -> None:
+    driver = FakeRoutingDriver({"FROM pg_extension WHERE extname": [{"present": 1}]})
+    with pytest.raises(PrewarmError, match="schedule contains"):
+        await schedule_autowarm(driver, schedule="'; DROP TABLE cron.job; --")  # type: ignore[arg-type]
+
+
+async def test_schedule_autowarm_rejects_bad_mode() -> None:
+    driver = FakeRoutingDriver({"FROM pg_extension WHERE extname": [{"present": 1}]})
+    with pytest.raises(PrewarmError, match="prewarm_mode"):
+        await schedule_autowarm(driver, prewarm_mode="bogus")  # type: ignore[arg-type]
+
+
+async def test_unschedule_autowarm_returns_false_when_pg_cron_absent() -> None:
+    driver = FakeRoutingDriver({"FROM pg_extension WHERE extname": []})
+    result = await unschedule_autowarm(driver)  # type: ignore[arg-type]
+    assert result == UnscheduleAutowarmResult(name="mcpg_autowarm", removed=False)
+
+
+async def test_unschedule_autowarm_calls_cron_unschedule() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "FROM pg_extension WHERE extname": [{"present": 1}],
+            "SELECT cron.unschedule(": [{"removed": True}],
+        }
+    )
+    result = await unschedule_autowarm(driver)  # type: ignore[arg-type]
+    assert result.removed is True
+
+
+async def test_list_autowarm_jobs_filters_to_mcpg_prefix() -> None:
+    driver = FakeRoutingDriver(
+        {
+            "FROM pg_extension WHERE extname": [{"present": 1}],
+            "FROM cron.job WHERE jobname LIKE": [
+                {"jobid": 1, "jobname": "mcpg_autowarm", "schedule": "@reboot", "command": "SELECT 1"},
+                {"jobid": 2, "jobname": "mcpg_autowarm_nightly", "schedule": "0 3 * * *", "command": "SELECT 2"},
+            ],
+        }
+    )
+    jobs = await list_autowarm_jobs(driver)  # type: ignore[arg-type]
+    assert jobs == [
+        AutowarmJob(1, "mcpg_autowarm", "@reboot", "SELECT 1"),
+        AutowarmJob(2, "mcpg_autowarm_nightly", "0 3 * * *", "SELECT 2"),
+    ]
+
+
+async def test_list_autowarm_jobs_empty_when_cron_absent() -> None:
+    driver = FakeRoutingDriver({"FROM pg_extension WHERE extname": []})
+    assert await list_autowarm_jobs(driver) == []  # type: ignore[arg-type]
+
+
+def test_recommendation_dataclass_shape() -> None:
+    rec = PrewarmRecommendation(
+        schema="public",
+        relation="orders",
+        reason="high_cold_miss_rate",
+        prewarm_mode="buffer",
+        estimated_buffer_cost=1000,
+        heap_blks_read=50_000,
+        heap_blks_hit=1_000,
+        cache_miss_ratio=0.98,
+        ready_to_run_sql="SELECT pg_prewarm('public.orders'::regclass, 'buffer');",
+    )
+    assert rec.reason == "high_cold_miss_rate"
+
+
+def test_recommend_result_shape() -> None:
+    result = RecommendPrewarmTargetsResult(
+        shared_buffers_blocks=16384, budget_blocks=9830, total_cost_blocks=500, candidates=[]
+    )
+    assert result.shared_buffers_blocks == 16384


### PR DESCRIPTION
## Summary

Closes #119. Lands the full pg_prewarm coverage scope: extension status, shared-buffer residency reads, the `recommend_prewarm_targets` advisor with `shared_buffers` budget enforcement, single-relation + bulk-recommended prewarm wrappers, and a pg_cron-backed autowarm scheduler — eight new tools in a new `cache_warming` capability bucket.

Also lands the **contributing playbook** for adding new tools — `docs/contributing/adding-tools.md` plus a `mcpg-add-tool` Claude Code skill.

### New tools (8)

| Tool | Surface | Purpose |
|---|---|---|
| `get_prewarm_extension_status` | read | Reports pg_prewarm / pg_buffercache presence + `shared_preload_libraries` setting. |
| `list_prewarmed_relations` | read | Shared-buffer residency per relation via `pg_buffercache` join. |
| `recommend_prewarm_targets` | read advisor | The headline. Inspects miss-rate + seq/idx scan ratio; caps cumulative cost at `shared_buffers_budget_pct` × `shared_buffers`. Emits ready-to-run `SELECT pg_prewarm(...)` stubs. |
| `list_autowarm_jobs` | read | Filters `cron.job` to MCPg-owned autowarm rows. |
| `prewarm_relation` | write | Single `pg_prewarm('schema.rel'::regclass, mode)` invocation. |
| `prewarm_recommended` | write | Runs the advisor and prewarms every recommendation (with `dry_run=true` mode). |
| `schedule_autowarm` | write | Registers a pg_cron job that calls the bulk helper at a cadence (default `@reboot`). |
| `unschedule_autowarm` | write | Symmetric removal. |

### Advisor heuristic

- Inputs: `pg_stat_user_tables` (seq_scan vs idx_scan), `pg_statio_user_tables` (heap_blks_read vs heap_blks_hit), `pg_relation_size` (estimated cost in 8 KiB blocks).
- Ranks candidates by miss-volume descending.
- Caps the running total at `shared_buffers_budget_pct` * `shared_buffers` (default 60%) so the recommendation never silently exceeds the buffer pool.
- Emits stable reason codes: `seq_scan_dominant` / `high_cold_miss_rate` / `small_hot_relation_uncached` / `index_in_critical_path`.

### Security posture

- Identifier validation on `schema` / `relation` (rejects quote / control chars).
- Mode allowlist (`buffer` / `prefetch` / `read`).
- Cron schedule + job name validation.
- All DDL is parameter-bound or runs through `extension_installed()` gates.

### Module + plumbing

- New `src/mcpg/pg_prewarm.py` (~700 lines) — dataclasses, advisor, write helpers, autowarm scheduler.
- `pg_prewarm` added to `ENABLEABLE_EXTENSIONS`.
- New `cache_warming` capability bucket in `mcpg.about`; every tool mapped via `_TOOL_TO_BUCKET_OVERRIDES`.
- Snapshot regenerated; contract + bucket-classification tests pass.

### Contributing playbook (`docs/contributing/adding-tools.md`)

Captures the consistent end-to-end shape every new MCPg capability follows — module layout, validation patterns, tool registration, description conventions (the "Returns ..." sentence from PR #121), naming conventions, capability bucket overrides, test patterns, snapshot regen, quality gates, commit cadence. Cross-references three worked examples: redis_fdw (#118 / PR #122), pg_prewarm (this PR), describe_self (#117).

Same content is installed as a `mcpg-add-tool` Claude Code skill so the agent picks it up automatically when the user asks to add a new tool or expose a new extension's surface.

### Tests

- 24 unit tests in `tests/unit/test_pg_prewarm.py` covering all functions, classifier branches, budget enforcement, dry-run path, validation rejection.
- Full unit + contract suite passes locally.

## Test plan

- [x] `python -m pytest tests/unit/test_pg_prewarm.py` — 24 / 24 pass
- [x] `python -m pytest tests/contract/ tests/unit/test_about.py` — 10 / 10 pass
- [x] `ruff check src/mcpg/pg_prewarm.py tests/unit/test_pg_prewarm.py` — clean
- [x] `mypy src/mcpg/pg_prewarm.py` — clean
- [x] `bandit -r src/mcpg/pg_prewarm.py` — clean

> Note: This PR branches off `main` before #122 (redis_fdw) merges. Should be a clean fast-forward once #122 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Add pg_prewarm-based cache warming support including advisor, prewarm, and autowarm tools, plus contributor guidance for adding new tools.

New Features:
- Expose eight pg_prewarm cache-warming tools for extension status, buffer residency, recommendations, direct prewarm, and pg_cron-backed autowarm management.
- Introduce a new cache_warming capability bucket and map all pg_prewarm-related tools into it for tool classification and discovery.
- Add a contributor playbook documenting the standard process and conventions for adding new tools and capabilities, and surface it as a Claude Code skill.

Enhancements:
- Allow enabling the pg_prewarm extension via the global enableable extensions list so cache warming can be turned on declaratively.

Documentation:
- Document the workflow for adding new tools in docs/contributing/adding-tools.md and reference it from CONTRIBUTING.md.

Tests:
- Add unit tests for pg_prewarm covering status checks, advisor behavior, prewarm operations, and autowarm scheduling plus update the tool surface snapshot.