### PR TITLE
feat(pg19_ddl): validate_check_constraint + pg_get_*def() family — Phase 3 PR-9 — #120

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **PG 19 DDL helpers** (`mcpg.pg19_ddl`). Five new tools that close
+  the "validate-and-ship constraints, dump cluster-level DDL without
+  pg_dumpall" gap on the agent surface. `validate_check_constraint`
+  issues `ALTER TABLE … VALIDATE CONSTRAINT` for a constraint
+  originally added with `NOT VALID` — idempotent (returns
+  `changed=false` when the constraint is already validated) and
+  works on every supported PG version (the SQL has been around
+  since 9.x). Three PG 19+ DDL-dump tools wrap the new
+  `pg_get_roledef(oid)` / `pg_get_databasedef(oid)` /
+  `pg_get_tablespacedef(oid)` SQL functions: `get_role_ddl`,
+  `get_database_ddl`, `get_tablespace_ddl`. `get_pg19_ddl_status` is
+  the per-function presence probe; never raises.
+
+  PR-9 of the PG 19 Phase 3 plan (bundles PO matrix rows #10 + #11,
+  combined PO score 34). The four read tools route to the
+  `schema_introspection` capability bucket; `validate_check_constraint`
+  sits in `operations_and_health` next to `run_maintenance`.
+
+  Per the no-deprecation rule, the `pg_dumpall --roles-only` /
+  `--globals-only` / `--tablespaces-only` shell-out paths stay valid
+  on PG ≤ 18 — `get_pg19_ddl_status` returns `available=false` with
+  a pointer at the fallback, and the per-object DDL tools raise
+  `Pg19DdlError` with the same hint in the message. Advances #120.
+
+  Side win: the return-shape contract test now also recognises
+  `mcpg.aio`, `mcpg.pg19_runtime`, `mcpg.pg19_stats`, and
+  `mcpg.pg19_ddl` as helper modules, so every Phase 3 PG 19 tool
+  contributes its dataclass field set to the snapshot rather than
+  appearing as `opaque`.
+
 - **PG 19 runtime toggles** (`mcpg.pg19_runtime`). Five new tools that
   flip cluster-wide settings without a restart — previously
   "plan a maintenance window" tasks. Online checksums:

