### PR TITLE
feat(aio): PG 19 recommend_io_method advisor — Phase 3 PR-3 — #120

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **PG 19 async-I/O advisor** (`mcpg.aio`). Two new tools:
+  `get_aio_status` (version probe + current `io_method` /
+  `io_min_workers` / `io_max_workers` GUCs; never raises) and
+  `recommend_io_method` (read-only advisor that maps workload
+  signals from `pg_stat_database` aggregates to one of `io_uring` /
+  `worker` / `sync` with a stable reason code:
+  `high_concurrent_read_load`, `bursty_io_with_cache_pressure`,
+  `low_io_pressure`, `current_setting_optimal`, or
+  `insufficient_stats`).
+
+  PR-3 of the PG 19 Phase 3 plan; the headline differentiator —
+  release-blog tagline: "Tell me which `io_method` is right for this
+  workload." Emits a `ready_to_run_sql` (`ALTER SYSTEM SET io_method
+  = '…';`) only when the recommendation differs from the current
+  setting; the advisor never invokes ALTER SYSTEM itself.
+
+  Per the no-deprecation rule, the existing `read_pg_stat_io`
+  surface in `mcpg.io_stats` is untouched. Both new tools route to
+  the `operations_and_health` capability bucket. Advances #120.
+
 - **PG 19 in-server `REPACK` coverage** (`mcpg.repack`). Two new
   tools: `get_repack_status` (version probe; never raises) and
   `repack_table` (`REPACK <relation> [CONCURRENTLY]`, defaults to

--- a/src/mcpg/about.py
+++ b/src/mcpg/about.py
@@ -655,6 +655,10 @@ _TOOL_TO_BUCKET_OVERRIDES: dict[str, str] = {
     # run_maintenance / check_database_health.
     "get_repack_status": "operations_and_health",
     "repack_table": "operations_and_health",
+    # PG 19 async-I/O subsystem — observability + advisor; sits in the
+    # operations_and_health bucket next to read_pg_stat_io.
+    "get_aio_status": "operations_and_health",
+    "recommend_io_method": "operations_and_health",
 }
 
 

--- a/src/mcpg/aio.py
+++ b/src/mcpg/aio.py
@@ -1,0 +1,410 @@
+"""``AIO`` — PG 19 asynchronous-I/O subsystem coverage.
+
+PG 19 introduces a true async-I/O subsystem. The headline knob is the
+``io_method`` GUC, which selects between ``sync`` (the historical
+behaviour), ``worker`` (a pool of background workers issues I/O), and
+``io_uring`` (kernel-side completion queues on Linux 5.1+). The default
+in PG 19 is ``worker`` with adaptive scaling controlled by
+``io_min_workers`` / ``io_max_workers``.
+
+Operators don't intuitively know which ``io_method`` is right for their
+workload. This module ships two tools:
+
+* ``get_aio_status`` — version probe; never raises. Reports whether the
+  subsystem is available and the current setting values.
+* ``recommend_io_method`` — the advisor. Inspects ``pg_stat_io``,
+  ``pg_stat_database`` (cache pressure), and the configured GUCs, then
+  emits a recommendation (``io_uring`` / ``worker`` / ``sync`` /
+  ``current_optimal``) with a stable reason code.
+
+The advisor is read-only — it never changes ``io_method`` itself.
+Operators apply the recommendation manually via ``ALTER SYSTEM`` or a
+postgresql.conf edit; the returned ``ready_to_run_sql`` carries the
+canonical ``ALTER SYSTEM SET io_method = '…'`` so the agent can hand
+it to the operator verbatim.
+
+Backward compatibility
+----------------------
+This module is additive. The existing ``read_pg_stat_io`` tool in
+``mcpg.io_stats`` keeps its current return shape — any new PG 19
+columns it surfaces appear as additional fields with safe defaults
+(per the no-deprecation rule documented in
+``docs/plans/pg19-readiness.md``).
+
+Security posture
+----------------
+Read-only; no DDL, no identifier substitution into SQL. PG 19+ gate via
+``server_version_num >= 190000``; on older servers the advisor reports
+``available=false`` with a guidance string pointing at the existing
+maintenance / IO-stat tools.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from mcpg._vendor.sql import SqlDriver
+
+# PG 19 ships the AIO subsystem. The version-num probe is the boundary
+# guard — no extension to install.
+_MIN_AIO_VERSION = 190000
+
+# Allowed io_method values per the PG 19 docs. Used both for parsing
+# pg_settings and for the recommendation enum.
+_VALID_IO_METHODS = frozenset({"sync", "worker", "io_uring"})
+
+# Heuristic thresholds. Inline so the advisor and the docstring share
+# one source of truth.
+
+# Cache miss ratio = read_bytes / (read_bytes + hit_bytes). Above this
+# the workload is "I/O-pressured" — worth recommending an async method.
+_HIGH_CACHE_MISS_RATIO = 0.30
+
+# Reads per second below which the workload is too light to bother
+# recommending a method change. Avoids "io_uring all the things".
+_MIN_READS_PER_SECOND = 50.0
+
+# Reads per second above which io_uring (where supported) really shines
+# — kernel-side completion queues amortise the syscall overhead.
+_HIGH_READ_RATE_THRESHOLD = 5_000.0
+
+# Minimum recent stats window to be confident in the recommendation
+# (in seconds since the most recent ``stats_reset``).
+_MIN_STATS_WINDOW_SECONDS = 300.0
+
+
+class AioError(Exception):
+    """Raised when an AIO operation cannot complete."""
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class AioStatus:
+    """Reports whether the PG 19 AIO subsystem is usable on this server.
+
+    ``available`` is True when ``server_version_num`` >= 190000.
+    ``io_method``, ``io_min_workers``, ``io_max_workers`` are the current
+    setting values (``None`` when unavailable). ``detail`` is a
+    human-readable guidance string suitable for surfacing to an agent.
+    """
+
+    available: bool
+    server_version_num: int
+    server_version: str
+    io_method: str | None
+    io_min_workers: int | None
+    io_max_workers: int | None
+    detail: str
+
+
+@dataclass(frozen=True, slots=True)
+class IoMethodRecommendation:
+    """One recommendation row from :func:`recommend_io_method`.
+
+    ``recommended_method`` is one of ``io_uring`` / ``worker`` / ``sync``.
+    ``reason`` is a stable identifier the agent can react to:
+
+    * ``high_concurrent_read_load`` — high read-rate + high miss-ratio →
+      io_uring on supported kernels.
+    * ``bursty_io_with_cache_pressure`` — moderate read-rate + high
+      miss-ratio → worker (the PG 19 default; bias safely).
+    * ``low_io_pressure`` — workload doesn't touch enough I/O to
+      justify async; sync is fine.
+    * ``current_setting_optimal`` — already on the recommended method;
+      no change suggested.
+    * ``insufficient_stats`` — pg_stat_io window too short to give a
+      confident recommendation.
+
+    ``ready_to_run_sql`` is the canonical ``ALTER SYSTEM SET …`` operators
+    paste; only emitted when the recommendation differs from the current
+    setting.
+    """
+
+    recommended_method: str
+    reason: str
+    current_method: str | None
+    cache_miss_ratio: float
+    reads_per_second: float
+    stats_window_seconds: float
+    ready_to_run_sql: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class RecommendIoMethodResult:
+    """Roll-up of :func:`recommend_io_method` — the recommendation plus
+    the AIO status that produced it.
+
+    Always returns exactly one ``recommendation``; the list shape is for
+    forward-compat if future PG versions partition the recommendation
+    per backend type.
+    """
+
+    available: bool
+    server_version_num: int
+    detail: str
+    recommendations: list[IoMethodRecommendation] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Shared probes
+# ---------------------------------------------------------------------------
+
+
+async def _server_version(driver: SqlDriver) -> tuple[int, str]:
+    """Return ``(server_version_num, server_version)`` in one round trip."""
+    rows = await driver.execute_query(
+        "SELECT current_setting('server_version_num')::int AS ver_num, current_setting('server_version') AS ver",
+        force_readonly=True,
+    )
+    if not rows:
+        return 0, ""
+    cells = rows[0].cells
+    return int(cells.get("ver_num") or 0), str(cells.get("ver") or "")
+
+
+async def _aio_settings(driver: SqlDriver) -> tuple[str | None, int | None, int | None]:
+    """Probe pg_settings for ``io_method`` / ``io_min_workers`` / ``io_max_workers``.
+
+    Returns ``(None, None, None)`` when the settings aren't recognised
+    (older PG, or PG 19 build without AIO enabled). We use a single
+    ``current_setting(..., true)`` per knob because pg_settings is too
+    broad and the ``missing_ok`` form (``true``) returns ``NULL`` rather
+    than ERROR when a knob doesn't exist.
+    """
+    rows = await driver.execute_query(
+        "SELECT current_setting('io_method', true) AS method, "
+        "current_setting('io_min_workers', true) AS min_w, "
+        "current_setting('io_max_workers', true) AS max_w",
+        force_readonly=True,
+    )
+    if not rows:
+        return None, None, None
+    cells = rows[0].cells
+    method = cells.get("method")
+    if method is not None and method not in _VALID_IO_METHODS:
+        # Unrecognised value — better to surface as unavailable than to
+        # pass through an unknown string.
+        method = None
+    min_w = cells.get("min_w")
+    max_w = cells.get("max_w")
+    try:
+        min_w_int = int(min_w) if min_w is not None else None
+    except (TypeError, ValueError):
+        min_w_int = None
+    try:
+        max_w_int = int(max_w) if max_w is not None else None
+    except (TypeError, ValueError):
+        max_w_int = None
+    return method, min_w_int, max_w_int
+
+
+# ---------------------------------------------------------------------------
+# Status — never raises
+# ---------------------------------------------------------------------------
+
+
+async def get_aio_status(driver: SqlDriver) -> AioStatus:
+    """Report whether the PG 19 AIO subsystem is usable.
+
+    Read-only; never raises. On PG < 19 returns ``available=False`` with
+    a diagnostic pointing the agent at the existing ``read_pg_stat_io`` /
+    ``run_maintenance`` tools. The version probe and settings lookup are
+    wrapped in ``try/except`` so a transient driver error here still
+    yields a clean ``available=False`` result instead of crashing the
+    tool call.
+    """
+    try:
+        ver_num, ver = await _server_version(driver)
+    except Exception as exc:
+        return AioStatus(
+            available=False,
+            server_version_num=0,
+            server_version="",
+            io_method=None,
+            io_min_workers=None,
+            io_max_workers=None,
+            detail=(
+                f"AIO status is unavailable (server version probe failed: {exc}). "
+                "Fall back to read_pg_stat_io / run_maintenance for I/O observability "
+                "and tuning on older servers."
+            ),
+        )
+    if ver_num < _MIN_AIO_VERSION:
+        return AioStatus(
+            available=False,
+            server_version_num=ver_num,
+            server_version=ver,
+            io_method=None,
+            io_min_workers=None,
+            io_max_workers=None,
+            detail=(
+                "PG 19's async-I/O subsystem requires PostgreSQL 19 or newer; "
+                "this server is older. Use read_pg_stat_io for I/O observability "
+                "on PG ≤ 18."
+            ),
+        )
+    try:
+        method, min_w, max_w = await _aio_settings(driver)
+    except Exception as exc:
+        return AioStatus(
+            available=False,
+            server_version_num=ver_num,
+            server_version=ver,
+            io_method=None,
+            io_min_workers=None,
+            io_max_workers=None,
+            detail=(
+                f"AIO subsystem is reachable but settings probe failed: {exc}. Re-run after the server is back online."
+            ),
+        )
+    return AioStatus(
+        available=True,
+        server_version_num=ver_num,
+        server_version=ver,
+        io_method=method,
+        io_min_workers=min_w,
+        io_max_workers=max_w,
+        detail=(
+            f"AIO subsystem is available. Current io_method={method or 'unknown'} "
+            f"(io_min_workers={min_w}, io_max_workers={max_w}). "
+            "Call recommend_io_method to get a workload-aware recommendation."
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Advisor — recommend_io_method
+# ---------------------------------------------------------------------------
+
+
+async def _io_pressure(driver: SqlDriver) -> tuple[float, float, float]:
+    """Probe pg_stat_io / pg_stat_database for cache pressure and read rate.
+
+    Returns ``(cache_miss_ratio, reads_per_second, stats_window_seconds)``.
+
+    Uses ``pg_stat_database`` aggregates (``blks_read`` / ``blks_hit`` /
+    ``stats_reset``) because they're stable across PG 14+; PG 19 augments
+    ``pg_stat_io`` but we don't depend on the new columns here so the
+    advisor still works while pg_stat_io is being reshaped. Aggregates
+    across all non-template databases.
+    """
+    rows = await driver.execute_query(
+        "SELECT "
+        "  COALESCE(SUM(blks_read), 0) AS reads, "
+        "  COALESCE(SUM(blks_hit), 0) AS hits, "
+        "  EXTRACT(epoch FROM (now() - MIN(stats_reset))) AS window_seconds "
+        "FROM pg_stat_database "
+        "WHERE datname IS NOT NULL "
+        "  AND datname NOT IN ('template0', 'template1')",
+        force_readonly=True,
+    )
+    if not rows:
+        return 0.0, 0.0, 0.0
+    cells = rows[0].cells
+    reads = int(cells.get("reads") or 0)
+    hits = int(cells.get("hits") or 0)
+    window_seconds = float(cells.get("window_seconds") or 0)
+    total = reads + hits
+    miss_ratio = (reads / total) if total > 0 else 0.0
+    reads_per_second = (reads / window_seconds) if window_seconds > 0 else 0.0
+    return miss_ratio, reads_per_second, window_seconds
+
+
+def _classify_io_method(
+    *,
+    current_method: str | None,
+    cache_miss_ratio: float,
+    reads_per_second: float,
+    stats_window_seconds: float,
+) -> tuple[str, str]:
+    """Map workload signals to ``(recommended_method, reason)``.
+
+    The decision tree is deliberately conservative — never recommends
+    ``io_uring`` for low-traffic workloads (the syscall amortisation
+    pays off only at scale), and never recommends ``sync`` for already
+    I/O-pressured workloads (it would regress).
+    """
+    if stats_window_seconds < _MIN_STATS_WINDOW_SECONDS:
+        return current_method or "worker", "insufficient_stats"
+    if reads_per_second < _MIN_READS_PER_SECOND:
+        return "sync", "low_io_pressure"
+    if reads_per_second >= _HIGH_READ_RATE_THRESHOLD and cache_miss_ratio >= _HIGH_CACHE_MISS_RATIO:
+        return "io_uring", "high_concurrent_read_load"
+    if cache_miss_ratio >= _HIGH_CACHE_MISS_RATIO:
+        return "worker", "bursty_io_with_cache_pressure"
+    # I/O pressure exists but cache is doing its job — current default
+    # (worker on PG 19) is fine. Don't churn.
+    return current_method or "worker", "current_setting_optimal"
+
+
+async def recommend_io_method(driver: SqlDriver) -> RecommendIoMethodResult:
+    """Recommend a PG 19 ``io_method`` for this workload.
+
+    Inspects ``pg_stat_database`` aggregates (blks_read / blks_hit /
+    stats_reset) and the current ``io_method`` setting, then maps the
+    workload signals to one of ``io_uring`` / ``worker`` / ``sync``.
+
+    Read-only — never invokes ``ALTER SYSTEM``. The result carries a
+    ``ready_to_run_sql`` snippet operators can paste manually when the
+    recommendation differs from the current setting.
+
+    Returns an empty ``recommendations`` list with a clear ``detail``
+    string on PG < 19.
+    """
+    ver_num, ver = await _server_version(driver)
+    if ver_num < _MIN_AIO_VERSION:
+        return RecommendIoMethodResult(
+            available=False,
+            server_version_num=ver_num,
+            detail=(
+                "PG 19's async-I/O subsystem requires PostgreSQL 19 or newer; "
+                f"this server reports {ver or 'unknown'} (server_version_num={ver_num})."
+            ),
+            recommendations=[],
+        )
+    current_method, _, _ = await _aio_settings(driver)
+    cache_miss_ratio, reads_per_second, stats_window_seconds = await _io_pressure(driver)
+    recommended_method, reason = _classify_io_method(
+        current_method=current_method,
+        cache_miss_ratio=cache_miss_ratio,
+        reads_per_second=reads_per_second,
+        stats_window_seconds=stats_window_seconds,
+    )
+    ready_sql: str | None = None
+    if recommended_method != current_method:
+        # ALTER SYSTEM SET is the canonical persistent-setting path.
+        # Single-quoted value, no identifier interpolation — safe.
+        ready_sql = f"ALTER SYSTEM SET io_method = '{recommended_method}';"
+    rec = IoMethodRecommendation(
+        recommended_method=recommended_method,
+        reason=reason,
+        current_method=current_method,
+        cache_miss_ratio=round(cache_miss_ratio, 3),
+        reads_per_second=round(reads_per_second, 1),
+        stats_window_seconds=round(stats_window_seconds, 1),
+        ready_to_run_sql=ready_sql,
+    )
+    return RecommendIoMethodResult(
+        available=True,
+        server_version_num=ver_num,
+        detail=(
+            f"Recommended io_method={recommended_method} for current workload "
+            f"(reason={reason}, reads/s={reads_per_second:.1f}, "
+            f"cache_miss_ratio={cache_miss_ratio:.3f})."
+        ),
+        recommendations=[rec],
+    )
+
+
+__all__ = [
+    "AioError",
+    "AioStatus",
+    "IoMethodRecommendation",
+    "RecommendIoMethodResult",
+    "get_aio_status",
+    "recommend_io_method",
+]

--- a/src/mcpg/aio.py
+++ b/src/mcpg/aio.py
@@ -261,6 +261,24 @@ async def get_aio_status(driver: SqlDriver) -> AioStatus:
                 f"AIO subsystem is reachable but settings probe failed: {exc}. Re-run after the server is back online."
             ),
         )
+    if method is None:
+        # PG ≥ 19 but the `io_method` GUC isn't recognised — server was
+        # built without AIO, or returned an unrecognised value. Surface
+        # available=False so the agent doesn't try to ALTER SYSTEM SET
+        # something that will fail (gemini review on PR #131).
+        return AioStatus(
+            available=False,
+            server_version_num=ver_num,
+            server_version=ver,
+            io_method=None,
+            io_min_workers=None,
+            io_max_workers=None,
+            detail=(
+                "PG 19 async-I/O GUC 'io_method' is not available on this server. "
+                "The server may have been compiled without AIO support, or it returned "
+                "an unrecognised value. Fall back to read_pg_stat_io / run_maintenance."
+            ),
+        )
     return AioStatus(
         available=True,
         server_version_num=ver_num,
@@ -269,7 +287,7 @@ async def get_aio_status(driver: SqlDriver) -> AioStatus:
         io_min_workers=min_w,
         io_max_workers=max_w,
         detail=(
-            f"AIO subsystem is available. Current io_method={method or 'unknown'} "
+            f"AIO subsystem is available. Current io_method={method} "
             f"(io_min_workers={min_w}, io_max_workers={max_w}). "
             "Call recommend_io_method to get a workload-aware recommendation."
         ),
@@ -292,11 +310,17 @@ async def _io_pressure(driver: SqlDriver) -> tuple[float, float, float]:
     advisor still works while pg_stat_io is being reshaped. Aggregates
     across all non-template databases.
     """
+    # Use COALESCE(MIN(stats_reset), pg_postmaster_start_time()) so the
+    # window doesn't collapse to 0 on a cluster where stats have never
+    # been reset (the default state on a fresh install) — gemini review
+    # on PR #131. pg_postmaster_start_time() is the correct upper bound
+    # on accumulated stats when stats_reset is NULL.
     rows = await driver.execute_query(
         "SELECT "
         "  COALESCE(SUM(blks_read), 0) AS reads, "
         "  COALESCE(SUM(blks_hit), 0) AS hits, "
-        "  EXTRACT(epoch FROM (now() - MIN(stats_reset))) AS window_seconds "
+        "  EXTRACT(epoch FROM (now() - COALESCE(MIN(stats_reset), pg_postmaster_start_time()))) "
+        "    AS window_seconds "
         "FROM pg_stat_database "
         "WHERE datname IS NOT NULL "
         "  AND datname NOT IN ('template0', 'template1')",
@@ -367,6 +391,21 @@ async def recommend_io_method(driver: SqlDriver) -> RecommendIoMethodResult:
             recommendations=[],
         )
     current_method, _, _ = await _aio_settings(driver)
+    if current_method is None:
+        # GUC missing / unrecognised — server was built without AIO, or
+        # returned a value we don't know about. Bail early rather than
+        # recommend a change that will fail (gemini review on PR #131).
+        return RecommendIoMethodResult(
+            available=False,
+            server_version_num=ver_num,
+            detail=(
+                "PG 19 async-I/O GUC 'io_method' is not available on this server. "
+                "The server may have been compiled without AIO support, or it "
+                "returned an unrecognised value. Fall back to read_pg_stat_io / "
+                "run_maintenance for I/O observability and tuning."
+            ),
+            recommendations=[],
+        )
     cache_miss_ratio, reads_per_second, stats_window_seconds = await _io_pressure(driver)
     recommended_method, reason = _classify_io_method(
         current_method=current_method,

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -17,6 +17,7 @@ from mcp.server.session import ServerSession
 from mcpg import (
     __version__,
     advisors,
+    aio,
     audit,
     audit_trail,
     composite,
@@ -4448,6 +4449,59 @@ def _register_pg_prewarm_writes(server: FastMCP[AppContext]) -> None:
         return asdict(result)
 
 
+def _register_aio_reads(server: FastMCP[AppContext]) -> None:
+    @server.tool(
+        name="get_aio_status",
+        description=_with_example(
+            "Report whether PG 19's async-I/O subsystem is usable. On "
+            "PG < 19 returns `available=false` with a diagnostic pointing "
+            "the agent at the existing `read_pg_stat_io` / `run_maintenance` "
+            "tools. Never raises — driver-level errors during the version "
+            "or settings probe also surface as `available=false`. "
+            "Returns an object with `available` (bool), `server_version_num` "
+            "(int), `server_version`, `io_method` ('sync' / 'worker' / "
+            "'io_uring' / null), `io_min_workers`, `io_max_workers`, and "
+            "`detail` (a guidance string).",
+            "get_aio_status()",
+        ),
+    )
+    async def get_aio_status(ctx: _Ctx) -> dict[str, Any]:
+        async def _run() -> dict[str, Any]:
+            status = await aio.get_aio_status(_driver(ctx))
+            return asdict(status)
+
+        return await _cached_call(ctx, "get_aio_status", _run)
+
+    @server.tool(
+        name="recommend_io_method",
+        description=_with_example(
+            "Recommend a PG 19 `io_method` ('sync' / 'worker' / 'io_uring') "
+            "for the current workload. Reads `pg_stat_database` aggregates "
+            "(blks_read / blks_hit / stats_reset) and the current setting, "
+            "then maps the workload signals to one of: "
+            "`high_concurrent_read_load` (→ io_uring), "
+            "`bursty_io_with_cache_pressure` (→ worker), "
+            "`low_io_pressure` (→ sync), `current_setting_optimal` "
+            "(no change), or `insufficient_stats` (window too short). "
+            "Read-only — never invokes ALTER SYSTEM; emits a "
+            "ready_to_run_sql snippet the operator can paste when the "
+            "recommendation differs from the current setting. "
+            "Returns an object with `available` (bool), `server_version_num`, "
+            "`detail`, and `recommendations` — a list of objects with "
+            "`recommended_method`, `reason`, `current_method`, "
+            "`cache_miss_ratio`, `reads_per_second`, `stats_window_seconds`, "
+            "and `ready_to_run_sql` (null when no change suggested).",
+            "recommend_io_method()",
+        ),
+    )
+    async def recommend_io_method(ctx: _Ctx) -> dict[str, Any]:
+        async def _run() -> dict[str, Any]:
+            result = await aio.recommend_io_method(_driver(ctx))
+            return asdict(result)
+
+        return await _cached_call(ctx, "recommend_io_method", _run)
+
+
 def _register_repack_reads(server: FastMCP[AppContext]) -> None:
     @server.tool(
         name="get_repack_status",
@@ -4850,6 +4904,7 @@ def register_tools(server: FastMCP[AppContext], settings: Settings) -> None:
         _register_pg_prewarm_reads(server)
         _register_pgq_reads(server)
         _register_repack_reads(server)
+        _register_aio_reads(server)
     if is_permitted(settings.access_mode, Capability.WRITE):
         _register_write(server)
         _register_maintenance(server)

--- a/tests/contract/tool_return_shapes.snapshot.json
+++ b/tests/contract/tool_return_shapes.snapshot.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "schema_version": 1,
-    "tool_count": 198
+    "tool_count": 200
   },
   "tools": {
     "add_compression_policy": {
@@ -561,6 +561,9 @@
         "matches"
       ],
       "kind": "scalar"
+    },
+    "get_aio_status": {
+      "kind": "opaque"
     },
     "get_compact_schema": {
       "kind": "opaque"
@@ -1479,6 +1482,9 @@
         "table"
       ],
       "kind": "list"
+    },
+    "recommend_io_method": {
+      "kind": "opaque"
     },
     "recommend_pg_search_maintenance": {
       "dataclass": "PgSearchAdvisorFinding",

--- a/tests/contract/tool_surface.snapshot.json
+++ b/tests/contract/tool_surface.snapshot.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "schema_version": 1,
-    "tool_count": 198
+    "tool_count": 200
   },
   "tools": [
     {
@@ -2058,6 +2058,15 @@
         "type": "object"
       },
       "name": "geo_search"
+    },
+    {
+      "description": "Report whether PG 19's async-I/O subsystem is usable. On PG < 19 returns `available=false` with a diagnostic pointing the agent at the existing `read_pg_stat_io` / `run_maintenance` tools. Never raises — driver-level errors during the version or settings probe also surface as `available=false`. Returns an object with `available` (bool), `server_version_num` (int), `server_version`, `io_method` ('sync' / 'worker' / 'io_uring' / null), `io_min_workers`, `io_max_workers`, and `detail` (a guidance string).\n\nExample: `get_aio_status()`",
+      "inputSchema": {
+        "properties": {},
+        "title": "get_aio_statusArguments",
+        "type": "object"
+      },
+      "name": "get_aio_status"
     },
     {
       "description": "Return a highly condensed, token-efficient text summary of a schema's tables, columns, primary keys, nullability, and relations to save context window tokens.",
@@ -4193,6 +4202,15 @@
         "type": "object"
       },
       "name": "recommend_indexes"
+    },
+    {
+      "description": "Recommend a PG 19 `io_method` ('sync' / 'worker' / 'io_uring') for the current workload. Reads `pg_stat_database` aggregates (blks_read / blks_hit / stats_reset) and the current setting, then maps the workload signals to one of: `high_concurrent_read_load` (→ io_uring), `bursty_io_with_cache_pressure` (→ worker), `low_io_pressure` (→ sync), `current_setting_optimal` (no change), or `insufficient_stats` (window too short). Read-only — never invokes ALTER SYSTEM; emits a ready_to_run_sql snippet the operator can paste when the recommendation differs from the current setting. Returns an object with `available` (bool), `server_version_num`, `detail`, and `recommendations` — a list of objects with `recommended_method`, `reason`, `current_method`, `cache_miss_ratio`, `reads_per_second`, `stats_window_seconds`, and `ready_to_run_sql` (null when no change suggested).\n\nExample: `recommend_io_method()`",
+      "inputSchema": {
+        "properties": {},
+        "title": "recommend_io_methodArguments",
+        "type": "object"
+      },
+      "name": "recommend_io_method"
     },
     {
       "description": "Walk every pg_search BM25 index and emit advisor findings. Rules currently surfaced: ``missing_key_field`` (CRITICAL — the key_field reloption is required by upstream; an index without it can't satisfy queries) and ``no_field_configs`` (WARNING — none of the six *_fields reloptions are set, so the index falls back to default tokenization for every indexed column). Each finding carries a ready-to-run ``suggested_action`` SQL statement. Returns an empty list when the extension is not installed. Also feeds the ``pg_search BM25 Indexes`` category in audit_database.",

--- a/tests/unit/test_aio.py
+++ b/tests/unit/test_aio.py
@@ -73,23 +73,40 @@ async def test_status_never_raises_on_driver_failure() -> None:
 
 
 async def test_status_handles_unknown_io_method_value() -> None:
-    """An io_method value the module doesn't recognise normalises to None."""
+    """An io_method value the module doesn't recognise → available=False
+    so the agent doesn't try to ALTER SYSTEM SET something that will fail
+    (gemini review on PR #131)."""
     routes = _version_route(190001, "19beta1")
     routes.update(_settings_route("frobnicate", 4, 16))
     driver = FakeRoutingDriver(routes)
     status = await get_aio_status(driver)  # type: ignore[arg-type]
-    assert status.available is True
-    assert status.io_method is None  # unrecognised value gets nulled
+    assert status.available is False
+    assert status.io_method is None
+    assert "io_method" in status.detail
 
 
 async def test_status_handles_missing_settings_rows() -> None:
-    """PG 19 build without AIO enabled returns NULL for the GUCs."""
+    """PG 19 build without AIO enabled returns NULL for the GUCs →
+    available=False so the agent falls back to the existing IO tools."""
     routes = _version_route(190001, "19beta1")
     routes.update(_settings_route(None, None, None))
     driver = FakeRoutingDriver(routes)
     status = await get_aio_status(driver)  # type: ignore[arg-type]
-    assert status.available is True
+    assert status.available is False
     assert status.io_method is None
+    assert "io_method" in status.detail
+
+
+async def test_recommend_bails_when_io_method_guc_missing() -> None:
+    """recommend_io_method on PG 19 without AIO support → available=False
+    + empty recommendations, no ALTER SYSTEM guess (gemini review)."""
+    routes = _version_route(190001, "19beta1")
+    routes.update(_settings_route(None, None, None))
+    driver = FakeRoutingDriver(routes)
+    result = await recommend_io_method(driver)  # type: ignore[arg-type]
+    assert result.available is False
+    assert result.recommendations == []
+    assert "io_method" in result.detail
 
 
 # --- recommend_io_method ---------------------------------------------------

--- a/tests/unit/test_aio.py
+++ b/tests/unit/test_aio.py
@@ -1,0 +1,222 @@
+"""Tests for the PG 19 async-I/O coverage module."""
+
+from __future__ import annotations
+
+from _fakes import FakeDriver, FakeRoutingDriver
+
+from mcpg.aio import (
+    AioStatus,
+    IoMethodRecommendation,
+    RecommendIoMethodResult,
+    get_aio_status,
+    recommend_io_method,
+)
+
+
+def _version_route(num: int, ver: str) -> dict[str, list[dict[str, object]]]:
+    """Helper — wires the server-version probe to a specific version."""
+    return {"current_setting('server_version_num')": [{"ver_num": num, "ver": ver}]}
+
+
+def _settings_route(method: str | None, min_w: int | None, max_w: int | None) -> dict[str, list[dict[str, object]]]:
+    """Helper — wires the io_method / io_min_workers / io_max_workers probe."""
+    return {
+        "current_setting('io_method'": [
+            {
+                "method": method,
+                "min_w": str(min_w) if min_w is not None else None,
+                "max_w": str(max_w) if max_w is not None else None,
+            }
+        ]
+    }
+
+
+def _pressure_route(reads: int, hits: int, window_seconds: float) -> dict[str, list[dict[str, object]]]:
+    """Helper — wires the pg_stat_database aggregate probe."""
+    return {"FROM pg_stat_database": [{"reads": reads, "hits": hits, "window_seconds": window_seconds}]}
+
+
+# --- get_aio_status --------------------------------------------------------
+
+
+async def test_status_available_on_pg19_with_settings() -> None:
+    routes = _version_route(190001, "19beta1")
+    routes.update(_settings_route("worker", 4, 16))
+    driver = FakeRoutingDriver(routes)
+    status = await get_aio_status(driver)  # type: ignore[arg-type]
+    assert isinstance(status, AioStatus)
+    assert status.available is True
+    assert status.io_method == "worker"
+    assert status.io_min_workers == 4
+    assert status.io_max_workers == 16
+    assert "worker" in status.detail
+
+
+async def test_status_unavailable_on_pg18_with_diagnostic() -> None:
+    driver = FakeRoutingDriver(_version_route(180003, "18.3"))
+    status = await get_aio_status(driver)  # type: ignore[arg-type]
+    assert status.available is False
+    assert status.server_version_num == 180003
+    # Diagnostic must point the agent at the existing IO stat tools.
+    assert "read_pg_stat_io" in status.detail
+    # All AIO-specific fields nulled when unavailable.
+    assert status.io_method is None
+    assert status.io_min_workers is None
+
+
+async def test_status_never_raises_on_driver_failure() -> None:
+    """get_aio_status documents 'never raises' — confirm with a failing driver."""
+    driver = FakeDriver(fail=True)
+    status = await get_aio_status(driver)  # type: ignore[arg-type]
+    assert status.available is False
+    assert "read_pg_stat_io" in status.detail
+
+
+async def test_status_handles_unknown_io_method_value() -> None:
+    """An io_method value the module doesn't recognise normalises to None."""
+    routes = _version_route(190001, "19beta1")
+    routes.update(_settings_route("frobnicate", 4, 16))
+    driver = FakeRoutingDriver(routes)
+    status = await get_aio_status(driver)  # type: ignore[arg-type]
+    assert status.available is True
+    assert status.io_method is None  # unrecognised value gets nulled
+
+
+async def test_status_handles_missing_settings_rows() -> None:
+    """PG 19 build without AIO enabled returns NULL for the GUCs."""
+    routes = _version_route(190001, "19beta1")
+    routes.update(_settings_route(None, None, None))
+    driver = FakeRoutingDriver(routes)
+    status = await get_aio_status(driver)  # type: ignore[arg-type]
+    assert status.available is True
+    assert status.io_method is None
+
+
+# --- recommend_io_method ---------------------------------------------------
+
+
+async def test_recommend_io_uring_for_high_concurrent_read_load() -> None:
+    routes = _version_route(190001, "19beta1")
+    routes.update(_settings_route("worker", 4, 16))
+    # 10_000 reads/s with 50% miss ratio over a 10-minute window.
+    routes.update(_pressure_route(reads=6_000_000, hits=6_000_000, window_seconds=600.0))
+    driver = FakeRoutingDriver(routes)
+    result = await recommend_io_method(driver)  # type: ignore[arg-type]
+    assert isinstance(result, RecommendIoMethodResult)
+    assert result.available is True
+    assert len(result.recommendations) == 1
+    rec = result.recommendations[0]
+    assert rec.recommended_method == "io_uring"
+    assert rec.reason == "high_concurrent_read_load"
+    assert rec.current_method == "worker"
+    # Differs from current → ready_to_run_sql emitted.
+    assert rec.ready_to_run_sql == "ALTER SYSTEM SET io_method = 'io_uring';"
+
+
+async def test_recommend_worker_for_bursty_io_with_cache_pressure() -> None:
+    routes = _version_route(190001, "19beta1")
+    routes.update(_settings_route("sync", 4, 16))
+    # Moderate read rate, 50% miss ratio → worker.
+    routes.update(_pressure_route(reads=200_000, hits=200_000, window_seconds=600.0))
+    driver = FakeRoutingDriver(routes)
+    result = await recommend_io_method(driver)  # type: ignore[arg-type]
+    rec = result.recommendations[0]
+    assert rec.recommended_method == "worker"
+    assert rec.reason == "bursty_io_with_cache_pressure"
+    assert rec.ready_to_run_sql == "ALTER SYSTEM SET io_method = 'worker';"
+
+
+async def test_recommend_sync_for_low_io_pressure() -> None:
+    routes = _version_route(190001, "19beta1")
+    routes.update(_settings_route("worker", 4, 16))
+    # 10 reads/s — below the 50-reads/s floor.
+    routes.update(_pressure_route(reads=6_000, hits=100_000, window_seconds=600.0))
+    driver = FakeRoutingDriver(routes)
+    result = await recommend_io_method(driver)  # type: ignore[arg-type]
+    rec = result.recommendations[0]
+    assert rec.recommended_method == "sync"
+    assert rec.reason == "low_io_pressure"
+
+
+async def test_recommend_current_setting_optimal_when_no_change_needed() -> None:
+    routes = _version_route(190001, "19beta1")
+    routes.update(_settings_route("worker", 4, 16))
+    # I/O exists but cache miss ratio is low (< 30%) → current is fine.
+    routes.update(_pressure_route(reads=60_000, hits=10_000_000, window_seconds=600.0))
+    driver = FakeRoutingDriver(routes)
+    result = await recommend_io_method(driver)  # type: ignore[arg-type]
+    rec = result.recommendations[0]
+    assert rec.reason == "current_setting_optimal"
+    assert rec.recommended_method == "worker"
+    # Same as current → no ready_to_run_sql.
+    assert rec.ready_to_run_sql is None
+
+
+async def test_recommend_insufficient_stats_when_window_too_short() -> None:
+    routes = _version_route(190001, "19beta1")
+    routes.update(_settings_route("worker", 4, 16))
+    # 5-minute window threshold; 100s is too short.
+    routes.update(_pressure_route(reads=200_000, hits=200_000, window_seconds=100.0))
+    driver = FakeRoutingDriver(routes)
+    result = await recommend_io_method(driver)  # type: ignore[arg-type]
+    rec = result.recommendations[0]
+    assert rec.reason == "insufficient_stats"
+    # Stays on current method while collecting more data.
+    assert rec.recommended_method == "worker"
+    assert rec.ready_to_run_sql is None
+
+
+async def test_recommend_empty_on_pg18() -> None:
+    driver = FakeRoutingDriver(_version_route(180003, "18.3"))
+    result = await recommend_io_method(driver)  # type: ignore[arg-type]
+    assert result.available is False
+    assert result.recommendations == []
+    assert "PostgreSQL 19" in result.detail
+
+
+async def test_recommend_handles_zero_total_reads_safely() -> None:
+    """Div-by-zero guard on a quiet cluster (no blks read/hit at all)."""
+    routes = _version_route(190001, "19beta1")
+    routes.update(_settings_route("worker", 4, 16))
+    routes.update(_pressure_route(reads=0, hits=0, window_seconds=600.0))
+    driver = FakeRoutingDriver(routes)
+    result = await recommend_io_method(driver)  # type: ignore[arg-type]
+    rec = result.recommendations[0]
+    # 0 reads/s → low_io_pressure → sync.
+    assert rec.reason == "low_io_pressure"
+    assert rec.recommended_method == "sync"
+    assert rec.cache_miss_ratio == 0.0
+    assert rec.reads_per_second == 0.0
+
+
+# --- Dataclass shapes ------------------------------------------------------
+
+
+def test_dataclass_shapes() -> None:
+    status = AioStatus(
+        available=True,
+        server_version_num=190001,
+        server_version="19beta1",
+        io_method="worker",
+        io_min_workers=4,
+        io_max_workers=16,
+        detail="ok",
+    )
+    assert status.available is True
+    rec = IoMethodRecommendation(
+        recommended_method="io_uring",
+        reason="high_concurrent_read_load",
+        current_method="worker",
+        cache_miss_ratio=0.5,
+        reads_per_second=10_000.0,
+        stats_window_seconds=600.0,
+        ready_to_run_sql="ALTER SYSTEM SET io_method = 'io_uring';",
+    )
+    assert rec.recommended_method == "io_uring"
+    result = RecommendIoMethodResult(
+        available=True,
+        server_version_num=190001,
+        detail="ok",
+        recommendations=[rec],
+    )
+    assert len(result.recommendations) == 1


### PR DESCRIPTION
## Summary

Phase 3 PR-3 of #120. The headline PG 19 differentiator: an advisor that tells operators which `io_method` (`sync` / `worker` / `io_uring`) is right for their workload. PO score **25/25** in the prioritisation matrix (#126).

### New tools (2)

| Tool | Surface | Purpose |
|---|---|---|
| `get_aio_status` | read | Version probe + current `io_method` / `io_min_workers` / `io_max_workers` GUC values. Never raises — driver-level errors surface as `available=false`. |
| `recommend_io_method` | read advisor | Reads `pg_stat_database` aggregates (`blks_read` / `blks_hit` / `stats_reset`) and maps the workload to one of five stable reason codes. |

### Decision tree

| Signal | Recommended | Reason code |
|---|---|---|
| reads/s ≥ 5000 AND cache_miss_ratio ≥ 0.30 | `io_uring` | `high_concurrent_read_load` |
| cache_miss_ratio ≥ 0.30 (lower read rate) | `worker` | `bursty_io_with_cache_pressure` |
| reads/s < 50 | `sync` | `low_io_pressure` |
| I/O exists but cache is doing its job | (current) | `current_setting_optimal` |
| stats_reset window < 5 min | (current) | `insufficient_stats` |

Heuristic thresholds inline at module top as named constants so the docstring and the advisor share one source of truth.

### Read-only advisor

The advisor never invokes `ALTER SYSTEM`. It emits a `ready_to_run_sql` snippet (`ALTER SYSTEM SET io_method = '…';`) only when the recommendation differs from the current setting; the operator applies it manually.

### Backward compatibility

Per the no-deprecation rule (#128):

- The existing `read_pg_stat_io` tool in `mcpg.io_stats` is **untouched**.
- `get_aio_status` wraps the version + settings probe in `try/except` so it satisfies its "never raises" contract even on driver-level errors (gemini-review pattern from PR #129).
- On PG ≤ 18, both tools return `available=false` with a diagnostic pointing the agent at the existing IO-stat tools.

### Module + plumbing

- New `src/mcpg/aio.py` (~410 lines) — dataclasses, version helpers, settings probe, advisor.
- Both tools routed to `operations_and_health` via `_TOOL_TO_BUCKET_OVERRIDES`.
- Both contract snapshots regenerated.

### Tests

- 13 unit tests in `tests/unit/test_aio.py` covering every reason-code branch, version-gate behaviour, never-raises contract, unknown-setting-value normalisation, and zero-total-reads div-by-zero guard.
- Full unit + contract suite: 2008 tests pass locally.

## Test plan

- [x] `python -m pytest tests/unit/test_aio.py` — 13 / 13 pass
- [x] `python -m pytest tests/unit/ tests/contract/` — 2008 pass
- [x] `ruff check src/mcpg/aio.py tests/unit/test_aio.py` — clean
- [x] `mypy src/mcpg/aio.py` — clean
- [x] `bandit -r src/mcpg/aio.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_