### PR TITLE
feat(wait_for_lsn): WAIT FOR LSN + read-your-writes advisor — Phase 3 PR-7 — #120

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,35 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **PG 19 `WAIT FOR LSN` + read-your-writes advisor** (`mcpg.wait_for_lsn`).
+  Four new tools that turn the "read your own writes from a hot
+  standby" pattern into a one-call primitive. `get_wait_for_lsn_status`
+  is the version probe + standby detection (never raises).
+  `get_current_wal_lsn` returns the primary write LSN or the standby
+  replay LSN — the natural pairing for the RYW workflow. `wait_for_lsn`
+  issues `WAIT FOR LSN '<lsn>' TIMEOUT <ms>` with strict
+  `^[0-9A-Fa-f]+/[0-9A-Fa-f]+$` LSN validation up-front (the grammar
+  can't parameter-bind LSN literals, so we validate then embed
+  verbatim). `recommend_read_your_writes` is the advisor — combines
+  server role + replay lag + version into a structured recommendation
+  with reason codes `primary_no_wait_needed`, `standby_no_lag`,
+  `standby_lag_unknown`, `standby_with_lag`, `standby_pg18_or_older`,
+  `unavailable`.
+
+  PR-7 of the PG 19 Phase 3 plan (PO matrix row #7, PO score 22).
+  All four tools route to the `operations_and_health` capability
+  bucket next to the existing replication / replica advisors.
+
+  Per the no-deprecation rule, the poll-loop pattern stays valid on
+  PG ≤ 18 — `get_wait_for_lsn_status` and `recommend_read_your_writes`
+  both point at it; `wait_for_lsn` raises `WaitForLsnError` on older
+  servers with the same fallback in the message. The wait surface
+  also reports `timed_out=true` instead of raising when PG's own
+  TIMEOUT fires; timeout detection is SQLSTATE-57014-based for
+  locale-independence, and the advisor uses a single atomic
+  SELECT so a transient recovery-state probe can't mis-classify a
+  standby as a primary.
+
 - **PG 19 skip-scan-aware index advisor** (`mcpg.pg19_skip_scan`). Two
   new tools that expose PG 19's B-tree skip-scan optimisation as an
   actionable advisor. `get_skip_scan_status` is the version probe

--- a/scripts/smoke_test_pg19.py
+++ b/scripts/smoke_test_pg19.py
@@ -75,7 +75,17 @@ async def _exercise_status_probes(database: Database) -> dict[str, dict[str, Any
     phase can decide which writes to attempt based on per-feature
     availability.
     """
-    from mcpg import aio, pg19_ddl, pg19_partitions, pg19_runtime, pg19_skip_scan, pg19_stats, pgq, repack
+    from mcpg import (
+        aio,
+        pg19_ddl,
+        pg19_partitions,
+        pg19_runtime,
+        pg19_skip_scan,
+        pg19_stats,
+        pgq,
+        repack,
+        wait_for_lsn,
+    )
 
     driver = database.driver()
     results: dict[str, dict[str, Any]] = {}
@@ -93,6 +103,7 @@ async def _exercise_status_probes(database: Database) -> dict[str, dict[str, Any
         ("get_pg19_ddl_status", pg19_ddl.get_pg19_ddl_status(driver)),
         ("get_pg19_partitions_status", pg19_partitions.get_pg19_partitions_status(driver)),
         ("get_skip_scan_status", pg19_skip_scan.get_skip_scan_status(driver)),
+        ("get_wait_for_lsn_status", wait_for_lsn.get_wait_for_lsn_status(driver)),
     ):
         result = await _safe(label, helper)
         if result is not None:
@@ -102,7 +113,7 @@ async def _exercise_status_probes(database: Database) -> dict[str, dict[str, Any
 
 async def _exercise_advisors(database: Database) -> None:
     """Phase 2 — read-only advisors that are safe to call on any cluster."""
-    from mcpg import aio, pg19_ddl, pg19_skip_scan, pg19_stats
+    from mcpg import aio, pg19_ddl, pg19_skip_scan, pg19_stats, wait_for_lsn
 
     driver = database.driver()
     await _safe("recommend_io_method", aio.recommend_io_method(driver))
@@ -131,6 +142,12 @@ async def _exercise_advisors(database: Database) -> None:
         "recommend_skip_scan_indexes",
         pg19_skip_scan.recommend_skip_scan_indexes(driver),
     )
+    # WAIT FOR LSN — exercise the advisor + the LSN snapshot. The actual
+    # wait_for_lsn() call is skipped: on the smoke harness the container
+    # is a single primary (no standby), so the wait would trivially
+    # return; behavioural coverage lives in tests/unit/test_wait_for_lsn.py.
+    await _safe("recommend_read_your_writes", wait_for_lsn.recommend_read_your_writes(driver))
+    await _safe("get_current_wal_lsn", wait_for_lsn.get_current_wal_lsn(driver))
 
 
 async def pgq_list_safely(driver: Any) -> Any:

--- a/src/mcpg/about.py
+++ b/src/mcpg/about.py
@@ -689,6 +689,13 @@ _TOOL_TO_BUCKET_OVERRIDES: dict[str, str] = {
     # recommend_index_drops; routes to the advisors bucket.
     "get_skip_scan_status": "advisors",
     "recommend_skip_scan_indexes": "advisors",
+    # PG 19 WAIT FOR LSN — read-your-writes consistency on standbys.
+    # Operational concern (replica lag + RYW pattern) — sits next to
+    # replication / replica advisors.
+    "get_wait_for_lsn_status": "operations_and_health",
+    "get_current_wal_lsn": "operations_and_health",
+    "wait_for_lsn": "operations_and_health",
+    "recommend_read_your_writes": "operations_and_health",
 }
 
 

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -75,6 +75,7 @@ from mcpg import (
     vector_ops,
     vector_tuner_advanced,
     vector_tuning,
+    wait_for_lsn,
     walinspect,
     workload,
     write,
@@ -4840,6 +4841,93 @@ def _register_pg19_partitions_writes(server: FastMCP[AppContext]) -> None:
         return asdict(result)
 
 
+def _register_wait_for_lsn_reads(server: FastMCP[AppContext]) -> None:
+    @server.tool(
+        name="get_wait_for_lsn_status",
+        description=_with_example(
+            "Report whether PG 19's `WAIT FOR LSN` is usable on this server. "
+            "Also reports whether the current backend is a standby (the only "
+            "context where the wait does meaningful work). Never raises. "
+            "On PG ≤ 18 returns `available=false` and points at the poll-loop "
+            "fallback. "
+            "Returns an object with `available` (bool), `server_version_num` "
+            "(int), `server_version`, `is_in_recovery` (bool), and `detail`.",
+            "get_wait_for_lsn_status()",
+        ),
+    )
+    async def get_wait_for_lsn_status(ctx: _Ctx) -> dict[str, Any]:
+        # Live cluster state — never cache. is_in_recovery flips on
+        # promotion / demotion and the agent needs to see the new
+        # state on the next call.
+        status = await wait_for_lsn.get_wait_for_lsn_status(_driver(ctx))
+        return asdict(status)
+
+    @server.tool(
+        name="get_current_wal_lsn",
+        description=_with_example(
+            "Return the current WAL LSN — write-side on a primary "
+            "(`pg_current_wal_lsn()`) or replay-side on a standby "
+            "(`pg_last_wal_replay_lsn()`). Natural pairing for the "
+            "read-your-writes workflow: capture on the primary right "
+            "after a write, then pass to `wait_for_lsn` on the standby "
+            "session before the follow-up read. Works on every "
+            "supported PG version. "
+            "Returns an object with `role` (`'primary'` or `'standby'`) "
+            "and `lsn` (PostgreSQL LSN literal, e.g. `'0/1234ABCD'`).",
+            "get_current_wal_lsn()",
+        ),
+    )
+    async def get_current_wal_lsn(ctx: _Ctx) -> dict[str, Any]:
+        # Snapshot — never cache; the LSN advances monotonically with
+        # every WAL-emitting transaction.
+        result = await wait_for_lsn.get_current_wal_lsn(_driver(ctx))
+        return asdict(result)
+
+    @server.tool(
+        name="recommend_read_your_writes",
+        description=_with_example(
+            "Advise whether the caller should use `WAIT FOR LSN` for "
+            "read-your-writes consistency. Combines server role "
+            "(primary vs standby), replay lag, and PG version into a "
+            "structured recommendation. Never raises. `reason` is one "
+            "of `primary_no_wait_needed`, `standby_no_lag`, "
+            "`standby_lag_unknown`, `standby_with_lag`, "
+            "`standby_pg18_or_older`, `unavailable`. "
+            "Returns an object with `recommend_use` (bool), `reason`, "
+            "`is_in_recovery`, `server_version_num`, `current_lag_bytes` "
+            "(int / null), and `detail`.",
+            "recommend_read_your_writes()",
+        ),
+    )
+    async def recommend_read_your_writes(ctx: _Ctx) -> dict[str, Any]:
+        # Live advisor — never cache. Lag and role change in real time.
+        result = await wait_for_lsn.recommend_read_your_writes(_driver(ctx))
+        return asdict(result)
+
+
+def _register_wait_for_lsn_writes(server: FastMCP[AppContext]) -> None:
+    @server.tool(
+        name="wait_for_lsn",
+        description=_with_example(
+            "Issue `WAIT FOR LSN '<lsn>' TIMEOUT <ms>` and block until "
+            "WAL replay catches up on the connected backend. `timeout_ms` "
+            "defaults to 0 (wait indefinitely); a positive value bounds "
+            "the wait — on timeout the helper returns `timed_out=true` "
+            "rather than raising so the caller can decide whether to "
+            "retry or fall through. LSN format is strictly validated "
+            "(`hex/hex`) before any SQL is composed. Requires PG 19+; "
+            "raises on older servers with the poll-loop fallback in "
+            "the message. "
+            "Returns an object with `lsn`, `timeout_ms` (int), `timed_out` "
+            "(bool), and `wait_sql` (the rendered statement).",
+            "wait_for_lsn(lsn='0/1234ABCD', timeout_ms=5000)",
+        ),
+    )
+    async def wait_for_lsn_tool(ctx: _Ctx, lsn: str, timeout_ms: int = 0) -> dict[str, Any]:
+        result = await wait_for_lsn.wait_for_lsn(_driver(ctx), lsn=lsn, timeout_ms=timeout_ms)
+        return asdict(result)
+
+
 def _register_pg19_stats_reads(server: FastMCP[AppContext]) -> None:
     @server.tool(
         name="get_pg19_stats_status",
@@ -5387,6 +5475,8 @@ def register_tools(server: FastMCP[AppContext], settings: Settings) -> None:
         _register_pg19_ddl_reads(server)
         _register_pg19_partitions_reads(server)
         _register_pg19_skip_scan_reads(server)
+        _register_wait_for_lsn_reads(server)
+        _register_wait_for_lsn_writes(server)
     if is_permitted(settings.access_mode, Capability.WRITE):
         _register_write(server)
         _register_maintenance(server)

--- a/src/mcpg/wait_for_lsn.py
+++ b/src/mcpg/wait_for_lsn.py
@@ -1,0 +1,453 @@
+"""PG 19 ``WAIT FOR LSN`` — read-your-writes (RYW) consistency on hot standbys.
+
+PG 19 introduces ``WAIT FOR LSN '<lsn>' [TIMEOUT <ms>]`` — a
+server-side wait that blocks the current backend until WAL replay
+catches up to the supplied LSN. Combined with capturing
+``pg_current_wal_lsn()`` on the primary right after a write, this
+turns "read your own writes from a hot standby" from a hand-rolled
+poll loop into a one-call primitive.
+
+Module surface (four tools):
+
+* ``get_wait_for_lsn_status`` — version probe; never raises. Reports
+  whether the SQL form is usable on this server + whether the current
+  backend is a standby (the only context where WAIT FOR LSN does
+  meaningful work).
+* ``get_current_wal_lsn`` — returns ``pg_current_wal_lsn()`` on a
+  primary or ``pg_last_wal_replay_lsn()`` on a standby. Works on every
+  supported PG version; bracketed in this module because it's the
+  natural pairing with WAIT FOR LSN for the RYW workflow.
+* ``wait_for_lsn`` — issues ``WAIT FOR LSN '<lsn>' TIMEOUT <ms>``.
+  Strict LSN format validation up-front; embeds the literal verbatim
+  because the grammar can't parameter-bind LSN literals.
+* ``recommend_read_your_writes`` — advisor that combines server-role
+  + lag analysis + version detection and returns a structured
+  recommendation: should the caller use WAIT FOR LSN, and with what
+  bounds.
+
+Backward compatibility
+----------------------
+Additive. ``get_current_wal_lsn`` and the advisor work on every PG
+version (the advisor returns ``available=False`` with a guidance
+string when the server is < 19). ``wait_for_lsn`` raises
+``WaitForLsnError`` on PG ≤ 18 with the documented poll-loop fallback
+in the message.
+
+Security posture
+----------------
+* LSN values pass through a strict format check (``^[0-9A-Fa-f]+/[0-9A-Fa-f]+$``).
+  Anything else raises ``WaitForLsnError`` before any SQL is composed.
+  PG's WAIT FOR LSN grammar takes a string literal, not a bound
+  parameter — strict validation lets us safely embed verbatim.
+* ``timeout_ms`` is coerced to ``int`` and bounded to >= 0; non-int
+  inputs raise.
+* All reads are parameter-free pure SQL; the wait dispatches through
+  the regular driver (no DDL / autocommit requirement).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from mcpg._vendor.sql import SqlDriver
+
+# PG 19 ships WAIT FOR LSN. The version-num boundary.
+_MIN_PG19_WAIT_VERSION = 190000
+
+# PostgreSQL LSN literal: two hex segments separated by '/'.
+# `pg_lsn` accepts 1-8 hex digits per segment but the canonical form is
+# 1-16; the regex is intentionally permissive within hex+/+hex.
+_LSN_PATTERN = re.compile(r"^[0-9A-Fa-f]+/[0-9A-Fa-f]+$")
+
+
+class WaitForLsnError(Exception):
+    """Raised when a WAIT FOR LSN request is rejected or fails."""
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class WaitForLsnStatus:
+    """Reports whether PG 19's WAIT FOR LSN is usable on this server.
+
+    ``available`` is True when ``server_version_num`` >= 190000.
+    ``is_in_recovery`` is True when the current backend is a standby —
+    the only context where WAIT FOR LSN meaningfully waits. On a
+    primary the SQL is accepted but trivially returns (the LSN is
+    always reached). ``detail`` is the agent-facing guidance string.
+    """
+
+    available: bool
+    server_version_num: int
+    server_version: str
+    is_in_recovery: bool
+    detail: str
+
+
+@dataclass(frozen=True, slots=True)
+class CurrentWalLsnResult:
+    """One LSN snapshot — what the helper returned at call time.
+
+    ``role`` is ``"primary"`` or ``"standby"``. The LSN field
+    semantically differs between the two: on a primary it's the
+    most-recently-flushed write position; on a standby it's the
+    most-recently-replayed position.
+    """
+
+    role: str
+    lsn: str
+
+
+@dataclass(frozen=True, slots=True)
+class WaitForLsnResult:
+    """Outcome of `wait_for_lsn`.
+
+    ``timed_out`` is True when the configured ``timeout_ms`` elapsed
+    before WAL replay reached the target LSN — the wait surface
+    returns control without an error so the caller can decide what to
+    do (retry / fall through / fail). ``wait_sql`` is the rendered
+    statement that actually executed.
+    """
+
+    lsn: str
+    timeout_ms: int
+    timed_out: bool
+    wait_sql: str
+
+
+@dataclass(frozen=True, slots=True)
+class ReadYourWritesRecommendation:
+    """Advisor output for the RYW workflow.
+
+    ``recommend_use`` is True when the caller would meaningfully
+    benefit from WAIT FOR LSN — i.e. the current backend is a standby
+    on PG 19+ with non-trivial replay lag. ``reason`` is one of:
+
+    * ``primary_no_wait_needed`` — call landed on the primary; reads
+      already see writes.
+    * ``standby_no_lag`` — standby with zero observed replay lag;
+      WAIT FOR LSN is harmless but unnecessary.
+    * ``standby_with_lag`` — standby with non-zero replay lag; WAIT
+      FOR LSN is the right primitive.
+    * ``standby_pg18_or_older`` — standby but server is PG ≤ 18;
+      fall back to the poll-loop pattern.
+    * ``unavailable`` — version probe failed; can't tell.
+    """
+
+    recommend_use: bool
+    reason: str
+    is_in_recovery: bool
+    server_version_num: int
+    current_lag_bytes: int | None
+    detail: str
+
+
+# ---------------------------------------------------------------------------
+# Shared probes
+# ---------------------------------------------------------------------------
+
+
+async def _server_version(driver: SqlDriver) -> tuple[int, str]:
+    """Return ``(server_version_num, server_version)`` in one round trip."""
+    rows = await driver.execute_query(
+        "SELECT current_setting('server_version_num')::int AS ver_num, current_setting('server_version') AS ver",
+        force_readonly=True,
+    )
+    if not rows:
+        return 0, ""
+    cells = rows[0].cells
+    return int(cells.get("ver_num") or 0), str(cells.get("ver") or "")
+
+
+async def _is_in_recovery(driver: SqlDriver) -> bool:
+    """Return True when the connected backend is a standby."""
+    rows = await driver.execute_query(
+        "SELECT pg_is_in_recovery() AS in_recovery",
+        force_readonly=True,
+    )
+    if not rows:
+        return False
+    raw = rows[0].cells.get("in_recovery")
+    if raw is None:
+        return False
+    if isinstance(raw, bool):
+        return raw
+    return str(raw).strip().lower() in {"on", "true", "yes", "t", "1"}
+
+
+def _validate_lsn(lsn: str) -> str:
+    """Strict LSN format check. Returns the validated LSN unchanged."""
+    if not isinstance(lsn, str) or not _LSN_PATTERN.fullmatch(lsn):
+        raise WaitForLsnError(f"invalid LSN format: {lsn!r}; expected hex/hex (e.g. '0/1234ABCD').")
+    return lsn
+
+
+def _validate_timeout_ms(value: int) -> int:
+    """Coerce + bound the WAIT FOR LSN timeout."""
+    if isinstance(value, bool):  # bool is an int subclass; reject explicitly
+        raise WaitForLsnError(f"timeout_ms must be a non-negative int, got bool {value!r}")
+    if not isinstance(value, int):
+        raise WaitForLsnError(f"timeout_ms must be a non-negative int, got {type(value).__name__}")
+    if value < 0:
+        raise WaitForLsnError(f"timeout_ms must be >= 0, got {value}")
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Status probe
+# ---------------------------------------------------------------------------
+
+
+async def get_wait_for_lsn_status(driver: SqlDriver) -> WaitForLsnStatus:
+    """Report whether PG 19's WAIT FOR LSN is usable on this server.
+
+    Read-only; never raises. Reports both the version-num gate and
+    whether the connected backend is a standby (where the wait is
+    meaningful). On PG ≤ 18 returns ``available=False`` with a
+    guidance string pointing at the poll-loop fallback.
+    """
+    try:
+        ver_num, ver = await _server_version(driver)
+    except Exception as exc:
+        return WaitForLsnStatus(
+            available=False,
+            server_version_num=0,
+            server_version="",
+            is_in_recovery=False,
+            detail=(
+                f"WAIT FOR LSN status unavailable (version probe failed: {exc}). "
+                "Re-run after the server is back online."
+            ),
+        )
+    try:
+        in_recovery = await _is_in_recovery(driver)
+    except Exception:
+        in_recovery = False
+    available = ver_num >= _MIN_PG19_WAIT_VERSION
+    if not available:
+        detail = (
+            "WAIT FOR LSN requires PostgreSQL 19 or newer; this server is older. "
+            "Fall back to the poll-loop pattern: capture pg_current_wal_lsn() on "
+            "the primary, then poll pg_last_wal_replay_lsn() on the standby until "
+            "it catches up."
+        )
+    elif in_recovery:
+        detail = (
+            "WAIT FOR LSN is available and the current backend is a standby — "
+            "this is the canonical context for the read-your-writes pattern. "
+            "Capture the LSN on the primary right after a write, then call "
+            "wait_for_lsn() on this connection before the follow-up read."
+        )
+    else:
+        detail = (
+            "WAIT FOR LSN is available but the current backend is a primary. "
+            "The wait is accepted but trivially returns (LSN is always reached). "
+            "Run wait_for_lsn() on a standby session instead."
+        )
+    return WaitForLsnStatus(
+        available=available,
+        server_version_num=ver_num,
+        server_version=ver,
+        is_in_recovery=in_recovery,
+        detail=detail,
+    )
+
+
+# ---------------------------------------------------------------------------
+# get_current_wal_lsn — works on every PG version
+# ---------------------------------------------------------------------------
+
+
+async def get_current_wal_lsn(driver: SqlDriver) -> CurrentWalLsnResult:
+    """Return the current WAL LSN — write-side on a primary, replay-side on a standby.
+
+    The natural pairing for the RYW workflow: write on the primary →
+    call this → take the result to a standby session and pass it to
+    ``wait_for_lsn``.
+
+    Works on every supported PG version. Raises
+    :class:`WaitForLsnError` only when both LSN-getter SQL calls fail.
+    """
+    try:
+        in_recovery = await _is_in_recovery(driver)
+    except Exception as exc:
+        raise WaitForLsnError(f"pg_is_in_recovery() probe failed: {exc}") from exc
+    func = "pg_last_wal_replay_lsn" if in_recovery else "pg_current_wal_lsn"
+    try:
+        rows = await driver.execute_query(f"SELECT {func}() AS lsn", force_readonly=True)
+    except Exception as exc:
+        raise WaitForLsnError(f"{func}() call failed: {exc}") from exc
+    if not rows:
+        raise WaitForLsnError(f"{func}() returned no rows.")
+    raw = rows[0].cells.get("lsn")
+    if raw is None:
+        raise WaitForLsnError(f"{func}() returned NULL.")
+    return CurrentWalLsnResult(
+        role="standby" if in_recovery else "primary",
+        lsn=str(raw),
+    )
+
+
+# ---------------------------------------------------------------------------
+# wait_for_lsn — PG 19+
+# ---------------------------------------------------------------------------
+
+
+async def wait_for_lsn(driver: SqlDriver, *, lsn: str, timeout_ms: int = 0) -> WaitForLsnResult:
+    """Issue ``WAIT FOR LSN '<lsn>' TIMEOUT <ms>`` and return the outcome.
+
+    ``timeout_ms`` defaults to 0, which means "wait indefinitely" per
+    PG's WAIT FOR LSN semantics. Set it to a positive value for
+    bounded waits; on timeout the helper returns
+    ``timed_out=True`` rather than raising so the caller can decide
+    how to proceed.
+
+    Requires PG 19+. Strict LSN format validation runs before any SQL
+    is composed; invalid input raises :class:`WaitForLsnError`.
+    """
+    lsn = _validate_lsn(lsn)
+    timeout_ms = _validate_timeout_ms(timeout_ms)
+    ver_num, ver = await _server_version(driver)
+    if ver_num < _MIN_PG19_WAIT_VERSION:
+        raise WaitForLsnError(
+            "WAIT FOR LSN requires PostgreSQL 19 or newer; this server "
+            f"reports {ver or 'unknown'} (server_version_num={ver_num}). "
+            "Fall back to the poll-loop on pg_last_wal_replay_lsn()."
+        )
+    # Format check already enforced — embed verbatim.
+    wait_sql = f"WAIT FOR LSN '{lsn}' TIMEOUT {timeout_ms}"
+    try:
+        await driver.execute_query(wait_sql, force_readonly=True)
+    except Exception as exc:
+        msg = str(exc).lower()
+        # PG's WAIT FOR LSN raises a SQLSTATE 57014 (query_canceled) /
+        # "wait for lsn timed out" message on timeout. Catch the
+        # documented shape; let everything else propagate.
+        if "timed out" in msg or "timeout" in msg:
+            return WaitForLsnResult(lsn=lsn, timeout_ms=timeout_ms, timed_out=True, wait_sql=wait_sql)
+        raise WaitForLsnError(f"WAIT FOR LSN failed: {exc}") from exc
+    return WaitForLsnResult(lsn=lsn, timeout_ms=timeout_ms, timed_out=False, wait_sql=wait_sql)
+
+
+# ---------------------------------------------------------------------------
+# recommend_read_your_writes — advisor
+# ---------------------------------------------------------------------------
+
+
+async def _replay_lag_bytes(driver: SqlDriver) -> int | None:
+    """Return current replay lag in bytes for the connected standby.
+
+    Computed as ``pg_wal_lsn_diff(pg_last_wal_receive_lsn(),
+    pg_last_wal_replay_lsn())``. Returns None when the server isn't a
+    standby (both LSN functions return NULL).
+    """
+    rows = await driver.execute_query(
+        "SELECT pg_wal_lsn_diff(pg_last_wal_receive_lsn(), pg_last_wal_replay_lsn())::bigint AS lag",
+        force_readonly=True,
+    )
+    if not rows:
+        return None
+    raw = rows[0].cells.get("lag")
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+async def recommend_read_your_writes(driver: SqlDriver) -> ReadYourWritesRecommendation:
+    """Advisor — should the caller use WAIT FOR LSN for read-your-writes?
+
+    Read-only; never raises. Returns a structured recommendation with
+    one of five ``reason`` codes (see :class:`ReadYourWritesRecommendation`).
+    The caller can branch on ``recommend_use`` for the simple
+    yes / no answer and surface ``detail`` to the human / agent.
+    """
+    try:
+        ver_num, ver = await _server_version(driver)
+    except Exception as exc:
+        return ReadYourWritesRecommendation(
+            recommend_use=False,
+            reason="unavailable",
+            is_in_recovery=False,
+            server_version_num=0,
+            current_lag_bytes=None,
+            detail=f"Version probe failed: {exc}. Re-run after the server is back online.",
+        )
+    try:
+        in_recovery = await _is_in_recovery(driver)
+    except Exception:
+        in_recovery = False
+    if not in_recovery:
+        return ReadYourWritesRecommendation(
+            recommend_use=False,
+            reason="primary_no_wait_needed",
+            is_in_recovery=False,
+            server_version_num=ver_num,
+            current_lag_bytes=None,
+            detail=(
+                "Connection is to a primary — your reads already see your writes. "
+                f"Server version: {ver or 'unknown'}. WAIT FOR LSN is unnecessary in this context."
+            ),
+        )
+    try:
+        lag = await _replay_lag_bytes(driver)
+    except Exception:
+        lag = None
+    if ver_num < _MIN_PG19_WAIT_VERSION:
+        return ReadYourWritesRecommendation(
+            recommend_use=False,
+            reason="standby_pg18_or_older",
+            is_in_recovery=True,
+            server_version_num=ver_num,
+            current_lag_bytes=lag,
+            detail=(
+                f"Standby on PG {ver or 'unknown'} (< 19) — WAIT FOR LSN is unavailable. "
+                "Fall back to the poll-loop on pg_last_wal_replay_lsn() until it "
+                "catches up to the captured primary LSN."
+            ),
+        )
+    if lag is None or lag == 0:
+        return ReadYourWritesRecommendation(
+            recommend_use=False,
+            reason="standby_no_lag",
+            is_in_recovery=True,
+            server_version_num=ver_num,
+            current_lag_bytes=lag,
+            detail=(
+                "Standby with no observable replay lag — WAIT FOR LSN is harmless "
+                "but unnecessary. Re-evaluate during traffic spikes if you start "
+                "seeing stale-read reports."
+            ),
+        )
+    return ReadYourWritesRecommendation(
+        recommend_use=True,
+        reason="standby_with_lag",
+        is_in_recovery=True,
+        server_version_num=ver_num,
+        current_lag_bytes=lag,
+        detail=(
+            f"Standby with {lag} bytes of replay lag. Use the RYW pattern: "
+            "capture pg_current_wal_lsn() on the primary right after the write, "
+            "then call wait_for_lsn(lsn=<captured>, timeout_ms=<budget>) on this "
+            "connection before the follow-up read."
+        ),
+    )
+
+
+__all__ = [
+    "CurrentWalLsnResult",
+    "ReadYourWritesRecommendation",
+    "WaitForLsnError",
+    "WaitForLsnResult",
+    "WaitForLsnStatus",
+    "get_current_wal_lsn",
+    "get_wait_for_lsn_status",
+    "recommend_read_your_writes",
+    "wait_for_lsn",
+]

--- a/src/mcpg/wait_for_lsn.py
+++ b/src/mcpg/wait_for_lsn.py
@@ -129,13 +129,18 @@ class ReadYourWritesRecommendation:
 
     * ``primary_no_wait_needed`` — call landed on the primary; reads
       already see writes.
-    * ``standby_no_lag`` — standby with zero observed replay lag;
+    * ``standby_no_lag`` — standby with a measured 0-byte replay lag;
       WAIT FOR LSN is harmless but unnecessary.
+    * ``standby_lag_unknown`` — standby where the lag probe returned
+      NULL or an unparseable value (transient receive-LSN gap,
+      pg_wal_lsn_diff() failure, etc.). Distinct from
+      ``standby_no_lag`` so the caller can tell "measured zero" from
+      "couldn't measure".
     * ``standby_with_lag`` — standby with non-zero replay lag; WAIT
       FOR LSN is the right primitive.
     * ``standby_pg18_or_older`` — standby but server is PG ≤ 18;
       fall back to the poll-loop pattern.
-    * ``unavailable`` — version probe failed; can't tell.
+    * ``unavailable`` — version / recovery / lag probe failed; can't tell.
     """
 
     recommend_use: bool
@@ -269,8 +274,11 @@ async def get_current_wal_lsn(driver: SqlDriver) -> CurrentWalLsnResult:
     call this → take the result to a standby session and pass it to
     ``wait_for_lsn``.
 
-    Works on every supported PG version. Raises
-    :class:`WaitForLsnError` only when both LSN-getter SQL calls fail.
+    Works on every supported PG version. Raises :class:`WaitForLsnError`
+    when the recovery probe or the LSN SQL call fails, or when the
+    role-appropriate LSN function returns NULL (sourcery bug-risk on
+    PR #146: the prior docstring claimed "only when both LSN-getter
+    calls fail" while pg_is_in_recovery() exceptions leaked).
     """
     try:
         in_recovery = await _is_in_recovery(driver)
@@ -323,11 +331,17 @@ async def wait_for_lsn(driver: SqlDriver, *, lsn: str, timeout_ms: int = 0) -> W
     try:
         await driver.execute_query(wait_sql, force_readonly=True)
     except Exception as exc:
+        # PG raises SQLSTATE 57014 (query_canceled) on TIMEOUT — that's
+        # the locale-independent signal and the only reliable one
+        # (gemini + sourcery critical on PR #146: substring matching
+        # on "timed out" / "timeout" misfires under non-English
+        # lc_messages and conflates statement_timeout with the
+        # WAIT FOR LSN timeout). The English-message check stays as a
+        # belt-and-braces fallback for drivers that don't surface the
+        # SQLSTATE attribute.
+        sqlstate = getattr(exc, "sqlstate", None) or getattr(exc, "pgcode", None)
         msg = str(exc).lower()
-        # PG's WAIT FOR LSN raises a SQLSTATE 57014 (query_canceled) /
-        # "wait for lsn timed out" message on timeout. Catch the
-        # documented shape; let everything else propagate.
-        if "timed out" in msg or "timeout" in msg:
+        if sqlstate == "57014" or "timed out" in msg or "timeout" in msg:
             return WaitForLsnResult(lsn=lsn, timeout_ms=timeout_ms, timed_out=True, wait_sql=wait_sql)
         raise WaitForLsnError(f"WAIT FOR LSN failed: {exc}") from exc
     return WaitForLsnResult(lsn=lsn, timeout_ms=timeout_ms, timed_out=False, wait_sql=wait_sql)
@@ -338,38 +352,32 @@ async def wait_for_lsn(driver: SqlDriver, *, lsn: str, timeout_ms: int = 0) -> W
 # ---------------------------------------------------------------------------
 
 
-async def _replay_lag_bytes(driver: SqlDriver) -> int | None:
-    """Return current replay lag in bytes for the connected standby.
-
-    Computed as ``pg_wal_lsn_diff(pg_last_wal_receive_lsn(),
-    pg_last_wal_replay_lsn())``. Returns None when the server isn't a
-    standby (both LSN functions return NULL).
-    """
-    rows = await driver.execute_query(
-        "SELECT pg_wal_lsn_diff(pg_last_wal_receive_lsn(), pg_last_wal_replay_lsn())::bigint AS lag",
-        force_readonly=True,
-    )
-    if not rows:
-        return None
-    raw = rows[0].cells.get("lag")
-    if raw is None:
-        return None
-    try:
-        return int(raw)
-    except (TypeError, ValueError):
-        return None
-
-
 async def recommend_read_your_writes(driver: SqlDriver) -> ReadYourWritesRecommendation:
     """Advisor — should the caller use WAIT FOR LSN for read-your-writes?
 
     Read-only; never raises. Returns a structured recommendation with
-    one of five ``reason`` codes (see :class:`ReadYourWritesRecommendation`).
-    The caller can branch on ``recommend_use`` for the simple
-    yes / no answer and surface ``detail`` to the human / agent.
+    one of six ``reason`` codes (see :class:`ReadYourWritesRecommendation`).
+
+    Implementation note: version + recovery + lag are captured in a
+    single round-trip SELECT so the advisor cannot mis-classify a
+    standby as a primary if the recovery probe transiently fails
+    (gemini critical on PR #146 — the prior split-query implementation
+    swallowed an `_is_in_recovery` exception, defaulted to
+    `in_recovery=False`, and would route the caller to
+    `primary_no_wait_needed` on a real standby). The atomic query also
+    eliminates the race window between probes during a fail-over.
     """
     try:
-        ver_num, ver = await _server_version(driver)
+        rows = await driver.execute_query(
+            "SELECT "
+            "  current_setting('server_version_num')::int AS ver_num, "
+            "  current_setting('server_version') AS ver, "
+            "  pg_is_in_recovery() AS in_recovery, "
+            "  CASE WHEN pg_is_in_recovery() "
+            "       THEN pg_wal_lsn_diff(pg_last_wal_receive_lsn(), pg_last_wal_replay_lsn())::bigint "
+            "       ELSE NULL END AS lag",
+            force_readonly=True,
+        )
     except Exception as exc:
         return ReadYourWritesRecommendation(
             recommend_use=False,
@@ -377,12 +385,40 @@ async def recommend_read_your_writes(driver: SqlDriver) -> ReadYourWritesRecomme
             is_in_recovery=False,
             server_version_num=0,
             current_lag_bytes=None,
-            detail=f"Version probe failed: {exc}. Re-run after the server is back online.",
+            detail=f"Combined probe failed: {exc}. Re-run after the server is back online.",
         )
+    if not rows:
+        return ReadYourWritesRecommendation(
+            recommend_use=False,
+            reason="unavailable",
+            is_in_recovery=False,
+            server_version_num=0,
+            current_lag_bytes=None,
+            detail="Combined probe returned no rows.",
+        )
+    cells = rows[0].cells
     try:
-        in_recovery = await _is_in_recovery(driver)
-    except Exception:
+        ver_num = int(cells.get("ver_num") or 0)
+    except (TypeError, ValueError):
+        ver_num = 0
+    ver = str(cells.get("ver") or "")
+    raw_in_recovery = cells.get("in_recovery")
+    if isinstance(raw_in_recovery, bool):
+        in_recovery = raw_in_recovery
+    elif raw_in_recovery is None:
         in_recovery = False
+    else:
+        in_recovery = str(raw_in_recovery).strip().lower() in {"on", "true", "yes", "t", "1"}
+    raw_lag = cells.get("lag")
+    lag: int | None
+    if raw_lag is None:
+        lag = None
+    else:
+        try:
+            lag = int(raw_lag)
+        except (TypeError, ValueError):
+            lag = None
+
     if not in_recovery:
         return ReadYourWritesRecommendation(
             recommend_use=False,
@@ -395,10 +431,6 @@ async def recommend_read_your_writes(driver: SqlDriver) -> ReadYourWritesRecomme
                 f"Server version: {ver or 'unknown'}. WAIT FOR LSN is unnecessary in this context."
             ),
         )
-    try:
-        lag = await _replay_lag_bytes(driver)
-    except Exception:
-        lag = None
     if ver_num < _MIN_PG19_WAIT_VERSION:
         return ReadYourWritesRecommendation(
             recommend_use=False,
@@ -412,15 +444,33 @@ async def recommend_read_your_writes(driver: SqlDriver) -> ReadYourWritesRecomme
                 "catches up to the captured primary LSN."
             ),
         )
-    if lag is None or lag == 0:
+    if lag is None:
+        # Distinct from `standby_no_lag` — sourcery critical on PR #146:
+        # `None` means "couldn't measure" (NULL from pg_wal_lsn_diff,
+        # missing receive LSN on a freshly-started standby, …), not
+        # "measured zero".
+        return ReadYourWritesRecommendation(
+            recommend_use=False,
+            reason="standby_lag_unknown",
+            is_in_recovery=True,
+            server_version_num=ver_num,
+            current_lag_bytes=None,
+            detail=(
+                "Standby but replay lag could not be measured "
+                "(pg_wal_lsn_diff returned NULL or pg_last_wal_receive_lsn is unset). "
+                "Re-run after the receive LSN is reported; if the symptom persists, "
+                "use the RYW pattern conservatively (capture-then-wait) as a precaution."
+            ),
+        )
+    if lag == 0:
         return ReadYourWritesRecommendation(
             recommend_use=False,
             reason="standby_no_lag",
             is_in_recovery=True,
             server_version_num=ver_num,
-            current_lag_bytes=lag,
+            current_lag_bytes=0,
             detail=(
-                "Standby with no observable replay lag — WAIT FOR LSN is harmless "
+                "Standby with a measured 0-byte replay lag — WAIT FOR LSN is harmless "
                 "but unnecessary. Re-evaluate during traffic spikes if you start "
                 "seeing stale-read reports."
             ),

--- a/tests/contract/test_tool_return_shapes.py
+++ b/tests/contract/test_tool_return_shapes.py
@@ -103,6 +103,7 @@ _KNOWN_HELPER_MODULES = (
     "turboquant",
     "vector_ops",
     "vector_tuning",
+    "wait_for_lsn",
     "walinspect",
     "workload",
     "write",

--- a/tests/contract/tool_return_shapes.snapshot.json
+++ b/tests/contract/tool_return_shapes.snapshot.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "schema_version": 1,
-    "tool_count": 219
+    "tool_count": 223
   },
   "tools": {
     "add_compression_policy": {
@@ -618,6 +618,14 @@
     "get_compact_schema": {
       "kind": "opaque"
     },
+    "get_current_wal_lsn": {
+      "dataclass": "CurrentWalLsnResult",
+      "fields": [
+        "lsn",
+        "role"
+      ],
+      "kind": "scalar"
+    },
     "get_data_checksums_status": {
       "dataclass": "DataChecksumsStatus",
       "fields": [
@@ -828,6 +836,17 @@
     },
     "get_turboquant_last_scan_stats": {
       "kind": "opaque"
+    },
+    "get_wait_for_lsn_status": {
+      "dataclass": "WaitForLsnStatus",
+      "fields": [
+        "available",
+        "detail",
+        "is_in_recovery",
+        "server_version",
+        "server_version_num"
+      ],
+      "kind": "scalar"
     },
     "hybrid_bm25_vector_search": {
       "dataclass": "HybridHit",
@@ -1695,6 +1714,18 @@
       ],
       "kind": "scalar"
     },
+    "recommend_read_your_writes": {
+      "dataclass": "ReadYourWritesRecommendation",
+      "fields": [
+        "current_lag_bytes",
+        "detail",
+        "is_in_recovery",
+        "reason",
+        "recommend_use",
+        "server_version_num"
+      ],
+      "kind": "scalar"
+    },
     "recommend_redis_cache_targets": {
       "dataclass": "RecommendRedisCacheTargetsResult",
       "fields": [
@@ -2120,6 +2151,16 @@
         "total_connections",
         "unencrypted_connections",
         "version"
+      ],
+      "kind": "scalar"
+    },
+    "wait_for_lsn": {
+      "dataclass": "WaitForLsnResult",
+      "fields": [
+        "lsn",
+        "timed_out",
+        "timeout_ms",
+        "wait_sql"
       ],
       "kind": "scalar"
     },

--- a/tests/contract/tool_surface.snapshot.json
+++ b/tests/contract/tool_surface.snapshot.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "schema_version": 1,
-    "tool_count": 219
+    "tool_count": 223
   },
   "tools": [
     {
@@ -2122,6 +2122,15 @@
       "name": "get_compact_schema"
     },
     {
+      "description": "Return the current WAL LSN — write-side on a primary (`pg_current_wal_lsn()`) or replay-side on a standby (`pg_last_wal_replay_lsn()`). Natural pairing for the read-your-writes workflow: capture on the primary right after a write, then pass to `wait_for_lsn` on the standby session before the follow-up read. Works on every supported PG version. Returns an object with `role` (`'primary'` or `'standby'`) and `lsn` (PostgreSQL LSN literal, e.g. `'0/1234ABCD'`).\n\nExample: `get_current_wal_lsn()`",
+      "inputSchema": {
+        "properties": {},
+        "title": "get_current_wal_lsnArguments",
+        "type": "object"
+      },
+      "name": "get_current_wal_lsn"
+    },
+    {
       "description": "Report whether PG 19's online `data_checksums` toggle is usable + the current setting. Never raises — driver-level errors surface as `available=false`. On PG ≤ 18 reports `available=false` but still surfaces the current state (set at initdb time) so the agent has context, and points at the offline `pg_checksums` fallback. Returns an object with `available` (bool), `server_version_num` (int), `server_version`, `enabled` (bool / null), and `detail` (guidance string).\n\nExample: `get_data_checksums_status()`",
       "inputSchema": {
         "properties": {},
@@ -2362,6 +2371,15 @@
         "type": "object"
       },
       "name": "get_turboquant_last_scan_stats"
+    },
+    {
+      "description": "Report whether PG 19's `WAIT FOR LSN` is usable on this server. Also reports whether the current backend is a standby (the only context where the wait does meaningful work). Never raises. On PG ≤ 18 returns `available=false` and points at the poll-loop fallback. Returns an object with `available` (bool), `server_version_num` (int), `server_version`, `is_in_recovery` (bool), and `detail`.\n\nExample: `get_wait_for_lsn_status()`",
+      "inputSchema": {
+        "properties": {},
+        "title": "get_wait_for_lsn_statusArguments",
+        "type": "object"
+      },
+      "name": "get_wait_for_lsn_status"
     },
     {
       "description": "Combine a BM25 search and a pgvector search via Reciprocal Rank Fusion — the canonical v2 pattern ParadeDB documents in the 2025-10-22 'Hybrid Search Missing Manual' blog post. Returns hits as {id, score, bm25_rank, vector_rank}. ``score`` is the summed ``sum(weight * 1.0 / (k + rank))`` across both legs; per-leg ranks are surfaced for transparency (either can be NULL if a row only appeared in one leg's top-K). ``distance_op`` is the pgvector operator ('<=>'/'<->'/'<#>' — RRF is operator-agnostic). ``bm25_columns=None`` searches the whole BM25 index; ``bm25_columns=[\"col\"]`` restricts the BM25 leg to a single field. Defaults mirror upstream's demonstrated form (cosine, k=60, equal weights, per_leg_limit=20). Requires the pg_search and pgvector extensions.",
@@ -4446,6 +4464,15 @@
       "name": "recommend_prewarm_targets"
     },
     {
+      "description": "Advise whether the caller should use `WAIT FOR LSN` for read-your-writes consistency. Combines server role (primary vs standby), replay lag, and PG version into a structured recommendation. Never raises. `reason` is one of `primary_no_wait_needed`, `standby_no_lag`, `standby_lag_unknown`, `standby_with_lag`, `standby_pg18_or_older`, `unavailable`. Returns an object with `recommend_use` (bool), `reason`, `is_in_recovery`, `server_version_num`, `current_lag_bytes` (int / null), and `detail`.\n\nExample: `recommend_read_your_writes()`",
+      "inputSchema": {
+        "properties": {},
+        "title": "recommend_read_your_writesArguments",
+        "type": "object"
+      },
+      "name": "recommend_read_your_writes"
+    },
+    {
       "description": "Recommend tables that would benefit from a Redis cache layer. Inspects ``pg_stat_user_tables`` for read-heavy, low-write relations whose working set fits comfortably in Redis (default: read/write ratio ≥ 10, ≥ 1000 reads, ≤ 1M rows). When ``server`` is provided the generated ``ready_to_run_sql`` stub targets that server name; otherwise the stub uses a placeholder operators must substitute. Advisor is read-only — never touches Redis itself. Returns an object with `server` and `candidates` — a list of objects with `schema`, `table`, `reads`, `writes`, `read_write_ratio`, `estimated_row_count`, `reason` (`read_only_lookup_table` / `small_hot_relation` / `read_heavy_low_write` / `moderate_read_dominant`), and `ready_to_run_sql` (a CREATE FOREIGN TABLE stub).\n\nExample: `recommend_redis_cache_targets(server='redis_primary', limit=10)`",
       "inputSchema": {
         "properties": {
@@ -5936,6 +5963,28 @@
         "type": "object"
       },
       "name": "verify_connection_encryption"
+    },
+    {
+      "description": "Issue `WAIT FOR LSN '<lsn>' TIMEOUT <ms>` and block until WAL replay catches up on the connected backend. `timeout_ms` defaults to 0 (wait indefinitely); a positive value bounds the wait — on timeout the helper returns `timed_out=true` rather than raising so the caller can decide whether to retry or fall through. LSN format is strictly validated (`hex/hex`) before any SQL is composed. Requires PG 19+; raises on older servers with the poll-loop fallback in the message. Returns an object with `lsn`, `timeout_ms` (int), `timed_out` (bool), and `wait_sql` (the rendered statement).\n\nExample: `wait_for_lsn(lsn='0/1234ABCD', timeout_ms=5000)`",
+      "inputSchema": {
+        "properties": {
+          "lsn": {
+            "title": "Lsn",
+            "type": "string"
+          },
+          "timeout_ms": {
+            "default": 0,
+            "title": "Timeout Ms",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "lsn"
+        ],
+        "title": "wait_for_lsn_toolArguments",
+        "type": "object"
+      },
+      "name": "wait_for_lsn"
     },
     {
       "description": "Walk and reconstruct the lock-wait graph of the database. Detects deadlock cycles, traces linear blocking paths to their root blockers, and renders a Mermaid flowchart representing the lock dependency graph. Read-only. Returns an object with `cycles` (list of detected cycle PID lists), `paths` (linear blocking paths as PID lists), `roots` (root blocker PIDs), `nodes` (dict keyed by PID with per-backend lock detail), and `mermaid` (the pre-rendered flowchart string).",

--- a/tests/unit/test_wait_for_lsn.py
+++ b/tests/unit/test_wait_for_lsn.py
@@ -142,6 +142,38 @@ async def test_wait_for_lsn_timeout_reported_not_raised() -> None:
     assert result.lsn == "0/1234ABCD"
 
 
+class _SqlstateError(Exception):
+    """Driver exception that carries a `sqlstate` attribute, like psycopg's
+    DatabaseError. Used to test the locale-independent timeout path."""
+
+    def __init__(self, msg: str, sqlstate: str) -> None:
+        super().__init__(msg)
+        self.sqlstate = sqlstate
+
+
+async def test_wait_for_lsn_timeout_detected_via_sqlstate_57014() -> None:
+    """A non-English error carrying SQLSTATE 57014 still surfaces as timed_out=True
+    (gemini + sourcery critical on PR #146 — locale-independent timeout detection)."""
+    driver = _WaitForLsnDriver()
+    # Override the driver's failure with a SQLSTATE-bearing exception.
+    driver._fail_with = None
+
+    async def fail_with_sqlstate(query, params=None, force_readonly=False):  # type: ignore[no-untyped-def]
+        from mcpg._vendor.sql import SqlDriver
+
+        driver.calls.append((query, params, force_readonly))
+        if "current_setting" in query:
+            return [SqlDriver.RowResult(cells={"ver_num": 190001, "ver": "19beta1"})]
+        driver.executed.append(query)
+        # Mimic a localized error string (German for "canceled by query timeout").
+        raise _SqlstateError("Anfrage durch Anweisungs-Timeout abgebrochen", sqlstate="57014")
+
+    driver.execute_query = fail_with_sqlstate  # type: ignore[method-assign]
+    result = await wait_for_lsn(driver, lsn="0/1234ABCD", timeout_ms=100)  # type: ignore[arg-type]
+    assert result.timed_out is True
+    assert result.lsn == "0/1234ABCD"
+
+
 async def test_wait_for_lsn_other_driver_failure_raises() -> None:
     driver = _WaitForLsnDriver(fail_with="connection refused")
     with pytest.raises(WaitForLsnError, match="WAIT FOR LSN failed"):
@@ -196,8 +228,30 @@ async def test_wait_for_lsn_rejects_bool_timeout() -> None:
 # --- recommend_read_your_writes ------------------------------------------
 
 
+def _advisor_route(*, ver_num: int, ver: str, in_recovery: bool, lag: int | None) -> FakeRoutingDriver:
+    """Build a FakeRoutingDriver for the new combined advisor query.
+
+    The advisor runs a single SELECT that returns ver_num / ver /
+    in_recovery / lag in one row — match on the (unique) substring of
+    that SELECT so the fake doesn't accidentally route via the
+    legacy per-probe keys.
+    """
+    return FakeRoutingDriver(
+        {
+            "AS in_recovery": [
+                {
+                    "ver_num": ver_num,
+                    "ver": ver,
+                    "in_recovery": in_recovery,
+                    "lag": lag,
+                }
+            ],
+        }
+    )
+
+
 async def test_recommend_primary_returns_no_wait_needed() -> None:
-    driver = FakeRoutingDriver(_route(190001, "19beta1", in_recovery=False))
+    driver = _advisor_route(ver_num=190001, ver="19beta1", in_recovery=False, lag=None)
     rec = await recommend_read_your_writes(driver)  # type: ignore[arg-type]
     assert isinstance(rec, ReadYourWritesRecommendation)
     assert rec.recommend_use is False
@@ -206,9 +260,7 @@ async def test_recommend_primary_returns_no_wait_needed() -> None:
 
 
 async def test_recommend_standby_with_lag_recommends_use() -> None:
-    routes = _route(190001, "19beta1", in_recovery=True)
-    routes["pg_wal_lsn_diff"] = [{"lag": 50_000_000}]
-    driver = FakeRoutingDriver(routes)
+    driver = _advisor_route(ver_num=190001, ver="19beta1", in_recovery=True, lag=50_000_000)
     rec = await recommend_read_your_writes(driver)  # type: ignore[arg-type]
     assert rec.recommend_use is True
     assert rec.reason == "standby_with_lag"
@@ -216,19 +268,25 @@ async def test_recommend_standby_with_lag_recommends_use() -> None:
 
 
 async def test_recommend_standby_no_lag_does_not_recommend() -> None:
-    routes = _route(190001, "19beta1", in_recovery=True)
-    routes["pg_wal_lsn_diff"] = [{"lag": 0}]
-    driver = FakeRoutingDriver(routes)
+    driver = _advisor_route(ver_num=190001, ver="19beta1", in_recovery=True, lag=0)
     rec = await recommend_read_your_writes(driver)  # type: ignore[arg-type]
     assert rec.recommend_use is False
     assert rec.reason == "standby_no_lag"
     assert rec.current_lag_bytes == 0
 
 
+async def test_recommend_standby_lag_unknown_is_distinct_from_no_lag() -> None:
+    """lag=NULL → standby_lag_unknown, not standby_no_lag — sourcery critical on PR #146."""
+    driver = _advisor_route(ver_num=190001, ver="19beta1", in_recovery=True, lag=None)
+    rec = await recommend_read_your_writes(driver)  # type: ignore[arg-type]
+    assert rec.recommend_use is False
+    assert rec.reason == "standby_lag_unknown"
+    assert rec.current_lag_bytes is None
+    assert "could not be measured" in rec.detail
+
+
 async def test_recommend_standby_pg18_falls_back() -> None:
-    routes = _route(180003, "18.3", in_recovery=True)
-    routes["pg_wal_lsn_diff"] = [{"lag": 100}]
-    driver = FakeRoutingDriver(routes)
+    driver = _advisor_route(ver_num=180003, ver="18.3", in_recovery=True, lag=100)
     rec = await recommend_read_your_writes(driver)  # type: ignore[arg-type]
     assert rec.recommend_use is False
     assert rec.reason == "standby_pg18_or_older"
@@ -236,10 +294,26 @@ async def test_recommend_standby_pg18_falls_back() -> None:
 
 
 async def test_recommend_never_raises_on_driver_failure() -> None:
+    """A bare driver failure must surface as reason=unavailable, not raise.
+
+    Gemini critical on PR #146: the prior split-query implementation
+    could mis-classify a standby as a primary if the recovery probe
+    swallowed an exception. The combined query collapses that risk
+    into a single try/except that always routes to `unavailable`.
+    """
     driver = FakeDriver(fail=True)
     rec = await recommend_read_your_writes(driver)  # type: ignore[arg-type]
     assert rec.recommend_use is False
     assert rec.reason == "unavailable"
+    assert rec.is_in_recovery is False
+
+
+async def test_recommend_handles_empty_rows() -> None:
+    """A driver that returns zero rows from the combined SELECT routes to `unavailable`."""
+    driver = FakeRoutingDriver({"AS in_recovery": []})
+    rec = await recommend_read_your_writes(driver)  # type: ignore[arg-type]
+    assert rec.reason == "unavailable"
+    assert "no rows" in rec.detail.lower()
 
 
 # --- Dataclass shapes -----------------------------------------------------

--- a/tests/unit/test_wait_for_lsn.py
+++ b/tests/unit/test_wait_for_lsn.py
@@ -1,0 +1,269 @@
+"""Tests for the PG 19 WAIT FOR LSN module."""
+
+from __future__ import annotations
+
+import pytest
+from _fakes import FakeDriver, FakeRoutingDriver
+
+from mcpg.wait_for_lsn import (
+    CurrentWalLsnResult,
+    ReadYourWritesRecommendation,
+    WaitForLsnError,
+    WaitForLsnResult,
+    WaitForLsnStatus,
+    get_current_wal_lsn,
+    get_wait_for_lsn_status,
+    recommend_read_your_writes,
+    wait_for_lsn,
+)
+
+
+def _route(num: int, ver: str, *, in_recovery: bool = False) -> dict[str, list[dict[str, object]]]:
+    return {
+        "current_setting('server_version_num')": [{"ver_num": num, "ver": ver}],
+        "pg_is_in_recovery()": [{"in_recovery": in_recovery}],
+    }
+
+
+# --- get_wait_for_lsn_status ---------------------------------------------
+
+
+async def test_status_available_on_pg19_primary() -> None:
+    driver = FakeRoutingDriver(_route(190001, "19beta1", in_recovery=False))
+    status = await get_wait_for_lsn_status(driver)  # type: ignore[arg-type]
+    assert isinstance(status, WaitForLsnStatus)
+    assert status.available is True
+    assert status.is_in_recovery is False
+    assert "primary" in status.detail
+
+
+async def test_status_available_on_pg19_standby() -> None:
+    driver = FakeRoutingDriver(_route(190001, "19beta1", in_recovery=True))
+    status = await get_wait_for_lsn_status(driver)  # type: ignore[arg-type]
+    assert status.available is True
+    assert status.is_in_recovery is True
+    assert "standby" in status.detail.lower()
+
+
+async def test_status_unavailable_on_pg18() -> None:
+    driver = FakeRoutingDriver(_route(180003, "18.3"))
+    status = await get_wait_for_lsn_status(driver)  # type: ignore[arg-type]
+    assert status.available is False
+    assert "poll-loop" in status.detail
+
+
+async def test_status_never_raises_on_driver_failure() -> None:
+    driver = FakeDriver(fail=True)
+    status = await get_wait_for_lsn_status(driver)  # type: ignore[arg-type]
+    assert status.available is False
+    assert "version probe failed" in status.detail
+
+
+# --- get_current_wal_lsn -------------------------------------------------
+
+
+async def test_get_current_wal_lsn_on_primary() -> None:
+    routes = {
+        "pg_is_in_recovery()": [{"in_recovery": False}],
+        "pg_current_wal_lsn()": [{"lsn": "0/1234ABCD"}],
+    }
+    driver = FakeRoutingDriver(routes)
+    result = await get_current_wal_lsn(driver)  # type: ignore[arg-type]
+    assert isinstance(result, CurrentWalLsnResult)
+    assert result.role == "primary"
+    assert result.lsn == "0/1234ABCD"
+
+
+async def test_get_current_wal_lsn_on_standby() -> None:
+    routes = {
+        "pg_is_in_recovery()": [{"in_recovery": True}],
+        "pg_last_wal_replay_lsn()": [{"lsn": "0/56789ABC"}],
+    }
+    driver = FakeRoutingDriver(routes)
+    result = await get_current_wal_lsn(driver)  # type: ignore[arg-type]
+    assert result.role == "standby"
+    assert result.lsn == "0/56789ABC"
+
+
+async def test_get_current_wal_lsn_wraps_driver_failure() -> None:
+    driver = FakeDriver(fail=True)
+    with pytest.raises(WaitForLsnError, match="pg_is_in_recovery"):
+        await get_current_wal_lsn(driver)  # type: ignore[arg-type]
+
+
+# --- wait_for_lsn --------------------------------------------------------
+
+
+class _WaitForLsnDriver:
+    """Custom driver: routes version probe; records wait SQL; can simulate timeout / error."""
+
+    def __init__(self, *, ver_num: int = 190001, ver: str = "19beta1", fail_with: str | None = None) -> None:
+        self._ver_num = ver_num
+        self._ver = ver
+        self._fail_with = fail_with
+        self.executed: list[str] = []
+        self.calls: list[tuple[str, object, bool]] = []
+
+    async def execute_query(self, query, params=None, force_readonly=False):  # type: ignore[no-untyped-def]
+        from mcpg._vendor.sql import SqlDriver
+
+        self.calls.append((query, params, force_readonly))
+        if "current_setting" in query:
+            return [SqlDriver.RowResult(cells={"ver_num": self._ver_num, "ver": self._ver})]
+        # WAIT FOR LSN path.
+        self.executed.append(query)
+        if self._fail_with is not None:
+            raise RuntimeError(self._fail_with)
+        return []
+
+
+async def test_wait_for_lsn_success_returns_not_timed_out() -> None:
+    driver = _WaitForLsnDriver()
+    result = await wait_for_lsn(driver, lsn="0/1234ABCD", timeout_ms=5000)  # type: ignore[arg-type]
+    assert isinstance(result, WaitForLsnResult)
+    assert result.lsn == "0/1234ABCD"
+    assert result.timeout_ms == 5000
+    assert result.timed_out is False
+    assert driver.executed == ["WAIT FOR LSN '0/1234ABCD' TIMEOUT 5000"]
+
+
+async def test_wait_for_lsn_default_timeout_is_zero() -> None:
+    driver = _WaitForLsnDriver()
+    result = await wait_for_lsn(driver, lsn="0/abcd")  # type: ignore[arg-type]
+    assert result.timeout_ms == 0
+    assert "TIMEOUT 0" in result.wait_sql
+
+
+async def test_wait_for_lsn_timeout_reported_not_raised() -> None:
+    """A 'timed out' message from the driver surfaces as `timed_out=True`."""
+    driver = _WaitForLsnDriver(fail_with="WAIT FOR LSN timed out")
+    result = await wait_for_lsn(driver, lsn="0/1234ABCD", timeout_ms=100)  # type: ignore[arg-type]
+    assert result.timed_out is True
+    assert result.lsn == "0/1234ABCD"
+
+
+async def test_wait_for_lsn_other_driver_failure_raises() -> None:
+    driver = _WaitForLsnDriver(fail_with="connection refused")
+    with pytest.raises(WaitForLsnError, match="WAIT FOR LSN failed"):
+        await wait_for_lsn(driver, lsn="0/1234ABCD", timeout_ms=100)  # type: ignore[arg-type]
+
+
+async def test_wait_for_lsn_raises_on_pg18() -> None:
+    driver = _WaitForLsnDriver(ver_num=180003, ver="18.3")
+    with pytest.raises(WaitForLsnError, match="PostgreSQL 19"):
+        await wait_for_lsn(driver, lsn="0/1234ABCD")  # type: ignore[arg-type]
+    assert driver.executed == []
+
+
+@pytest.mark.parametrize(
+    "bad_lsn",
+    [
+        "not-an-lsn",
+        "0/",
+        "/1234",
+        "0/XYZ",  # non-hex
+        "'; DROP TABLE evil; --",
+        "0/1234 OR 1=1",
+        "",
+    ],
+)
+async def test_wait_for_lsn_rejects_malformed_lsn(bad_lsn: str) -> None:
+    driver = _WaitForLsnDriver()
+    with pytest.raises(WaitForLsnError, match="invalid LSN format"):
+        await wait_for_lsn(driver, lsn=bad_lsn)  # type: ignore[arg-type]
+    assert driver.executed == []
+
+
+async def test_wait_for_lsn_rejects_negative_timeout() -> None:
+    driver = _WaitForLsnDriver()
+    with pytest.raises(WaitForLsnError, match=">= 0"):
+        await wait_for_lsn(driver, lsn="0/1234", timeout_ms=-1)  # type: ignore[arg-type]
+
+
+async def test_wait_for_lsn_rejects_non_int_timeout() -> None:
+    driver = _WaitForLsnDriver()
+    with pytest.raises(WaitForLsnError, match="non-negative int"):
+        await wait_for_lsn(driver, lsn="0/1234", timeout_ms="5000")  # type: ignore[arg-type]
+
+
+async def test_wait_for_lsn_rejects_bool_timeout() -> None:
+    """bool is an int subclass — reject explicitly so True isn't silently 1."""
+    driver = _WaitForLsnDriver()
+    with pytest.raises(WaitForLsnError, match="bool"):
+        await wait_for_lsn(driver, lsn="0/1234", timeout_ms=True)  # type: ignore[arg-type]
+
+
+# --- recommend_read_your_writes ------------------------------------------
+
+
+async def test_recommend_primary_returns_no_wait_needed() -> None:
+    driver = FakeRoutingDriver(_route(190001, "19beta1", in_recovery=False))
+    rec = await recommend_read_your_writes(driver)  # type: ignore[arg-type]
+    assert isinstance(rec, ReadYourWritesRecommendation)
+    assert rec.recommend_use is False
+    assert rec.reason == "primary_no_wait_needed"
+    assert rec.is_in_recovery is False
+
+
+async def test_recommend_standby_with_lag_recommends_use() -> None:
+    routes = _route(190001, "19beta1", in_recovery=True)
+    routes["pg_wal_lsn_diff"] = [{"lag": 50_000_000}]
+    driver = FakeRoutingDriver(routes)
+    rec = await recommend_read_your_writes(driver)  # type: ignore[arg-type]
+    assert rec.recommend_use is True
+    assert rec.reason == "standby_with_lag"
+    assert rec.current_lag_bytes == 50_000_000
+
+
+async def test_recommend_standby_no_lag_does_not_recommend() -> None:
+    routes = _route(190001, "19beta1", in_recovery=True)
+    routes["pg_wal_lsn_diff"] = [{"lag": 0}]
+    driver = FakeRoutingDriver(routes)
+    rec = await recommend_read_your_writes(driver)  # type: ignore[arg-type]
+    assert rec.recommend_use is False
+    assert rec.reason == "standby_no_lag"
+    assert rec.current_lag_bytes == 0
+
+
+async def test_recommend_standby_pg18_falls_back() -> None:
+    routes = _route(180003, "18.3", in_recovery=True)
+    routes["pg_wal_lsn_diff"] = [{"lag": 100}]
+    driver = FakeRoutingDriver(routes)
+    rec = await recommend_read_your_writes(driver)  # type: ignore[arg-type]
+    assert rec.recommend_use is False
+    assert rec.reason == "standby_pg18_or_older"
+    assert "poll-loop" in rec.detail
+
+
+async def test_recommend_never_raises_on_driver_failure() -> None:
+    driver = FakeDriver(fail=True)
+    rec = await recommend_read_your_writes(driver)  # type: ignore[arg-type]
+    assert rec.recommend_use is False
+    assert rec.reason == "unavailable"
+
+
+# --- Dataclass shapes -----------------------------------------------------
+
+
+def test_dataclass_shapes() -> None:
+    s = WaitForLsnStatus(
+        available=True,
+        server_version_num=190001,
+        server_version="19beta1",
+        is_in_recovery=False,
+        detail="ok",
+    )
+    assert s.available is True
+    c = CurrentWalLsnResult(role="primary", lsn="0/1")
+    assert c.role == "primary"
+    w = WaitForLsnResult(lsn="0/1", timeout_ms=0, timed_out=False, wait_sql="WAIT ...")
+    assert w.timed_out is False
+    r = ReadYourWritesRecommendation(
+        recommend_use=False,
+        reason="primary_no_wait_needed",
+        is_in_recovery=False,
+        server_version_num=190001,
+        current_lag_bytes=None,
+        detail="ok",
+    )
+    assert r.recommend_use is False


### PR DESCRIPTION
## Summary

PR-7 of the PG 19 Phase 3 plan — four new tools in a new `mcpg.wait_for_lsn` module. PO matrix row #7 (PO score 22).

- **`wait_for_lsn`** — `WAIT FOR LSN '<lsn>' TIMEOUT <ms>` with strict `^[0-9A-Fa-f]+/[0-9A-Fa-f]+$` LSN validation before any SQL is composed (the grammar can't parameter-bind LSN literals). On PG's own TIMEOUT the helper returns `timed_out=true` instead of raising — caller decides whether to retry.
- **`get_current_wal_lsn`** — `pg_current_wal_lsn()` on primary / `pg_last_wal_replay_lsn()` on standby. Works on every supported PG version; the natural pairing for the RYW workflow.
- **`recommend_read_your_writes`** — advisor that combines server role + replay lag + version into a structured recommendation. Reason codes: `primary_no_wait_needed`, `standby_no_lag`, `standby_with_lag`, `standby_pg18_or_older`, `unavailable`.
- **`get_wait_for_lsn_status`** — version probe + standby detection; never raises.

### Backward compatibility

Per the no-deprecation rule (`docs/plans/pg19-readiness.md`), the poll-loop pattern stays valid on PG ≤ 18 — both reads point at it; the wait surface raises `WaitForLsnError` on older servers with the fallback in the message.

### Bucket routing

All four tools land in `operations_and_health` next to the existing replication / replica advisors.

### Security posture

- LSN format strictly validated (hex/hex) before any SQL is composed.
- `timeout_ms` coerced to int, bounded to >= 0; bool rejected explicitly (would otherwise be silently coerced via int-subclass).
- 7-case `pytest.mark.parametrize` test asserts every malformed LSN attempt — including SQL-injection-shaped strings — is rejected before reaching the driver.

## Test plan

- [x] `uv run pytest -q --ignore=tests/integration` — 2,147 passed
- [x] `uv run pytest tests/unit/test_wait_for_lsn.py -q` — 28 new tests (LSN format rejection incl. injection attempts, timeout reporting vs raising, primary vs standby branches, all 5 advisor reason codes)
- [x] `uv run pytest tests/contract/ -q` — snapshots updated
- [x] `uv run ruff check src/mcpg/wait_for_lsn.py tests/unit/test_wait_for_lsn.py` — clean
- [ ] GA-day-0 verification (per `docs/plans/pg19-readiness.md`): re-run against a real primary+standby pair to confirm the `WAIT FOR LSN '<lsn>' TIMEOUT <ms>` syntax matches assumptions and the PG-side timeout message contains "timed out"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Introduce a new mcpg.wait_for_lsn module and expose PG 19 WAIT FOR LSN and read-your-writes advisor tooling through the MCP server and smoke tests.

New Features:
- Add four WAIT FOR LSN-related tools (get_wait_for_lsn_status, get_current_wal_lsn, wait_for_lsn, recommend_read_your_writes) for read-your-writes consistency on PostgreSQL 19+ standbys.
- Expose the new wait_for_lsn tools via the FastMCP server tool registry and classify them under the operations_and_health capability bucket.

Enhancements:
- Extend the PG 19 smoke test harness to exercise WAIT FOR LSN status and advisor helpers without performing actual waits.
- Document the new WAIT FOR LSN capabilities and behavior in the changelog, including fallback guidance for PostgreSQL 18 and earlier.

Tests:
- Add unit tests for the wait_for_lsn module covering LSN/timeout validation, PG version gating, timeout reporting, and advisor reason codes.
- Update contract snapshots to include the new wait_for_lsn tool surface and return shapes.