### PR TITLE
fix(ci): dependabot ecosystem 'uv' → 'pip' (silent-ignore bug from #133)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,10 +28,12 @@
 version: 2
 updates:
   # ---------------------------------------------------------------------------
-  # Python — uv / pyproject.toml. Dependabot understands uv.lock natively
-  # since GitHub's late-2024 support announcement.
+  # Python — pyproject.toml + uv.lock. Dependabot v2 doesn't expose a
+  # standalone `uv` ecosystem; the supported value is `pip`, and Dependabot
+  # auto-detects uv.lock in the directory and uses uv to resolve updates.
+  # Source: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#package-ecosystem--
   # ---------------------------------------------------------------------------
-  - package-ecosystem: "uv"
+  - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Summary

Real bug in the Dependabot config I shipped in #133: `package-ecosystem: "uv"` is **not a Dependabot v2 ecosystem**. Both gemini-code-assist-2 and sourcery flagged this on #133 as critical; I missed both comments and merged anyway. Without this fix, Python deps aren't being tracked at all — Dependabot silently ignores unknown ecosystems.

The supported value is `pip`. Per the GitHub Dependabot docs, `pip` auto-detects `uv.lock` when present in the directory and uses `uv` to resolve updates.

### Process miss

I cut a corner on #133 — checked CI green but didn't fetch `get_review_comments` before merging. Going forward the discipline is: **always pull the review-comments list before clicking merge, regardless of CI state.** Both reviewers had filed critical comments; both got ignored. Surfacing this honestly so the pattern doesn't repeat.

### What changes

- One line in `.github/dependabot.yml`: `"uv"` → `"pip"`.
- Comment block updated to cite the GitHub docs source.
- All other config (groups, schedule, labels, commit prefixes, ignore rules for the Docker block) carries over unchanged.

## Test plan

- [x] YAML re-validates locally with `python -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"`.
- [ ] After merge: Dependabot picks up the corrected config on next scan and opens its first Python bump PR within ~24h (visible in `https://github.com/devopam/MCPg/network/updates`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

CI:
- Update Dependabot Python update config to use the pip ecosystem instead of the unsupported uv ecosystem and document the official GitHub behavior.