### PR TITLE
feat(ops): get_wal_archive_status — WAL archive health (roadmap 5.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **`get_wal_archive_status`** — WAL-archiving health probe
+  (`mcpg.wal_archive`, roadmap **5.2**). Reads `pg_stat_archiver`
+  + the archive-mode GUCs and returns a one-call verdict on whether
+  continuous archiving is healthy. The early-warning signal for a
+  failing `archive_command` / `archive_library` (full archive
+  volume, bad object-store credentials, network partition), which
+  otherwise silently accumulates WAL in `pg_wal/` until the volume
+  fills. `healthy` is false when archiving is on and the latest
+  attempt failed (`last_failed_time` newer than `last_archived_time`).
+  The `archive_command` string is never echoed (it can carry
+  credentials) — only a boolean `archive_command_set`. Read-only;
+  never raises. Typed return → emits an `outputSchema` (manifest
+  floor 192 → 193). Companion to `read_pg_wal_records` (2.3, WAL
+  *records*); this covers the WAL *archive*. Routed to the
+  `operations_and_health` bucket.
+
 ### Changed
 
 ### Fixed

--- a/docs/feature-shortlist.md
+++ b/docs/feature-shortlist.md
@@ -77,7 +77,7 @@ not covered there:
 | # | Item | Effort | Value | Notes |
 |---|---|---|---|---|
 | 5.1 ✅ | Scheduled logical backups via `pg_cron` + `dump_database` | S | Medium | Shipped as `schedule_logical_backup`: composes `cron.schedule` with `COPY TO PROGRAM 'pg_dump ...'`. Tight allowlist on `destination`/`pg_dump_path`/`database`. PostgreSQL-superuser-only at runtime. |
-| 5.2 | WAL archive inspection | M | Low | Niche; only useful where WAL archiving is configured. |
+| 5.2 | ✅ **Shipped.** **`get_wal_archive_status`** — WAL-archiving health from `pg_stat_archiver` + the archive-mode GUCs. The early-warning signal for a failing `archive_command` / `archive_library` (full volume, bad object-store credentials, network partition) that otherwise silently accumulates WAL in `pg_wal/` until the volume fills. Computes a `healthy` verdict (false when archiving is on and the latest attempt failed) + human-readable `detail`. The `archive_command` string is never echoed (credentials) — only a boolean `archive_command_set`. Read-only; never raises. Lives in `mcpg.wal_archive`; `operations_and_health` bucket; typed return → emits an `outputSchema`. | M | Low | Niche; only useful where WAL archiving is configured. |
 | 5.3 | Point-in-time recovery prep helpers | M | Low-Medium | Heavy lift for a narrow audience. |
 
 ## 6. Schema design / quality

--- a/src/mcpg/about.py
+++ b/src/mcpg/about.py
@@ -618,6 +618,8 @@ _TOOL_TO_BUCKET_OVERRIDES: dict[str, str] = {
     "test_rls_for_role": "advisors",
     # verify_connection_encryption is operations (TLS check).
     "verify_connection_encryption": "operations_and_health",
+    # get_wal_archive_status — WAL-archiving health probe.
+    "get_wal_archive_status": "operations_and_health",
     # verify_audit_chain stays in audit_trail (the name-pattern would route to ops).
     "verify_audit_chain": "audit_trail",
     # enable_extension is operations setup.

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -81,6 +81,7 @@ from mcpg import (
     vector_tuner_advanced,
     vector_tuning,
     wait_for_lsn,
+    wal_archive,
     walinspect,
     warehousepg,
     workload,
@@ -842,6 +843,30 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
         per_record: bool = False,
     ) -> walinspect.WalStatsReport:
         return await walinspect.read_pg_wal_stats(_driver(ctx), start_lsn, end_lsn, per_record)
+
+    @server.tool(
+        name="get_wal_archive_status",
+        description=_with_example(
+            "Report WAL-archiving health from `pg_stat_archiver` + the "
+            "archive-mode GUCs — the early-warning signal for a failing "
+            "`archive_command` / `archive_library` (full archive volume, "
+            "bad object-store credentials, network partition), which "
+            "otherwise silently accumulates WAL in `pg_wal/` until the "
+            "volume fills. Companion to `read_pg_wal_records` (which "
+            "inspects WAL *records*); this covers the WAL *archive*. "
+            "Read-only; never raises. The `archive_command` string is NOT "
+            "echoed (it can embed credentials) — only a boolean "
+            "`archive_command_set`. Returns an object with `available`, "
+            "`archiving_enabled`, `archive_mode`, `archive_command_set`, "
+            "`archived_count`, `last_archived_wal`, `last_archived_time`, "
+            "`failed_count`, `last_failed_wal`, `last_failed_time`, "
+            "`stats_reset`, `healthy` (bool — false when archiving is on "
+            "and the latest attempt failed), and `detail`.",
+            "get_wal_archive_status()",
+        ),
+    )
+    async def get_wal_archive_status(ctx: _Ctx) -> wal_archive.WalArchiveStatus:
+        return await wal_archive.get_wal_archive_status(_driver(ctx))
 
     @server.tool(
         name="get_compact_schema",

--- a/src/mcpg/wal_archive.py
+++ b/src/mcpg/wal_archive.py
@@ -1,0 +1,198 @@
+"""WAL archive inspection — `pg_stat_archiver` + archive configuration.
+
+Realises roadmap row **5.2**. Companion to `pg_walinspect` (roadmap
+2.3, which inspects WAL *records*): this surfaces the WAL *archive*
+status — whether continuous archiving is on, how many segments have
+been archived vs failed, and the last-archived / last-failed segment
+and timestamp.
+
+The single read tool `get_wal_archive_status` answers the operator
+question "is my WAL archiving healthy?" in one call, with a computed
+`healthy` verdict and a human-readable `detail` so an agent can branch
+without re-deriving the heuristic.
+
+Why this matters
+================
+
+WAL archiving is the backbone of point-in-time recovery and
+streaming-replica seeding. When `archive_command` / `archive_library`
+starts failing (full archive volume, bad credentials, network
+partition to the object store), Postgres retries the *same* segment
+forever and WAL accumulates in `pg_wal/` until the volume fills — a
+silent, slow-motion outage. The early signal lives in
+`pg_stat_archiver`: a rising `failed_count` and a `last_failed_time`
+more recent than `last_archived_time`. This tool makes that signal a
+one-call check.
+
+Read-only; never raises — a driver failure surfaces as
+`available=False` with the error in `detail`. The `archive_command`
+string is **not** echoed (it can embed credentials for the object
+store); only a boolean `archive_command_set` is reported.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mcpg._vendor.sql import SqlDriver
+
+
+@dataclass(frozen=True)
+class WalArchiveStatus:
+    """Roll-up of WAL-archiving health from `pg_stat_archiver` + GUCs.
+
+    ``available`` is ``False`` only when the status probe itself fails
+    (driver error). ``archiving_enabled`` reflects ``archive_mode``
+    (``on`` / ``always``); when it's off the counters are reported as-is
+    but ``healthy`` is ``True`` (nothing to fail).
+
+    ``archive_command_set`` is a boolean — the raw command/library
+    string is deliberately not surfaced (it can carry object-store
+    credentials). ``healthy`` is ``False`` when archiving is enabled and
+    the most recent archive attempt *failed* (``last_failed_time`` is
+    newer than ``last_archived_time``, or there are failures and nothing
+    has ever archived).
+    """
+
+    available: bool
+    archiving_enabled: bool
+    archive_mode: str
+    archive_command_set: bool
+    archived_count: int
+    last_archived_wal: str | None
+    last_archived_time: str | None
+    failed_count: int
+    last_failed_wal: str | None
+    last_failed_time: str | None
+    stats_reset: str | None
+    healthy: bool
+    detail: str
+
+
+def _assess(
+    *,
+    archiving_enabled: bool,
+    archived_count: int,
+    failed_count: int,
+    last_archived_time: str | None,
+    last_failed_time: str | None,
+) -> tuple[bool, str]:
+    """Return ``(healthy, detail)`` from the archiver counters.
+
+    Heuristic: archiving is unhealthy when it's enabled AND the latest
+    attempt failed. We compare ISO-8601 text timestamps — they sort
+    lexicographically in the same order as chronologically when both
+    carry the same offset (Postgres renders both from the same
+    ``timestamptz`` column, so the offsets match), which is good enough
+    for "which happened more recently".
+    """
+    if not archiving_enabled:
+        return True, "WAL archiving is disabled (archive_mode = off); nothing to monitor."
+    if failed_count == 0:
+        return True, f"WAL archiving healthy — {archived_count} segment(s) archived, no failures."
+    # There have been failures at some point. Unhealthy only if the most
+    # recent attempt was a failure.
+    latest_failed_more_recent = last_failed_time is not None and (
+        last_archived_time is None or last_failed_time > last_archived_time
+    )
+    if latest_failed_more_recent:
+        return False, (
+            f"WAL archiving is FAILING — {failed_count} failure(s); the most recent attempt failed. "
+            "Check the archive_command / archive_library target (full volume, credentials, "
+            "or network to the object store). WAL will accumulate in pg_wal/ until resolved."
+        )
+    return True, (
+        f"WAL archiving recovered — {failed_count} historical failure(s) but the latest "
+        f"attempt succeeded ({archived_count} segment(s) archived total)."
+    )
+
+
+async def get_wal_archive_status(driver: SqlDriver) -> WalArchiveStatus:
+    """Report WAL-archiving health from ``pg_stat_archiver`` + GUCs.
+
+    Single round trip. Read-only; never raises — a driver failure comes
+    back as ``available=False`` with the error in ``detail``.
+    """
+    try:
+        rows = await driver.execute_query(
+            "SELECT "
+            "  current_setting('archive_mode') AS archive_mode, "
+            "  NULLIF(current_setting('archive_command'), '') IS NOT NULL AS archive_command_set, "
+            "  s.archived_count, "
+            "  s.last_archived_wal, "
+            "  s.last_archived_time::text AS last_archived_time, "
+            "  s.failed_count, "
+            "  s.last_failed_wal, "
+            "  s.last_failed_time::text AS last_failed_time, "
+            "  s.stats_reset::text AS stats_reset "
+            "FROM pg_stat_archiver s",
+            force_readonly=True,
+        )
+    except Exception as exc:
+        return WalArchiveStatus(
+            available=False,
+            archiving_enabled=False,
+            archive_mode="unknown",
+            archive_command_set=False,
+            archived_count=0,
+            last_archived_wal=None,
+            last_archived_time=None,
+            failed_count=0,
+            last_failed_wal=None,
+            last_failed_time=None,
+            stats_reset=None,
+            healthy=False,
+            detail=f"Could not read pg_stat_archiver: {exc}",
+        )
+
+    if not rows:
+        return WalArchiveStatus(
+            available=False,
+            archiving_enabled=False,
+            archive_mode="unknown",
+            archive_command_set=False,
+            archived_count=0,
+            last_archived_wal=None,
+            last_archived_time=None,
+            failed_count=0,
+            last_failed_wal=None,
+            last_failed_time=None,
+            stats_reset=None,
+            healthy=False,
+            detail="pg_stat_archiver returned no rows.",
+        )
+
+    c = rows[0].cells
+    archive_mode = str(c.get("archive_mode") or "off")
+    archiving_enabled = archive_mode in {"on", "always"}
+    archived_count = int(c.get("archived_count") or 0)
+    failed_count = int(c.get("failed_count") or 0)
+    last_archived_time = c.get("last_archived_time")
+    last_failed_time = c.get("last_failed_time")
+
+    healthy, detail = _assess(
+        archiving_enabled=archiving_enabled,
+        archived_count=archived_count,
+        failed_count=failed_count,
+        last_archived_time=last_archived_time,
+        last_failed_time=last_failed_time,
+    )
+
+    return WalArchiveStatus(
+        available=True,
+        archiving_enabled=archiving_enabled,
+        archive_mode=archive_mode,
+        archive_command_set=bool(c.get("archive_command_set")),
+        archived_count=archived_count,
+        last_archived_wal=c.get("last_archived_wal"),
+        last_archived_time=last_archived_time,
+        failed_count=failed_count,
+        last_failed_wal=c.get("last_failed_wal"),
+        last_failed_time=last_failed_time,
+        stats_reset=c.get("stats_reset"),
+        healthy=healthy,
+        detail=detail,
+    )
+
+
+__all__ = ["WalArchiveStatus", "get_wal_archive_status"]

--- a/src/mcpg/wal_archive.py
+++ b/src/mcpg/wal_archive.py
@@ -74,17 +74,17 @@ def _assess(
     archiving_enabled: bool,
     archived_count: int,
     failed_count: int,
-    last_archived_time: str | None,
-    last_failed_time: str | None,
+    latest_failed_more_recent: bool,
 ) -> tuple[bool, str]:
     """Return ``(healthy, detail)`` from the archiver counters.
 
     Heuristic: archiving is unhealthy when it's enabled AND the latest
-    attempt failed. We compare ISO-8601 text timestamps — they sort
-    lexicographically in the same order as chronologically when both
-    carry the same offset (Postgres renders both from the same
-    ``timestamptz`` column, so the offsets match), which is good enough
-    for "which happened more recently".
+    attempt failed. The "is the most recent attempt a failure?" decision
+    is made by the caller — ideally in SQL via ``last_failed_time >
+    last_archived_time`` on the native ``timestamptz`` columns (which
+    compares chronologically regardless of the rendered offset), rather
+    than by lexicographically comparing ISO-8601 *text*, which is only
+    correct when both strings carry the same UTC offset.
     """
     if not archiving_enabled:
         return True, "WAL archiving is disabled (archive_mode = off); nothing to monitor."
@@ -92,9 +92,6 @@ def _assess(
         return True, f"WAL archiving healthy — {archived_count} segment(s) archived, no failures."
     # There have been failures at some point. Unhealthy only if the most
     # recent attempt was a failure.
-    latest_failed_more_recent = last_failed_time is not None and (
-        last_archived_time is None or last_failed_time > last_archived_time
-    )
     if latest_failed_more_recent:
         return False, (
             f"WAL archiving is FAILING — {failed_count} failure(s); the most recent attempt failed. "
@@ -124,6 +121,8 @@ async def get_wal_archive_status(driver: SqlDriver) -> WalArchiveStatus:
             "  s.failed_count, "
             "  s.last_failed_wal, "
             "  s.last_failed_time::text AS last_failed_time, "
+            "  COALESCE(s.last_failed_time > s.last_archived_time, s.last_failed_time IS NOT NULL) "
+            "    AS latest_failed_more_recent, "
             "  s.stats_reset::text AS stats_reset "
             "FROM pg_stat_archiver s",
             force_readonly=True,
@@ -170,12 +169,23 @@ async def get_wal_archive_status(driver: SqlDriver) -> WalArchiveStatus:
     last_archived_time = c.get("last_archived_time")
     last_failed_time = c.get("last_failed_time")
 
+    # Prefer the SQL-computed comparison (correct across timezone offsets,
+    # since it runs on the native ``timestamptz`` columns). Fall back to a
+    # text comparison only when the column is absent (e.g. older callers /
+    # test fakes that don't project it).
+    latest_failed_more_recent = c.get("latest_failed_more_recent")
+    if latest_failed_more_recent is None:
+        latest_failed_more_recent = last_failed_time is not None and (
+            last_archived_time is None or last_failed_time > last_archived_time
+        )
+    else:
+        latest_failed_more_recent = bool(latest_failed_more_recent)
+
     healthy, detail = _assess(
         archiving_enabled=archiving_enabled,
         archived_count=archived_count,
         failed_count=failed_count,
-        last_archived_time=last_archived_time,
-        last_failed_time=last_failed_time,
+        latest_failed_more_recent=latest_failed_more_recent,
     )
 
     return WalArchiveStatus(

--- a/tests/contract/test_tool_output_schemas.py
+++ b/tests/contract/test_tool_output_schemas.py
@@ -197,6 +197,24 @@ _TOOLS_WITH_STRUCTURED_OUTPUT: dict[str, frozenset[str]] = {
     "list_cron_jobs": frozenset({"result"}),
     "partman_run_maintenance": frozenset({"parent_table", "detail"}),
     "enable_extension": frozenset({"name", "enabled"}),
+    # WAL archive health (roadmap 5.2).
+    "get_wal_archive_status": frozenset(
+        {
+            "available",
+            "archiving_enabled",
+            "archive_mode",
+            "archive_command_set",
+            "archived_count",
+            "last_archived_wal",
+            "last_archived_time",
+            "failed_count",
+            "last_failed_wal",
+            "last_failed_time",
+            "stats_reset",
+            "healthy",
+            "detail",
+        }
+    ),
     # --- Batch 4: schema-introspection catalogue reads ---
     "list_schemas": frozenset({"result"}),
     "list_tables": frozenset({"result"}),
@@ -772,7 +790,7 @@ def test_converted_tool_count_grows_monotonically() -> None:
     never decrement it without a deliberate "we're rolling back
     structured output for tool X" conversation in the PR.
     """
-    floor = 192
+    floor = 193
     actual = len(_TOOLS_WITH_STRUCTURED_OUTPUT)
     assert actual >= floor, (
         f"structured-output manifest dropped from at-least-{floor} tools "

--- a/tests/contract/tool_return_shapes.snapshot.json
+++ b/tests/contract/tool_return_shapes.snapshot.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "schema_version": 1,
-    "tool_count": 243
+    "tool_count": 244
   },
   "tools": {
     "add_compression_policy": {
@@ -883,6 +883,9 @@
         "server_version_num"
       ],
       "kind": "scalar"
+    },
+    "get_wal_archive_status": {
+      "kind": "opaque"
     },
     "get_warehousepg_status": {
       "kind": "opaque"

--- a/tests/contract/tool_surface.snapshot.json
+++ b/tests/contract/tool_surface.snapshot.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "schema_version": 1,
-    "tool_count": 243
+    "tool_count": 244
   },
   "tools": [
     {
@@ -2704,6 +2704,15 @@
         "type": "object"
       },
       "name": "get_wait_for_lsn_status"
+    },
+    {
+      "description": "Report WAL-archiving health from `pg_stat_archiver` + the archive-mode GUCs — the early-warning signal for a failing `archive_command` / `archive_library` (full archive volume, bad object-store credentials, network partition), which otherwise silently accumulates WAL in `pg_wal/` until the volume fills. Companion to `read_pg_wal_records` (which inspects WAL *records*); this covers the WAL *archive*. Read-only; never raises. The `archive_command` string is NOT echoed (it can embed credentials) — only a boolean `archive_command_set`. Returns an object with `available`, `archiving_enabled`, `archive_mode`, `archive_command_set`, `archived_count`, `last_archived_wal`, `last_archived_time`, `failed_count`, `last_failed_wal`, `last_failed_time`, `stats_reset`, `healthy` (bool — false when archiving is on and the latest attempt failed), and `detail`.\n\nExample: `get_wal_archive_status()`",
+      "inputSchema": {
+        "properties": {},
+        "title": "get_wal_archive_statusArguments",
+        "type": "object"
+      },
+      "name": "get_wal_archive_status"
     },
     {
       "description": "Probe the connected server for the WarehousePG (Greenplum-derived MPP) signature. Reports `available=true` only when BOTH the version string mentions WarehousePG / Greenplum AND the `gp_segment_configuration` catalog view exists. Surfaces `coordinator_role`, `segment_count` (primary segments only), and `mirroring` (bool). On vanilla PostgreSQL clusters returns `available=false` with a clean diagnostic — the rest of the `mcpg.warehousepg.*` family advertise themselves inert via this probe. Read-only; never raises.\n\nExample: `get_warehousepg_status()`",

--- a/tests/unit/test_wal_archive.py
+++ b/tests/unit/test_wal_archive.py
@@ -1,0 +1,109 @@
+"""Tests for the WAL archive status reader (roadmap 5.2)."""
+
+from __future__ import annotations
+
+from _fakes import FakeDriver, FakeRoutingDriver
+
+from mcpg.wal_archive import WalArchiveStatus, get_wal_archive_status
+
+
+def _archiver_row(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "archive_mode": "on",
+        "archive_command_set": True,
+        "archived_count": 100,
+        "last_archived_wal": "000000010000000000000064",
+        "last_archived_time": "2026-06-27 08:00:00+00",
+        "failed_count": 0,
+        "last_failed_wal": None,
+        "last_failed_time": None,
+        "stats_reset": "2026-06-20 00:00:00+00",
+    }
+    base.update(overrides)
+    return base
+
+
+def _driver(row: dict[str, object]) -> FakeRoutingDriver:
+    return FakeRoutingDriver({"FROM pg_stat_archiver": [row]})
+
+
+async def test_healthy_when_archiving_on_no_failures() -> None:
+    result = await get_wal_archive_status(_driver(_archiver_row()))  # type: ignore[arg-type]
+    assert isinstance(result, WalArchiveStatus)
+    assert result.available is True
+    assert result.archiving_enabled is True
+    assert result.healthy is True
+    assert result.archived_count == 100
+    assert "healthy" in result.detail.lower()
+
+
+async def test_archive_command_never_echoed_only_boolean() -> None:
+    result = await get_wal_archive_status(_driver(_archiver_row()))  # type: ignore[arg-type]
+    assert result.archive_command_set is True
+    # No field carries the raw command string.
+    assert "archive_command" not in {f for f in vars(result) if "command" in f and f != "archive_command_set"}
+
+
+async def test_unhealthy_when_latest_attempt_failed() -> None:
+    # last_failed_time newer than last_archived_time → FAILING.
+    row = _archiver_row(
+        failed_count=3,
+        last_failed_wal="000000010000000000000065",
+        last_failed_time="2026-06-27 08:05:00+00",
+        last_archived_time="2026-06-27 08:00:00+00",
+    )
+    result = await get_wal_archive_status(_driver(row))  # type: ignore[arg-type]
+    assert result.healthy is False
+    assert "FAILING" in result.detail
+    assert result.failed_count == 3
+
+
+async def test_recovered_when_failures_historical_but_latest_succeeded() -> None:
+    # failures exist, but last_archived_time is newer than last_failed_time.
+    row = _archiver_row(
+        failed_count=2,
+        last_failed_wal="000000010000000000000050",
+        last_failed_time="2026-06-27 07:00:00+00",
+        last_archived_time="2026-06-27 08:00:00+00",
+    )
+    result = await get_wal_archive_status(_driver(row))  # type: ignore[arg-type]
+    assert result.healthy is True
+    assert "recovered" in result.detail.lower()
+
+
+async def test_disabled_archiving_is_healthy_nothing_to_monitor() -> None:
+    row = _archiver_row(archive_mode="off", archive_command_set=False, archived_count=0)
+    result = await get_wal_archive_status(_driver(row))  # type: ignore[arg-type]
+    assert result.archiving_enabled is False
+    assert result.healthy is True
+    assert "disabled" in result.detail.lower()
+
+
+async def test_archive_mode_always_counts_as_enabled() -> None:
+    result = await get_wal_archive_status(_driver(_archiver_row(archive_mode="always")))  # type: ignore[arg-type]
+    assert result.archiving_enabled is True
+
+
+async def test_failures_with_no_archives_ever_is_unhealthy() -> None:
+    row = _archiver_row(
+        archived_count=0,
+        last_archived_wal=None,
+        last_archived_time=None,
+        failed_count=5,
+        last_failed_wal="000000010000000000000001",
+        last_failed_time="2026-06-27 08:05:00+00",
+    )
+    result = await get_wal_archive_status(_driver(row))  # type: ignore[arg-type]
+    assert result.healthy is False
+
+
+async def test_driver_failure_surfaces_as_unavailable() -> None:
+    result = await get_wal_archive_status(FakeDriver(fail=True))  # type: ignore[arg-type]
+    assert result.available is False
+    assert "Could not read pg_stat_archiver" in result.detail
+
+
+async def test_empty_result_is_unavailable() -> None:
+    result = await get_wal_archive_status(FakeRoutingDriver({"FROM pg_stat_archiver": []}))  # type: ignore[arg-type]
+    assert result.available is False
+    assert "no rows" in result.detail


### PR DESCRIPTION
## Summary

Realises roadmap **5.2**. A new read-only tool `get_wal_archive_status` that surfaces WAL-archiving health from `pg_stat_archiver` + the archive-mode GUCs. Companion to `read_pg_wal_records` (2.3, which inspects WAL *records*); this covers the WAL *archive*.

## Why

When `archive_command` / `archive_library` starts failing (full archive volume, bad object-store credentials, network partition to the object store), Postgres retries the **same** segment forever and WAL accumulates in `pg_wal/` until the volume fills — a silent, slow-motion outage. The early signal lives in `pg_stat_archiver`: a rising `failed_count` and a `last_failed_time` more recent than `last_archived_time`. This tool makes that a one-call check with a computed `healthy` verdict + human-readable `detail`.

## Behaviour

- `healthy = false` when archiving is enabled AND the latest attempt failed (`last_failed_time` newer than `last_archived_time`, or failures with nothing ever archived).
- Disabled archiving (`archive_mode = off`) → `healthy = true` (nothing to monitor); `always` / `on` both count as enabled.
- Read-only; never raises — driver failure / empty result → `available = false` with the error in `detail`.

## Security

The `archive_command` string is **not** echoed (it can embed object-store credentials) — only a boolean `archive_command_set`.

## Test plan

- [x] `uv run pytest tests/unit/test_wal_archive.py` — 9/9 pass (healthy / failing / recovered / disabled / always-mode / no-archives-ever / driver-failure / empty / command-redaction)
- [x] Typed dataclass return → emits an `outputSchema`; added to the manifest (floor 192 → 193)
- [x] Surface + return-shape snapshots regenerated
- [x] Full suite: 2514 passed, 110 skipped
- [x] `ruff` + `mypy` clean

## Roadmap linkage

Advances roadmap row: 5.2


---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Add a new read-only WAL archiving health probe and wire it into the tools surface, capability routing, and structured-output manifest.

New Features:
- Introduce the get_wal_archive_status tool to report WAL archiving health from pg_stat_archiver and related configuration, returning a structured WalArchiveStatus payload.

Enhancements:
- Classify get_wal_archive_status in the operations_and_health capability bucket and expose it through the server tool registry.

Documentation:
- Document the new get_wal_archive_status WAL archiving health probe in the changelog and mark roadmap item 5.2 as shipped in the feature shortlist.

Tests:
- Add unit tests and contract snapshots to verify get_wal_archive_status behavior, output schema, and handling of error and edge conditions.