### PR TITLE
feat(pg19_stats): lock + recovery analytics — Phase 3 PR-4 — #120

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **PG 19 lock + recovery analytics** (`mcpg.pg19_stats`). Four new
+  read tools: `get_pg19_stats_status` (per-view presence probe; never
+  raises), `read_pg_stat_lock` (per-lock-type acquire / wait /
+  wait_time counters from the new PG 19 view), `read_pg_stat_recovery`
+  (replay LSN + lag + startup state on standbys), and
+  `analyze_lock_hotspots` (read-only advisor classifying each lock
+  type by wait dominance with stable reason codes:
+  `contention_dominant`, `high_wait_time`, `high_wait_count`,
+  `low_contention`).
+
+  PR-4 of the PG 19 Phase 3 plan (bundles PO matrix rows #5 + #12,
+  combined PO score 38). Routes all four tools to the existing
+  `operations_and_health` capability bucket so `describe_self`
+  groups them next to `find_blocking_chains` / `walk_blocking_chains` /
+  `read_pg_stat_io`. Per the no-deprecation rule, the existing
+  `find_blocking_chains` / `list_locks` tools in `mcpg.locks` are
+  untouched and the advisor diagnostics on PG ≤ 18 point operators
+  at them as the fallback path. Advances #120.
+
 - **PG 19 async-I/O advisor** (`mcpg.aio`). Two new tools:
   `get_aio_status` (version probe + current `io_method` /
   `io_min_workers` / `io_max_workers` GUCs; never raises) and

--- a/src/mcpg/about.py
+++ b/src/mcpg/about.py
@@ -659,6 +659,12 @@ _TOOL_TO_BUCKET_OVERRIDES: dict[str, str] = {
     # operations_and_health bucket next to read_pg_stat_io.
     "get_aio_status": "operations_and_health",
     "recommend_io_method": "operations_and_health",
+    # PG 19 lock + recovery analytics — sits next to find_blocking_chains
+    # / walk_blocking_chains in the operations_and_health bucket.
+    "get_pg19_stats_status": "operations_and_health",
+    "read_pg_stat_lock": "operations_and_health",
+    "read_pg_stat_recovery": "operations_and_health",
+    "analyze_lock_hotspots": "operations_and_health",
 }
 
 

