### PR TITLE
docs(policy): no deprecations of existing tools for PG 19 features

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,24 @@ Claude Code users: the same playbook is installed as a `mcpg-add-tool` skill
 and auto-triggers when you ask to add a new tool or expose a new extension's
 surface.
 
+### Backward compatibility — no deprecations
+
+**Adding new surface never removes existing surface.** Every tool that
+ships today must keep working on PG 14-18, and a user upgrading their
+database to PG 19 (or beyond) must keep every tool they relied on at PG 18.
+
+When a new feature *would* obsolete an existing tool (e.g. SQL/PGQ vs the
+AGE-style Cypher tools), the right answer is **coexist** — add a new tool
+with a new name; let agents pick via a status probe (`get_pgq_status`-style).
+Deprecation is a separate conversation, gated on telemetry, and would land
+behind its own SemVer-major release.
+
+The `tests/contract/test_tool_surface_snapshot.py` contract test is the
+operational guard — any tool removal trips it. PG 19 readiness work is
+explicitly **additive only**; see
+[`docs/plans/pg19-readiness.md`](docs/plans/pg19-readiness.md) for the
+end-to-end policy.
+
 ## Test-Driven Development
 
 MCPg is a TDD project. For all **authored** code:

--- a/docs/contributing/adding-tools.md
+++ b/docs/contributing/adding-tools.md
@@ -4,6 +4,21 @@ Every new capability in MCPg follows the same shape. Don't reinvent — this gui
 
 > Claude Code users: this playbook is also installed as a [`mcpg-add-tool`](../../) skill at `~/.claude/skills/mcpg-add-tool/SKILL.md`. The skill auto-triggers when the user asks to add a new tool or expose a new extension's surface, and reads the same content as this file.
 
+## 0a. Backward compatibility — no deprecations
+
+**Adding new surface never removes existing surface.** This is a hard rule, not a soft preference. Every tool that ships today must keep working on PG 14-18, and a user upgrading their database to PG 19 (or beyond) must keep every tool they relied on at PG 18.
+
+When a new feature *would* obsolete an existing tool (e.g. SQL/PGQ vs the AGE-style Cypher tools, or in-server `REPACK` vs the pg_repack shell-out path), the right answer is **coexist** — add a new tool with a new name; let agents pick via a status probe (`get_pgq_status`-style). Deprecation conversations are gated on telemetry and land behind their own SemVer-major release. Don't pre-empt them.
+
+Concretely when writing a PR:
+
+- **Don't delete a tool** — the `tests/contract/test_tool_surface_snapshot.py` contract test will trip if you do.
+- **Don't rename a tool** — bind the new behaviour to a new name.
+- **Don't change a tool's return shape** — add new fields with safe defaults; never remove or rename existing ones.
+- **Version-detect inside the tool when a faster PG ≥ 19 path is available** — keep the PG ≤ 18 fallback in the same function, e.g. `if server_version_num >= 190000: use pg_get_acl() else: use the catalogue-walking query`. The result shape doesn't change; only the SQL underneath does.
+
+The end-to-end PG 19 readiness policy lives in [`docs/plans/pg19-readiness.md`](../plans/pg19-readiness.md).
+
 ## 0. Branch and commit cadence
 
 - Branch off `main`: `git checkout -b claude/<feature>-coverage`.

--- a/docs/plans/pg19-readiness.md
+++ b/docs/plans/pg19-readiness.md
@@ -2,6 +2,42 @@
 
 Tracking document for MCPg's PG 19 readiness work. Spawned by issue #120.
 