--- a/scripts/smoke_test_pg19.py
+++ b/scripts/smoke_test_pg19.py
@@ -75,7 +75,7 @@ async def _exercise_status_probes(database: Database) -> dict[str, dict[str, Any
     phase can decide which writes to attempt based on per-feature
     availability.
     """
-    from mcpg import aio, pg19_runtime, pg19_stats, pgq, repack
+    from mcpg import aio, pg19_ddl, pg19_runtime, pg19_stats, pgq, repack
 
     driver = database.driver()
     results: dict[str, dict[str, Any]] = {}
@@ -90,6 +90,7 @@ async def _exercise_status_probes(database: Database) -> dict[str, dict[str, Any
             "get_logical_replication_status",
             pg19_runtime.get_logical_replication_status(driver),
         ),
+        ("get_pg19_ddl_status", pg19_ddl.get_pg19_ddl_status(driver)),
     ):
         result = await _safe(label, helper)
         if result is not None:
@@ -99,7 +100,7 @@ async def _exercise_status_probes(database: Database) -> dict[str, dict[str, Any
 
 async def _exercise_advisors(database: Database) -> None:
     """Phase 2 — read-only advisors that are safe to call on any cluster."""
-    from mcpg import aio, pg19_stats
+    from mcpg import aio, pg19_ddl, pg19_stats
 
     driver = database.driver()
     await _safe("recommend_io_method", aio.recommend_io_method(driver))
@@ -107,6 +108,19 @@ async def _exercise_advisors(database: Database) -> None:
     await _safe("read_pg_stat_lock", pg19_stats.read_pg_stat_lock(driver))
     await _safe("read_pg_stat_recovery", pg19_stats.read_pg_stat_recovery(driver))
     await _safe("list_property_graphs", pgq_list_safely(driver))
+    # PG 19 DDL dumps — exercise on stock-cluster objects that always
+    # exist (the bootstrap superuser, the connected database, the
+    # default tablespace). Each tool raises on PG ≤ 18; _safe captures
+    # the error so the smoke run keeps moving.
+    await _safe("get_role_ddl(postgres)", pg19_ddl.get_role_ddl(driver, "postgres"))
+    await _safe(
+        "get_database_ddl(postgres)",
+        pg19_ddl.get_database_ddl(driver, "postgres"),
+    )
+    await _safe(
+        "get_tablespace_ddl(pg_default)",
+        pg19_ddl.get_tablespace_ddl(driver, "pg_default"),
+    )
 
 
 async def pgq_list_safely(driver: Any) -> Any:
@@ -164,6 +178,17 @@ async def _exercise_safe_writes(database: Database, probes: dict[str, dict[str, 
             "enable_data_checksums",
             {"skipped": ("status reports unavailable or already enabled — skipping to keep the smoke read-mostly")},
         )
+
+    # validate_check_constraint exercises ALTER TABLE on a caller-supplied
+    # constraint — there's no stock NOT VALID constraint in a fresh PG 19
+    # cluster, so we'd need to seed one. Round-tripping create-table +
+    # add-NOT-VALID + validate + drop here would blur the "what does
+    # MCPg do" report; skip with a note and rely on the unit tests
+    # (tests/unit/test_pg19_ddl.py) for behavioural coverage.
+    _emit(
+        "validate_check_constraint",
+        {"skipped": ("requires a pre-seeded NOT VALID constraint — see tests/unit/test_pg19_ddl.py")},
+    )
 
 
 async def main() -> int:

--- a/src/mcpg/about.py
+++ b/src/mcpg/about.py
@@ -672,6 +672,14 @@ _TOOL_TO_BUCKET_OVERRIDES: dict[str, str] = {
     "disable_data_checksums": "operations_and_health",
     "get_logical_replication_status": "operations_and_health",
     "enable_logical_replication_on_demand": "operations_and_health",
+    # PG 19 DDL helpers — pg_get_*def() reads route to schema_introspection
+    # (cluster-level CREATE-statement dumps); validate_check_constraint is
+    # a maintenance op that touches data validation, not schema shape.
+    "get_pg19_ddl_status": "schema_introspection",
+    "get_role_ddl": "schema_introspection",
+    "get_database_ddl": "schema_introspection",
+    "get_tablespace_ddl": "schema_introspection",
+    "validate_check_constraint": "operations_and_health",
 }
 
 

--- a/src/mcpg/pg19_ddl.py
+++ b/src/mcpg/pg19_ddl.py
@@ -1,0 +1,430 @@
+"""PG 19 DDL helpers — `validate_check_constraint` + `pg_get_*def()` family.
+
+Two related operator workflows, bundled here because the PG 19 release
+blog ships them in the same "DDL & schema management" group:
+
+* **Validate a `NOT VALID` constraint** — issuing the
+  ``ALTER TABLE … VALIDATE CONSTRAINT`` follow-up after a constraint
+  was first added with ``NOT VALID``. The SQL has worked since PG 9.x,
+  so this tool is *not* gated on PG 19; it ships now because it closes
+  the "create-NOT-VALID, validate later" loop that the agent surface
+  has been missing.
+* **Dump DDL for roles / databases / tablespaces** — PG 19 ships new
+  ``pg_get_roledef(oid)``, ``pg_get_databasedef(oid)``, and
+  ``pg_get_tablespacedef(oid)`` SQL functions that return the
+  ``CREATE``-statement text for the cluster-level objects that used to
+  require shelling out to ``pg_dumpall``. On PG ≤ 18 the read tools
+  surface ``available=False`` with a diagnostic pointing the agent at
+  ``pg_dumpall --roles-only`` / ``--globals-only`` / ``--tablespaces-only``.
+
+Backward compatibility
+----------------------
+Additive. ``validate_check_constraint`` works on every supported PG
+version. The ``get_*_ddl`` tools degrade to ``available=False`` on
+PG ≤ 18 — the agent gets a useful diagnostic instead of a crash.
+
+Security posture
+----------------
+* ``validate_check_constraint`` quotes every identifier (schema, table,
+  constraint). The status probe of ``pg_constraint`` is parameter-bound
+  and read-only; the ``ALTER TABLE`` runs through the regular driver,
+  not ``run_unmanaged`` (no autocommit requirement).
+* The ``pg_get_*def()`` reads use parameter-bound lookups on
+  ``pg_authid`` / ``pg_database`` / ``pg_tablespace`` — no caller
+  identifiers in identifier slots.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mcpg._vendor.sql import SqlDriver
+from mcpg.database import Database
+
+# PG 19 ships the new pg_get_*def() functions. The version-num boundary.
+_MIN_PG19_DDL_VERSION = 190000
+
+
+class Pg19DdlError(Exception):
+    """Raised when a PG 19 DDL helper operation cannot complete."""
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class Pg19DdlStatus:
+    """Reports whether PG 19's `pg_get_*def()` DDL functions are usable.
+
+    ``available`` is True when ``server_version_num`` >= 190000. The
+    individual ``has_*`` flags let the agent know which of the three
+    helpers a given build actually ships (Beta 1 ships all three; this
+    keeps the shape stable if a future PG release adds more).
+    """
+
+    available: bool
+    server_version_num: int
+    server_version: str
+    has_pg_get_roledef: bool
+    has_pg_get_databasedef: bool
+    has_pg_get_tablespacedef: bool
+    detail: str
+
+
+@dataclass(frozen=True, slots=True)
+class ValidateCheckConstraintResult:
+    """Outcome of `validate_check_constraint`.
+
+    ``was_valid`` reflects the pre-call ``pg_constraint.convalidated``
+    state; ``now_valid`` reflects the post-call state. When the
+    constraint was already valid ``changed=False`` and no DDL is
+    emitted. ``validate_sql`` is the rendered ``ALTER TABLE`` text.
+    """
+
+    schema: str
+    table: str
+    constraint_name: str
+    was_valid: bool | None
+    now_valid: bool
+    changed: bool
+    validate_sql: str
+
+
+@dataclass(frozen=True, slots=True)
+class ObjectDdlResult:
+    """The DDL text for a cluster-level object (role / database / tablespace).
+
+    ``object_type`` is one of ``"role"``, ``"database"``, ``"tablespace"``.
+    ``ddl`` is the verbatim ``CREATE`` statement returned by the
+    server-side ``pg_get_*def()`` function — empty string when the
+    object doesn't exist (paired with ``found=False``).
+    """
+
+    object_type: str
+    object_name: str
+    found: bool
+    ddl: str
+
+
+# ---------------------------------------------------------------------------
+# Shared probes
+# ---------------------------------------------------------------------------
+
+
+async def _server_version(driver: SqlDriver) -> tuple[int, str]:
+    """Return ``(server_version_num, server_version)`` in one round trip."""
+    rows = await driver.execute_query(
+        "SELECT current_setting('server_version_num')::int AS ver_num, current_setting('server_version') AS ver",
+        force_readonly=True,
+    )
+    if not rows:
+        return 0, ""
+    cells = rows[0].cells
+    return int(cells.get("ver_num") or 0), str(cells.get("ver") or "")
+
+
+async def _function_exists(driver: SqlDriver, name: str) -> bool:
+    """Return True when ``name`` resolves to a pg_proc row in pg_catalog."""
+    rows = await driver.execute_query(
+        "SELECT 1 AS present FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace "
+        "WHERE n.nspname = 'pg_catalog' AND p.proname = %s LIMIT 1",
+        params=[name],
+        force_readonly=True,
+    )
+    return bool(rows)
+
+
+def _quote_identifier(name: str) -> str:
+    """Quote a SQL identifier, escaping embedded double-quotes."""
+    if not name or "\x00" in name:
+        raise Pg19DdlError(f"invalid identifier: {name!r}")
+    return '"' + name.replace('"', '""') + '"'
+
+
+# ---------------------------------------------------------------------------
+# Status probe
+# ---------------------------------------------------------------------------
+
+
+async def get_pg19_ddl_status(driver: SqlDriver) -> Pg19DdlStatus:
+    """Report whether PG 19's `pg_get_*def()` DDL helpers are usable.
+
+    Read-only; never raises. The probe checks each function
+    independently via ``pg_proc`` so the result is robust against
+    incremental PG releases that ship the family piecemeal. On PG ≤ 18
+    every flag is ``False`` and ``detail`` points at the ``pg_dumpall``
+    fallback path.
+    """
+    try:
+        ver_num, ver = await _server_version(driver)
+    except Exception as exc:
+        return Pg19DdlStatus(
+            available=False,
+            server_version_num=0,
+            server_version="",
+            has_pg_get_roledef=False,
+            has_pg_get_databasedef=False,
+            has_pg_get_tablespacedef=False,
+            detail=(
+                f"PG 19 DDL helpers unavailable (version probe failed: {exc}). Re-run after the server is back online."
+            ),
+        )
+    if ver_num < _MIN_PG19_DDL_VERSION:
+        return Pg19DdlStatus(
+            available=False,
+            server_version_num=ver_num,
+            server_version=ver,
+            has_pg_get_roledef=False,
+            has_pg_get_databasedef=False,
+            has_pg_get_tablespacedef=False,
+            detail=(
+                "PG 19's pg_get_roledef() / pg_get_databasedef() / "
+                "pg_get_tablespacedef() functions require PostgreSQL 19 "
+                "or newer; this server is older. Fall back to "
+                "`pg_dumpall --roles-only` / `--globals-only` / "
+                "`--tablespaces-only` for cluster-level DDL."
+            ),
+        )
+    try:
+        has_role = await _function_exists(driver, "pg_get_roledef")
+        has_database = await _function_exists(driver, "pg_get_databasedef")
+        has_tablespace = await _function_exists(driver, "pg_get_tablespacedef")
+    except Exception as exc:
+        return Pg19DdlStatus(
+            available=False,
+            server_version_num=ver_num,
+            server_version=ver,
+            has_pg_get_roledef=False,
+            has_pg_get_databasedef=False,
+            has_pg_get_tablespacedef=False,
+            detail=f"PG 19 reachable but pg_proc probe failed: {exc}. Re-run after the server is back online.",
+        )
+    available = has_role or has_database or has_tablespace
+    if available:
+        detail = (
+            "PG 19 DDL helpers available: "
+            f"role={'yes' if has_role else 'no'}, "
+            f"database={'yes' if has_database else 'no'}, "
+            f"tablespace={'yes' if has_tablespace else 'no'}. "
+            "Call get_role_ddl / get_database_ddl / get_tablespace_ddl."
+        )
+    else:
+        detail = (
+            "PG 19 reachable but none of the pg_get_*def() functions "
+            "are present in pg_catalog — your build may have stripped "
+            "them. Fall back to pg_dumpall for cluster-level DDL."
+        )
+    return Pg19DdlStatus(
+        available=available,
+        server_version_num=ver_num,
+        server_version=ver,
+        has_pg_get_roledef=has_role,
+        has_pg_get_databasedef=has_database,
+        has_pg_get_tablespacedef=has_tablespace,
+        detail=detail,
+    )
+
+
+# ---------------------------------------------------------------------------
+# validate_check_constraint — works on every supported PG version
+# ---------------------------------------------------------------------------
+
+
+async def _read_constraint_validated(
+    driver: SqlDriver,
+    *,
+    schema: str,
+    table: str,
+    constraint_name: str,
+) -> bool | None:
+    """Return ``pg_constraint.convalidated`` for the named constraint.
+
+    Returns ``None`` when the constraint doesn't exist (the caller
+    surfaces that as a ``Pg19DdlError`` with a useful message). The
+    join through ``pg_class`` / ``pg_namespace`` keeps the lookup
+    scoped to the exact (schema, table, constraint) triple — two
+    tables in different schemas can legally share a constraint name.
+    """
+    rows = await driver.execute_query(
+        "SELECT c.convalidated FROM pg_constraint c "
+        "JOIN pg_class t ON t.oid = c.conrelid "
+        "JOIN pg_namespace n ON n.oid = t.relnamespace "
+        "WHERE n.nspname = %s AND t.relname = %s AND c.conname = %s LIMIT 1",
+        params=[schema, table, constraint_name],
+        force_readonly=True,
+    )
+    if not rows:
+        return None
+    raw = rows[0].cells.get("convalidated")
+    if raw is None:
+        return None
+    if isinstance(raw, bool):
+        return raw
+    return str(raw).strip().lower() in {"on", "true", "yes", "t", "1"}
+
+
+async def validate_check_constraint(
+    database: Database,
+    *,
+    schema: str,
+    table: str,
+    constraint_name: str,
+) -> ValidateCheckConstraintResult:
+    """Issue ``ALTER TABLE … VALIDATE CONSTRAINT`` for a `NOT VALID` constraint.
+
+    Closes the "added NOT VALID at low cost, now actually validate"
+    loop. Idempotent — if the constraint is already valid, no DDL is
+    emitted and ``changed=False`` is returned. Works on every supported
+    PG version (the SQL has been around since 9.x); not gated on PG 19.
+
+    Raises :class:`Pg19DdlError` when the named constraint doesn't
+    exist or when the underlying ``ALTER TABLE`` fails (lock timeout,
+    permission denied, constraint actually violated by data, etc.).
+    """
+    driver = database.driver()
+    was_valid = await _read_constraint_validated(
+        driver,
+        schema=schema,
+        table=table,
+        constraint_name=constraint_name,
+    )
+    if was_valid is None:
+        raise Pg19DdlError(f"constraint {constraint_name!r} not found on {schema}.{table} (no row in pg_constraint).")
+    qualified = f"{_quote_identifier(schema)}.{_quote_identifier(table)}"
+    validate_sql = f"ALTER TABLE {qualified} VALIDATE CONSTRAINT {_quote_identifier(constraint_name)}"
+    if was_valid:
+        return ValidateCheckConstraintResult(
+            schema=schema,
+            table=table,
+            constraint_name=constraint_name,
+            was_valid=True,
+            now_valid=True,
+            changed=False,
+            validate_sql=f"-- {constraint_name} already validated; no-op",
+        )
+    try:
+        await driver.execute_query(validate_sql, force_readonly=False)
+    except Exception as exc:
+        raise Pg19DdlError(f"VALIDATE CONSTRAINT {constraint_name} on {schema}.{table} failed: {exc}") from exc
+    return ValidateCheckConstraintResult(
+        schema=schema,
+        table=table,
+        constraint_name=constraint_name,
+        was_valid=False,
+        now_valid=True,
+        changed=True,
+        validate_sql=validate_sql,
+    )
+
+
+# ---------------------------------------------------------------------------
+# pg_get_*def() — cluster-level DDL dumps (PG 19+)
+# ---------------------------------------------------------------------------
+
+
+async def _ensure_pg19(driver: SqlDriver, feature: str) -> None:
+    """Common version gate for the get_*_ddl tools."""
+    ver_num, ver = await _server_version(driver)
+    if ver_num < _MIN_PG19_DDL_VERSION:
+        raise Pg19DdlError(
+            f"{feature} requires PostgreSQL 19 or newer; this server "
+            f"reports {ver or 'unknown'} (server_version_num={ver_num}). "
+            "Fall back to pg_dumpall for cluster-level DDL."
+        )
+
+
+async def get_role_ddl(driver: SqlDriver, role_name: str) -> ObjectDdlResult:
+    """Return the ``CREATE ROLE`` DDL for ``role_name``.
+
+    Wraps PG 19's ``pg_get_roledef(oid)``. Returns ``found=False`` with
+    an empty ``ddl`` when no matching role exists. Requires PG 19+;
+    raises :class:`Pg19DdlError` on older servers with a pg_dumpall
+    fallback hint.
+    """
+    await _ensure_pg19(driver, "get_role_ddl")
+    try:
+        rows = await driver.execute_query(
+            "SELECT pg_get_roledef(oid) AS ddl FROM pg_authid WHERE rolname = %s LIMIT 1",
+            params=[role_name],
+            force_readonly=True,
+        )
+    except Exception as exc:
+        raise Pg19DdlError(f"pg_get_roledef({role_name!r}) failed: {exc}") from exc
+    if not rows:
+        return ObjectDdlResult(object_type="role", object_name=role_name, found=False, ddl="")
+    ddl = rows[0].cells.get("ddl")
+    return ObjectDdlResult(
+        object_type="role",
+        object_name=role_name,
+        found=True,
+        ddl="" if ddl is None else str(ddl),
+    )
+
+
+async def get_database_ddl(driver: SqlDriver, database_name: str) -> ObjectDdlResult:
+    """Return the ``CREATE DATABASE`` DDL for ``database_name``.
+
+    Wraps PG 19's ``pg_get_databasedef(oid)``. Returns ``found=False``
+    with an empty ``ddl`` when no matching database exists. Requires
+    PG 19+.
+    """
+    await _ensure_pg19(driver, "get_database_ddl")
+    try:
+        rows = await driver.execute_query(
+            "SELECT pg_get_databasedef(oid) AS ddl FROM pg_database WHERE datname = %s LIMIT 1",
+            params=[database_name],
+            force_readonly=True,
+        )
+    except Exception as exc:
+        raise Pg19DdlError(f"pg_get_databasedef({database_name!r}) failed: {exc}") from exc
+    if not rows:
+        return ObjectDdlResult(object_type="database", object_name=database_name, found=False, ddl="")
+    ddl = rows[0].cells.get("ddl")
+    return ObjectDdlResult(
+        object_type="database",
+        object_name=database_name,
+        found=True,
+        ddl="" if ddl is None else str(ddl),
+    )
+
+
+async def get_tablespace_ddl(driver: SqlDriver, tablespace_name: str) -> ObjectDdlResult:
+    """Return the ``CREATE TABLESPACE`` DDL for ``tablespace_name``.
+
+    Wraps PG 19's ``pg_get_tablespacedef(oid)``. Returns ``found=False``
+    with an empty ``ddl`` when no matching tablespace exists. Requires
+    PG 19+.
+    """
+    await _ensure_pg19(driver, "get_tablespace_ddl")
+    try:
+        rows = await driver.execute_query(
+            "SELECT pg_get_tablespacedef(oid) AS ddl FROM pg_tablespace WHERE spcname = %s LIMIT 1",
+            params=[tablespace_name],
+            force_readonly=True,
+        )
+    except Exception as exc:
+        raise Pg19DdlError(f"pg_get_tablespacedef({tablespace_name!r}) failed: {exc}") from exc
+    if not rows:
+        return ObjectDdlResult(object_type="tablespace", object_name=tablespace_name, found=False, ddl="")
+    ddl = rows[0].cells.get("ddl")
+    return ObjectDdlResult(
+        object_type="tablespace",
+        object_name=tablespace_name,
+        found=True,
+        ddl="" if ddl is None else str(ddl),
+    )
+
+
+__all__ = [
+    "ObjectDdlResult",
+    "Pg19DdlError",
+    "Pg19DdlStatus",
+    "ValidateCheckConstraintResult",
+    "get_database_ddl",
+    "get_pg19_ddl_status",
+    "get_role_ddl",
+    "get_tablespace_ddl",
+    "validate_check_constraint",
+]

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -5225,10 +5225,10 @@ def register_tools(server: FastMCP[AppContext], settings: Settings) -> None:
         _register_pg_prewarm_writes(server)
         _register_repack_writes(server)
         _register_pg19_runtime_writes(server)
-        _register_pg19_ddl_writes(server)
     if is_permitted(settings.access_mode, Capability.DDL) and settings.allow_ddl:
         _register_ddl(server)
         _register_partman(server)
+        _register_pg19_ddl_writes(server)
         _register_turboquant_ddl(server)
         _register_pg_search_ddl(server)
         _register_rag_telemetry_ddl(server)

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -48,6 +48,7 @@ from mcpg import (
     naming,
     nl2sql,
     partman,
+    pg19_ddl,
     pg19_runtime,
     pg19_stats,
     pg_prewarm,
@@ -4558,6 +4559,116 @@ def _register_pg19_runtime_writes(server: FastMCP[AppContext]) -> None:
         return asdict(result)
 
 
+def _register_pg19_ddl_reads(server: FastMCP[AppContext]) -> None:
+    @server.tool(
+        name="get_pg19_ddl_status",
+        description=_with_example(
+            "Report whether PG 19's `pg_get_roledef()` / `pg_get_databasedef()` "
+            "/ `pg_get_tablespacedef()` DDL-dump functions are usable on this "
+            "server. Never raises — driver-level errors surface as "
+            "`available=false`. On PG ≤ 18 reports `available=false` and "
+            "points the agent at `pg_dumpall --roles-only` / `--globals-only` "
+            "/ `--tablespaces-only` as the fallback. "
+            "Returns an object with `available` (bool), `server_version_num` "
+            "(int), `server_version`, `has_pg_get_roledef` (bool), "
+            "`has_pg_get_databasedef` (bool), `has_pg_get_tablespacedef` "
+            "(bool), and `detail` (guidance string).",
+            "get_pg19_ddl_status()",
+        ),
+    )
+    async def get_pg19_ddl_status(ctx: _Ctx) -> dict[str, Any]:
+        # Catalog probe — never cache: an extension install / build flip
+        # mid-session needs to be visible on the next call.
+        status = await pg19_ddl.get_pg19_ddl_status(_driver(ctx))
+        return asdict(status)
+
+    @server.tool(
+        name="get_role_ddl",
+        description=_with_example(
+            "Return the `CREATE ROLE` DDL for a named role using PG 19's "
+            "`pg_get_roledef(oid)` function — no shell-out to `pg_dumpall "
+            "--roles-only` required. Returns `found=false` with an empty "
+            "`ddl` when the role doesn't exist. Requires PG 19+; raises "
+            "on older servers (pair with `get_pg19_ddl_status` to "
+            "feature-detect). "
+            "Returns an object with `object_type` (`'role'`), `object_name`, "
+            "`found` (bool), and `ddl` (the verbatim CREATE statement).",
+            "get_role_ddl(role_name='app_user')",
+        ),
+    )
+    async def get_role_ddl(ctx: _Ctx, role_name: str) -> dict[str, Any]:
+        result = await pg19_ddl.get_role_ddl(_driver(ctx), role_name)
+        return asdict(result)
+
+    @server.tool(
+        name="get_database_ddl",
+        description=_with_example(
+            "Return the `CREATE DATABASE` DDL for a named database using "
+            "PG 19's `pg_get_databasedef(oid)` function. Returns "
+            "`found=false` with an empty `ddl` when the database doesn't "
+            "exist. Requires PG 19+. "
+            "Returns an object with `object_type` (`'database'`), "
+            "`object_name`, `found`, and `ddl`.",
+            "get_database_ddl(database_name='analytics')",
+        ),
+    )
+    async def get_database_ddl(ctx: _Ctx, database_name: str) -> dict[str, Any]:
+        result = await pg19_ddl.get_database_ddl(_driver(ctx), database_name)
+        return asdict(result)
+
+    @server.tool(
+        name="get_tablespace_ddl",
+        description=_with_example(
+            "Return the `CREATE TABLESPACE` DDL for a named tablespace using "
+            "PG 19's `pg_get_tablespacedef(oid)` function. Returns "
+            "`found=false` with an empty `ddl` when the tablespace doesn't "
+            "exist. Requires PG 19+. "
+            "Returns an object with `object_type` (`'tablespace'`), "
+            "`object_name`, `found`, and `ddl`.",
+            "get_tablespace_ddl(tablespace_name='fast_ssd')",
+        ),
+    )
+    async def get_tablespace_ddl(ctx: _Ctx, tablespace_name: str) -> dict[str, Any]:
+        result = await pg19_ddl.get_tablespace_ddl(_driver(ctx), tablespace_name)
+        return asdict(result)
+
+
+def _register_pg19_ddl_writes(server: FastMCP[AppContext]) -> None:
+    @server.tool(
+        name="validate_check_constraint",
+        description=_with_example(
+            "Run `ALTER TABLE schema.table VALIDATE CONSTRAINT name` to "
+            "validate a constraint that was originally added with "
+            "`NOT VALID`. Idempotent — when the constraint is already "
+            "validated, returns `changed=false` and emits no DDL. Works "
+            "on every supported PG version (the SQL has been around "
+            "since 9.x); ships in the PG 19 DDL helpers module because "
+            "it closes the create-NOT-VALID / validate-later loop on "
+            "the agent surface. "
+            "Returns an object with `schema`, `table`, `constraint_name`, "
+            "`was_valid` (bool / null), `now_valid` (bool), `changed` "
+            "(bool), and `validate_sql` (the rendered DDL that actually "
+            "executed, or a `-- no-op` comment when nothing was needed).",
+            "validate_check_constraint(schema='public', table='orders', constraint_name='orders_total_nonneg')",
+        ),
+    )
+    async def validate_check_constraint(
+        ctx: _Ctx,
+        schema: str,
+        table: str,
+        constraint_name: str,
+    ) -> dict[str, Any]:
+        database = ctx.request_context.lifespan_context.database
+        result = await pg19_ddl.validate_check_constraint(
+            database,
+            schema=schema,
+            table=table,
+            constraint_name=constraint_name,
+        )
+        await ctx.request_context.lifespan_context.cache.clear()
+        return asdict(result)
+
+
 def _register_pg19_stats_reads(server: FastMCP[AppContext]) -> None:
     @server.tool(
         name="get_pg19_stats_status",
@@ -5102,6 +5213,7 @@ def register_tools(server: FastMCP[AppContext], settings: Settings) -> None:
         _register_aio_reads(server)
         _register_pg19_stats_reads(server)
         _register_pg19_runtime_reads(server)
+        _register_pg19_ddl_reads(server)
     if is_permitted(settings.access_mode, Capability.WRITE):
         _register_write(server)
         _register_maintenance(server)
@@ -5113,6 +5225,7 @@ def register_tools(server: FastMCP[AppContext], settings: Settings) -> None:
         _register_pg_prewarm_writes(server)
         _register_repack_writes(server)
         _register_pg19_runtime_writes(server)
+        _register_pg19_ddl_writes(server)
     if is_permitted(settings.access_mode, Capability.DDL) and settings.allow_ddl:
         _register_ddl(server)
         _register_partman(server)

--- a/tests/contract/test_tool_return_shapes.py
+++ b/tests/contract/test_tool_return_shapes.py
@@ -56,6 +56,7 @@ _SNAPSHOT_PATH = Path(__file__).parent / "tool_return_shapes.snapshot.json"
 # isn't strictly needed — kept here only as documentation for the reviewer.
 _KNOWN_HELPER_MODULES = (
     "advisors",
+    "aio",
     "audit",
     "audit_trail",
     "composite",
@@ -80,6 +81,9 @@ _KNOWN_HELPER_MODULES = (
     "naming",
     "nl2sql",
     "partman",
+    "pg19_ddl",
+    "pg19_runtime",
+    "pg19_stats",
     "pg_prewarm",
     "pg_search",
     "pgq",

--- a/tests/contract/tool_return_shapes.snapshot.json
+++ b/tests/contract/tool_return_shapes.snapshot.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "schema_version": 1,
-    "tool_count": 209
+    "tool_count": 214
   },
   "tools": {
     "add_compression_policy": {
@@ -40,7 +40,14 @@
       "kind": "opaque"
     },
     "analyze_lock_hotspots": {
-      "kind": "opaque"
+      "dataclass": "LockHotspotsResult",
+      "fields": [
+        "available",
+        "detail",
+        "hotspots",
+        "server_version_num"
+      ],
+      "kind": "scalar"
     },
     "analyze_query_plan": {
       "kind": "opaque"
@@ -396,7 +403,14 @@
       "kind": "scalar"
     },
     "disable_data_checksums": {
-      "kind": "opaque"
+      "dataclass": "ToggleDataChecksumsResult",
+      "fields": [
+        "changed",
+        "now_enabled",
+        "toggle_sql",
+        "was_enabled"
+      ],
+      "kind": "scalar"
     },
     "drop_graph": {
       "kind": "opaque"
@@ -425,7 +439,14 @@
       "kind": "scalar"
     },
     "enable_data_checksums": {
-      "kind": "opaque"
+      "dataclass": "ToggleDataChecksumsResult",
+      "fields": [
+        "changed",
+        "now_enabled",
+        "toggle_sql",
+        "was_enabled"
+      ],
+      "kind": "scalar"
     },
     "enable_extension": {
       "dataclass": "EnableExtensionResult",
@@ -436,7 +457,14 @@
       "kind": "scalar"
     },
     "enable_logical_replication_on_demand": {
-      "kind": "opaque"
+      "dataclass": "EnableLogicalReplicationOnDemandResult",
+      "fields": [
+        "detail",
+        "new_wal_level",
+        "previous_wal_level",
+        "requires_restart"
+      ],
+      "kind": "scalar"
     },
     "enable_redis_fdw": {
       "dataclass": "EnableExtensionResult",
@@ -575,22 +603,82 @@
       "kind": "scalar"
     },
     "get_aio_status": {
-      "kind": "opaque"
+      "dataclass": "AioStatus",
+      "fields": [
+        "available",
+        "detail",
+        "io_max_workers",
+        "io_method",
+        "io_min_workers",
+        "server_version",
+        "server_version_num"
+      ],
+      "kind": "scalar"
     },
     "get_compact_schema": {
       "kind": "opaque"
     },
     "get_data_checksums_status": {
-      "kind": "opaque"
+      "dataclass": "DataChecksumsStatus",
+      "fields": [
+        "available",
+        "detail",
+        "enabled",
+        "server_version",
+        "server_version_num"
+      ],
+      "kind": "scalar"
+    },
+    "get_database_ddl": {
+      "dataclass": "ObjectDdlResult",
+      "fields": [
+        "ddl",
+        "found",
+        "object_name",
+        "object_type"
+      ],
+      "kind": "scalar"
     },
     "get_logical_replication_status": {
-      "kind": "opaque"
+      "dataclass": "LogicalReplicationStatus",
+      "fields": [
+        "available",
+        "detail",
+        "effective_wal_level",
+        "max_replication_slots",
+        "server_version",
+        "server_version_num",
+        "wal_level"
+      ],
+      "kind": "scalar"
     },
     "get_metrics_exposition": {
       "kind": "opaque"
     },
+    "get_pg19_ddl_status": {
+      "dataclass": "Pg19DdlStatus",
+      "fields": [
+        "available",
+        "detail",
+        "has_pg_get_databasedef",
+        "has_pg_get_roledef",
+        "has_pg_get_tablespacedef",
+        "server_version",
+        "server_version_num"
+      ],
+      "kind": "scalar"
+    },
     "get_pg19_stats_status": {
-      "kind": "opaque"
+      "dataclass": "Pg19StatsStatus",
+      "fields": [
+        "available",
+        "detail",
+        "has_pg_stat_lock",
+        "has_pg_stat_recovery",
+        "server_version",
+        "server_version_num"
+      ],
+      "kind": "scalar"
     },
     "get_pg_search_index_metadata": {
       "dataclass": "PgSearchIndexInfo",
@@ -657,8 +745,28 @@
       ],
       "kind": "scalar"
     },
+    "get_role_ddl": {
+      "dataclass": "ObjectDdlResult",
+      "fields": [
+        "ddl",
+        "found",
+        "object_name",
+        "object_type"
+      ],
+      "kind": "scalar"
+    },
     "get_server_info": {
       "kind": "opaque"
+    },
+    "get_tablespace_ddl": {
+      "dataclass": "ObjectDdlResult",
+      "fields": [
+        "ddl",
+        "found",
+        "object_name",
+        "object_type"
+      ],
+      "kind": "scalar"
     },
     "get_turboquant_heap_stats": {
       "dataclass": "TurboQuantHeapStats",
@@ -1440,10 +1548,24 @@
       "kind": "scalar"
     },
     "read_pg_stat_lock": {
-      "kind": "opaque"
+      "dataclass": "LockStatRow",
+      "fields": [
+        "acquires",
+        "lock_type",
+        "wait_time_us",
+        "waits"
+      ],
+      "kind": "list"
     },
     "read_pg_stat_recovery": {
-      "kind": "opaque"
+      "dataclass": "RecoveryStatRow",
+      "fields": [
+        "last_replayed_at",
+        "replay_lag_seconds",
+        "replay_lsn",
+        "startup_state"
+      ],
+      "kind": "list"
     },
     "read_pg_wal_records": {
       "dataclass": "WalRecordsReport",
@@ -1511,7 +1633,14 @@
       "kind": "list"
     },
     "recommend_io_method": {
-      "kind": "opaque"
+      "dataclass": "RecommendIoMethodResult",
+      "fields": [
+        "available",
+        "detail",
+        "recommendations",
+        "server_version_num"
+      ],
+      "kind": "scalar"
     },
     "recommend_pg_search_maintenance": {
       "dataclass": "PgSearchAdvisorFinding",
@@ -1860,6 +1989,19 @@
     },
     "unsubscribe_channel": {
       "kind": "opaque"
+    },
+    "validate_check_constraint": {
+      "dataclass": "ValidateCheckConstraintResult",
+      "fields": [
+        "changed",
+        "constraint_name",
+        "now_valid",
+        "schema",
+        "table",
+        "validate_sql",
+        "was_valid"
+      ],
+      "kind": "scalar"
     },
     "validate_migration": {
       "dataclass": "ValidationResult",

--- a/tests/contract/tool_surface.snapshot.json
+++ b/tests/contract/tool_surface.snapshot.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "schema_version": 1,
-    "tool_count": 209
+    "tool_count": 214
   },
   "tools": [
     {
@@ -2131,6 +2131,23 @@
       "name": "get_data_checksums_status"
     },
     {
+      "description": "Return the `CREATE DATABASE` DDL for a named database using PG 19's `pg_get_databasedef(oid)` function. Returns `found=false` with an empty `ddl` when the database doesn't exist. Requires PG 19+. Returns an object with `object_type` (`'database'`), `object_name`, `found`, and `ddl`.\n\nExample: `get_database_ddl(database_name='analytics')`",
+      "inputSchema": {
+        "properties": {
+          "database_name": {
+            "title": "Database Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "database_name"
+        ],
+        "title": "get_database_ddlArguments",
+        "type": "object"
+      },
+      "name": "get_database_ddl"
+    },
+    {
       "description": "Report whether PG 19's on-demand wal_level flip is usable, plus the configured `wal_level`, the new PG 19 `effective_wal_level` preset GUC, and `max_replication_slots`. When configured and effective diverge the agent can tell that an `ALTER SYSTEM` has been done but a reload is still pending. Never raises. Returns an object with `available` (bool), `server_version_num`, `server_version`, `wal_level`, `effective_wal_level`, `max_replication_slots`, and `detail`.\n\nExample: `get_logical_replication_status()`",
       "inputSchema": {
         "properties": {},
@@ -2147,6 +2164,15 @@
         "type": "object"
       },
       "name": "get_metrics_exposition"
+    },
+    {
+      "description": "Report whether PG 19's `pg_get_roledef()` / `pg_get_databasedef()` / `pg_get_tablespacedef()` DDL-dump functions are usable on this server. Never raises — driver-level errors surface as `available=false`. On PG ≤ 18 reports `available=false` and points the agent at `pg_dumpall --roles-only` / `--globals-only` / `--tablespaces-only` as the fallback. Returns an object with `available` (bool), `server_version_num` (int), `server_version`, `has_pg_get_roledef` (bool), `has_pg_get_databasedef` (bool), `has_pg_get_tablespacedef` (bool), and `detail` (guidance string).\n\nExample: `get_pg19_ddl_status()`",
+      "inputSchema": {
+        "properties": {},
+        "title": "get_pg19_ddl_statusArguments",
+        "type": "object"
+      },
+      "name": "get_pg19_ddl_status"
     },
     {
       "description": "Report whether PG 19's `pg_stat_lock` and `pg_stat_recovery` views are usable on this server. Never raises — driver-level errors surface as `available=false`. On PG < 19 returns `available=false` with a diagnostic pointing the agent at `find_blocking_chains` / `pg_stat_replication`. Returns an object with `available` (bool), `server_version_num` (int), `server_version`, `has_pg_stat_lock` (bool), `has_pg_stat_recovery` (bool), and `detail` (guidance string).\n\nExample: `get_pg19_stats_status()`",
@@ -2224,6 +2250,23 @@
       "name": "get_repack_status"
     },
     {
+      "description": "Return the `CREATE ROLE` DDL for a named role using PG 19's `pg_get_roledef(oid)` function — no shell-out to `pg_dumpall --roles-only` required. Returns `found=false` with an empty `ddl` when the role doesn't exist. Requires PG 19+; raises on older servers (pair with `get_pg19_ddl_status` to feature-detect). Returns an object with `object_type` (`'role'`), `object_name`, `found` (bool), and `ddl` (the verbatim CREATE statement).\n\nExample: `get_role_ddl(role_name='app_user')`",
+      "inputSchema": {
+        "properties": {
+          "role_name": {
+            "title": "Role Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "role_name"
+        ],
+        "title": "get_role_ddlArguments",
+        "type": "object"
+      },
+      "name": "get_role_ddl"
+    },
+    {
       "description": "Return the MCPg server version, access mode, transport, and database connection status.",
       "inputSchema": {
         "properties": {},
@@ -2231,6 +2274,23 @@
         "type": "object"
       },
       "name": "get_server_info"
+    },
+    {
+      "description": "Return the `CREATE TABLESPACE` DDL for a named tablespace using PG 19's `pg_get_tablespacedef(oid)` function. Returns `found=false` with an empty `ddl` when the tablespace doesn't exist. Requires PG 19+. Returns an object with `object_type` (`'tablespace'`), `object_name`, `found`, and `ddl`.\n\nExample: `get_tablespace_ddl(tablespace_name='fast_ssd')`",
+      "inputSchema": {
+        "properties": {
+          "tablespace_name": {
+            "title": "Tablespace Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "tablespace_name"
+        ],
+        "title": "get_tablespace_ddlArguments",
+        "type": "object"
+      },
+      "name": "get_tablespace_ddl"
     },
     {
       "description": "Return the exact heap row count tq_index_heap_stats() reports for a single turboquant index (schema.index). The raw upstream payload is preserved in ``raw`` for any extra counters upstream may add. Requires the pg_turboquant extension.",
@@ -5529,6 +5589,33 @@
         "type": "object"
       },
       "name": "unsubscribe_channel"
+    },
+    {
+      "description": "Run `ALTER TABLE schema.table VALIDATE CONSTRAINT name` to validate a constraint that was originally added with `NOT VALID`. Idempotent — when the constraint is already validated, returns `changed=false` and emits no DDL. Works on every supported PG version (the SQL has been around since 9.x); ships in the PG 19 DDL helpers module because it closes the create-NOT-VALID / validate-later loop on the agent surface. Returns an object with `schema`, `table`, `constraint_name`, `was_valid` (bool / null), `now_valid` (bool), `changed` (bool), and `validate_sql` (the rendered DDL that actually executed, or a `-- no-op` comment when nothing was needed).\n\nExample: `validate_check_constraint(schema='public', table='orders', constraint_name='orders_total_nonneg')`",
+      "inputSchema": {
+        "properties": {
+          "constraint_name": {
+            "title": "Constraint Name",
+            "type": "string"
+          },
+          "schema": {
+            "title": "Schema",
+            "type": "string"
+          },
+          "table": {
+            "title": "Table",
+            "type": "string"
+          }
+        },
+        "required": [
+          "schema",
+          "table",
+          "constraint_name"
+        ],
+        "title": "validate_check_constraintArguments",
+        "type": "object"
+      },
+      "name": "validate_check_constraint"
     },
     {
       "description": "Apply candidate_sql to a TRANSIENT shadow of target_schema that's pre-populated with up to sample_rows_per_table rows copied from each base table. The shadow is dropped before returning regardless of outcome. Catches failure modes a pure structural diff misses: NOT NULL added to a column with existing NULLs, CHECK constraints violated by live rows, type narrowings that fail on real values, triggers that error against actual data. Reports per-table rows_before / rows_after so the effect of a DELETE-shaped candidate is visible. error is non-null iff the candidate raised. Performs DDL — requires unrestricted mode + MCPG_ALLOW_DDL.",

--- a/tests/unit/test_pg19_ddl.py
+++ b/tests/unit/test_pg19_ddl.py
@@ -1,0 +1,260 @@
+"""Tests for the PG 19 DDL helpers module."""
+
+from __future__ import annotations
+
+import pytest
+from _fakes import FakeDatabase, FakeDriver, FakeRoutingDriver
+
+from mcpg.pg19_ddl import (
+    ObjectDdlResult,
+    Pg19DdlError,
+    Pg19DdlStatus,
+    ValidateCheckConstraintResult,
+    get_database_ddl,
+    get_pg19_ddl_status,
+    get_role_ddl,
+    get_tablespace_ddl,
+    validate_check_constraint,
+)
+
+
+def _version_route(num: int, ver: str) -> dict[str, list[dict[str, object]]]:
+    return {"current_setting('server_version_num')": [{"ver_num": num, "ver": ver}]}
+
+
+# --- get_pg19_ddl_status --------------------------------------------------
+
+
+async def test_status_available_on_pg19_all_functions_present() -> None:
+    routes = _version_route(190001, "19beta1")
+    # All three pg_get_*def() probes hit the same pg_proc query.
+    routes["pg_proc p JOIN pg_namespace"] = [{"present": 1}]
+    driver = FakeRoutingDriver(routes)
+    status = await get_pg19_ddl_status(driver)  # type: ignore[arg-type]
+    assert isinstance(status, Pg19DdlStatus)
+    assert status.available is True
+    assert status.has_pg_get_roledef is True
+    assert status.has_pg_get_databasedef is True
+    assert status.has_pg_get_tablespacedef is True
+    assert "available" in status.detail.lower()
+
+
+async def test_status_unavailable_on_pg18() -> None:
+    routes = _version_route(180003, "18.3")
+    driver = FakeRoutingDriver(routes)
+    status = await get_pg19_ddl_status(driver)  # type: ignore[arg-type]
+    assert status.available is False
+    assert status.has_pg_get_roledef is False
+    assert "pg_dumpall" in status.detail
+
+
+async def test_status_pg19_with_no_functions_reports_unavailable() -> None:
+    """A PG 19 build that stripped the pg_get_*def() family still reports cleanly."""
+    routes = _version_route(190001, "19beta1")
+    # pg_proc probe returns no rows.
+    routes["pg_proc p JOIN pg_namespace"] = []
+    driver = FakeRoutingDriver(routes)
+    status = await get_pg19_ddl_status(driver)  # type: ignore[arg-type]
+    assert status.available is False
+    assert status.has_pg_get_roledef is False
+    assert "pg_dumpall" in status.detail
+
+
+async def test_status_never_raises_on_driver_failure() -> None:
+    driver = FakeDriver(fail=True)
+    status = await get_pg19_ddl_status(driver)  # type: ignore[arg-type]
+    assert status.available is False
+    assert "version probe failed" in status.detail
+
+
+# --- validate_check_constraint --------------------------------------------
+
+
+class _ValidateDriver:
+    """Custom driver: routes the convalidated read by query substring;
+    every other query (the ALTER TABLE) gets recorded into ``executed``."""
+
+    def __init__(self, *, convalidated: bool | None, alter_fails: bool = False) -> None:
+        self._convalidated = convalidated
+        self._alter_fails = alter_fails
+        self.executed: list[str] = []
+        self.calls: list[tuple[str, object, bool]] = []
+
+    async def execute_query(self, query, params=None, force_readonly=False):  # type: ignore[no-untyped-def]
+        from mcpg._vendor.sql import SqlDriver
+
+        self.calls.append((query, params, force_readonly))
+        if "pg_constraint" in query:
+            if self._convalidated is None:
+                return []
+            return [SqlDriver.RowResult(cells={"convalidated": self._convalidated})]
+        # ALTER TABLE path.
+        self.executed.append(query)
+        if self._alter_fails:
+            raise RuntimeError("lock timeout")
+        return []
+
+
+async def test_validate_constraint_emits_alter_table_when_not_valid() -> None:
+    driver = _ValidateDriver(convalidated=False)
+    db = FakeDatabase(driver)  # type: ignore[arg-type]
+    result = await validate_check_constraint(
+        db,  # type: ignore[arg-type]
+        schema="public",
+        table="orders",
+        constraint_name="orders_total_nonneg",
+    )
+    assert isinstance(result, ValidateCheckConstraintResult)
+    assert result.was_valid is False
+    assert result.now_valid is True
+    assert result.changed is True
+    assert driver.executed == ['ALTER TABLE "public"."orders" VALIDATE CONSTRAINT "orders_total_nonneg"']
+    assert "ALTER TABLE" in result.validate_sql
+
+
+async def test_validate_constraint_is_noop_when_already_valid() -> None:
+    driver = _ValidateDriver(convalidated=True)
+    db = FakeDatabase(driver)  # type: ignore[arg-type]
+    result = await validate_check_constraint(
+        db,  # type: ignore[arg-type]
+        schema="public",
+        table="orders",
+        constraint_name="orders_total_nonneg",
+    )
+    assert result.was_valid is True
+    assert result.now_valid is True
+    assert result.changed is False
+    assert driver.executed == []
+    assert "no-op" in result.validate_sql
+
+
+async def test_validate_constraint_raises_when_not_found() -> None:
+    driver = _ValidateDriver(convalidated=None)
+    db = FakeDatabase(driver)  # type: ignore[arg-type]
+    with pytest.raises(Pg19DdlError, match="not found"):
+        await validate_check_constraint(
+            db,  # type: ignore[arg-type]
+            schema="public",
+            table="orders",
+            constraint_name="missing",
+        )
+    assert driver.executed == []
+
+
+async def test_validate_constraint_wraps_alter_failure() -> None:
+    driver = _ValidateDriver(convalidated=False, alter_fails=True)
+    db = FakeDatabase(driver)  # type: ignore[arg-type]
+    with pytest.raises(Pg19DdlError, match="VALIDATE CONSTRAINT"):
+        await validate_check_constraint(
+            db,  # type: ignore[arg-type]
+            schema="public",
+            table="orders",
+            constraint_name="orders_total_nonneg",
+        )
+
+
+async def test_validate_constraint_quotes_identifiers_against_injection() -> None:
+    """Embedded double-quotes get escaped; the SQL is still safe."""
+    driver = _ValidateDriver(convalidated=False)
+    db = FakeDatabase(driver)  # type: ignore[arg-type]
+    result = await validate_check_constraint(
+        db,  # type: ignore[arg-type]
+        schema='evil"schema',
+        table='evil"table',
+        constraint_name='evil"name',
+    )
+    assert driver.executed == ['ALTER TABLE "evil""schema"."evil""table" VALIDATE CONSTRAINT "evil""name"']
+    assert result.changed is True
+
+
+# --- get_role_ddl / get_database_ddl / get_tablespace_ddl -----------------
+
+
+async def test_get_role_ddl_returns_ddl_on_pg19() -> None:
+    routes = _version_route(190001, "19beta1")
+    routes["pg_get_roledef"] = [{"ddl": "CREATE ROLE app_user LOGIN;"}]
+    driver = FakeRoutingDriver(routes)
+    result = await get_role_ddl(driver, "app_user")  # type: ignore[arg-type]
+    assert isinstance(result, ObjectDdlResult)
+    assert result.object_type == "role"
+    assert result.object_name == "app_user"
+    assert result.found is True
+    assert "CREATE ROLE" in result.ddl
+
+
+async def test_get_role_ddl_not_found_returns_empty() -> None:
+    routes = _version_route(190001, "19beta1")
+    routes["pg_get_roledef"] = []  # no rows
+    driver = FakeRoutingDriver(routes)
+    result = await get_role_ddl(driver, "ghost")  # type: ignore[arg-type]
+    assert result.found is False
+    assert result.ddl == ""
+
+
+async def test_get_role_ddl_raises_on_pg18() -> None:
+    routes = _version_route(180003, "18.3")
+    driver = FakeRoutingDriver(routes)
+    with pytest.raises(Pg19DdlError, match="PostgreSQL 19"):
+        await get_role_ddl(driver, "app_user")  # type: ignore[arg-type]
+
+
+async def test_get_database_ddl_returns_ddl_on_pg19() -> None:
+    routes = _version_route(190001, "19beta1")
+    routes["pg_get_databasedef"] = [{"ddl": "CREATE DATABASE analytics;"}]
+    driver = FakeRoutingDriver(routes)
+    result = await get_database_ddl(driver, "analytics")  # type: ignore[arg-type]
+    assert result.object_type == "database"
+    assert result.found is True
+    assert "CREATE DATABASE" in result.ddl
+
+
+async def test_get_database_ddl_raises_on_pg18() -> None:
+    routes = _version_route(180003, "18.3")
+    driver = FakeRoutingDriver(routes)
+    with pytest.raises(Pg19DdlError, match="PostgreSQL 19"):
+        await get_database_ddl(driver, "analytics")  # type: ignore[arg-type]
+
+
+async def test_get_tablespace_ddl_returns_ddl_on_pg19() -> None:
+    routes = _version_route(190001, "19beta1")
+    routes["pg_get_tablespacedef"] = [{"ddl": "CREATE TABLESPACE fast_ssd LOCATION '/mnt/ssd';"}]
+    driver = FakeRoutingDriver(routes)
+    result = await get_tablespace_ddl(driver, "fast_ssd")  # type: ignore[arg-type]
+    assert result.object_type == "tablespace"
+    assert result.found is True
+    assert "CREATE TABLESPACE" in result.ddl
+
+
+async def test_get_tablespace_ddl_raises_on_pg18() -> None:
+    routes = _version_route(180003, "18.3")
+    driver = FakeRoutingDriver(routes)
+    with pytest.raises(Pg19DdlError, match="PostgreSQL 19"):
+        await get_tablespace_ddl(driver, "fast_ssd")  # type: ignore[arg-type]
+
+
+# --- Dataclass shapes -----------------------------------------------------
+
+
+def test_dataclass_shapes() -> None:
+    status = Pg19DdlStatus(
+        available=True,
+        server_version_num=190001,
+        server_version="19beta1",
+        has_pg_get_roledef=True,
+        has_pg_get_databasedef=True,
+        has_pg_get_tablespacedef=True,
+        detail="ok",
+    )
+    assert status.available is True
+    vc = ValidateCheckConstraintResult(
+        schema="public",
+        table="t",
+        constraint_name="c",
+        was_valid=False,
+        now_valid=True,
+        changed=True,
+        validate_sql='ALTER TABLE "public"."t" VALIDATE CONSTRAINT "c"',
+    )
+    assert vc.changed is True
+    obj = ObjectDdlResult(object_type="role", object_name="x", found=False, ddl="")
+    assert obj.found is False


### PR DESCRIPTION
## Summary

PR-9 of the PG 19 Phase 3 plan — five new tools in a new `mcpg.pg19_ddl` module. Bundles PO matrix rows #10 + #11 (combined PO score 34, highest remaining tier).

- **`validate_check_constraint`** — runs `ALTER TABLE … VALIDATE CONSTRAINT` to validate a constraint originally added with `NOT VALID`. Idempotent (returns `changed=false` when already validated). Works on every supported PG version (the SQL has been around since 9.x); ships in the PG 19 DDL module because it closes the create-NOT-VALID / validate-later loop on the agent surface.
- **`get_role_ddl` / `get_database_ddl` / `get_tablespace_ddl`** — wrap PG 19's new `pg_get_roledef(oid)` / `pg_get_databasedef(oid)` / `pg_get_tablespacedef(oid)` SQL functions. Cluster-level CREATE statements without shelling out to `pg_dumpall`. Each raises `Pg19DdlError` on PG ≤ 18 with the documented fallback (`pg_dumpall --roles-only` / `--globals-only` / `--tablespaces-only`) in the message.
- **`get_pg19_ddl_status`** — per-function presence probe via `pg_proc`; never raises.

### Backward compatibility

Per the no-deprecation rule (`docs/plans/pg19-readiness.md`), the `pg_dumpall` shell-out paths stay valid on PG ≤ 18 — agents pick at runtime via `get_pg19_ddl_status`.

### Bucket routing

The four read tools land in `schema_introspection` next to `describe_table`; `validate_check_constraint` lives in `operations_and_health` next to `run_maintenance`.

### Side win

The return-shape contract test now recognises four additional helper modules (`aio`, `pg19_runtime`, `pg19_stats`, `pg19_ddl`), so every Phase 3 PG 19 tool now contributes its dataclass field set to the snapshot instead of being recorded as `opaque`.

### Smoke harness

`scripts/smoke_test_pg19.py` exercises `get_pg19_ddl_status` + each of the three live DDL-dump tools against stock cluster objects (`postgres` role, `postgres` database, `pg_default` tablespace). `validate_check_constraint` is skipped in the smoke (requires a pre-seeded `NOT VALID` constraint) — behavioural coverage lives in `tests/unit/test_pg19_ddl.py`.

## Test plan

- [x] `uv run pytest -q --ignore=tests/integration` — 2,136 passed
- [x] `uv run pytest tests/unit/test_pg19_ddl.py -q` — 17 new tests pass
- [x] `uv run pytest tests/contract/ -q` — surface + return-shape snapshots updated
- [x] `uv run ruff check src/mcpg/pg19_ddl.py tests/unit/test_pg19_ddl.py` — clean
- [ ] GA-day-0 verification (per `docs/plans/pg19-readiness.md`): re-run `scripts/smoke_test_pg19.sh` against the GA build to confirm `pg_get_*def()` signatures and behaviour match the assumed shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_