### PR TITLE
ci: add Dependabot config — weekly grouped bumps + security-alert PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,124 @@
+# Dependabot configuration for MCPg.
+#
+# Tracks three ecosystems and opens grouped PRs on a weekly cadence so
+# routine bumps don't drown the review queue.
+#
+# Coverage:
+#   - Python deps (uv / pyproject.toml + uv.lock)
+#   - GitHub Actions workflow pins (actions/checkout@v4 etc)
+#   - Docker base images in the CI Dockerfiles + the project Dockerfile
+#
+# When a security advisory drops, Dependabot will open a PR *outside*
+# the weekly schedule regardless of `schedule` — that's the whole point
+# of having this file: security alerts surface as PRs the CI gates,
+# not just as nudges in the security tab. See:
+# https://docs.github.com/en/code-security/dependabot/dependabot-security-updates
+#
+# Each ecosystem follows the same template:
+#   - weekly schedule, Monday morning UTC (lines up with the start of
+#     the working week)
+#   - open-pull-requests-limit: 5 so a backlog can't flood
+#   - labels: "dependencies" + the ecosystem name for easy filtering
+#   - commit-message prefix matches Conventional Commits so the
+#     changelog rollup picks them up cleanly
+#   - groups for related updates (e.g. all Python minor/patch into one PR,
+#     all GH Action major bumps separately) so reviewers see the change
+#     set at the right granularity
+
+version: 2
+updates:
+  # ---------------------------------------------------------------------------
+  # Python — uv / pyproject.toml. Dependabot understands uv.lock natively
+  # since GitHub's late-2024 support announcement.
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      # `chore(deps): bump …` matches Conventional Commits so the
+      # release rollup script picks them up under the right section.
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      # All non-major Python bumps (minor + patch) into one weekly PR.
+      # Major bumps land separately so they can be reviewed individually.
+      python-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # ---------------------------------------------------------------------------
+  # GitHub Actions — the workflow YAML pins.
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci(deps)"
+      include: "scope"
+    groups:
+      gh-actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # ---------------------------------------------------------------------------
+  # Docker — every Dockerfile in the repo gets its `FROM` lines watched.
+  # Three directories: the project Dockerfile at repo root, the CI image
+  # for PG 14-18, and the PG 19 beta scaffold.
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "build(deps)"
+      include: "scope"
+
+  - package-ecosystem: "docker"
+    directory: "/.github"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "docker"
+      - "ci"
+    commit-message:
+      prefix: "ci(deps)"
+      include: "scope"
+    # Pin pgvector/pgvector tag bumps and postgres:19beta1 transitions
+    # for explicit review — those Dockerfiles are part of the PG-version
+    # readiness story (issue #120) and deserve eyeballs.
+    ignore:
+      # Don't auto-bump pgvector while we're tracking specific PG-version
+      # tags (`pg14` / `pg15` / `pg16` / `pg17` / `pg18`) — the matrix
+      # entry pins the tag deliberately.
+      - dependency-name: "pgvector/pgvector"
+      - dependency-name: "postgres"


### PR DESCRIPTION
## Summary

User direction: *"yes, this will be a good automation"* — wiring up `.github/dependabot.yml` so dependency security alerts surface as **PRs the CI gates**, not just nudges in the security tab. (The earlier `pydantic-settings` CVE was only caught because `pip-audit` happened to fail on a random PR — without this config there's no proactive channel.)

### What lands

| Ecosystem | Coverage | Schedule | PR limit | Commit prefix |
|---|---|---|---|---|
| `uv` | `pyproject.toml` + `uv.lock` | Weekly Mon 06:00 UTC | 5 | `chore(deps)` |
| `github-actions` | All workflow YAML pins | Weekly Mon 06:00 UTC | 3 | `ci(deps)` |
| `docker` (root) | Project `Dockerfile` | Weekly Mon 06:00 UTC | 3 | `build(deps)` |
| `docker` (`/.github`) | CI Dockerfiles (PG 14-18 + PG 19) | Weekly Mon 06:00 UTC | 3 | `ci(deps)` |

### Design choices

- **Grouped minor + patch bumps** (Python and GH-Actions) so each weekly run produces one rollup PR per ecosystem, not 10 noisy ones. Major bumps land separately so each gets individual review.
- **Security advisories override the schedule** and open PRs immediately — that's the whole point of having this file.
- **PG-version-pinned Docker tags are ignored** (`pgvector/pgvector`, `postgres`) so the PG 19 readiness work in issue #120 isn't thrashed by an auto-bump to `pg20` / off-matrix tags.
- **Commit prefixes match Conventional Commits** so the changelog rollup script picks them up under the right section.
- **Labels**: `dependencies` + ecosystem name on every PR for filterability.

### Why `uv` not `pip`

GitHub added first-class `uv` support to Dependabot in late 2024. Since the repo is uv-managed (`uv.lock`), the `uv` ecosystem picks up locked transitive deps; `pip` would only see direct `pyproject.toml` requirements.

## Test plan

- [x] YAML syntax validated locally with `python -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` — parses cleanly.
- [x] No code changes; CI runs the same as a no-op PR.
- [ ] Dependabot picks up the config on merge and opens its first bump batch within ~24h (visible in `https://github.com/devopam/MCPg/network/updates`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

CI:
- Configure Dependabot to create grouped weekly PRs for uv-managed Python dependencies, GitHub Actions workflow pins, and Dockerfiles, with limits and labeling for manageable review load.