+## Compatibility principle — no deprecations
+
+**Adding PG 19 surface never removes existing surface.** Every tool that ships
+today must keep working on PG 14-18, and a user upgrading their database to
+PG 19 must keep every tool they relied on at PG 18. This is a hard rule —
+not a soft preference — and applies to every PR in the Phase 3 plan below.
+
+Concretely:
+
+- **AGE-style `graph_operations` bucket stays.** SQL/PGQ (`property_graph_queries`
+  bucket) ships alongside it. Agents pick by `get_pgq_status` — never forced.
+- **pg_repack shell-out path stays** even after the in-server `REPACK` tool
+  lands. PG ≤ 18 users continue to use pg_repack; PG 19 users can choose.
+- **Existing advisor heuristics stay.** Skip-scan-aware ranking adds a new
+  ``reason`` code (`pg19_skip_scan_candidate`) when PG 19 is detected; the
+  existing reason codes remain valid.
+- **`pg_get_acl()` upgrade in `list_grants` is opt-in via version detection**
+  — the PG ≤ 18 catalog-walking query is kept as a fallback in the same
+  function, not deleted. The result shape doesn't change; only the SQL
+  underneath does.
+- **Schema migrations are additive.** New columns are added with safe
+  defaults; never `DROP COLUMN`, never rename. Existing snapshot rows stay
+  comparable across versions.
+- **Tool naming.** New tools take new names (`run_pgq` next to `run_cypher`).
+  We never silently re-bind an existing tool name to a new behaviour.
+
+When a PG 19 feature *would* obsolete an existing surface (e.g. SQL/PGQ
+vs AGE-style Cypher), the right answer is **coexist** until a separate
+deprecation conversation happens with telemetry behind it. That
+conversation is not part of the PG 19 readiness work and would land
+behind its own SemVer-major release.
+
+The contract test at `tests/contract/test_tool_surface_snapshot.py` is the
+operational guard: any tool removal trips the contract test, so a PG 19 PR
+that accidentally deletes a tool fails CI.
+
 ## Current status
 
 | Phase | Status | Notes |


### PR DESCRIPTION
## Summary

User direction after #127 (SQL/PGQ MVP) merged: "we don't want to remove any backward compatible tool for new features in PG19. We ought to support all."

This PR codifies that as a hard policy in three places so future PRs — by humans or agents — can't miss it.

### Changes

| File | What lands |
|---|---|
| `docs/plans/pg19-readiness.md` | New top-level **Compatibility principle — no deprecations** section. Concrete worked examples: AGE coexists with SQL/PGQ; pg_repack coexists with the in-server `REPACK` tool; advisor reason codes are additive; `pg_get_acl()` upgrade is opt-in via version detection (PG ≤ 18 catalogue-walking fallback stays in the same function); schema migrations are additive only. |
| `CONTRIBUTING.md` | New **Backward compatibility — no deprecations** sub-section under "Adding new tools / capabilities". Names the contract snapshot test as the operational guard. |
| `docs/contributing/adding-tools.md` *(playbook copy)* | New **0a. Backward compatibility** section right above the branch/commit cadence block, with a concrete don't-do-this list: don't delete a tool, don't rename a tool, don't change a return shape, version-detect inside the tool when a PG ≥ 19 path is faster. |
| `~/.claude/skills/mcpg-add-tool/SKILL.md` *(out-of-tree)* | Same 0a section mirrored into the live Claude Code skill so the auto-trigger picks it up. *(Not in this PR — installed locally.)* |

### Concretely, what this means for the rest of Phase 3

- **PR-2 (REPACK CONCURRENTLY)** — keeps the existing pg_repack shell-out path. New `repack_table` tool lands alongside.
- **PR-3 (Async I/O advisor)** — `read_pg_stat_io` gains new columns when PG 19 is detected; the existing column set stays.
- **PR-8 (skip-scan-aware `recommend_indexes`)** — adds a new `reason` code (`pg19_skip_scan_candidate`) when PG 19 is detected; existing reason codes remain.
- **PR-5 (`pg_get_acl()` upgrade)** — wraps `list_grants` with a version check; the catalogue-walking fallback stays.
- No tool deletions or renames anywhere in the Phase 3 plan.

The contract test at `tests/contract/test_tool_surface_snapshot.py` is the operational guard — any tool removal trips it in CI.

## Test plan

- [x] Pure docs change — no tool surface, no test changes.
- [x] `ruff check` / `mypy` / contract test all already green on main (this PR only touches markdown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Document and enforce a strict backward-compatibility policy for PG 19-related features, ensuring new tools and capabilities are additive and do not deprecate or alter existing ones.

Documentation:
- Add a compatibility principle section to the PG 19 readiness plan describing additive-only changes and concrete coexistence examples for new features.
- Document a backward-compatibility policy in CONTRIBUTING, linking it to the contract test as the guard against tool removals.
- Extend the adding-tools playbook with explicit backward-compatibility guidelines covering tool naming, return shapes, and version-detection patterns.