### PR TITLE
ci(pg19): bump pgvector to v0.8.3 + Windows event-loop policy (cherry-pick from fix/pg19-compat-and-demo)

### DIFF
--- a/.github/ci-postgres-pg19.Dockerfile
+++ b/.github/ci-postgres-pg19.Dockerfile
@@ -1,19 +1,16 @@
 # PG 19 (beta) CI image. PostGIS is omitted — its PG 19 apt package
 # isn't published yet — so any test that requires PostGIS is expected
-# to skip / fail under PG 19. pgvector v0.8.0 also doesn't compile
-# against PG 19 (LWLock API moved: `AddinShmemInitLock`, `LW_EXCLUSIVE`,
-# `LWLockAcquire` / `LWLockNewTrancheId` / `LWLockRegisterTranche`
-# / `LWLockRelease` symbols changed mid-PG 18→19; observed on PR #152
-# 2026-06-22), so this image now tries the build and continues without
-# pgvector when it fails — same posture as PostGIS. Vector-dependent
-# tests skip under PG 19 until pgvector publishes PG 19-compatible
-# upstream support. The `continue-on-error` matrix entry in
-# `.github/workflows/ci.yml` makes those skips non-blocking while
-# PG 19 is still in beta.
+# to skip / fail under PG 19. pgvector now ships v0.8.3 which adapts
+# to PG 19's LWLock API rename (`AddinShmemInitLock`, `LW_EXCLUSIVE`,
+# `LWLockAcquire` / `LWLockNewTrancheId` / `LWLockRegisterTranche` /
+# `LWLockRelease` symbols changed mid-PG-18→19; pgvector v0.8.0 didn't
+# compile against PG 19, v0.8.3 does). We pin to v0.8.3 so the image
+# is reproducible, and keep the best-effort try-and-continue wrapper
+# from PR #152 as a safety net in case a future PG 20 introduces
+# similar churn before pgvector tracks it.
 #
 # Drop this file and route PG 19 back to `ci-postgres.Dockerfile` once:
-#   1. pgvector ships an official `pgvector/pgvector:pg19` image (or a
-#      PG 19-compatible source release), and
+#   1. pgvector ships an official `pgvector/pgvector:pg19` image, and
 #   2. PostGIS ships a `postgresql-19-postgis-3` apt package.
 #
 # Until then, this Dockerfile is the PG 19 readiness scaffold (issue #120
@@ -24,8 +21,8 @@ FROM postgres:19beta1
 
 ARG PG_MAJOR=19
 
-# Build dependencies for pgvector (best-effort below). apt-get retries
-# are courtesy — the pgdg repo occasionally returns 502 mid-fetch.
+# Build dependencies for pgvector. apt-get retries are courtesy — the
+# pgdg repo occasionally returns 502 mid-fetch.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         build-essential \
@@ -34,19 +31,18 @@ RUN apt-get update \
         "postgresql-server-dev-${PG_MAJOR}" \
     && rm -rf /var/lib/apt/lists/*
 
-# Try pgvector v0.8.0 build. When pgvector publishes PG 19 support, the
-# build succeeds and vector tests run. Until then the build fails on
-# the LWLock API rename — log it loudly to the image build output and
-# continue, so the rest of the image (which is what actually exercises
-# PG 19's planner / catalog drift) still ships. Tests that need
-# pgvector skip cleanly via the existing `extension_installed("vector")`
-# guard.
+# Try pgvector v0.8.3 (PG 19-compatible) build. The build is expected
+# to succeed; the try-and-continue wrapper from PR #152 stays as a
+# safety net so a future upstream churn doesn't gate the rest of the
+# image. Tests that need pgvector skip cleanly via the existing
+# `extension_installed("vector")` guard when the build does fall
+# through.
 RUN set -e; \
-    git clone --depth 1 --branch v0.8.0 https://github.com/pgvector/pgvector.git /tmp/pgvector; \
+    git clone --depth 1 --branch v0.8.3 https://github.com/pgvector/pgvector.git /tmp/pgvector; \
     cd /tmp/pgvector; \
     if make && make install; then \
-        echo "pgvector built successfully against PG ${PG_MAJOR}."; \
+        echo "pgvector v0.8.3 built successfully against PG ${PG_MAJOR}."; \
     else \
-        echo "pgvector v0.8.0 does not compile against PG ${PG_MAJOR} (LWLock API moved). Continuing without pgvector — vector tests will skip on this image. Roadmap 14.1 tracks the wait-for-upstream-support."; \
+        echo "pgvector v0.8.3 did not compile against PG ${PG_MAJOR}. Continuing without pgvector — vector tests will skip on this image. Roadmap 14.1 tracks the wait-for-upstream-support."; \
     fi; \
     rm -rf /tmp/pgvector

--- a/scripts/smoke_test_pg19.py
+++ b/scripts/smoke_test_pg19.py
@@ -260,4 +260,12 @@ async def main() -> int:
 
 
 if __name__ == "__main__":
+    # Windows shells default to ProactorEventLoop, which the psycopg async
+    # subsystem doesn't play well with. Switch to the selector loop on
+    # Windows so the smoke harness runs against `wsl-postgres:19beta1` or
+    # a Windows-native test cluster without spurious connection errors.
+    # No-op on Linux / macOS. Picked up from user-side feedback on
+    # branch `fix/pg19-compat-and-demo`.
+    if sys.platform == "win32":
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
     sys.exit(asyncio.run(main()))


### PR DESCRIPTION
## Summary

Cherry-picks the two valuable PG 19 compat fixes from your `fix/pg19-compat-and-demo` branch (which was based on an older `main` predating the Phase 3 PRs and would have wiped out ~1,800 lines if merged directly). Both fixes are rebased onto current `main`.

## What's in

**1. pgvector `v0.8.0 → v0.8.3` in `.github/ci-postgres-pg19.Dockerfile`**

This is the *proper* fix for the pgvector PG 19 compile issue I worked around in PR #152 with a best-effort try-and-continue. v0.8.3 carries upstream PG 19 support (LWLock API rename handled). Now the expected path is "build succeeds and vector tests run on the PG 19 matrix entry."

PR #152's safety-net wrapper stays so a future PG 20 / upstream-lag scenario doesn't gate the rest of the image — but the warning text is updated to reflect v0.8.3 being the new pin.

**2. Windows event-loop policy in `scripts/smoke_test_pg19.py`**

Adds:
```python
if sys.platform == "win32":
    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
```

Windows shells default to ProactorEventLoop which psycopg's async subsystem doesn't play well with. Selector loop runs cleanly. No-op on Linux / macOS.

## What's intentionally left out

| File | Why skipped |
|---|---|
| `scratch/fetch_pgvector.py` | Hardcoded `c:\Users\devop\OneDrive\…` path — personal local scratch |
| `tests/unit/test_demo.py` | Imports from a `demo` module that doesn't exist on either branch — broken on land |

## Roadmap impact

Closes the practical concern behind roadmap row 14.1's pgvector-on-PG-19 follow-up. Once this merges + main rebuilds, vector tests should run on the PG 19 matrix entry instead of skipping.

After this lands you can safely delete the source branch `fix/pg19-compat-and-demo`.

## Test plan

- [x] `uv run ruff check scripts/smoke_test_pg19.py` — clean
- [ ] Next CI run: Tests (PG 19) job's image build step succeeds with v0.8.3
- [ ] Vector-dependent integration tests no longer skip under PG 19

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_