### PR TITLE
feat(pg19_partitions): MERGE / SPLIT PARTITION — Phase 3 PR-5 — #120

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,32 @@ adheres to [Semantic Versioning](https://semver.org/).
   contributes its dataclass field set to the snapshot rather than
   appearing as `opaque`.
 
+- **PG 19 partition reorganisation** (`mcpg.pg19_partitions`). Three
+  new tools that finally make partition boundaries reshapable without
+  the detach / create / copy / attach dance. `get_pg19_partitions_status`
+  is the version probe (never raises). `merge_partitions` issues
+  `ALTER TABLE … MERGE PARTITIONS (p1, p2, …) INTO new`; reuses the
+  existing partition data files. `split_partition` issues
+  `ALTER TABLE … SPLIT PARTITION existing INTO (PARTITION new1 FOR
+  VALUES …, PARTITION new2 FOR VALUES …)`; takes a list of `{name,
+  for_values_clause}` specs because PG's DDL grammar can't
+  parameter-bind partition bounds (we quote the `name` identifier;
+  the `for_values_clause` is embedded verbatim under the existing
+  `Capability.DDL` + `allow_ddl` trust gate, same model as `run_ddl`).
+
+  PR-5 of the PG 19 Phase 3 plan (PO matrix row #4, PO score 23 —
+  next-highest after the PR-9 bundle). All three tools route to the
+  existing `timeseries_partitioning` capability bucket next to the
+  `partman_*` lifecycle.
+
+  Per the no-deprecation rule, the detach / create / attach fallback
+  path stays valid on PG ≤ 18 — `get_pg19_partitions_status` returns
+  `available=false` with the fallback in `detail`, and both write
+  surfaces raise `Pg19PartitionsError` on older servers with the
+  same hint in the message. Both writes dispatch through
+  `Database.run_unmanaged` (cannot run inside a transaction block,
+  same constraint as VACUUM / REPACK). Advances #120.
+
 - **PG 19 runtime toggles** (`mcpg.pg19_runtime`). Five new tools that
   flip cluster-wide settings without a restart — previously
   "plan a maintenance window" tasks. Online checksums:

--- a/scripts/smoke_test_pg19.py
+++ b/scripts/smoke_test_pg19.py
@@ -75,7 +75,7 @@ async def _exercise_status_probes(database: Database) -> dict[str, dict[str, Any
     phase can decide which writes to attempt based on per-feature
     availability.
     """
-    from mcpg import aio, pg19_ddl, pg19_runtime, pg19_stats, pgq, repack
+    from mcpg import aio, pg19_ddl, pg19_partitions, pg19_runtime, pg19_stats, pgq, repack
 
     driver = database.driver()
     results: dict[str, dict[str, Any]] = {}
@@ -91,6 +91,7 @@ async def _exercise_status_probes(database: Database) -> dict[str, dict[str, Any
             pg19_runtime.get_logical_replication_status(driver),
         ),
         ("get_pg19_ddl_status", pg19_ddl.get_pg19_ddl_status(driver)),
+        ("get_pg19_partitions_status", pg19_partitions.get_pg19_partitions_status(driver)),
     ):
         result = await _safe(label, helper)
         if result is not None:
@@ -179,15 +180,22 @@ async def _exercise_safe_writes(database: Database, probes: dict[str, dict[str, 
             {"skipped": ("status reports unavailable or already enabled — skipping to keep the smoke read-mostly")},
         )
 
-    # validate_check_constraint exercises ALTER TABLE on a caller-supplied
-    # constraint — there's no stock NOT VALID constraint in a fresh PG 19
-    # cluster, so we'd need to seed one. Round-tripping create-table +
-    # add-NOT-VALID + validate + drop here would blur the "what does
-    # MCPg do" report; skip with a note and rely on the unit tests
-    # (tests/unit/test_pg19_ddl.py) for behavioural coverage.
+    # validate_check_constraint / merge_partitions / split_partition all
+    # require pre-seeded objects (a NOT VALID constraint, a partitioned
+    # table with the right shape). Round-tripping create + populate +
+    # exercise + drop would blur the "what does MCPg do" report — skip
+    # with notes and rely on the unit tests for behavioural coverage.
     _emit(
         "validate_check_constraint",
-        {"skipped": ("requires a pre-seeded NOT VALID constraint — see tests/unit/test_pg19_ddl.py")},
+        {"skipped": "requires a pre-seeded NOT VALID constraint — see tests/unit/test_pg19_ddl.py"},
+    )
+    _emit(
+        "merge_partitions",
+        {"skipped": "requires a pre-seeded partitioned table — see tests/unit/test_pg19_partitions.py"},
+    )
+    _emit(
+        "split_partition",
+        {"skipped": "requires a pre-seeded partitioned table — see tests/unit/test_pg19_partitions.py"},
     )
 
 

--- a/src/mcpg/about.py
+++ b/src/mcpg/about.py
@@ -680,6 +680,11 @@ _TOOL_TO_BUCKET_OVERRIDES: dict[str, str] = {
     "get_database_ddl": "schema_introspection",
     "get_tablespace_ddl": "schema_introspection",
     "validate_check_constraint": "operations_and_health",
+    # PG 19 partition reorganisation — MERGE / SPLIT PARTITION live in
+    # the same bucket as the partman_* lifecycle tools.
+    "get_pg19_partitions_status": "timeseries_partitioning",
+    "merge_partitions": "timeseries_partitioning",
+    "split_partition": "timeseries_partitioning",
 }
 
 

--- a/src/mcpg/pg19_partitions.py
+++ b/src/mcpg/pg19_partitions.py
@@ -1,0 +1,327 @@
+"""PG 19 partition reorganisation — ``MERGE PARTITIONS`` + ``SPLIT PARTITION``.
+
+PG 19 ships two ``ALTER TABLE`` extensions that finally make partition
+boundaries reshapable without dumping and reloading data:
+
+* ``ALTER TABLE parent MERGE PARTITIONS (p1, p2, …) INTO new_partition``
+  — consolidates two or more existing partitions into a new partition
+  whose bounds span the merged range / list. Replaces the
+  hand-rolled "create new, copy, drop old, swap" dance.
+* ``ALTER TABLE parent SPLIT PARTITION existing_partition INTO (…)``
+  — splits a single partition into two or more with caller-defined
+  bounds. Useful for hot-partition splits during traffic growth.
+
+This module provides three tools:
+
+* ``get_pg19_partitions_status`` — version probe; never raises. Reports
+  whether MERGE / SPLIT PARTITION are usable on this server.
+* ``merge_partitions`` — runs the MERGE PARTITIONS form. All inputs
+  are identifiers; the rendered SQL has no caller-supplied expression
+  slots.
+* ``split_partition`` — runs the SPLIT PARTITION form. Caller supplies
+  per-new-partition specs (``name`` identifier + ``for_values_clause``
+  expression fragment); we quote the identifier and embed the
+  expression verbatim (see *Security posture* below).
+
+Backward compatibility
+----------------------
+Additive. PG ≤ 18 operators continue using the long-standing
+detach / create / attach dance — both write surfaces raise
+``Pg19PartitionsError`` on older servers with a guidance string.
+``get_pg19_partitions_status`` returns ``available=False`` with the
+same pointer.
+
+Integrates with the existing ``mcpg.partman`` lifecycle: the
+partman_* tools manage rolling-window partition creation; these
+PG 19 tools handle the rarer "reshape an existing range" case
+without coupling.
+
+Security posture
+----------------
+* Schema, table, source partition, and new-partition identifier names
+  are validated through ``_quote_identifier`` — embedded double-quotes
+  are escaped; NUL bytes / empty strings rejected.
+* The ``for_values_clause`` fragment on ``split_partition`` is
+  embedded verbatim. SPLIT PARTITION can't accept parameter-bound
+  expressions (DDL grammar), so the caller is responsible for
+  composing a safe fragment from validated values. The MCP tool sits
+  behind the ``Capability.DDL`` + ``allow_ddl`` gate; the same trust
+  model as ``run_ddl``. Each helper raises ``Pg19PartitionsError``
+  with the rendered SQL in the message on failure, so an operator
+  can replay or roll back.
+* All writes dispatch through :meth:`Database.run_unmanaged` because
+  the partition reorganisation operations cannot run inside a
+  transaction block.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mcpg._vendor.sql import SqlDriver
+from mcpg.database import Database
+
+# PG 19 ships both forms. The version-num boundary.
+_MIN_PG19_PARTITIONS_VERSION = 190000
+
+
+class Pg19PartitionsError(Exception):
+    """Raised when a PG 19 partition reorganisation cannot complete."""
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class Pg19PartitionsStatus:
+    """Reports whether PG 19 partition reorganisation is usable.
+
+    ``available`` is True when ``server_version_num`` >= 190000.
+    ``detail`` is a guidance string suitable for surfacing to an LLM
+    agent — on PG ≤ 18 it points at the detach / create / attach
+    fallback.
+    """
+
+    available: bool
+    server_version_num: int
+    server_version: str
+    detail: str
+
+
+@dataclass(frozen=True, slots=True)
+class MergePartitionsResult:
+    """Outcome of `merge_partitions`.
+
+    ``merge_sql`` is the rendered DDL that actually executed — same
+    audit-friendly shape as ``maintenance_sql`` / ``repack_sql`` on
+    sibling tools.
+    """
+
+    parent_schema: str
+    parent_table: str
+    source_partitions: tuple[str, ...]
+    target_partition: str
+    merge_sql: str
+
+
+@dataclass(frozen=True, slots=True)
+class SplitPartitionSpec:
+    """One new-partition spec for `split_partition`.
+
+    ``name`` is the new partition identifier (we quote it).
+    ``for_values_clause`` is the verbatim text that follows
+    ``FOR VALUES`` in the rendered SQL — caller supplies it because
+    the syntax varies by partition kind (RANGE / LIST / HASH).
+    Example RANGE form: ``"FROM ('2024-01-01') TO ('2024-04-01')"``.
+    Example LIST form: ``"IN ('north', 'south')"``.
+    """
+
+    name: str
+    for_values_clause: str
+
+
+@dataclass(frozen=True, slots=True)
+class SplitPartitionResult:
+    """Outcome of `split_partition`."""
+
+    parent_schema: str
+    parent_table: str
+    source_partition: str
+    new_partitions: tuple[str, ...]
+    split_sql: str
+
+
+# ---------------------------------------------------------------------------
+# Shared probes
+# ---------------------------------------------------------------------------
+
+
+def _quote_identifier(name: str) -> str:
+    """Quote a SQL identifier, escaping embedded double-quotes."""
+    if not name or "\x00" in name:
+        raise Pg19PartitionsError(f"invalid identifier: {name!r}")
+    return '"' + name.replace('"', '""') + '"'
+
+
+async def _server_version(driver: SqlDriver) -> tuple[int, str]:
+    """Return ``(server_version_num, server_version)`` in one round trip."""
+    rows = await driver.execute_query(
+        "SELECT current_setting('server_version_num')::int AS ver_num, current_setting('server_version') AS ver",
+        force_readonly=True,
+    )
+    if not rows:
+        return 0, ""
+    cells = rows[0].cells
+    return int(cells.get("ver_num") or 0), str(cells.get("ver") or "")
+
+
+# ---------------------------------------------------------------------------
+# Status probe
+# ---------------------------------------------------------------------------
+
+
+async def get_pg19_partitions_status(driver: SqlDriver) -> Pg19PartitionsStatus:
+    """Report whether PG 19's MERGE / SPLIT PARTITION forms are usable.
+
+    Read-only; never raises. On PG ≤ 18 returns ``available=False``
+    with a diagnostic pointing at the detach / create / attach
+    fallback path.
+    """
+    try:
+        ver_num, ver = await _server_version(driver)
+    except Exception as exc:
+        return Pg19PartitionsStatus(
+            available=False,
+            server_version_num=0,
+            server_version="",
+            detail=(
+                f"PG 19 partition reorganisation unavailable (version probe failed: {exc}). "
+                "Re-run after the server is back online."
+            ),
+        )
+    available = ver_num >= _MIN_PG19_PARTITIONS_VERSION
+    if available:
+        detail = (
+            "PG 19 MERGE PARTITIONS / SPLIT PARTITION are available. "
+            "Use merge_partitions() to consolidate adjacent partitions or "
+            "split_partition() to reshape a hot partition without rewriting data."
+        )
+    else:
+        detail = (
+            "MERGE PARTITIONS / SPLIT PARTITION require PostgreSQL 19 or newer; "
+            "this server is older. Fall back to the detach / create / attach dance: "
+            "DETACH the source partition(s), CREATE the replacement(s), INSERT to "
+            "redistribute data, then ATTACH with the new bounds."
+        )
+    return Pg19PartitionsStatus(
+        available=available,
+        server_version_num=ver_num,
+        server_version=ver,
+        detail=detail,
+    )
+
+
+# ---------------------------------------------------------------------------
+# MERGE PARTITIONS
+# ---------------------------------------------------------------------------
+
+
+async def merge_partitions(
+    database: Database,
+    *,
+    parent_schema: str,
+    parent_table: str,
+    source_partitions: list[str],
+    target_partition_name: str,
+) -> MergePartitionsResult:
+    """Consolidate two or more partitions into a single new partition.
+
+    Issues ``ALTER TABLE schema.parent MERGE PARTITIONS (p1, p2, …)
+    INTO new_partition``. PG 19's MERGE PARTITIONS reuses the existing
+    partition data files; no row-by-row copy. The merged partition's
+    bounds span the union of the source bounds (PG validates contiguity
+    — non-adjacent ranges are rejected by the server).
+
+    Cannot run inside a transaction block; dispatches through
+    :meth:`Database.run_unmanaged`. Requires PG 19+; raises
+    :class:`Pg19PartitionsError` on older versions.
+    """
+    if len(source_partitions) < 2:
+        raise Pg19PartitionsError(
+            f"MERGE PARTITIONS requires at least two source partitions; got {len(source_partitions)}."
+        )
+    driver = database.driver()
+    ver_num, ver = await _server_version(driver)
+    if ver_num < _MIN_PG19_PARTITIONS_VERSION:
+        raise Pg19PartitionsError(
+            "MERGE PARTITIONS requires PostgreSQL 19 or newer; this server "
+            f"reports {ver or 'unknown'} (server_version_num={ver_num}). "
+            "Use the detach / create / attach fallback during a maintenance window."
+        )
+    qualified_parent = f"{_quote_identifier(parent_schema)}.{_quote_identifier(parent_table)}"
+    quoted_sources = ", ".join(_quote_identifier(p) for p in source_partitions)
+    quoted_target = _quote_identifier(target_partition_name)
+    merge_sql = f"ALTER TABLE {qualified_parent} MERGE PARTITIONS ({quoted_sources}) INTO {quoted_target}"
+    try:
+        await database.run_unmanaged(merge_sql)
+    except Exception as exc:
+        raise Pg19PartitionsError(f"MERGE PARTITIONS failed: {exc}") from exc
+    return MergePartitionsResult(
+        parent_schema=parent_schema,
+        parent_table=parent_table,
+        source_partitions=tuple(source_partitions),
+        target_partition=target_partition_name,
+        merge_sql=merge_sql,
+    )
+
+
+# ---------------------------------------------------------------------------
+# SPLIT PARTITION
+# ---------------------------------------------------------------------------
+
+
+async def split_partition(
+    database: Database,
+    *,
+    parent_schema: str,
+    parent_table: str,
+    source_partition: str,
+    new_partitions: list[SplitPartitionSpec],
+) -> SplitPartitionResult:
+    """Split one partition into two or more new partitions.
+
+    Issues ``ALTER TABLE schema.parent SPLIT PARTITION existing INTO
+    (PARTITION new1 FOR VALUES …, PARTITION new2 FOR VALUES …)``.
+
+    ``new_partitions`` is a list of :class:`SplitPartitionSpec`. The
+    ``name`` of each spec is quoted as an identifier; the
+    ``for_values_clause`` is embedded verbatim because PG's DDL grammar
+    doesn't accept parameter-bound bounds expressions. Caller is
+    responsible for composing safe ``FOR VALUES`` fragments from
+    validated values — see the module docstring.
+
+    Cannot run inside a transaction block; dispatches through
+    :meth:`Database.run_unmanaged`. Requires PG 19+; raises
+    :class:`Pg19PartitionsError` on older versions.
+    """
+    if len(new_partitions) < 2:
+        raise Pg19PartitionsError(f"SPLIT PARTITION requires at least two new partitions; got {len(new_partitions)}.")
+    driver = database.driver()
+    ver_num, ver = await _server_version(driver)
+    if ver_num < _MIN_PG19_PARTITIONS_VERSION:
+        raise Pg19PartitionsError(
+            "SPLIT PARTITION requires PostgreSQL 19 or newer; this server "
+            f"reports {ver or 'unknown'} (server_version_num={ver_num}). "
+            "Use the detach / create / attach fallback during a maintenance window."
+        )
+    qualified_parent = f"{_quote_identifier(parent_schema)}.{_quote_identifier(parent_table)}"
+    quoted_source = _quote_identifier(source_partition)
+    new_parts_sql = ", ".join(
+        f"PARTITION {_quote_identifier(spec.name)} FOR VALUES {spec.for_values_clause}" for spec in new_partitions
+    )
+    split_sql = f"ALTER TABLE {qualified_parent} SPLIT PARTITION {quoted_source} INTO ({new_parts_sql})"
+    try:
+        await database.run_unmanaged(split_sql)
+    except Exception as exc:
+        raise Pg19PartitionsError(f"SPLIT PARTITION failed: {exc}") from exc
+    return SplitPartitionResult(
+        parent_schema=parent_schema,
+        parent_table=parent_table,
+        source_partition=source_partition,
+        new_partitions=tuple(spec.name for spec in new_partitions),
+        split_sql=split_sql,
+    )
+
+
+__all__ = [
+    "MergePartitionsResult",
+    "Pg19PartitionsError",
+    "Pg19PartitionsStatus",
+    "SplitPartitionResult",
+    "SplitPartitionSpec",
+    "get_pg19_partitions_status",
+    "merge_partitions",
+    "split_partition",
+]

--- a/src/mcpg/pg19_partitions.py
+++ b/src/mcpg/pg19_partitions.py
@@ -304,9 +304,7 @@ async def split_partition(
     # explicit (gemini-review critical on PR #145).
     for spec in new_partitions:
         if "\x00" in spec.for_values_clause:
-            raise Pg19PartitionsError(
-                f"invalid for_values_clause for partition {spec.name!r}: contains NUL byte"
-            )
+            raise Pg19PartitionsError(f"invalid for_values_clause for partition {spec.name!r}: contains NUL byte")
     new_parts_sql = ", ".join(
         f"PARTITION {_quote_identifier(spec.name)} FOR VALUES {spec.for_values_clause}" for spec in new_partitions
     )

--- a/src/mcpg/pg19_partitions.py
+++ b/src/mcpg/pg19_partitions.py
@@ -298,6 +298,15 @@ async def split_partition(
         )
     qualified_parent = f"{_quote_identifier(parent_schema)}.{_quote_identifier(parent_table)}"
     quoted_source = _quote_identifier(source_partition)
+    # Defensive: PG-libpq truncates queries at NUL bytes — a caller-supplied
+    # for_values_clause carrying \x00 could silently chop off the trailing
+    # partitions and emit a partial DDL. Reject early so the failure is
+    # explicit (gemini-review critical on PR #145).
+    for spec in new_partitions:
+        if "\x00" in spec.for_values_clause:
+            raise Pg19PartitionsError(
+                f"invalid for_values_clause for partition {spec.name!r}: contains NUL byte"
+            )
     new_parts_sql = ", ".join(
         f"PARTITION {_quote_identifier(spec.name)} FOR VALUES {spec.for_values_clause}" for spec in new_partitions
     )

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -49,6 +49,7 @@ from mcpg import (
     nl2sql,
     partman,
     pg19_ddl,
+    pg19_partitions,
     pg19_runtime,
     pg19_stats,
     pg_prewarm,
@@ -4669,6 +4670,122 @@ def _register_pg19_ddl_writes(server: FastMCP[AppContext]) -> None:
         return asdict(result)
 
 
+def _register_pg19_partitions_reads(server: FastMCP[AppContext]) -> None:
+    @server.tool(
+        name="get_pg19_partitions_status",
+        description=_with_example(
+            "Report whether PG 19's `ALTER TABLE … MERGE PARTITIONS` and "
+            "`ALTER TABLE … SPLIT PARTITION` forms are usable on this "
+            "server. Never raises — driver-level errors surface as "
+            "`available=false`. On PG ≤ 18 reports `available=false` and "
+            "points the agent at the detach / create / attach fallback "
+            "path. "
+            "Returns an object with `available` (bool), `server_version_num` "
+            "(int), `server_version`, and `detail` (guidance string).",
+            "get_pg19_partitions_status()",
+        ),
+    )
+    async def get_pg19_partitions_status(ctx: _Ctx) -> dict[str, Any]:
+        # Cluster version probe — never cache: a server upgrade mid-session
+        # needs to flip availability on the next call.
+        status = await pg19_partitions.get_pg19_partitions_status(_driver(ctx))
+        return asdict(status)
+
+
+def _register_pg19_partitions_writes(server: FastMCP[AppContext]) -> None:
+    @server.tool(
+        name="merge_partitions",
+        description=_with_example(
+            "Consolidate two or more partitions into a single new "
+            "partition using PG 19's `ALTER TABLE … MERGE PARTITIONS (p1, "
+            "p2, …) INTO new`. Reuses the existing partition data "
+            "files — no row-by-row copy. PG validates that the source "
+            "partition bounds are contiguous; non-adjacent ranges are "
+            "rejected by the server. Requires PG 19+; raises on older "
+            "versions with the detach / create / attach fallback in the "
+            "message. "
+            "Returns an object with `parent_schema`, `parent_table`, "
+            "`source_partitions` (list of strings), `target_partition`, "
+            "and `merge_sql` (the rendered DDL that actually executed).",
+            "merge_partitions(parent_schema='public', parent_table='measurement', "
+            "source_partitions=['measurement_y2024_q1', 'measurement_y2024_q2'], "
+            "target_partition_name='measurement_y2024_h1')",
+        ),
+    )
+    async def merge_partitions(
+        ctx: _Ctx,
+        parent_schema: str,
+        parent_table: str,
+        source_partitions: list[str],
+        target_partition_name: str,
+    ) -> dict[str, Any]:
+        database = ctx.request_context.lifespan_context.database
+        result = await pg19_partitions.merge_partitions(
+            database,
+            parent_schema=parent_schema,
+            parent_table=parent_table,
+            source_partitions=source_partitions,
+            target_partition_name=target_partition_name,
+        )
+        await ctx.request_context.lifespan_context.cache.clear()
+        return asdict(result)
+
+    @server.tool(
+        name="split_partition",
+        description=_with_example(
+            "Split one partition into two or more new partitions using "
+            "PG 19's `ALTER TABLE … SPLIT PARTITION existing INTO ("
+            "PARTITION new1 FOR VALUES …, PARTITION new2 FOR VALUES …)`. "
+            "`new_partitions` is a list of `{name, for_values_clause}` "
+            "objects — the `name` is quoted as an identifier; the "
+            "`for_values_clause` is embedded verbatim (DDL grammar can't "
+            "parameter-bind partition bounds — caller composes safe "
+            "fragments from validated values). Example RANGE form: "
+            "`\"FROM ('2024-01-01') TO ('2024-04-01')\"`. Requires PG 19+. "
+            "Returns an object with `parent_schema`, `parent_table`, "
+            "`source_partition`, `new_partitions` (the new names), and "
+            "`split_sql`.",
+            "split_partition(parent_schema='public', parent_table='measurement', "
+            "source_partition='measurement_y2024', new_partitions=["
+            "{'name': 'measurement_y2024_h1', 'for_values_clause': \"FROM ('2024-01-01') TO ('2024-07-01')\"}, "
+            "{'name': 'measurement_y2024_h2', 'for_values_clause': \"FROM ('2024-07-01') TO ('2025-01-01')\"}])",
+        ),
+    )
+    async def split_partition(
+        ctx: _Ctx,
+        parent_schema: str,
+        parent_table: str,
+        source_partition: str,
+        new_partitions: list[dict[str, str]],
+    ) -> dict[str, Any]:
+        # Wire-format adapter: MCP passes list-of-dict; helper expects
+        # a typed dataclass. Validate keys here so a missing field
+        # surfaces a sane error message instead of an AttributeError.
+        try:
+            specs = [
+                pg19_partitions.SplitPartitionSpec(
+                    name=spec["name"],
+                    for_values_clause=spec["for_values_clause"],
+                )
+                for spec in new_partitions
+            ]
+        except KeyError as exc:
+            raise pg19_partitions.Pg19PartitionsError(
+                f"new_partitions entry missing required key {exc.args[0]!r}; "
+                "expected {'name': str, 'for_values_clause': str}."
+            ) from exc
+        database = ctx.request_context.lifespan_context.database
+        result = await pg19_partitions.split_partition(
+            database,
+            parent_schema=parent_schema,
+            parent_table=parent_table,
+            source_partition=source_partition,
+            new_partitions=specs,
+        )
+        await ctx.request_context.lifespan_context.cache.clear()
+        return asdict(result)
+
+
 def _register_pg19_stats_reads(server: FastMCP[AppContext]) -> None:
     @server.tool(
         name="get_pg19_stats_status",
@@ -5214,6 +5331,7 @@ def register_tools(server: FastMCP[AppContext], settings: Settings) -> None:
         _register_pg19_stats_reads(server)
         _register_pg19_runtime_reads(server)
         _register_pg19_ddl_reads(server)
+        _register_pg19_partitions_reads(server)
     if is_permitted(settings.access_mode, Capability.WRITE):
         _register_write(server)
         _register_maintenance(server)
@@ -5229,6 +5347,7 @@ def register_tools(server: FastMCP[AppContext], settings: Settings) -> None:
         _register_ddl(server)
         _register_partman(server)
         _register_pg19_ddl_writes(server)
+        _register_pg19_partitions_writes(server)
         _register_turboquant_ddl(server)
         _register_pg_search_ddl(server)
         _register_rag_telemetry_ddl(server)

--- a/tests/contract/test_tool_return_shapes.py
+++ b/tests/contract/test_tool_return_shapes.py
@@ -82,6 +82,7 @@ _KNOWN_HELPER_MODULES = (
     "nl2sql",
     "partman",
     "pg19_ddl",
+    "pg19_partitions",
     "pg19_runtime",
     "pg19_stats",
     "pg_prewarm",

--- a/tests/contract/tool_return_shapes.snapshot.json
+++ b/tests/contract/tool_return_shapes.snapshot.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "schema_version": 1,
-    "tool_count": 214
+    "tool_count": 217
   },
   "tools": {
     "add_compression_policy": {
@@ -663,6 +663,16 @@
         "has_pg_get_databasedef",
         "has_pg_get_roledef",
         "has_pg_get_tablespacedef",
+        "server_version",
+        "server_version_num"
+      ],
+      "kind": "scalar"
+    },
+    "get_pg19_partitions_status": {
+      "dataclass": "Pg19PartitionsStatus",
+      "fields": [
+        "available",
+        "detail",
         "server_version",
         "server_version_num"
       ],
@@ -1342,6 +1352,17 @@
       ],
       "kind": "scalar"
     },
+    "merge_partitions": {
+      "dataclass": "MergePartitionsResult",
+      "fields": [
+        "merge_sql",
+        "parent_schema",
+        "parent_table",
+        "source_partitions",
+        "target_partition"
+      ],
+      "kind": "scalar"
+    },
     "migrate_vector_to_halfvec": {
       "dataclass": "HalfvecMigrationPlan",
       "fields": [
@@ -1885,6 +1906,17 @@
         "schema_created",
         "setup_sql",
         "table_created"
+      ],
+      "kind": "scalar"
+    },
+    "split_partition": {
+      "dataclass": "SplitPartitionResult",
+      "fields": [
+        "new_partitions",
+        "parent_schema",
+        "parent_table",
+        "source_partition",
+        "split_sql"
       ],
       "kind": "scalar"
     },

--- a/tests/contract/tool_surface.snapshot.json
+++ b/tests/contract/tool_surface.snapshot.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "schema_version": 1,
-    "tool_count": 214
+    "tool_count": 217
   },
   "tools": [
     {
@@ -2175,6 +2175,15 @@
       "name": "get_pg19_ddl_status"
     },
     {
+      "description": "Report whether PG 19's `ALTER TABLE … MERGE PARTITIONS` and `ALTER TABLE … SPLIT PARTITION` forms are usable on this server. Never raises — driver-level errors surface as `available=false`. On PG ≤ 18 reports `available=false` and points the agent at the detach / create / attach fallback path. Returns an object with `available` (bool), `server_version_num` (int), `server_version`, and `detail` (guidance string).\n\nExample: `get_pg19_partitions_status()`",
+      "inputSchema": {
+        "properties": {},
+        "title": "get_pg19_partitions_statusArguments",
+        "type": "object"
+      },
+      "name": "get_pg19_partitions_status"
+    },
+    {
       "description": "Report whether PG 19's `pg_stat_lock` and `pg_stat_recovery` views are usable on this server. Never raises — driver-level errors surface as `available=false`. On PG < 19 returns `available=false` with a diagnostic pointing the agent at `find_blocking_chains` / `pg_stat_replication`. Returns an object with `available` (bool), `server_version_num` (int), `server_version`, `has_pg_stat_lock` (bool), `has_pg_stat_recovery` (bool), and `detail` (guidance string).\n\nExample: `get_pg19_stats_status()`",
       "inputSchema": {
         "properties": {},
@@ -3420,6 +3429,41 @@
         "type": "object"
       },
       "name": "maintain_turboquant_index"
+    },
+    {
+      "description": "Consolidate two or more partitions into a single new partition using PG 19's `ALTER TABLE … MERGE PARTITIONS (p1, p2, …) INTO new`. Reuses the existing partition data files — no row-by-row copy. PG validates that the source partition bounds are contiguous; non-adjacent ranges are rejected by the server. Requires PG 19+; raises on older versions with the detach / create / attach fallback in the message. Returns an object with `parent_schema`, `parent_table`, `source_partitions` (list of strings), `target_partition`, and `merge_sql` (the rendered DDL that actually executed).\n\nExample: `merge_partitions(parent_schema='public', parent_table='measurement', source_partitions=['measurement_y2024_q1', 'measurement_y2024_q2'], target_partition_name='measurement_y2024_h1')`",
+      "inputSchema": {
+        "properties": {
+          "parent_schema": {
+            "title": "Parent Schema",
+            "type": "string"
+          },
+          "parent_table": {
+            "title": "Parent Table",
+            "type": "string"
+          },
+          "source_partitions": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Source Partitions",
+            "type": "array"
+          },
+          "target_partition_name": {
+            "title": "Target Partition Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "parent_schema",
+          "parent_table",
+          "source_partitions",
+          "target_partition_name"
+        ],
+        "title": "merge_partitionsArguments",
+        "type": "object"
+      },
+      "name": "merge_partitions"
     },
     {
       "description": "Generate a DDL plan that converts a pgvector vector(N) column to halfvec(N) — halving per-element storage (4 → 2 bytes) with typically negligible recall impact at d ≥ 768. Reads the column's current type + dimension from the catalog, finds every index on the column, and emits an ordered `migration_sql` plan: DROP each affected index, ALTER COLUMN to halfvec(N) via a `USING` cast, then recreate each index with its halfvec opclass. Also returns a mirror `rollback_sql` that restores the original vector(N) type plus the original index definitions. Nothing is executed — feed the plan through the shadow-migration workflow (`prepare_migration` / `validate_migration_schema`) before applying. Returns `already_halfvec=true` (and an empty plan) when the column is already halfvec, and refuses any index whose opclass has no halfvec sibling rather than rewriting it incorrectly. Requires the vector extension.",
@@ -5174,6 +5218,44 @@
         "type": "object"
       },
       "name": "setup_rag_telemetry"
+    },
+    {
+      "description": "Split one partition into two or more new partitions using PG 19's `ALTER TABLE … SPLIT PARTITION existing INTO (PARTITION new1 FOR VALUES …, PARTITION new2 FOR VALUES …)`. `new_partitions` is a list of `{name, for_values_clause}` objects — the `name` is quoted as an identifier; the `for_values_clause` is embedded verbatim (DDL grammar can't parameter-bind partition bounds — caller composes safe fragments from validated values). Example RANGE form: `\"FROM ('2024-01-01') TO ('2024-04-01')\"`. Requires PG 19+. Returns an object with `parent_schema`, `parent_table`, `source_partition`, `new_partitions` (the new names), and `split_sql`.\n\nExample: `split_partition(parent_schema='public', parent_table='measurement', source_partition='measurement_y2024', new_partitions=[{'name': 'measurement_y2024_h1', 'for_values_clause': \"FROM ('2024-01-01') TO ('2024-07-01')\"}, {'name': 'measurement_y2024_h2', 'for_values_clause': \"FROM ('2024-07-01') TO ('2025-01-01')\"}])`",
+      "inputSchema": {
+        "properties": {
+          "new_partitions": {
+            "items": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "title": "New Partitions",
+            "type": "array"
+          },
+          "parent_schema": {
+            "title": "Parent Schema",
+            "type": "string"
+          },
+          "parent_table": {
+            "title": "Parent Table",
+            "type": "string"
+          },
+          "source_partition": {
+            "title": "Source Partition",
+            "type": "string"
+          }
+        },
+        "required": [
+          "parent_schema",
+          "parent_table",
+          "source_partition",
+          "new_partitions"
+        ],
+        "title": "split_partitionArguments",
+        "type": "object"
+      },
+      "name": "split_partition"
     },
     {
       "description": "Open a PostgreSQL LISTEN on `channel` and return a subscription id. Notifications buffer in process memory; poll for them via poll_notifications. Channel name must match [A-Za-z_][A-Za-z0-9_]*. Subscriptions are lost on server restart. Requires unrestricted mode + MCPG_ALLOW_LISTEN.",

--- a/tests/unit/test_pg19_partitions.py
+++ b/tests/unit/test_pg19_partitions.py
@@ -1,0 +1,266 @@
+"""Tests for the PG 19 partition-reorganisation module."""
+
+from __future__ import annotations
+
+import pytest
+from _fakes import FakeDatabase, FakeDriver, FakeRoutingDriver
+
+from mcpg.pg19_partitions import (
+    MergePartitionsResult,
+    Pg19PartitionsError,
+    Pg19PartitionsStatus,
+    SplitPartitionResult,
+    SplitPartitionSpec,
+    get_pg19_partitions_status,
+    merge_partitions,
+    split_partition,
+)
+
+
+def _version_route(num: int, ver: str) -> dict[str, list[dict[str, object]]]:
+    return {"current_setting('server_version_num')": [{"ver_num": num, "ver": ver}]}
+
+
+# --- get_pg19_partitions_status -------------------------------------------
+
+
+async def test_status_available_on_pg19() -> None:
+    driver = FakeRoutingDriver(_version_route(190001, "19beta1"))
+    status = await get_pg19_partitions_status(driver)  # type: ignore[arg-type]
+    assert isinstance(status, Pg19PartitionsStatus)
+    assert status.available is True
+    assert "MERGE PARTITIONS" in status.detail
+
+
+async def test_status_unavailable_on_pg18() -> None:
+    driver = FakeRoutingDriver(_version_route(180003, "18.3"))
+    status = await get_pg19_partitions_status(driver)  # type: ignore[arg-type]
+    assert status.available is False
+    assert "detach" in status.detail.lower()
+
+
+async def test_status_never_raises_on_driver_failure() -> None:
+    driver = FakeDriver(fail=True)
+    status = await get_pg19_partitions_status(driver)  # type: ignore[arg-type]
+    assert status.available is False
+    assert "version probe failed" in status.detail
+
+
+# --- merge_partitions -----------------------------------------------------
+
+
+def _pg19_database() -> FakeDatabase:
+    driver = FakeDriver()
+    driver._rows = [{"ver_num": 190001, "ver": "19beta1"}]  # type: ignore[attr-defined]
+    return FakeDatabase(driver)
+
+
+def _pg18_database() -> FakeDatabase:
+    driver = FakeDriver()
+    driver._rows = [{"ver_num": 180003, "ver": "18.3"}]  # type: ignore[attr-defined]
+    return FakeDatabase(driver)
+
+
+async def test_merge_partitions_emits_alter_table() -> None:
+    db = _pg19_database()
+    result = await merge_partitions(
+        db,  # type: ignore[arg-type]
+        parent_schema="public",
+        parent_table="measurement",
+        source_partitions=["measurement_y2024_q1", "measurement_y2024_q2"],
+        target_partition_name="measurement_y2024_h1",
+    )
+    assert isinstance(result, MergePartitionsResult)
+    assert result.target_partition == "measurement_y2024_h1"
+    assert result.source_partitions == ("measurement_y2024_q1", "measurement_y2024_q2")
+    assert db.unmanaged == [
+        'ALTER TABLE "public"."measurement" MERGE PARTITIONS '
+        '("measurement_y2024_q1", "measurement_y2024_q2") INTO "measurement_y2024_h1"'
+    ]
+
+
+async def test_merge_partitions_requires_at_least_two_sources() -> None:
+    db = _pg19_database()
+    with pytest.raises(Pg19PartitionsError, match="at least two"):
+        await merge_partitions(
+            db,  # type: ignore[arg-type]
+            parent_schema="public",
+            parent_table="measurement",
+            source_partitions=["only_one"],
+            target_partition_name="target",
+        )
+    assert db.unmanaged == []
+
+
+async def test_merge_partitions_raises_on_pg18() -> None:
+    db = _pg18_database()
+    with pytest.raises(Pg19PartitionsError, match="PostgreSQL 19"):
+        await merge_partitions(
+            db,  # type: ignore[arg-type]
+            parent_schema="public",
+            parent_table="measurement",
+            source_partitions=["a", "b"],
+            target_partition_name="merged",
+        )
+    assert db.unmanaged == []
+
+
+async def test_merge_partitions_wraps_unmanaged_failure() -> None:
+    db = _pg19_database()
+    db.unmanaged_fail = True
+    with pytest.raises(Pg19PartitionsError, match="MERGE PARTITIONS failed"):
+        await merge_partitions(
+            db,  # type: ignore[arg-type]
+            parent_schema="public",
+            parent_table="measurement",
+            source_partitions=["a", "b"],
+            target_partition_name="merged",
+        )
+
+
+async def test_merge_partitions_quotes_identifiers_against_injection() -> None:
+    db = _pg19_database()
+    result = await merge_partitions(
+        db,  # type: ignore[arg-type]
+        parent_schema='evil"sch',
+        parent_table='evil"tbl',
+        source_partitions=['p"1', 'p"2'],
+        target_partition_name='t"arget',
+    )
+    assert db.unmanaged == ['ALTER TABLE "evil""sch"."evil""tbl" MERGE PARTITIONS ("p""1", "p""2") INTO "t""arget"']
+    assert result.target_partition == 't"arget'
+
+
+# --- split_partition ------------------------------------------------------
+
+
+async def test_split_partition_range_form() -> None:
+    db = _pg19_database()
+    specs = [
+        SplitPartitionSpec(name="measurement_y2024_h1", for_values_clause="FROM ('2024-01-01') TO ('2024-07-01')"),
+        SplitPartitionSpec(name="measurement_y2024_h2", for_values_clause="FROM ('2024-07-01') TO ('2025-01-01')"),
+    ]
+    result = await split_partition(
+        db,  # type: ignore[arg-type]
+        parent_schema="public",
+        parent_table="measurement",
+        source_partition="measurement_y2024",
+        new_partitions=specs,
+    )
+    assert isinstance(result, SplitPartitionResult)
+    assert result.new_partitions == ("measurement_y2024_h1", "measurement_y2024_h2")
+    assert db.unmanaged == [
+        'ALTER TABLE "public"."measurement" SPLIT PARTITION "measurement_y2024" INTO ('
+        """PARTITION "measurement_y2024_h1" FOR VALUES FROM ('2024-01-01') TO ('2024-07-01'), """
+        """PARTITION "measurement_y2024_h2" FOR VALUES FROM ('2024-07-01') TO ('2025-01-01'))"""
+    ]
+
+
+async def test_split_partition_list_form() -> None:
+    db = _pg19_database()
+    specs = [
+        SplitPartitionSpec(name="region_north", for_values_clause="IN ('north', 'north_east')"),
+        SplitPartitionSpec(name="region_south", for_values_clause="IN ('south', 'south_west')"),
+    ]
+    await split_partition(
+        db,  # type: ignore[arg-type]
+        parent_schema="public",
+        parent_table="orders",
+        source_partition="orders_by_region",
+        new_partitions=specs,
+    )
+    sql = db.unmanaged[0]
+    assert "FOR VALUES IN ('north', 'north_east')" in sql
+    assert "FOR VALUES IN ('south', 'south_west')" in sql
+
+
+async def test_split_partition_requires_at_least_two_new() -> None:
+    db = _pg19_database()
+    with pytest.raises(Pg19PartitionsError, match="at least two"):
+        await split_partition(
+            db,  # type: ignore[arg-type]
+            parent_schema="public",
+            parent_table="measurement",
+            source_partition="src",
+            new_partitions=[SplitPartitionSpec(name="only", for_values_clause="FROM (1) TO (2)")],
+        )
+    assert db.unmanaged == []
+
+
+async def test_split_partition_raises_on_pg18() -> None:
+    db = _pg18_database()
+    specs = [
+        SplitPartitionSpec(name="a", for_values_clause="FROM (1) TO (2)"),
+        SplitPartitionSpec(name="b", for_values_clause="FROM (2) TO (3)"),
+    ]
+    with pytest.raises(Pg19PartitionsError, match="PostgreSQL 19"):
+        await split_partition(
+            db,  # type: ignore[arg-type]
+            parent_schema="public",
+            parent_table="measurement",
+            source_partition="src",
+            new_partitions=specs,
+        )
+    assert db.unmanaged == []
+
+
+async def test_split_partition_wraps_unmanaged_failure() -> None:
+    db = _pg19_database()
+    db.unmanaged_fail = True
+    specs = [
+        SplitPartitionSpec(name="a", for_values_clause="FROM (1) TO (2)"),
+        SplitPartitionSpec(name="b", for_values_clause="FROM (2) TO (3)"),
+    ]
+    with pytest.raises(Pg19PartitionsError, match="SPLIT PARTITION failed"):
+        await split_partition(
+            db,  # type: ignore[arg-type]
+            parent_schema="public",
+            parent_table="measurement",
+            source_partition="src",
+            new_partitions=specs,
+        )
+
+
+async def test_split_partition_quotes_new_partition_names() -> None:
+    db = _pg19_database()
+    specs = [
+        SplitPartitionSpec(name='a"evil', for_values_clause="FROM (1) TO (2)"),
+        SplitPartitionSpec(name='b"evil', for_values_clause="FROM (2) TO (3)"),
+    ]
+    await split_partition(
+        db,  # type: ignore[arg-type]
+        parent_schema="public",
+        parent_table="measurement",
+        source_partition='s"rc',
+        new_partitions=specs,
+    )
+    sql = db.unmanaged[0]
+    assert 'SPLIT PARTITION "s""rc"' in sql
+    assert 'PARTITION "a""evil"' in sql
+    assert 'PARTITION "b""evil"' in sql
+
+
+# --- Dataclass shapes -----------------------------------------------------
+
+
+def test_dataclass_shapes() -> None:
+    status = Pg19PartitionsStatus(available=True, server_version_num=190001, server_version="19beta1", detail="ok")
+    assert status.available is True
+    merge = MergePartitionsResult(
+        parent_schema="public",
+        parent_table="t",
+        source_partitions=("a", "b"),
+        target_partition="m",
+        merge_sql="ALTER TABLE ...",
+    )
+    assert merge.target_partition == "m"
+    spec = SplitPartitionSpec(name="n", for_values_clause="FROM (1) TO (2)")
+    assert spec.name == "n"
+    split = SplitPartitionResult(
+        parent_schema="public",
+        parent_table="t",
+        source_partition="src",
+        new_partitions=("a", "b"),
+        split_sql="ALTER TABLE ...",
+    )
+    assert split.new_partitions == ("a", "b")

--- a/tests/unit/test_pg19_partitions.py
+++ b/tests/unit/test_pg19_partitions.py
@@ -221,6 +221,26 @@ async def test_split_partition_wraps_unmanaged_failure() -> None:
         )
 
 
+async def test_split_partition_rejects_nul_in_for_values_clause() -> None:
+    """NUL bytes in a for_values_clause would truncate the libpq query —
+    surface as an explicit error rather than silently emitting partial DDL
+    (gemini critical on PR #145)."""
+    db = _pg19_database()
+    specs = [
+        SplitPartitionSpec(name="a", for_values_clause="FROM (1) TO (2)"),
+        SplitPartitionSpec(name="b", for_values_clause="FROM (2) TO (3)\x00 DROP TABLE evil"),
+    ]
+    with pytest.raises(Pg19PartitionsError, match="NUL byte"):
+        await split_partition(
+            db,  # type: ignore[arg-type]
+            parent_schema="public",
+            parent_table="measurement",
+            source_partition="src",
+            new_partitions=specs,
+        )
+    assert db.unmanaged == []
+
+
 async def test_split_partition_quotes_new_partition_names() -> None:
     db = _pg19_database()
     specs = [


### PR DESCRIPTION
## Summary

PR-5 of the PG 19 Phase 3 plan — three new tools in a new `mcpg.pg19_partitions` module. PO matrix row #4 (PO score 23 — next-highest tier after the PR-9 bundle).

- **`merge_partitions`** — `ALTER TABLE … MERGE PARTITIONS (p1, p2, …) INTO new`. Reuses the existing partition data files; no row-by-row copy. PG validates contiguity at execution time.
- **`split_partition`** — `ALTER TABLE … SPLIT PARTITION existing INTO (PARTITION new1 FOR VALUES …, PARTITION new2 FOR VALUES …)`. Accepts `[{name, for_values_clause}]`; `name` is quoted as an identifier, `for_values_clause` is embedded verbatim (DDL grammar can't parameter-bind partition bounds — the tool sits behind `Capability.DDL` + `allow_ddl`, same trust model as `run_ddl`).
- **`get_pg19_partitions_status`** — version probe; never raises. Returns `available=false` on PG ≤ 18 with the detach / create / attach fallback in `detail`.

### Backward compatibility

Per the no-deprecation rule (`docs/plans/pg19-readiness.md`), the detach / create / attach dance stays valid on PG ≤ 18 — agents pick at runtime via the status probe. Both write surfaces raise `Pg19PartitionsError` on older servers with the fallback in the message.

### Bucket routing

All three tools land in `timeseries_partitioning` next to the existing `partman_*` lifecycle. partman covers rolling-window partition creation; these PG 19 tools cover the rarer "reshape an existing range" case — no coupling needed.

### Operational shape

Both writes dispatch through `Database.run_unmanaged` (cannot run inside a transaction block, same constraint as `VACUUM` / `REPACK`) and wrap driver exceptions in `Pg19PartitionsError` preserving `__cause__`.

### Smoke harness

`scripts/smoke_test_pg19.py` exercises `get_pg19_partitions_status` against the live container. `merge_partitions` / `split_partition` are skipped in the smoke (require pre-seeded partitioned tables); behavioural coverage lives in `tests/unit/test_pg19_partitions.py`.

## Test plan

- [x] `uv run pytest -q --ignore=tests/integration` — 2,134 passed
- [x] `uv run pytest tests/unit/test_pg19_partitions.py -q` — 15 new tests pass (identifier quoting incl. injection attempts, version gating, run_unmanaged failure wrapping, both RANGE and LIST forms)
- [x] `uv run pytest tests/contract/ -q` — snapshots updated
- [x] `uv run ruff check src/mcpg/pg19_partitions.py tests/unit/test_pg19_partitions.py` — clean
- [ ] GA-day-0 verification (per `docs/plans/pg19-readiness.md`): re-run against the GA build with a seeded partitioned table to confirm the MERGE / SPLIT syntax matches assumptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_