### PR TITLE
docs(changelog): fold roadmap 5.2/5.3 into the [0.6.4] release section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [0.6.4] - 2026-06-27
+
+### Added
+
 - **`check_pitr_readiness`** — point-in-time recovery readiness
   advisor (`mcpg.pitr`, roadmap **5.3**). Composes
   `get_wal_archive_status` (5.2) with the GUCs that gate PITR
@@ -29,21 +37,14 @@ adheres to [Semantic Versioning](https://semver.org/).
   volume, bad object-store credentials, network partition), which
   otherwise silently accumulates WAL in `pg_wal/` until the volume
   fills. `healthy` is false when archiving is on and the latest
-  attempt failed (`last_failed_time` newer than `last_archived_time`).
-  The `archive_command` string is never echoed (it can carry
+  attempt failed (the comparison is computed in SQL on the native
+  `timestamptz` columns, correct across timezone offsets). The
+  `archive_command` string is never echoed (it can carry
   credentials) — only a boolean `archive_command_set`. Read-only;
   never raises. Typed return → emits an `outputSchema` (manifest
   floor 192 → 193). Companion to `read_pg_wal_records` (2.3, WAL
   *records*); this covers the WAL *archive*. Routed to the
   `operations_and_health` bucket.
-
-### Changed
-
-### Fixed
-
-## [0.6.4] - 2026-06-27
-
-### Added
 
 - **Roadmap-row linkage tooling** (roadmap **14.6**). The PR template
   now prompts for `Advances roadmap row: N.M`, and a new


### PR DESCRIPTION
## Summary

`get_wal_archive_status` (5.2, #190) and `check_pitr_readiness` (5.3,
#191) merged **after** the 0.6.4 release-cut PR (#189), so the standard
add-tool checklist filed their changelog entries under `[Unreleased]`.
But the package version was never bumped past `0.6.4` — those two tools
ship *inside* 0.6.4. This moves their entries from `[Unreleased]` into
the `[0.6.4]` section so the `v0.6.4` tag documents everything the
release actually contains, and leaves `[Unreleased]` empty for the next
cycle.

Also refreshes the 5.2 bullet to note the `healthy` comparison is now
computed in SQL on the native `timestamptz` columns (correct across
timezone offsets) — the fix that landed in #190 after Gemini's review.

Docs-only; no code or test changes.

## Roadmap linkage

Advances roadmap row: N/A — release housekeeping for 5.2 / 5.3 (already shipped)

## Checklist

- [x] Tests added/updated first (TDD); suite passes locally (docs-only, no code change)
- [x] `ruff`, `ruff format`, and `mypy src/mcpg` pass (no source touched)
- [x] `CHANGELOG.md` updated
- [x] Roadmap row cited above (or `N/A`)
- [x] No hand-edits to `src/mcpg/_vendor/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Update the changelog to correctly attribute recently added tools to the 0.6.4 release and clarify their documented behavior.

Documentation:
- Move changelog entries for `get_wal_archive_status` and `check_pitr_readiness` from the Unreleased section into the 0.6.4 release section so the tag reflects the actual shipped contents.
- Refine the `get_wal_archive_status` description to note that the `healthy` status is computed in SQL on native timestamptz columns for timezone-correct comparisons.