--- a/src/mcpg/pg19_stats.py
+++ b/src/mcpg/pg19_stats.py
@@ -1,0 +1,485 @@
+"""PG 19 lock + recovery analytics — `pg_stat_lock` and `pg_stat_recovery`.
+
+PG 19 introduces two new monitoring views:
+
+* ``pg_stat_lock`` — per-lock-type wait / acquire counters that let
+  operators see *which* lock types (relation / page / tuple / xid /
+  virtualxid / advisory / etc.) are the source of contention.
+  Previously this required parsing `pg_locks` snapshots or guessing
+  from `pg_stat_activity.wait_event_type`.
+* ``pg_stat_recovery`` — detailed visibility into recovery operations
+  (replay LSN, replay throughput, last-applied-WAL-record timestamp,
+  startup-process state). Previously this lived in
+  `pg_stat_replication` + ad-hoc XLOG diagnostics.
+
+This module ships three read tools and one advisor:
+
+* ``get_pg19_stats_status`` — version + view-presence probe; never
+  raises. Lets agents feature-detect both views in one call before
+  calling the readers.
+* ``read_pg_stat_lock`` — surface every row from `pg_stat_lock`.
+* ``read_pg_stat_recovery`` — surface the single-row recovery summary.
+* ``analyze_lock_hotspots`` — read-only advisor that buckets lock
+  types by wait dominance and surfaces stable reason codes
+  (``high_wait_time``, ``contention_dominant``,
+  ``low_contention``).
+
+Backward compatibility
+----------------------
+The existing `find_blocking_chains` / `list_locks` tools in
+`mcpg.locks` are untouched. On PG ≤ 18 (where the new views don't
+exist) all four tools degrade to empty results + diagnostics pointing
+at the older tools, per the no-deprecation rule.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from mcpg._vendor.sql import SqlDriver
+
+# Both views landed in PG 19. The version-num probe is the boundary —
+# no extension to install.
+_MIN_PG19_VERSION = 190000
+
+# Heuristic thresholds for the advisor. Inline so the docstring and
+# the classifier share one source of truth.
+
+# Wait time above which a lock type is considered "hot" (microseconds).
+# 1 second of cumulative wait across the cluster is the smallest unit
+# worth flagging in a typical incident-response context.
+_HIGH_WAIT_TIME_US = 1_000_000
+
+# Wait count above which we surface the type even if cumulative wait
+# is low — high *frequency* of short waits often means lock-contention
+# from app-side hot-row updates.
+_HIGH_WAIT_COUNT = 1_000
+
+
+class Pg19StatsError(Exception):
+    """Raised when a PG 19 stats operation cannot complete."""
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses — one per return shape. frozen + slots throughout.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class Pg19StatsStatus:
+    """Reports whether the PG 19 lock + recovery views are usable.
+
+    ``available`` is True when ``server_version_num`` >= 190000 AND at
+    least one of the new views exists. The per-view booleans let agents
+    pick by exact feature without separate probes.
+
+    ``detail`` is a human-readable guidance string suitable for surfacing
+    back to an LLM when the answer is "not available" — points at the
+    legacy `find_blocking_chains` / `pg_stat_replication` paths.
+    """
+
+    available: bool
+    server_version_num: int
+    server_version: str
+    has_pg_stat_lock: bool
+    has_pg_stat_recovery: bool
+    detail: str
+
+
+@dataclass(frozen=True, slots=True)
+class LockStatRow:
+    """One row from ``pg_stat_lock``.
+
+    Field names follow the PG 19 Beta 1 docs. ``lock_type`` is the
+    category (e.g. ``relation`` / ``tuple`` / ``advisory``).
+    ``waits`` and ``wait_time_us`` are cumulative since the stats reset.
+    """
+
+    lock_type: str
+    acquires: int
+    waits: int
+    wait_time_us: int
+
+
+@dataclass(frozen=True, slots=True)
+class RecoveryStatRow:
+    """One row from ``pg_stat_recovery`` — typically a single-row view
+    that summarises the standby's replay progress.
+
+    ``replay_lsn`` is the standby's current replay LSN (string form);
+    ``replay_lag_seconds`` is the apparent lag from primary derived
+    from the last-applied-record timestamp. ``startup_state`` reports
+    the standby's startup-process status.
+    """
+
+    replay_lsn: str | None
+    replay_lag_seconds: float | None
+    last_replayed_at: str | None
+    startup_state: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class LockHotspot:
+    """One advisor recommendation row.
+
+    ``reason`` is a stable identifier the agent can react to:
+
+    * ``high_wait_time`` — cumulative wait_time_us >= 1 second.
+    * ``contention_dominant`` — high wait_time AND high wait_count.
+    * ``high_wait_count`` — high count but low cumulative time
+      (short-but-frequent waits — usually app-side hot-row contention).
+    * ``low_contention`` — included only when nothing crosses the
+      thresholds; reports the busiest lock type for context.
+    """
+
+    lock_type: str
+    waits: int
+    wait_time_us: int
+    reason: str
+    suggested_followup: str
+
+
+@dataclass(frozen=True, slots=True)
+class LockHotspotsResult:
+    """Roll-up of :func:`analyze_lock_hotspots`."""
+
+    available: bool
+    server_version_num: int
+    detail: str
+    hotspots: list[LockHotspot] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Shared probes
+# ---------------------------------------------------------------------------
+
+
+async def _server_version(driver: SqlDriver) -> tuple[int, str]:
+    """Return ``(server_version_num, server_version)`` in one round trip."""
+    rows = await driver.execute_query(
+        "SELECT current_setting('server_version_num')::int AS ver_num, "
+        "current_setting('server_version') AS ver",
+        force_readonly=True,
+    )
+    if not rows:
+        return 0, ""
+    cells = rows[0].cells
+    return int(cells.get("ver_num") or 0), str(cells.get("ver") or "")
+
+
+async def _view_present(driver: SqlDriver, view_name: str) -> bool:
+    """Check whether a system view exists. Parameter-bound — safe."""
+    rows = await driver.execute_query(
+        "SELECT 1 AS present FROM pg_class c "
+        "JOIN pg_namespace n ON n.oid = c.relnamespace "
+        "WHERE n.nspname = 'pg_catalog' AND c.relname = %s",
+        params=[view_name],
+        force_readonly=True,
+    )
+    return bool(rows)
+
+
+# ---------------------------------------------------------------------------
+# Status — never raises
+# ---------------------------------------------------------------------------
+
+
+async def get_pg19_stats_status(driver: SqlDriver) -> Pg19StatsStatus:
+    """Report whether the PG 19 lock + recovery views are usable.
+
+    Read-only; never raises. On PG < 19, or on PG 19 builds that don't
+    expose the new views yet, returns ``available=False`` with a
+    diagnostic pointing the agent at the legacy
+    `find_blocking_chains` / `pg_stat_replication` paths.
+    """
+    try:
+        ver_num, ver = await _server_version(driver)
+    except Exception as exc:
+        return Pg19StatsStatus(
+            available=False,
+            server_version_num=0,
+            server_version="",
+            has_pg_stat_lock=False,
+            has_pg_stat_recovery=False,
+            detail=(
+                f"PG 19 stats unavailable (server version probe failed: {exc}). "
+                "Fall back to find_blocking_chains / pg_stat_replication for "
+                "lock + recovery observability on older servers."
+            ),
+        )
+    if ver_num < _MIN_PG19_VERSION:
+        return Pg19StatsStatus(
+            available=False,
+            server_version_num=ver_num,
+            server_version=ver,
+            has_pg_stat_lock=False,
+            has_pg_stat_recovery=False,
+            detail=(
+                "pg_stat_lock and pg_stat_recovery require PostgreSQL 19 or "
+                "newer; this server is older. Use find_blocking_chains for "
+                "per-blocker visibility and pg_stat_replication for replay "
+                "lag on PG ≤ 18."
+            ),
+        )
+    try:
+        has_lock = await _view_present(driver, "pg_stat_lock")
+        has_recovery = await _view_present(driver, "pg_stat_recovery")
+    except Exception as exc:
+        return Pg19StatsStatus(
+            available=False,
+            server_version_num=ver_num,
+            server_version=ver,
+            has_pg_stat_lock=False,
+            has_pg_stat_recovery=False,
+            detail=(
+                f"PG 19 reachable but view-presence probe failed: {exc}. "
+                "Re-run after the server is back online."
+            ),
+        )
+    available = has_lock or has_recovery
+    if not available:
+        detail = (
+            "PG 19 server is reachable but neither pg_stat_lock nor "
+            "pg_stat_recovery is present. Early Beta build, or the views "
+            "are not yet populated. Fall back to find_blocking_chains / "
+            "pg_stat_replication."
+        )
+    else:
+        present = ", ".join(
+            v for v, ok in (("pg_stat_lock", has_lock), ("pg_stat_recovery", has_recovery)) if ok
+        )
+        detail = (
+            f"PG 19 lock + recovery views available: {present}. "
+            "Use read_pg_stat_lock / read_pg_stat_recovery for raw rows, "
+            "or analyze_lock_hotspots for a ranked advisor view."
+        )
+    return Pg19StatsStatus(
+        available=available,
+        server_version_num=ver_num,
+        server_version=ver,
+        has_pg_stat_lock=has_lock,
+        has_pg_stat_recovery=has_recovery,
+        detail=detail,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Readers
+# ---------------------------------------------------------------------------
+
+
+async def read_pg_stat_lock(driver: SqlDriver) -> list[LockStatRow]:
+    """Return every row from ``pg_stat_lock``.
+
+    Empty list on PG < 19 or when the view isn't present. The view
+    aggregates per-lock-type acquire / wait counts since the most
+    recent ``pg_stat_reset``.
+    """
+    ver_num, _ = await _server_version(driver)
+    if ver_num < _MIN_PG19_VERSION:
+        return []
+    if not await _view_present(driver, "pg_stat_lock"):
+        return []
+    rows = await driver.execute_query(
+        "SELECT "
+        "  lock_type, "
+        "  COALESCE(acquires, 0) AS acquires, "
+        "  COALESCE(waits, 0) AS waits, "
+        "  COALESCE(wait_time_us, 0) AS wait_time_us "
+        "FROM pg_stat_lock "
+        "ORDER BY wait_time_us DESC, waits DESC",
+        force_readonly=True,
+    )
+    return [
+        LockStatRow(
+            lock_type=str(row.cells["lock_type"]),
+            acquires=int(row.cells["acquires"]),
+            waits=int(row.cells["waits"]),
+            wait_time_us=int(row.cells["wait_time_us"]),
+        )
+        for row in rows or []
+    ]
+
+
+async def read_pg_stat_recovery(driver: SqlDriver) -> list[RecoveryStatRow]:
+    """Return the row(s) from ``pg_stat_recovery``.
+
+    Empty list on PG < 19 or when the view isn't present, or when the
+    server isn't in recovery (a primary running standalone returns no
+    rows). Wraps in a list for forward-compat if future PG versions
+    expose per-standby breakdowns.
+    """
+    ver_num, _ = await _server_version(driver)
+    if ver_num < _MIN_PG19_VERSION:
+        return []
+    if not await _view_present(driver, "pg_stat_recovery"):
+        return []
+    rows = await driver.execute_query(
+        "SELECT "
+        "  replay_lsn::text AS replay_lsn, "
+        "  EXTRACT(epoch FROM replay_lag) AS replay_lag_seconds, "
+        "  last_replayed_at::text AS last_replayed_at, "
+        "  startup_state "
+        "FROM pg_stat_recovery",
+        force_readonly=True,
+    )
+    return [
+        RecoveryStatRow(
+            replay_lsn=row.cells.get("replay_lsn"),
+            replay_lag_seconds=(
+                float(row.cells["replay_lag_seconds"])
+                if row.cells.get("replay_lag_seconds") is not None
+                else None
+            ),
+            last_replayed_at=row.cells.get("last_replayed_at"),
+            startup_state=row.cells.get("startup_state"),
+        )
+        for row in rows or []
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Advisor — analyze_lock_hotspots
+# ---------------------------------------------------------------------------
+
+
+def _classify_lock(*, waits: int, wait_time_us: int) -> tuple[str, str]:
+    """Map ``(waits, wait_time_us)`` to ``(reason, suggested_followup)``.
+
+    The decision tree is deliberately conservative — we don't push
+    operators toward a specific remedy because the right fix depends
+    on which lock type is hot (advisory locks need app-level review;
+    relation locks suggest VACUUM / DDL contention; tuple locks
+    suggest hot-row UPDATEs).
+    """
+    high_time = wait_time_us >= _HIGH_WAIT_TIME_US
+    high_count = waits >= _HIGH_WAIT_COUNT
+    if high_time and high_count:
+        return (
+            "contention_dominant",
+            "Investigate the workload generating these waits — check "
+            "find_blocking_chains for the active culprits.",
+        )
+    if high_time:
+        return (
+            "high_wait_time",
+            "Few but long waits — look for a long-running transaction "
+            "holding the lock (pg_stat_activity.xact_start).",
+        )
+    if high_count:
+        return (
+            "high_wait_count",
+            "Many short waits — usually app-side hot-row contention. "
+            "Consider rate-limiting the call site or batching writes.",
+        )
+    return (
+        "low_contention",
+        "Cluster-wide lock waits are within healthy bounds; no action needed.",
+    )
+
+
+async def analyze_lock_hotspots(driver: SqlDriver) -> LockHotspotsResult:
+    """Rank ``pg_stat_lock`` rows by wait dominance, emit reason codes.
+
+    Read-only — never modifies state. Returns at most one hotspot per
+    lock_type. When nothing crosses the thresholds we still emit one
+    ``low_contention`` row for the busiest lock type so the agent has
+    something to report back ("nothing to see here, but here's what's
+    happening anyway").
+
+    Empty ``hotspots`` list with a clear ``detail`` on PG < 19 or when
+    pg_stat_lock isn't present.
+    """
+    ver_num, ver = await _server_version(driver)
+    if ver_num < _MIN_PG19_VERSION:
+        return LockHotspotsResult(
+            available=False,
+            server_version_num=ver_num,
+            detail=(
+                f"pg_stat_lock requires PostgreSQL 19 or newer; this server "
+                f"reports {ver or 'unknown'} (server_version_num={ver_num}). "
+                "Use find_blocking_chains for per-blocker visibility on PG ≤ 18."
+            ),
+            hotspots=[],
+        )
+    if not await _view_present(driver, "pg_stat_lock"):
+        return LockHotspotsResult(
+            available=False,
+            server_version_num=ver_num,
+            detail=(
+                "PG 19 server is reachable but pg_stat_lock is not present. "
+                "Early Beta build, or the stats collector hasn't populated "
+                "it yet. Fall back to find_blocking_chains."
+            ),
+            hotspots=[],
+        )
+    rows = await read_pg_stat_lock(driver)
+    if not rows:
+        return LockHotspotsResult(
+            available=True,
+            server_version_num=ver_num,
+            detail="pg_stat_lock present but empty. No lock activity recorded since the last stats reset.",
+            hotspots=[],
+        )
+    hot: list[LockHotspot] = []
+    for row in rows:
+        if row.waits == 0 and row.wait_time_us == 0:
+            continue
+        reason, followup = _classify_lock(waits=row.waits, wait_time_us=row.wait_time_us)
+        if reason == "low_contention":
+            continue
+        hot.append(
+            LockHotspot(
+                lock_type=row.lock_type,
+                waits=row.waits,
+                wait_time_us=row.wait_time_us,
+                reason=reason,
+                suggested_followup=followup,
+            )
+        )
+    if not hot:
+        # Nothing crossed the threshold — still emit one informational
+        # row pointing at the busiest type so the agent has context.
+        top = rows[0]
+        hot.append(
+            LockHotspot(
+                lock_type=top.lock_type,
+                waits=top.waits,
+                wait_time_us=top.wait_time_us,
+                reason="low_contention",
+                suggested_followup=(
+                    "Cluster-wide lock waits are within healthy bounds; "
+                    "no action needed."
+                ),
+            )
+        )
+        detail = (
+            f"No lock-type crosses the contention threshold "
+            f"(>= {_HIGH_WAIT_TIME_US} us cumulative wait or >= {_HIGH_WAIT_COUNT} waits). "
+            "Busiest type included for context only."
+        )
+    else:
+        detail = (
+            f"{len(hot)} lock type(s) crossed the contention threshold. "
+            "Pair with find_blocking_chains for the active culprits."
+        )
+    return LockHotspotsResult(
+        available=True,
+        server_version_num=ver_num,
+        detail=detail,
+        hotspots=hot,
+    )
+
+
+__all__ = [
+    "LockHotspot",
+    "LockHotspotsResult",
+    "LockStatRow",
+    "Pg19StatsError",
+    "Pg19StatsStatus",
+    "RecoveryStatRow",
+    "analyze_lock_hotspots",
+    "get_pg19_stats_status",
+    "read_pg_stat_lock",
+    "read_pg_stat_recovery",
+]

--- a/src/mcpg/pg19_stats.py
+++ b/src/mcpg/pg19_stats.py
@@ -157,8 +157,7 @@ class LockHotspotsResult:
 async def _server_version(driver: SqlDriver) -> tuple[int, str]:
     """Return ``(server_version_num, server_version)`` in one round trip."""
     rows = await driver.execute_query(
-        "SELECT current_setting('server_version_num')::int AS ver_num, "
-        "current_setting('server_version') AS ver",
+        "SELECT current_setting('server_version_num')::int AS ver_num, current_setting('server_version') AS ver",
         force_readonly=True,
     )
     if not rows:
@@ -231,10 +230,7 @@ async def get_pg19_stats_status(driver: SqlDriver) -> Pg19StatsStatus:
             server_version=ver,
             has_pg_stat_lock=False,
             has_pg_stat_recovery=False,
-            detail=(
-                f"PG 19 reachable but view-presence probe failed: {exc}. "
-                "Re-run after the server is back online."
-            ),
+            detail=(f"PG 19 reachable but view-presence probe failed: {exc}. Re-run after the server is back online."),
         )
     available = has_lock or has_recovery
     if not available:
@@ -245,9 +241,7 @@ async def get_pg19_stats_status(driver: SqlDriver) -> Pg19StatsStatus:
             "pg_stat_replication."
         )
     else:
-        present = ", ".join(
-            v for v, ok in (("pg_stat_lock", has_lock), ("pg_stat_recovery", has_recovery)) if ok
-        )
+        present = ", ".join(v for v, ok in (("pg_stat_lock", has_lock), ("pg_stat_recovery", has_recovery)) if ok)
         detail = (
             f"PG 19 lock + recovery views available: {present}. "
             "Use read_pg_stat_lock / read_pg_stat_recovery for raw rows, "
@@ -327,9 +321,7 @@ async def read_pg_stat_recovery(driver: SqlDriver) -> list[RecoveryStatRow]:
         RecoveryStatRow(
             replay_lsn=row.cells.get("replay_lsn"),
             replay_lag_seconds=(
-                float(row.cells["replay_lag_seconds"])
-                if row.cells.get("replay_lag_seconds") is not None
-                else None
+                float(row.cells["replay_lag_seconds"]) if row.cells.get("replay_lag_seconds") is not None else None
             ),
             last_replayed_at=row.cells.get("last_replayed_at"),
             startup_state=row.cells.get("startup_state"),
@@ -357,14 +349,12 @@ def _classify_lock(*, waits: int, wait_time_us: int) -> tuple[str, str]:
     if high_time and high_count:
         return (
             "contention_dominant",
-            "Investigate the workload generating these waits — check "
-            "find_blocking_chains for the active culprits.",
+            "Investigate the workload generating these waits — check find_blocking_chains for the active culprits.",
         )
     if high_time:
         return (
             "high_wait_time",
-            "Few but long waits — look for a long-running transaction "
-            "holding the lock (pg_stat_activity.xact_start).",
+            "Few but long waits — look for a long-running transaction holding the lock (pg_stat_activity.xact_start).",
         )
     if high_count:
         return (
@@ -447,10 +437,7 @@ async def analyze_lock_hotspots(driver: SqlDriver) -> LockHotspotsResult:
                 waits=top.waits,
                 wait_time_us=top.wait_time_us,
                 reason="low_contention",
-                suggested_followup=(
-                    "Cluster-wide lock waits are within healthy bounds; "
-                    "no action needed."
-                ),
+                suggested_followup=("Cluster-wide lock waits are within healthy bounds; no action needed."),
             )
         )
         detail = (

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -48,6 +48,7 @@ from mcpg import (
     naming,
     nl2sql,
     partman,
+    pg19_stats,
     pg_prewarm,
     pg_search,
     pgq,
@@ -4449,6 +4450,93 @@ def _register_pg_prewarm_writes(server: FastMCP[AppContext]) -> None:
         return asdict(result)
 
 
+def _register_pg19_stats_reads(server: FastMCP[AppContext]) -> None:
+    @server.tool(
+        name="get_pg19_stats_status",
+        description=_with_example(
+            "Report whether PG 19's `pg_stat_lock` and `pg_stat_recovery` "
+            "views are usable on this server. Never raises — driver-level "
+            "errors surface as `available=false`. On PG < 19 returns "
+            "`available=false` with a diagnostic pointing the agent at "
+            "`find_blocking_chains` / `pg_stat_replication`. "
+            "Returns an object with `available` (bool), `server_version_num` "
+            "(int), `server_version`, `has_pg_stat_lock` (bool), "
+            "`has_pg_stat_recovery` (bool), and `detail` (guidance string).",
+            "get_pg19_stats_status()",
+        ),
+    )
+    async def get_pg19_stats_status(ctx: _Ctx) -> dict[str, Any]:
+        async def _run() -> dict[str, Any]:
+            status = await pg19_stats.get_pg19_stats_status(_driver(ctx))
+            return asdict(status)
+
+        return await _cached_call(ctx, "get_pg19_stats_status", _run)
+
+    @server.tool(
+        name="read_pg_stat_lock",
+        description=_with_example(
+            "Return every row from PG 19's `pg_stat_lock` view "
+            "(per-lock-type acquire / wait / wait-time counters since the "
+            "most recent `pg_stat_reset`). Empty list on PG < 19 or when "
+            "the view isn't present. "
+            "Returns a list of objects with `lock_type` (relation / page / "
+            "tuple / xid / virtualxid / advisory / ...), `acquires`, "
+            "`waits`, and `wait_time_us`.",
+            "read_pg_stat_lock()",
+        ),
+    )
+    async def read_pg_stat_lock(ctx: _Ctx) -> list[dict[str, Any]]:
+        async def _run() -> list[dict[str, Any]]:
+            rows = await pg19_stats.read_pg_stat_lock(_driver(ctx))
+            return [asdict(r) for r in rows]
+
+        return await _cached_call(ctx, "read_pg_stat_lock", _run)
+
+    @server.tool(
+        name="read_pg_stat_recovery",
+        description=_with_example(
+            "Return rows from PG 19's `pg_stat_recovery` view — replay "
+            "progress, lag, and startup state for a standby. Empty list "
+            "on PG < 19, when the view isn't present, or when the server "
+            "isn't in recovery (a primary running standalone returns no "
+            "rows). "
+            "Returns a list of objects with `replay_lsn`, "
+            "`replay_lag_seconds`, `last_replayed_at`, and `startup_state` "
+            "(any of which may be null when not applicable).",
+            "read_pg_stat_recovery()",
+        ),
+    )
+    async def read_pg_stat_recovery(ctx: _Ctx) -> list[dict[str, Any]]:
+        async def _run() -> list[dict[str, Any]]:
+            rows = await pg19_stats.read_pg_stat_recovery(_driver(ctx))
+            return [asdict(r) for r in rows]
+
+        return await _cached_call(ctx, "read_pg_stat_recovery", _run)
+
+    @server.tool(
+        name="analyze_lock_hotspots",
+        description=_with_example(
+            "Rank PG 19 `pg_stat_lock` rows by wait dominance and surface "
+            "stable reason codes. Read-only — never modifies state. Pair "
+            "with `find_blocking_chains` for the active culprits on a "
+            "specific hot lock_type. "
+            "Returns an object with `available` (bool), "
+            "`server_version_num`, `detail`, and `hotspots` — a list of "
+            "objects with `lock_type`, `waits`, `wait_time_us`, `reason` "
+            "(one of `contention_dominant` / `high_wait_time` / "
+            "`high_wait_count` / `low_contention`), and "
+            "`suggested_followup` (a human-readable next-step string).",
+            "analyze_lock_hotspots()",
+        ),
+    )
+    async def analyze_lock_hotspots(ctx: _Ctx) -> dict[str, Any]:
+        async def _run() -> dict[str, Any]:
+            result = await pg19_stats.analyze_lock_hotspots(_driver(ctx))
+            return asdict(result)
+
+        return await _cached_call(ctx, "analyze_lock_hotspots", _run)
+
+
 def _register_aio_reads(server: FastMCP[AppContext]) -> None:
     @server.tool(
         name="get_aio_status",
@@ -4905,6 +4993,7 @@ def register_tools(server: FastMCP[AppContext], settings: Settings) -> None:
         _register_pgq_reads(server)
         _register_repack_reads(server)
         _register_aio_reads(server)
+        _register_pg19_stats_reads(server)
     if is_permitted(settings.access_mode, Capability.WRITE):
         _register_write(server)
         _register_maintenance(server)

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -4486,11 +4486,11 @@ def _register_pg19_stats_reads(server: FastMCP[AppContext]) -> None:
         ),
     )
     async def read_pg_stat_lock(ctx: _Ctx) -> list[dict[str, Any]]:
-        async def _run() -> list[dict[str, Any]]:
-            rows = await pg19_stats.read_pg_stat_lock(_driver(ctx))
-            return [asdict(r) for r in rows]
-
-        return await _cached_call(ctx, "read_pg_stat_lock", _run)
+        # Live counters — never cache (matches find_blocking_chains /
+        # read_pg_stat_io pattern). Caching would return stale waits
+        # during real-time incident response (gemini review on PR #141).
+        rows = await pg19_stats.read_pg_stat_lock(_driver(ctx))
+        return [asdict(r) for r in rows]
 
     @server.tool(
         name="read_pg_stat_recovery",
@@ -4507,11 +4507,10 @@ def _register_pg19_stats_reads(server: FastMCP[AppContext]) -> None:
         ),
     )
     async def read_pg_stat_recovery(ctx: _Ctx) -> list[dict[str, Any]]:
-        async def _run() -> list[dict[str, Any]]:
-            rows = await pg19_stats.read_pg_stat_recovery(_driver(ctx))
-            return [asdict(r) for r in rows]
-
-        return await _cached_call(ctx, "read_pg_stat_recovery", _run)
+        # Live replay state — never cache. Stale lag readings during
+        # standby triage are worse than useless (gemini review on PR #141).
+        rows = await pg19_stats.read_pg_stat_recovery(_driver(ctx))
+        return [asdict(r) for r in rows]
 
     @server.tool(
         name="analyze_lock_hotspots",
@@ -4530,11 +4529,11 @@ def _register_pg19_stats_reads(server: FastMCP[AppContext]) -> None:
         ),
     )
     async def analyze_lock_hotspots(ctx: _Ctx) -> dict[str, Any]:
-        async def _run() -> dict[str, Any]:
-            result = await pg19_stats.analyze_lock_hotspots(_driver(ctx))
-            return asdict(result)
-
-        return await _cached_call(ctx, "analyze_lock_hotspots", _run)
+        # Live advisor over live counters — never cache. Incident-response
+        # callers need the current snapshot, not what we saw 60s ago
+        # (gemini review on PR #141).
+        result = await pg19_stats.analyze_lock_hotspots(_driver(ctx))
+        return asdict(result)
 
 
 def _register_aio_reads(server: FastMCP[AppContext]) -> None:

--- a/tests/contract/tool_return_shapes.snapshot.json
+++ b/tests/contract/tool_return_shapes.snapshot.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "schema_version": 1,
-    "tool_count": 200
+    "tool_count": 204
   },
   "tools": {
     "add_compression_policy": {
@@ -37,6 +37,9 @@
       "kind": "scalar"
     },
     "analyze_hnsw_recall": {
+      "kind": "opaque"
+    },
+    "analyze_lock_hotspots": {
       "kind": "opaque"
     },
     "analyze_query_plan": {
@@ -569,6 +572,9 @@
       "kind": "opaque"
     },
     "get_metrics_exposition": {
+      "kind": "opaque"
+    },
+    "get_pg19_stats_status": {
       "kind": "opaque"
     },
     "get_pg_search_index_metadata": {
@@ -1417,6 +1423,12 @@
         "server_version"
       ],
       "kind": "scalar"
+    },
+    "read_pg_stat_lock": {
+      "kind": "opaque"
+    },
+    "read_pg_stat_recovery": {
+      "kind": "opaque"
     },
     "read_pg_wal_records": {
       "dataclass": "WalRecordsReport",

--- a/tests/contract/tool_surface.snapshot.json
+++ b/tests/contract/tool_surface.snapshot.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "schema_version": 1,
-    "tool_count": 200
+    "tool_count": 204
   },
   "tools": [
     {
@@ -141,6 +141,15 @@
         "type": "object"
       },
       "name": "analyze_hnsw_recall"
+    },
+    {
+      "description": "Rank PG 19 `pg_stat_lock` rows by wait dominance and surface stable reason codes. Read-only — never modifies state. Pair with `find_blocking_chains` for the active culprits on a specific hot lock_type. Returns an object with `available` (bool), `server_version_num`, `detail`, and `hotspots` — a list of objects with `lock_type`, `waits`, `wait_time_us`, `reason` (one of `contention_dominant` / `high_wait_time` / `high_wait_count` / `low_contention`), and `suggested_followup` (a human-readable next-step string).\n\nExample: `analyze_lock_hotspots()`",
+      "inputSchema": {
+        "properties": {},
+        "title": "analyze_lock_hotspotsArguments",
+        "type": "object"
+      },
+      "name": "analyze_lock_hotspots"
     },
     {
       "description": "Summarise a query's execution plan: total estimated cost, estimated rows, node types used, and any sequentially-scanned tables.\n\nExample: `analyze_query_plan(sql='SELECT * FROM orders WHERE customer_id = 42')`",
@@ -2095,6 +2104,15 @@
       "name": "get_metrics_exposition"
     },
     {
+      "description": "Report whether PG 19's `pg_stat_lock` and `pg_stat_recovery` views are usable on this server. Never raises — driver-level errors surface as `available=false`. On PG < 19 returns `available=false` with a diagnostic pointing the agent at `find_blocking_chains` / `pg_stat_replication`. Returns an object with `available` (bool), `server_version_num` (int), `server_version`, `has_pg_stat_lock` (bool), `has_pg_stat_recovery` (bool), and `detail` (guidance string).\n\nExample: `get_pg19_stats_status()`",
+      "inputSchema": {
+        "properties": {},
+        "title": "get_pg19_stats_statusArguments",
+        "type": "object"
+      },
+      "name": "get_pg19_stats_status"
+    },
+    {
       "description": "Fetch the parsed reloptions for a single BM25 index (schema.index). Same shape as one entry of ``list_pg_search_indexes`` — typed accessors for the 13 documented options plus the raw ``index_options`` dict. Raises when the extension is not installed or no BM25 index by that name exists. Returns an object with `schema`, `index`, the typed option fields, and `index_options` (raw reloptions dict for forward-compat).",
       "inputSchema": {
         "properties": {
@@ -4036,6 +4054,24 @@
         "type": "object"
       },
       "name": "read_pg_stat_io"
+    },
+    {
+      "description": "Return every row from PG 19's `pg_stat_lock` view (per-lock-type acquire / wait / wait-time counters since the most recent `pg_stat_reset`). Empty list on PG < 19 or when the view isn't present. Returns a list of objects with `lock_type` (relation / page / tuple / xid / virtualxid / advisory / ...), `acquires`, `waits`, and `wait_time_us`.\n\nExample: `read_pg_stat_lock()`",
+      "inputSchema": {
+        "properties": {},
+        "title": "read_pg_stat_lockArguments",
+        "type": "object"
+      },
+      "name": "read_pg_stat_lock"
+    },
+    {
+      "description": "Return rows from PG 19's `pg_stat_recovery` view — replay progress, lag, and startup state for a standby. Empty list on PG < 19, when the view isn't present, or when the server isn't in recovery (a primary running standalone returns no rows). Returns a list of objects with `replay_lsn`, `replay_lag_seconds`, `last_replayed_at`, and `startup_state` (any of which may be null when not applicable).\n\nExample: `read_pg_stat_recovery()`",
+      "inputSchema": {
+        "properties": {},
+        "title": "read_pg_stat_recoveryArguments",
+        "type": "object"
+      },
+      "name": "read_pg_stat_recovery"
     },
     {
       "description": "Read Write-Ahead Log (WAL) records information over a specified LSN range. Requires the pg_walinspect extension. If not installed, returns available=false.",

--- a/tests/unit/test_pg19_stats.py
+++ b/tests/unit/test_pg19_stats.py
@@ -1,0 +1,288 @@
+"""Tests for the PG 19 lock + recovery analytics module."""
+
+from __future__ import annotations
+
+from _fakes import FakeDriver, FakeRoutingDriver
+
+from mcpg.pg19_stats import (
+    LockHotspot,
+    LockHotspotsResult,
+    LockStatRow,
+    Pg19StatsStatus,
+    RecoveryStatRow,
+    analyze_lock_hotspots,
+    get_pg19_stats_status,
+    read_pg_stat_lock,
+    read_pg_stat_recovery,
+)
+
+
+def _version_route(num: int, ver: str) -> dict[str, list[dict[str, object]]]:
+    """Helper — wires the server-version probe to a specific version."""
+    return {"current_setting('server_version_num')": [{"ver_num": num, "ver": ver}]}
+
+
+def _view_present_route(views: dict[str, bool]) -> dict[str, list[dict[str, object]]]:
+    """Helper — wires the pg_class view-presence probe.
+
+    The view-presence query is parameterised by view name, but
+    FakeRoutingDriver routes by substring, so we wire one route per
+    expected view name using a fingerprint substring that's stable for
+    each call (the param is bound, so query text is identical for each
+    view — we have to use FakeParamRoutingDriver or special-case the
+    helper). For these tests we use a single combined route: the
+    helper returns a "present" row for any view query, and individual
+    tests override by setting the rows for "FROM pg_class c" to []
+    when both views should be absent.
+    """
+    # This helper is only used in the *available* tests where both
+    # views are present. The simpler case (both absent) is captured by
+    # not setting this route at all.
+    present_any = any(views.values())
+    return {"FROM pg_class c ": [{"present": 1}] if present_any else []}
+
+
+# --- get_pg19_stats_status -------------------------------------------------
+
+
+async def test_status_available_on_pg19_with_both_views() -> None:
+    routes = _version_route(190001, "19beta1")
+    routes.update(_view_present_route({"pg_stat_lock": True, "pg_stat_recovery": True}))
+    driver = FakeRoutingDriver(routes)
+    status = await get_pg19_stats_status(driver)  # type: ignore[arg-type]
+    assert isinstance(status, Pg19StatsStatus)
+    assert status.available is True
+    assert status.has_pg_stat_lock is True
+    assert status.has_pg_stat_recovery is True
+    assert "pg_stat_lock" in status.detail
+
+
+async def test_status_unavailable_on_pg18_with_diagnostic() -> None:
+    driver = FakeRoutingDriver(_version_route(180003, "18.3"))
+    status = await get_pg19_stats_status(driver)  # type: ignore[arg-type]
+    assert status.available is False
+    assert status.has_pg_stat_lock is False
+    assert status.has_pg_stat_recovery is False
+    assert "find_blocking_chains" in status.detail
+
+
+async def test_status_never_raises_on_driver_failure() -> None:
+    """get_pg19_stats_status documents 'never raises' — confirm with FakeDriver(fail=True)."""
+    driver = FakeDriver(fail=True)
+    status = await get_pg19_stats_status(driver)  # type: ignore[arg-type]
+    assert status.available is False
+    assert "find_blocking_chains" in status.detail
+
+
+async def test_status_unavailable_on_pg19_without_views() -> None:
+    """PG 19 server up but neither view present (early Beta build)."""
+    routes = _version_route(190001, "19beta1")
+    # No view-present rows — _view_present returns False for both.
+    driver = FakeRoutingDriver(routes)
+    status = await get_pg19_stats_status(driver)  # type: ignore[arg-type]
+    assert status.available is False
+    assert status.has_pg_stat_lock is False
+    assert status.has_pg_stat_recovery is False
+    assert "fall back" in status.detail.lower()
+
+
+# --- read_pg_stat_lock -----------------------------------------------------
+
+
+async def test_read_lock_empty_on_pg18() -> None:
+    driver = FakeRoutingDriver(_version_route(180003, "18.3"))
+    rows = await read_pg_stat_lock(driver)  # type: ignore[arg-type]
+    assert rows == []
+
+
+async def test_read_lock_returns_rows_on_pg19() -> None:
+    routes = _version_route(190001, "19beta1")
+    routes["FROM pg_class c "] = [{"present": 1}]
+    routes["FROM pg_stat_lock"] = [
+        {"lock_type": "relation", "acquires": 100, "waits": 5, "wait_time_us": 1_500_000},
+        {"lock_type": "tuple", "acquires": 50, "waits": 2, "wait_time_us": 100_000},
+    ]
+    driver = FakeRoutingDriver(routes)
+    rows = await read_pg_stat_lock(driver)  # type: ignore[arg-type]
+    assert rows == [
+        LockStatRow(lock_type="relation", acquires=100, waits=5, wait_time_us=1_500_000),
+        LockStatRow(lock_type="tuple", acquires=50, waits=2, wait_time_us=100_000),
+    ]
+
+
+async def test_read_lock_empty_when_view_absent_on_pg19() -> None:
+    """PG 19 but pg_stat_lock view is missing — early Beta."""
+    routes = _version_route(190001, "19beta1")
+    # _view_present returns False for missing view.
+    driver = FakeRoutingDriver(routes)
+    rows = await read_pg_stat_lock(driver)  # type: ignore[arg-type]
+    assert rows == []
+
+
+# --- read_pg_stat_recovery -------------------------------------------------
+
+
+async def test_read_recovery_returns_row_for_standby() -> None:
+    routes = _version_route(190001, "19beta1")
+    routes["FROM pg_class c "] = [{"present": 1}]
+    routes["FROM pg_stat_recovery"] = [
+        {
+            "replay_lsn": "0/1234ABCD",
+            "replay_lag_seconds": 0.5,
+            "last_replayed_at": "2026-06-20 18:00:00+00",
+            "startup_state": "streaming",
+        }
+    ]
+    driver = FakeRoutingDriver(routes)
+    rows = await read_pg_stat_recovery(driver)  # type: ignore[arg-type]
+    assert rows == [
+        RecoveryStatRow(
+            replay_lsn="0/1234ABCD",
+            replay_lag_seconds=0.5,
+            last_replayed_at="2026-06-20 18:00:00+00",
+            startup_state="streaming",
+        )
+    ]
+
+
+async def test_read_recovery_empty_on_pg18() -> None:
+    driver = FakeRoutingDriver(_version_route(180003, "18.3"))
+    rows = await read_pg_stat_recovery(driver)  # type: ignore[arg-type]
+    assert rows == []
+
+
+async def test_read_recovery_handles_null_lag_field() -> None:
+    """Primary servers / not-yet-replaying standbys have NULL fields."""
+    routes = _version_route(190001, "19beta1")
+    routes["FROM pg_class c "] = [{"present": 1}]
+    routes["FROM pg_stat_recovery"] = [
+        {
+            "replay_lsn": None,
+            "replay_lag_seconds": None,
+            "last_replayed_at": None,
+            "startup_state": None,
+        }
+    ]
+    driver = FakeRoutingDriver(routes)
+    rows = await read_pg_stat_recovery(driver)  # type: ignore[arg-type]
+    assert rows == [
+        RecoveryStatRow(
+            replay_lsn=None,
+            replay_lag_seconds=None,
+            last_replayed_at=None,
+            startup_state=None,
+        )
+    ]
+
+
+# --- analyze_lock_hotspots -------------------------------------------------
+
+
+async def test_analyze_classifies_contention_dominant() -> None:
+    """High wait_time + high wait_count → contention_dominant."""
+    routes = _version_route(190001, "19beta1")
+    routes["FROM pg_class c "] = [{"present": 1}]
+    routes["FROM pg_stat_lock"] = [
+        {"lock_type": "relation", "acquires": 100_000, "waits": 5_000, "wait_time_us": 10_000_000},
+    ]
+    driver = FakeRoutingDriver(routes)
+    result = await analyze_lock_hotspots(driver)  # type: ignore[arg-type]
+    assert isinstance(result, LockHotspotsResult)
+    assert result.available is True
+    assert len(result.hotspots) == 1
+    assert result.hotspots[0].reason == "contention_dominant"
+    assert "find_blocking_chains" in result.hotspots[0].suggested_followup
+
+
+async def test_analyze_classifies_high_wait_time() -> None:
+    """High wait_time, low wait_count → high_wait_time (long-running txn)."""
+    routes = _version_route(190001, "19beta1")
+    routes["FROM pg_class c "] = [{"present": 1}]
+    routes["FROM pg_stat_lock"] = [
+        {"lock_type": "advisory", "acquires": 100, "waits": 5, "wait_time_us": 5_000_000},
+    ]
+    driver = FakeRoutingDriver(routes)
+    result = await analyze_lock_hotspots(driver)  # type: ignore[arg-type]
+    assert result.hotspots[0].reason == "high_wait_time"
+    assert "long-running transaction" in result.hotspots[0].suggested_followup
+
+
+async def test_analyze_classifies_high_wait_count() -> None:
+    """High wait_count, low wait_time → high_wait_count (hot-row contention)."""
+    routes = _version_route(190001, "19beta1")
+    routes["FROM pg_class c "] = [{"present": 1}]
+    routes["FROM pg_stat_lock"] = [
+        {"lock_type": "tuple", "acquires": 100_000, "waits": 5_000, "wait_time_us": 100_000},
+    ]
+    driver = FakeRoutingDriver(routes)
+    result = await analyze_lock_hotspots(driver)  # type: ignore[arg-type]
+    assert result.hotspots[0].reason == "high_wait_count"
+    assert "hot-row contention" in result.hotspots[0].suggested_followup
+
+
+async def test_analyze_low_contention_emits_busiest_for_context() -> None:
+    """No lock type crosses the threshold → emit busiest as low_contention."""
+    routes = _version_route(190001, "19beta1")
+    routes["FROM pg_class c "] = [{"present": 1}]
+    routes["FROM pg_stat_lock"] = [
+        {"lock_type": "tuple", "acquires": 1_000, "waits": 10, "wait_time_us": 5_000},
+    ]
+    driver = FakeRoutingDriver(routes)
+    result = await analyze_lock_hotspots(driver)  # type: ignore[arg-type]
+    assert len(result.hotspots) == 1
+    assert result.hotspots[0].reason == "low_contention"
+    assert result.hotspots[0].lock_type == "tuple"
+    assert "healthy bounds" in result.detail or "healthy bounds" in result.hotspots[0].suggested_followup
+
+
+async def test_analyze_empty_on_pg18() -> None:
+    driver = FakeRoutingDriver(_version_route(180003, "18.3"))
+    result = await analyze_lock_hotspots(driver)  # type: ignore[arg-type]
+    assert result.available is False
+    assert result.hotspots == []
+    assert "find_blocking_chains" in result.detail
+
+
+async def test_analyze_empty_when_view_absent_on_pg19() -> None:
+    routes = _version_route(190001, "19beta1")
+    driver = FakeRoutingDriver(routes)  # no view-present row
+    result = await analyze_lock_hotspots(driver)  # type: ignore[arg-type]
+    assert result.available is False
+    assert result.hotspots == []
+
+
+async def test_analyze_empty_view_returns_clean_result() -> None:
+    """View present but no rows — stats reset just happened."""
+    routes = _version_route(190001, "19beta1")
+    routes["FROM pg_class c "] = [{"present": 1}]
+    routes["FROM pg_stat_lock"] = []
+    driver = FakeRoutingDriver(routes)
+    result = await analyze_lock_hotspots(driver)  # type: ignore[arg-type]
+    assert result.available is True
+    assert result.hotspots == []
+    assert "empty" in result.detail.lower() or "no lock activity" in result.detail.lower()
+
+
+# --- Dataclass shapes ------------------------------------------------------
+
+
+def test_dataclass_shapes() -> None:
+    status = Pg19StatsStatus(
+        available=True,
+        server_version_num=190001,
+        server_version="19beta1",
+        has_pg_stat_lock=True,
+        has_pg_stat_recovery=True,
+        detail="ok",
+    )
+    assert status.available is True
+    row = LockStatRow(lock_type="relation", acquires=100, waits=5, wait_time_us=1_500_000)
+    assert row.lock_type == "relation"
+    hot = LockHotspot(
+        lock_type="relation",
+        waits=5,
+        wait_time_us=1_500_000,
+        reason="high_wait_time",
+        suggested_followup="x",
+    )
+    assert hot.reason == "high_wait_time"


### PR DESCRIPTION
## Summary

Phase 3 PR-4 of #120. Bundles PO matrix rows #5 + #12 (combined PO score 38). Surfaces the two new PG 19 monitoring views — `pg_stat_lock` and `pg_stat_recovery` — as MCPg tools, plus a lock-contention advisor that complements the existing `find_blocking_chains` path.

### New tools (4)

| Tool | Surface | Purpose |
|---|---|---|
| `get_pg19_stats_status` | read | Version + per-view-presence probe; never raises. Reports `has_pg_stat_lock` + `has_pg_stat_recovery` separately so agents feature-detect each in one call. |
| `read_pg_stat_lock` | read | Per-lock-type acquire / wait / wait_time counters from the new PG 19 view. Empty on PG ≤ 18 or when the view isn't present. |
| `read_pg_stat_recovery` | read | Replay LSN + lag + last-replayed-at + startup_state on standbys. Wrapped in a list for forward-compat with per-standby breakdowns. |
| `analyze_lock_hotspots` | read advisor | Ranks lock types by wait dominance; emits stable reason codes (`contention_dominant`, `high_wait_time`, `high_wait_count`, `low_contention`) with per-row suggested-followup strings. |

### Heuristic

Thresholds inline at module top as named constants:
- `_HIGH_WAIT_TIME_US = 1_000_000` (1 s cumulative wait)
- `_HIGH_WAIT_COUNT = 1_000`

Decision tree:
- `wait_time ≥ 1s` AND `waits ≥ 1000` → `contention_dominant` (→ `find_blocking_chains`)
- `wait_time ≥ 1s`, fewer waits → `high_wait_time` (→ look for long-running txn)
- `waits ≥ 1000`, short waits → `high_wait_count` (→ app-side hot-row contention)
- Nothing crosses thresholds → emit busiest type as `low_contention` for context

### Backward compatibility (no-deprecation rule)

- `mcpg.locks.find_blocking_chains` / `list_locks` untouched.
- Both `get_pg19_stats_status` and `analyze_lock_hotspots` on PG ≤ 18 return `available=false` with diagnostics pointing the agent at `find_blocking_chains` / `pg_stat_replication`.
- Driver-level failures in the status probe surface as `available=false`, not exceptions (matches the gemini review patterns from #129 / #131).

### Module + plumbing

- New `src/mcpg/pg19_stats.py` (~485 lines) — dataclasses, version + view-presence helpers, readers, classifier, advisor.
- All four tools route to `operations_and_health` via `_TOOL_TO_BUCKET_OVERRIDES`.
- Both contract snapshots regenerated.

### Tests

- 18 unit tests in `tests/unit/test_pg19_stats.py` covering all four reason-code branches, version + view-presence gates, NULL-field handling, never-raises contract.
- Full unit + contract suite: 2027 tests pass locally.

## Test plan

- [x] `python -m pytest tests/unit/test_pg19_stats.py` — 18 / 18 pass
- [x] `python -m pytest tests/unit/ tests/contract/` — 2027 pass
- [x] `ruff check src/mcpg/pg19_stats.py tests/unit/test_pg19_stats.py` — clean
- [x] `mypy src/mcpg/pg19_stats.py` — clean
- [x] `bandit -r src/mcpg/pg19_stats.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_