### PR TITLE
feat(outputschema): sweep 28 PG 19 tools onto typed returns (roadmap 8.6, second batch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,47 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **outputSchema sweep across the 8 PG 19 modules** — 28 tools
+  converted from `dict[str, Any]` returns to typed dataclass
+  returns, so every PG 19 tool now exposes a populated MCP
+  `outputSchema` for LangChain / LangGraph clients to validate
+  against. Modules covered: `pgq` (6 tools), `pg19_runtime` (5),
+  `pg19_partitions` (3), `pg19_stats` (4), `pg19_skip_scan` (2),
+  `wait_for_lsn` (4), `aio` (2), `repack` (2).
+
+  Per the established sweep playbook (`docs/contributing/adding-tools.md`):
+  - Stripped `slots=True` from every dataclass returned to the
+    wire — slot descriptors block Pydantic's schema generation.
+  - Re-annotated each `@server.tool` handler return type, plus the
+    7 nested `_run` helpers used by the `_cached_call` pattern in
+    `pgq` / `pg19_stats` / `aio` / `repack`.
+  - Removed `asdict(...)` calls; FastMCP serialises the dataclass
+    directly. Write tools preserve their `await cache.clear()`
+    between the helper call and the bare `return result`.
+
+  List-returning tools (`list_property_graphs`,
+  `recommend_skip_scan_indexes`, `read_pg_stat_lock`,
+  `read_pg_stat_recovery`) emit FastMCP's `{"result": [...]}`
+  envelope — the per-item dataclass fields live under `$defs` in
+  the schema. The manifest in `test_tool_output_schemas.py` pins
+  the envelope key for these; the field-level snapshot test
+  (`test_tool_return_shapes.py`) still pins the per-item fields,
+  so a rename / removal trips both tests in concert.
+
+  Realises the second batch of roadmap row **8.6** (PR-13 first
+  sweep covered the 5 PG 19 DDL helper tools). Manifest floor
+  bumped 5 → 33; remaining ~190 legacy `dict[str, Any]` tools
+  follow in further sweep PRs per the same checklist.
+
+  Wire-format note: backward-compatible — FastMCP continues to
+  emit the legacy text `content` array alongside the new
+  `structuredContent` for every converted tool. Clients reading
+  just `content` see no change.
+
+## [Unreleased]
+
 ### Added
 
 - **Tool-surface overlap analyser** (`tools/analyse_tool_overlap.py`).

--- a/src/mcpg/aio.py
+++ b/src/mcpg/aio.py
@@ -82,7 +82,7 @@ class AioError(Exception):
 # ---------------------------------------------------------------------------
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class AioStatus:
     """Reports whether the PG 19 AIO subsystem is usable on this server.
 
@@ -101,7 +101,7 @@ class AioStatus:
     detail: str
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class IoMethodRecommendation:
     """One recommendation row from :func:`recommend_io_method`.
 
@@ -133,7 +133,7 @@ class IoMethodRecommendation:
     ready_to_run_sql: str | None
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class RecommendIoMethodResult:
     """Roll-up of :func:`recommend_io_method` — the recommendation plus
     the AIO status that produced it.

--- a/src/mcpg/pg19_partitions.py
+++ b/src/mcpg/pg19_partitions.py
@@ -74,7 +74,7 @@ class Pg19PartitionsError(Exception):
 # ---------------------------------------------------------------------------
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class Pg19PartitionsStatus:
     """Reports whether PG 19 partition reorganisation is usable.
 
@@ -90,7 +90,7 @@ class Pg19PartitionsStatus:
     detail: str
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class MergePartitionsResult:
     """Outcome of `merge_partitions`.
 
@@ -106,7 +106,7 @@ class MergePartitionsResult:
     merge_sql: str
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class SplitPartitionSpec:
     """One new-partition spec for `split_partition`.
 
@@ -122,7 +122,7 @@ class SplitPartitionSpec:
     for_values_clause: str
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class SplitPartitionResult:
     """Outcome of `split_partition`."""
 

--- a/src/mcpg/pg19_runtime.py
+++ b/src/mcpg/pg19_runtime.py
@@ -62,7 +62,7 @@ class Pg19RuntimeError(Exception):
 # ---------------------------------------------------------------------------
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class DataChecksumsStatus:
     """Reports whether online checksum toggling is usable + the current state.
 
@@ -79,7 +79,7 @@ class DataChecksumsStatus:
     detail: str
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class ToggleDataChecksumsResult:
     """Outcome of `enable_data_checksums` / `disable_data_checksums`.
 
@@ -94,7 +94,7 @@ class ToggleDataChecksumsResult:
     toggle_sql: str
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class LogicalReplicationStatus:
     """Reports whether on-demand logical replication is usable + the current state.
 
@@ -113,7 +113,7 @@ class LogicalReplicationStatus:
     detail: str
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class EnableLogicalReplicationOnDemandResult:
     """Outcome of `enable_logical_replication_on_demand`.
 

--- a/src/mcpg/pg19_skip_scan.py
+++ b/src/mcpg/pg19_skip_scan.py
@@ -72,7 +72,7 @@ class Pg19SkipScanError(Exception):
 # ---------------------------------------------------------------------------
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class SkipScanStatus:
     """Reports whether PG 19's skip-scan optimisation is usable.
 
@@ -87,7 +87,7 @@ class SkipScanStatus:
     detail: str
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class SkipScanCandidate:
     """One composite B-tree index that PG 19's skip-scan unlocks.
 

--- a/src/mcpg/pg19_stats.py
+++ b/src/mcpg/pg19_stats.py
@@ -65,7 +65,7 @@ class Pg19StatsError(Exception):
 # ---------------------------------------------------------------------------
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class Pg19StatsStatus:
     """Reports whether the PG 19 lock + recovery views are usable.
 
@@ -86,7 +86,7 @@ class Pg19StatsStatus:
     detail: str
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class LockStatRow:
     """One row from ``pg_stat_lock``.
 
@@ -101,7 +101,7 @@ class LockStatRow:
     wait_time_us: int
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class RecoveryStatRow:
     """One row from ``pg_stat_recovery`` — typically a single-row view
     that summarises the standby's replay progress.
@@ -118,7 +118,7 @@ class RecoveryStatRow:
     startup_state: str | None
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class LockHotspot:
     """One advisor recommendation row.
 
@@ -139,7 +139,7 @@ class LockHotspot:
     suggested_followup: str
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class LockHotspotsResult:
     """Roll-up of :func:`analyze_lock_hotspots`."""
 

--- a/src/mcpg/pgq.py
+++ b/src/mcpg/pgq.py
@@ -89,7 +89,7 @@ class PgqError(Exception):
 # ---------------------------------------------------------------------------
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class PgqStatus:
     """Reports whether SQL/PGQ is usable on this server.
 
@@ -104,7 +104,7 @@ class PgqStatus:
     detail: str
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class PropertyGraphInfo:
     """A property graph defined in the database.
 
@@ -120,7 +120,7 @@ class PropertyGraphInfo:
     edge_tables: list[str]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class PgqRunResult:
     """The result of a ``SELECT ... FROM GRAPH_TABLE(...)`` query.
 
@@ -135,14 +135,14 @@ class PgqRunResult:
     truncated: bool
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class CreatePropertyGraphResult:
     schema: str
     name: str
     created: bool
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class DropPropertyGraphResult:
     schema: str
     name: str

--- a/src/mcpg/repack.py
+++ b/src/mcpg/repack.py
@@ -50,7 +50,7 @@ class RepackError(Exception):
     """Raised when a REPACK request is rejected or fails."""
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class RepackStatus:
     """Reports whether ``REPACK`` is usable on this server.
 
@@ -66,7 +66,7 @@ class RepackStatus:
     detail: str
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class RepackResult:
     """The outcome of a ``REPACK`` run.
 

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -4100,10 +4100,9 @@ def _register_pgq_reads(server: FastMCP[AppContext]) -> None:
             "get_pgq_status()",
         ),
     )
-    async def get_pgq_status(ctx: _Ctx) -> dict[str, Any]:
-        async def _run() -> dict[str, Any]:
-            status = await pgq.get_pgq_status(_driver(ctx))
-            return asdict(status)
+    async def get_pgq_status(ctx: _Ctx) -> pgq.PgqStatus:
+        async def _run() -> pgq.PgqStatus:
+            return await pgq.get_pgq_status(_driver(ctx))
 
         return await _cached_call(ctx, "get_pgq_status", _run)
 
@@ -4121,10 +4120,9 @@ def _register_pgq_reads(server: FastMCP[AppContext]) -> None:
             "list_property_graphs()",
         ),
     )
-    async def list_property_graphs(ctx: _Ctx) -> list[dict[str, Any]]:
-        async def _run() -> list[dict[str, Any]]:
-            graphs = await pgq.list_property_graphs(_driver(ctx))
-            return [asdict(g) for g in graphs]
+    async def list_property_graphs(ctx: _Ctx) -> list[pgq.PropertyGraphInfo]:
+        async def _run() -> list[pgq.PropertyGraphInfo]:
+            return await pgq.list_property_graphs(_driver(ctx))
 
         return await _cached_call(ctx, "list_property_graphs", _run)
 
@@ -4141,10 +4139,9 @@ def _register_pgq_reads(server: FastMCP[AppContext]) -> None:
             "describe_property_graph(schema='public', name='org_chart')",
         ),
     )
-    async def describe_property_graph(ctx: _Ctx, schema: str, name: str) -> dict[str, Any]:
-        async def _run() -> dict[str, Any]:
-            info = await pgq.describe_property_graph(_driver(ctx), schema, name)
-            return asdict(info)
+    async def describe_property_graph(ctx: _Ctx, schema: str, name: str) -> pgq.PropertyGraphInfo:
+        async def _run() -> pgq.PropertyGraphInfo:
+            return await pgq.describe_property_graph(_driver(ctx), schema, name)
 
         return await _cached_call(ctx, "describe_property_graph", _run, schema, name)
 
@@ -4167,9 +4164,8 @@ def _register_pgq_reads(server: FastMCP[AppContext]) -> None:
             ),
         ),
     )
-    async def run_pgq(ctx: _Ctx, query: str, max_rows: int = 200) -> dict[str, Any]:
-        result = await pgq.run_pgq(_driver(ctx), query, max_rows=max_rows)
-        return asdict(result)
+    async def run_pgq(ctx: _Ctx, query: str, max_rows: int = 200) -> pgq.PgqRunResult:
+        return await pgq.run_pgq(_driver(ctx), query, max_rows=max_rows)
 
 
 def _register_pgq_ddl(server: FastMCP[AppContext]) -> None:
@@ -4198,7 +4194,7 @@ def _register_pgq_ddl(server: FastMCP[AppContext]) -> None:
         schema: str,
         name: str,
         definition_body: str,
-    ) -> dict[str, Any]:
+    ) -> pgq.CreatePropertyGraphResult:
         result = await pgq.create_property_graph(
             _driver(ctx),
             schema=schema,
@@ -4206,7 +4202,7 @@ def _register_pgq_ddl(server: FastMCP[AppContext]) -> None:
             definition_body=definition_body,
         )
         await ctx.request_context.lifespan_context.cache.clear()
-        return asdict(result)
+        return result
 
     @server.tool(
         name="drop_property_graph",
@@ -4223,7 +4219,7 @@ def _register_pgq_ddl(server: FastMCP[AppContext]) -> None:
         schema: str,
         name: str,
         if_exists: bool = True,
-    ) -> dict[str, Any]:
+    ) -> pgq.DropPropertyGraphResult:
         result = await pgq.drop_property_graph(
             _driver(ctx),
             schema=schema,
@@ -4231,7 +4227,7 @@ def _register_pgq_ddl(server: FastMCP[AppContext]) -> None:
             if_exists=if_exists,
         )
         await ctx.request_context.lifespan_context.cache.clear()
-        return asdict(result)
+        return result
 
 
 def _register_pg_prewarm_reads(server: FastMCP[AppContext]) -> None:
@@ -4471,12 +4467,11 @@ def _register_pg19_runtime_reads(server: FastMCP[AppContext]) -> None:
             "get_data_checksums_status()",
         ),
     )
-    async def get_data_checksums_status(ctx: _Ctx) -> dict[str, Any]:
+    async def get_data_checksums_status(ctx: _Ctx) -> pg19_runtime.DataChecksumsStatus:
         # Live cluster setting — never cache (gemini-review pattern from
         # PR #141): an agent toggling checksums needs to see the
         # post-toggle state on the next probe.
-        status = await pg19_runtime.get_data_checksums_status(_driver(ctx))
-        return asdict(status)
+        return await pg19_runtime.get_data_checksums_status(_driver(ctx))
 
     @server.tool(
         name="get_logical_replication_status",
@@ -4493,10 +4488,11 @@ def _register_pg19_runtime_reads(server: FastMCP[AppContext]) -> None:
             "get_logical_replication_status()",
         ),
     )
-    async def get_logical_replication_status(ctx: _Ctx) -> dict[str, Any]:
+    async def get_logical_replication_status(
+        ctx: _Ctx,
+    ) -> pg19_runtime.LogicalReplicationStatus:
         # Live setting — never cache; status reflects post-toggle state.
-        status = await pg19_runtime.get_logical_replication_status(_driver(ctx))
-        return asdict(status)
+        return await pg19_runtime.get_logical_replication_status(_driver(ctx))
 
 
 def _register_pg19_runtime_writes(server: FastMCP[AppContext]) -> None:
@@ -4517,11 +4513,11 @@ def _register_pg19_runtime_writes(server: FastMCP[AppContext]) -> None:
             "enable_data_checksums()",
         ),
     )
-    async def enable_data_checksums(ctx: _Ctx) -> dict[str, Any]:
+    async def enable_data_checksums(ctx: _Ctx) -> pg19_runtime.ToggleDataChecksumsResult:
         database = ctx.request_context.lifespan_context.database
         result = await pg19_runtime.enable_data_checksums(database)
         await ctx.request_context.lifespan_context.cache.clear()
-        return asdict(result)
+        return result
 
     @server.tool(
         name="disable_data_checksums",
@@ -4535,11 +4531,11 @@ def _register_pg19_runtime_writes(server: FastMCP[AppContext]) -> None:
             "disable_data_checksums()",
         ),
     )
-    async def disable_data_checksums(ctx: _Ctx) -> dict[str, Any]:
+    async def disable_data_checksums(ctx: _Ctx) -> pg19_runtime.ToggleDataChecksumsResult:
         database = ctx.request_context.lifespan_context.database
         result = await pg19_runtime.disable_data_checksums(database)
         await ctx.request_context.lifespan_context.cache.clear()
-        return asdict(result)
+        return result
 
     @server.tool(
         name="enable_logical_replication_on_demand",
@@ -4555,11 +4551,13 @@ def _register_pg19_runtime_writes(server: FastMCP[AppContext]) -> None:
             "enable_logical_replication_on_demand()",
         ),
     )
-    async def enable_logical_replication_on_demand(ctx: _Ctx) -> dict[str, Any]:
+    async def enable_logical_replication_on_demand(
+        ctx: _Ctx,
+    ) -> pg19_runtime.EnableLogicalReplicationOnDemandResult:
         database = ctx.request_context.lifespan_context.database
         result = await pg19_runtime.enable_logical_replication_on_demand(database)
         await ctx.request_context.lifespan_context.cache.clear()
-        return asdict(result)
+        return result
 
 
 def _register_pg19_ddl_reads(server: FastMCP[AppContext]) -> None:
@@ -4691,11 +4689,10 @@ def _register_pg19_skip_scan_reads(server: FastMCP[AppContext]) -> None:
             "get_skip_scan_status()",
         ),
     )
-    async def get_skip_scan_status(ctx: _Ctx) -> dict[str, Any]:
+    async def get_skip_scan_status(ctx: _Ctx) -> pg19_skip_scan.SkipScanStatus:
         # Live version probe — never cache. A server upgrade mid-session
         # needs to flip availability on the next call.
-        status = await pg19_skip_scan.get_skip_scan_status(_driver(ctx))
-        return asdict(status)
+        return await pg19_skip_scan.get_skip_scan_status(_driver(ctx))
 
     @server.tool(
         name="recommend_skip_scan_indexes",
@@ -4718,11 +4715,12 @@ def _register_pg19_skip_scan_reads(server: FastMCP[AppContext]) -> None:
             "recommend_skip_scan_indexes()",
         ),
     )
-    async def recommend_skip_scan_indexes(ctx: _Ctx, max_leading_ndv: int = 1000) -> list[dict[str, Any]]:
+    async def recommend_skip_scan_indexes(
+        ctx: _Ctx, max_leading_ndv: int = 1000
+    ) -> list[pg19_skip_scan.SkipScanCandidate]:
         # Live catalog + stats walk — never cache. ANALYZE / index DDL
         # changes need to be visible on the next call.
-        candidates = await pg19_skip_scan.recommend_skip_scan_indexes(_driver(ctx), max_leading_ndv=max_leading_ndv)
-        return [asdict(c) for c in candidates]
+        return await pg19_skip_scan.recommend_skip_scan_indexes(_driver(ctx), max_leading_ndv=max_leading_ndv)
 
 
 def _register_pg19_partitions_reads(server: FastMCP[AppContext]) -> None:
@@ -4740,11 +4738,10 @@ def _register_pg19_partitions_reads(server: FastMCP[AppContext]) -> None:
             "get_pg19_partitions_status()",
         ),
     )
-    async def get_pg19_partitions_status(ctx: _Ctx) -> dict[str, Any]:
+    async def get_pg19_partitions_status(ctx: _Ctx) -> pg19_partitions.Pg19PartitionsStatus:
         # Cluster version probe — never cache: a server upgrade mid-session
         # needs to flip availability on the next call.
-        status = await pg19_partitions.get_pg19_partitions_status(_driver(ctx))
-        return asdict(status)
+        return await pg19_partitions.get_pg19_partitions_status(_driver(ctx))
 
 
 def _register_pg19_partitions_writes(server: FastMCP[AppContext]) -> None:
@@ -4773,7 +4770,7 @@ def _register_pg19_partitions_writes(server: FastMCP[AppContext]) -> None:
         parent_table: str,
         source_partitions: list[str],
         target_partition_name: str,
-    ) -> dict[str, Any]:
+    ) -> pg19_partitions.MergePartitionsResult:
         database = ctx.request_context.lifespan_context.database
         result = await pg19_partitions.merge_partitions(
             database,
@@ -4783,7 +4780,7 @@ def _register_pg19_partitions_writes(server: FastMCP[AppContext]) -> None:
             target_partition_name=target_partition_name,
         )
         await ctx.request_context.lifespan_context.cache.clear()
-        return asdict(result)
+        return result
 
     @server.tool(
         name="split_partition",
@@ -4812,7 +4809,7 @@ def _register_pg19_partitions_writes(server: FastMCP[AppContext]) -> None:
         parent_table: str,
         source_partition: str,
         new_partitions: list[dict[str, str]],
-    ) -> dict[str, Any]:
+    ) -> pg19_partitions.SplitPartitionResult:
         # Wire-format adapter: MCP passes list-of-dict; helper expects
         # a typed dataclass. Validate keys here so a missing field
         # surfaces a sane error message instead of an AttributeError.
@@ -4838,7 +4835,7 @@ def _register_pg19_partitions_writes(server: FastMCP[AppContext]) -> None:
             new_partitions=specs,
         )
         await ctx.request_context.lifespan_context.cache.clear()
-        return asdict(result)
+        return result
 
 
 def _register_wait_for_lsn_reads(server: FastMCP[AppContext]) -> None:
@@ -4855,12 +4852,11 @@ def _register_wait_for_lsn_reads(server: FastMCP[AppContext]) -> None:
             "get_wait_for_lsn_status()",
         ),
     )
-    async def get_wait_for_lsn_status(ctx: _Ctx) -> dict[str, Any]:
+    async def get_wait_for_lsn_status(ctx: _Ctx) -> wait_for_lsn.WaitForLsnStatus:
         # Live cluster state — never cache. is_in_recovery flips on
         # promotion / demotion and the agent needs to see the new
         # state on the next call.
-        status = await wait_for_lsn.get_wait_for_lsn_status(_driver(ctx))
-        return asdict(status)
+        return await wait_for_lsn.get_wait_for_lsn_status(_driver(ctx))
 
     @server.tool(
         name="get_current_wal_lsn",
@@ -4877,11 +4873,10 @@ def _register_wait_for_lsn_reads(server: FastMCP[AppContext]) -> None:
             "get_current_wal_lsn()",
         ),
     )
-    async def get_current_wal_lsn(ctx: _Ctx) -> dict[str, Any]:
+    async def get_current_wal_lsn(ctx: _Ctx) -> wait_for_lsn.CurrentWalLsnResult:
         # Snapshot — never cache; the LSN advances monotonically with
         # every WAL-emitting transaction.
-        result = await wait_for_lsn.get_current_wal_lsn(_driver(ctx))
-        return asdict(result)
+        return await wait_for_lsn.get_current_wal_lsn(_driver(ctx))
 
     @server.tool(
         name="recommend_read_your_writes",
@@ -4899,10 +4894,11 @@ def _register_wait_for_lsn_reads(server: FastMCP[AppContext]) -> None:
             "recommend_read_your_writes()",
         ),
     )
-    async def recommend_read_your_writes(ctx: _Ctx) -> dict[str, Any]:
+    async def recommend_read_your_writes(
+        ctx: _Ctx,
+    ) -> wait_for_lsn.ReadYourWritesRecommendation:
         # Live advisor — never cache. Lag and role change in real time.
-        result = await wait_for_lsn.recommend_read_your_writes(_driver(ctx))
-        return asdict(result)
+        return await wait_for_lsn.recommend_read_your_writes(_driver(ctx))
 
 
 def _register_wait_for_lsn_writes(server: FastMCP[AppContext]) -> None:
@@ -4923,9 +4919,8 @@ def _register_wait_for_lsn_writes(server: FastMCP[AppContext]) -> None:
             "wait_for_lsn(lsn='0/1234ABCD', timeout_ms=5000)",
         ),
     )
-    async def wait_for_lsn_tool(ctx: _Ctx, lsn: str, timeout_ms: int = 0) -> dict[str, Any]:
-        result = await wait_for_lsn.wait_for_lsn(_driver(ctx), lsn=lsn, timeout_ms=timeout_ms)
-        return asdict(result)
+    async def wait_for_lsn_tool(ctx: _Ctx, lsn: str, timeout_ms: int = 0) -> wait_for_lsn.WaitForLsnResult:
+        return await wait_for_lsn.wait_for_lsn(_driver(ctx), lsn=lsn, timeout_ms=timeout_ms)
 
 
 def _register_pg19_stats_reads(server: FastMCP[AppContext]) -> None:
@@ -4943,10 +4938,9 @@ def _register_pg19_stats_reads(server: FastMCP[AppContext]) -> None:
             "get_pg19_stats_status()",
         ),
     )
-    async def get_pg19_stats_status(ctx: _Ctx) -> dict[str, Any]:
-        async def _run() -> dict[str, Any]:
-            status = await pg19_stats.get_pg19_stats_status(_driver(ctx))
-            return asdict(status)
+    async def get_pg19_stats_status(ctx: _Ctx) -> pg19_stats.Pg19StatsStatus:
+        async def _run() -> pg19_stats.Pg19StatsStatus:
+            return await pg19_stats.get_pg19_stats_status(_driver(ctx))
 
         return await _cached_call(ctx, "get_pg19_stats_status", _run)
 
@@ -4963,12 +4957,11 @@ def _register_pg19_stats_reads(server: FastMCP[AppContext]) -> None:
             "read_pg_stat_lock()",
         ),
     )
-    async def read_pg_stat_lock(ctx: _Ctx) -> list[dict[str, Any]]:
+    async def read_pg_stat_lock(ctx: _Ctx) -> list[pg19_stats.LockStatRow]:
         # Live counters — never cache (matches find_blocking_chains /
         # read_pg_stat_io pattern). Caching would return stale waits
         # during real-time incident response (gemini review on PR #141).
-        rows = await pg19_stats.read_pg_stat_lock(_driver(ctx))
-        return [asdict(r) for r in rows]
+        return await pg19_stats.read_pg_stat_lock(_driver(ctx))
 
     @server.tool(
         name="read_pg_stat_recovery",
@@ -4984,11 +4977,10 @@ def _register_pg19_stats_reads(server: FastMCP[AppContext]) -> None:
             "read_pg_stat_recovery()",
         ),
     )
-    async def read_pg_stat_recovery(ctx: _Ctx) -> list[dict[str, Any]]:
+    async def read_pg_stat_recovery(ctx: _Ctx) -> list[pg19_stats.RecoveryStatRow]:
         # Live replay state — never cache. Stale lag readings during
         # standby triage are worse than useless (gemini review on PR #141).
-        rows = await pg19_stats.read_pg_stat_recovery(_driver(ctx))
-        return [asdict(r) for r in rows]
+        return await pg19_stats.read_pg_stat_recovery(_driver(ctx))
 
     @server.tool(
         name="analyze_lock_hotspots",
@@ -5006,12 +4998,11 @@ def _register_pg19_stats_reads(server: FastMCP[AppContext]) -> None:
             "analyze_lock_hotspots()",
         ),
     )
-    async def analyze_lock_hotspots(ctx: _Ctx) -> dict[str, Any]:
+    async def analyze_lock_hotspots(ctx: _Ctx) -> pg19_stats.LockHotspotsResult:
         # Live advisor over live counters — never cache. Incident-response
         # callers need the current snapshot, not what we saw 60s ago
         # (gemini review on PR #141).
-        result = await pg19_stats.analyze_lock_hotspots(_driver(ctx))
-        return asdict(result)
+        return await pg19_stats.analyze_lock_hotspots(_driver(ctx))
 
 
 def _register_aio_reads(server: FastMCP[AppContext]) -> None:
@@ -5030,10 +5021,9 @@ def _register_aio_reads(server: FastMCP[AppContext]) -> None:
             "get_aio_status()",
         ),
     )
-    async def get_aio_status(ctx: _Ctx) -> dict[str, Any]:
-        async def _run() -> dict[str, Any]:
-            status = await aio.get_aio_status(_driver(ctx))
-            return asdict(status)
+    async def get_aio_status(ctx: _Ctx) -> aio.AioStatus:
+        async def _run() -> aio.AioStatus:
+            return await aio.get_aio_status(_driver(ctx))
 
         return await _cached_call(ctx, "get_aio_status", _run)
 
@@ -5059,10 +5049,9 @@ def _register_aio_reads(server: FastMCP[AppContext]) -> None:
             "recommend_io_method()",
         ),
     )
-    async def recommend_io_method(ctx: _Ctx) -> dict[str, Any]:
-        async def _run() -> dict[str, Any]:
-            result = await aio.recommend_io_method(_driver(ctx))
-            return asdict(result)
+    async def recommend_io_method(ctx: _Ctx) -> aio.RecommendIoMethodResult:
+        async def _run() -> aio.RecommendIoMethodResult:
+            return await aio.recommend_io_method(_driver(ctx))
 
         return await _cached_call(ctx, "recommend_io_method", _run)
 
@@ -5083,10 +5072,9 @@ def _register_repack_reads(server: FastMCP[AppContext]) -> None:
             "get_repack_status()",
         ),
     )
-    async def get_repack_status(ctx: _Ctx) -> dict[str, Any]:
-        async def _run() -> dict[str, Any]:
-            status = await repack.get_repack_status(_driver(ctx))
-            return asdict(status)
+    async def get_repack_status(ctx: _Ctx) -> repack.RepackStatus:
+        async def _run() -> repack.RepackStatus:
+            return await repack.get_repack_status(_driver(ctx))
 
         return await _cached_call(ctx, "get_repack_status", _run)
 
@@ -5114,7 +5102,7 @@ def _register_repack_writes(server: FastMCP[AppContext]) -> None:
         schema: str,
         table: str,
         concurrently: bool = True,
-    ) -> dict[str, Any]:
+    ) -> repack.RepackResult:
         database = ctx.request_context.lifespan_context.database
         result = await repack.repack_table(
             database,
@@ -5123,7 +5111,7 @@ def _register_repack_writes(server: FastMCP[AppContext]) -> None:
             concurrently=concurrently,
         )
         await ctx.request_context.lifespan_context.cache.clear()
-        return asdict(result)
+        return result
 
 
 def _register_partman(server: FastMCP[AppContext]) -> None:

--- a/src/mcpg/wait_for_lsn.py
+++ b/src/mcpg/wait_for_lsn.py
@@ -70,7 +70,7 @@ class WaitForLsnError(Exception):
 # ---------------------------------------------------------------------------
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class WaitForLsnStatus:
     """Reports whether PG 19's WAIT FOR LSN is usable on this server.
 
@@ -88,7 +88,7 @@ class WaitForLsnStatus:
     detail: str
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class CurrentWalLsnResult:
     """One LSN snapshot — what the helper returned at call time.
 
@@ -102,7 +102,7 @@ class CurrentWalLsnResult:
     lsn: str
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class WaitForLsnResult:
     """Outcome of `wait_for_lsn`.
 
@@ -119,7 +119,7 @@ class WaitForLsnResult:
     wait_sql: str
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class ReadYourWritesRecommendation:
     """Advisor output for the RYW workflow.
 

--- a/tests/contract/test_tool_output_schemas.py
+++ b/tests/contract/test_tool_output_schemas.py
@@ -72,6 +72,105 @@ _TOOLS_WITH_STRUCTURED_OUTPUT: dict[str, frozenset[str]] = {
             "validate_sql",
         }
     ),
+    # PG 19 SQL/PGQ helpers (Phase 3 PR-13 sweep).
+    "get_pgq_status": frozenset({"available", "server_version_num", "server_version", "detail"}),
+    # List-returning handlers: FastMCP wraps `list[Dataclass]` returns into a
+    # `{"result": [...]}` envelope at the top level. The per-item dataclass
+    # fields live under `$defs` — the field-level snapshot test in
+    # `test_tool_return_shapes.py` pins those. We only assert the envelope key
+    # here so the schema-population gate still trips on a dict-typed regression.
+    "list_property_graphs": frozenset({"result"}),
+    "describe_property_graph": frozenset({"schema", "name", "vertex_tables", "edge_tables"}),
+    "run_pgq": frozenset({"columns", "rows", "row_count", "truncated"}),
+    "create_property_graph": frozenset({"schema", "name", "created"}),
+    "drop_property_graph": frozenset({"schema", "name", "dropped"}),
+    # PG 19 runtime toggles.
+    "get_data_checksums_status": frozenset({"available", "server_version_num", "server_version", "enabled", "detail"}),
+    "get_logical_replication_status": frozenset(
+        {
+            "available",
+            "server_version_num",
+            "server_version",
+            "wal_level",
+            "effective_wal_level",
+            "max_replication_slots",
+            "detail",
+        }
+    ),
+    "enable_data_checksums": frozenset({"was_enabled", "now_enabled", "changed", "toggle_sql"}),
+    "disable_data_checksums": frozenset({"was_enabled", "now_enabled", "changed", "toggle_sql"}),
+    "enable_logical_replication_on_demand": frozenset(
+        {"previous_wal_level", "new_wal_level", "requires_restart", "detail"}
+    ),
+    # PG 19 skip-scan.
+    "get_skip_scan_status": frozenset({"available", "server_version_num", "server_version", "detail"}),
+    "recommend_skip_scan_indexes": frozenset({"result"}),
+    # PG 19 partitions.
+    "get_pg19_partitions_status": frozenset({"available", "server_version_num", "server_version", "detail"}),
+    "merge_partitions": frozenset(
+        {
+            "parent_schema",
+            "parent_table",
+            "source_partitions",
+            "target_partition",
+            "merge_sql",
+        }
+    ),
+    "split_partition": frozenset(
+        {
+            "parent_schema",
+            "parent_table",
+            "source_partition",
+            "new_partitions",
+            "split_sql",
+        }
+    ),
+    # WAIT FOR LSN.
+    "get_wait_for_lsn_status": frozenset(
+        {"available", "server_version_num", "server_version", "is_in_recovery", "detail"}
+    ),
+    "get_current_wal_lsn": frozenset({"role", "lsn"}),
+    "recommend_read_your_writes": frozenset(
+        {
+            "recommend_use",
+            "reason",
+            "is_in_recovery",
+            "server_version_num",
+            "current_lag_bytes",
+            "detail",
+        }
+    ),
+    "wait_for_lsn": frozenset({"lsn", "timeout_ms", "timed_out", "wait_sql"}),
+    # PG 19 stats.
+    "get_pg19_stats_status": frozenset(
+        {
+            "available",
+            "server_version_num",
+            "server_version",
+            "has_pg_stat_lock",
+            "has_pg_stat_recovery",
+            "detail",
+        }
+    ),
+    "read_pg_stat_lock": frozenset({"result"}),
+    "read_pg_stat_recovery": frozenset({"result"}),
+    "analyze_lock_hotspots": frozenset({"available", "server_version_num", "detail", "hotspots"}),
+    # PG 19 async I/O.
+    "get_aio_status": frozenset(
+        {
+            "available",
+            "server_version_num",
+            "server_version",
+            "io_method",
+            "io_min_workers",
+            "io_max_workers",
+            "detail",
+        }
+    ),
+    "recommend_io_method": frozenset({"available", "server_version_num", "detail", "recommendations"}),
+    # PG 19 in-server REPACK.
+    "get_repack_status": frozenset({"available", "server_version_num", "server_version", "detail"}),
+    "repack_table": frozenset({"schema", "table", "concurrently", "repack_sql"}),
 }
 
 
@@ -162,7 +261,7 @@ def test_converted_tool_count_grows_monotonically() -> None:
     never decrement it without a deliberate "we're rolling back
     structured output for tool X" conversation in the PR.
     """
-    floor = 5
+    floor = 33
     actual = len(_TOOLS_WITH_STRUCTURED_OUTPUT)
     assert actual >= floor, (
         f"structured-output manifest dropped from at-least-{floor} tools "


### PR DESCRIPTION
## Summary

Continues the **outputSchema sweep** started in PR #150 (which converted the 5 PG 19 DDL helper tools). This PR converts every remaining PG 19 tool across 8 modules — **28 handlers** — so they expose a populated MCP `outputSchema` for LangChain / LangGraph clients to validate against.

Realises the **second batch of roadmap row 8.6**. Manifest floor bumped 5 → 33; ~190 legacy `dict[str, Any]` tools follow in further sweep PRs per the same checklist.

## Modules + tools converted

| Module | Tools |
|---|---|
| `pgq` (6) | `get_pgq_status`, `list_property_graphs`, `describe_property_graph`, `run_pgq`, `create_property_graph`, `drop_property_graph` |
| `pg19_runtime` (5) | `get_data_checksums_status`, `get_logical_replication_status`, `enable_data_checksums`, `disable_data_checksums`, `enable_logical_replication_on_demand` |
| `pg19_partitions` (3) | `get_pg19_partitions_status`, `merge_partitions`, `split_partition` |
| `pg19_stats` (4) | `get_pg19_stats_status`, `read_pg_stat_lock`, `read_pg_stat_recovery`, `analyze_lock_hotspots` |
| `pg19_skip_scan` (2) | `get_skip_scan_status`, `recommend_skip_scan_indexes` |
| `wait_for_lsn` (4) | `get_wait_for_lsn_status`, `get_current_wal_lsn`, `recommend_read_your_writes`, `wait_for_lsn` |
| `aio` (2) | `get_aio_status`, `recommend_io_method` |
| `repack` (2) | `get_repack_status`, `repack_table` |

## Mechanics (per the established sweep checklist)

1. **Stripped `slots=True`** from every dataclass returned to the wire — slot descriptors block Pydantic's schema generation.
2. **Re-annotated each `@server.tool` handler** with the helper's dataclass return type. Also touched the **7 nested `_run` helpers** used by the `_cached_call` pattern (`pgq` + `pg19_stats` + `aio` + `repack`) — inner and outer annotations now match.
3. **Removed `asdict(...)` calls** — FastMCP serialises the dataclass directly. Write tools preserve their `await cache.clear()` between the helper call and the bare `return result`.
4. **List-returning tools** (`list_property_graphs`, `recommend_skip_scan_indexes`, `read_pg_stat_lock`, `read_pg_stat_recovery`) now use `-> list[ModuleName.Item]`. FastMCP wraps these into a `{"result": [...]}` envelope at the top level — the manifest entries pin the envelope key, with the per-item field set staying pinned by the existing `test_tool_return_shapes.py` snapshot.

## Why this matters

Pairs with PR #157 (MCP resources `mcpg://…`) and PR #150 (PR-13 outputSchema first sweep) to give clients a complete **validate inputs + validate outputs + preload context** wire surface. Every PG 19 tool now satisfies the structured-output contract.

## Test plan

- [x] `uv run pytest -q --ignore=tests/integration` — **2,206 passed**
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] Contract tests: `test_tool_output_schemas.py` manifest at 33 entries, all asserting non-empty schemas + matching field sets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_