### PR TITLE
feat(multidb): named read-only secondary databases + per-tool selector (roadmap 13.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Multi-database selector with read-only secondaries** (roadmap
+  **13.1**). One MCPg server can now serve multiple databases. The
+  primary (`MCPG_DATABASE_URL`) stays the default target of every tool;
+  additional named, **read-only** secondaries are configured via the new
+  `MCPG_SECONDARY_DATABASE_URLS` env var (comma- or newline-separated
+  `name=dsn` entries, e.g.
+  `analytics=postgresql://…,reporting=postgresql://…`). Every
+  read-capable tool gains an optional `database` argument that selects a
+  secondary by name; omitting it targets the primary, so the
+  primary-only path is unchanged when the var is unset.
+
+  Secondaries are **read-only, enforced at the PostgreSQL level**: every
+  query against a secondary runs inside a `BEGIN TRANSACTION READ ONLY`,
+  so even a stray write is rejected by Postgres rather than by
+  convention. Write / DDL / shell / listen / migrate tools always target
+  the primary. A secondary that fails to open at startup is marked
+  unavailable but does not abort startup (mirrors the read-replica
+  tolerance). Secondary DSNs get the same TLS enforcement as the primary;
+  names must be simple identifiers (`[a-z0-9_]+`), unique, and not the
+  reserved `primary`.
+
+  New **`list_databases`** READ tool (typed return → `outputSchema`,
+  routed to `operations_and_health`) reports every configured database
+  id (primary first), which is the primary, each `read_only` flag, and a
+  live `SELECT 1` reachability probe + `detail`. New `mcpg.multidb`
+  module owns the read-only driver and the discovery shapes. Closes
+  13.1.
+
 ### Changed
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -233,6 +233,12 @@ everything else has a safe default.
 |---|---|---|
 | `MCPG_REPLICA_URLS` | — | Comma-separated replica DSNs. `force_readonly` queries round-robin across healthy replicas; primary fallback on failure; 30 s degraded-replica retry window. |
 
+#### Multiple databases (read-only secondaries)
+
+| Variable | Default | Description |
+|---|---|---|
+| `MCPG_SECONDARY_DATABASE_URLS` | — | Comma- or newline-separated `name=dsn` entries naming additional **read-only** databases this one server can serve (e.g. `analytics=postgresql://…?sslmode=require,reporting=postgresql://…?sslmode=require`). Read-capable tools accept an optional `database` argument selecting a secondary by name; omit it for the primary. Secondaries are read-only — **PostgreSQL-enforced** (every query runs in a `READ ONLY` transaction), so writes / DDL / shell / migrate always target the primary. Names must be simple identifiers (`[a-z0-9_]+`), unique, and not `primary` (the reserved id of `MCPG_DATABASE_URL`). Same TLS rules as the primary DSN. Call `list_databases` to discover the configured ids and their reachability. |
+
 #### Pool / timeouts / TLS
 
 | Variable | Default | Description |

--- a/docs/feature-shortlist.md
+++ b/docs/feature-shortlist.md
@@ -178,7 +178,7 @@ documented return conditions.
 
 | # | Item | Effort | Value | Notes |
 |---|---|---|---|---|
-| 13.1 | One MCPg server, multiple `MCPG_DATABASE_URL`s — tool-level db selector | L | Medium | Today: one server = one DSN. Multi-DB means a per-tool param, a pool-per-DB, and rethinking gates. Big lift; no concrete demand yet. |
+| 13.1 | One MCPg server, multiple `MCPG_DATABASE_URL`s — tool-level db selector | L | Medium | ✅ Shipped. `MCPG_SECONDARY_DATABASE_URLS` adds named, **read-only** secondary databases; every read-capable tool takes an optional `database` arg, `list_databases` discovers them. Read-only is PostgreSQL-enforced (every secondary query runs in a `READ ONLY` transaction), which sidesteps per-DB write/DDL gating — writes / DDL / shell / migrate stay primary-only. |
 
 ## 14. Release engineering & hygiene
 
@@ -251,8 +251,10 @@ non-overlapping gaps worth filling.
 
 ## Currently deferred (no commitments)
 
-- **Multi-database support** (13.1 above) — very ambitious;
-  preferred shape today is one MCPg instance per database.
+- **Multi-database support beyond read-only secondaries** — 13.1 ships
+  named, read-only secondaries (`MCPG_SECONDARY_DATABASE_URLS`); writable
+  secondaries with per-DB write/DDL gating remain deferred (the
+  read-only boundary deliberately sidesteps that complexity for now).
 - **Backups & DR** beyond what `dump_database` /
   `restore_database` already cover — narrow audience.
 - **Alembic / Flyway / Liquibase script ingestion** (7.1) — large

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -182,6 +182,7 @@ the minimum set per common scenario.
 | **Slow-call logging** | `MCPG_SLOW_CALL_THRESHOLD_MS=500` (any tool slower than this logs a structured record); `MCPG_LOG_FORMAT=json` for structured logging |
 | **Multi-tenant SaaS** | `MCPG_DEFAULT_ROLE=tenant_a` + `MCPG_ALLOWED_ROLES=tenant_a,tenant_b,…` |
 | **Read-replica fan-out** | `MCPG_REPLICA_URLS=postgresql://…?sslmode=require,postgresql://…?sslmode=require` |
+| **Multiple databases (read-only secondaries)** | `MCPG_SECONDARY_DATABASE_URLS=analytics=postgresql://…?sslmode=require,reporting=postgresql://…?sslmode=require` — read-capable tools take an optional `database` arg; secondaries are read-only (PostgreSQL-enforced). Call `list_databases` to discover ids. |
 | **NL→SQL** — single provider | Set `ANTHROPIC_API_KEY` (or `OPENAI_API_KEY` / `GEMINI_API_KEY`). MCPg auto-picks the default. |
 | **NL→SQL** — multi-provider routing | Set all the vendor keys you want active; callers pass `provider="anthropic"\|"openai"\|"gemini"` per call. |
 | **Audit persistence** | `MCPG_AUDIT_PERSIST=true` |
@@ -190,8 +191,8 @@ the minimum set per common scenario.
 ### TLS enforcement (important)
 
 By default MCPg **refuses to start** if `MCPG_DATABASE_URL` (or any
-entry in `MCPG_REPLICA_URLS`) points at a **non-loopback host**
-without TLS enforcement. PostgreSQL's libpq accepts plaintext
+entry in `MCPG_REPLICA_URLS` / `MCPG_SECONDARY_DATABASE_URLS`) points
+at a **non-loopback host** without TLS enforcement. PostgreSQL's libpq accepts plaintext
 fallback under `sslmode=disable | allow | prefer` (and an unset
 `sslmode` defaults to `prefer`) — which means a misconfigured
 production DSN can leak credentials over the network without anyone
@@ -215,7 +216,8 @@ export MCPG_ALLOW_INSECURE_TLS=true
 
 The startup error message names exactly which DSN failed the check
 (including the replica index if it was one of your
-`MCPG_REPLICA_URLS` entries).
+`MCPG_REPLICA_URLS` entries, or the secondary name if it was an
+`MCPG_SECONDARY_DATABASE_URLS` entry).
 
 ### HTTP transport TLS / mTLS
 

--- a/src/mcpg/about.py
+++ b/src/mcpg/about.py
@@ -586,6 +586,9 @@ _TOOL_TO_BUCKET_OVERRIDES: dict[str, str] = {
     "describe_tool": "observability",
     # check_database_health is operations.
     "check_database_health": "operations_and_health",
+    # Multi-database selector (roadmap 13.1) — discovery of configured
+    # primary + read-only secondary databases.
+    "list_databases": "operations_and_health",
     # read_autovacuum_priority is operations — shortlists tables for ops attention.
     "read_autovacuum_priority": "operations_and_health",
     # get_warehousepg_status is a status probe — same bucket as the other

--- a/src/mcpg/config.py
+++ b/src/mcpg/config.py
@@ -23,6 +23,12 @@ from mcpg.secrets import SecretsError, build_secrets_provider
 # is rejected up front rather than allowed to inject.
 _ROLE_IDENTIFIER = re.compile(r"\A[A-Za-z_][A-Za-z0-9_]*\Z")
 
+# Secondary-database ids are inlined into tool descriptions and used as dict
+# keys; we pin them to a conservative, lowercase, simple-identifier shape so
+# they're unambiguous as a ``database`` argument value. ``primary`` is the
+# reserved implicit id of ``MCPG_DATABASE_URL``.
+_SECONDARY_DB_NAME = re.compile(r"\A[a-z0-9_]+\Z")
+
 _LOG_LEVELS = frozenset({"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"})
 _TRUE_VALUES = frozenset({"true", "1", "yes", "on"})
 _FALSE_VALUES = frozenset({"false", "0", "no", "off"})
@@ -129,6 +135,17 @@ class Settings:
     # failure the call falls back to the primary once and the
     # replica is degraded for 30s.
     replica_urls: tuple[str, ...] = ()
+    # Multi-database selector (roadmap 13.1). Additional named, READ-ONLY
+    # secondary databases this one server can serve. Configured via
+    # ``MCPG_SECONDARY_DATABASE_URLS`` as ``name=dsn`` entries (comma- or
+    # newline-separated). Each name is a simple identifier (``[a-z0-9_]+``),
+    # unique, and not the reserved ``primary`` id (which is the implicit id
+    # of ``MCPG_DATABASE_URL``). Stored as an ordered tuple of (name, dsn)
+    # pairs so ``Settings`` stays frozen/hashable. Read-capable tools accept
+    # an optional ``database`` param to target one of these; writes / DDL /
+    # shell / listen / migrate always target the primary. Read-only is
+    # Postgres-enforced (see :mod:`mcpg.multidb`).
+    secondary_database_urls: tuple[tuple[str, str], ...] = ()
     # NL→SQL helper.
     # ``nl2sql_provider`` is the DEFAULT provider used when the
     # ``translate_nl_to_sql`` tool is called without an explicit ``provider``
@@ -281,6 +298,8 @@ class Settings:
             f"default_role={self.default_role!r}, "
             f"allowed_roles={self.allowed_roles!r}, "
             f"replica_urls={tuple(obfuscate_password(u) for u in self.replica_urls)!r}, "
+            f"secondary_database_urls="
+            f"{tuple((n, obfuscate_password(d)) for n, d in self.secondary_database_urls)!r}, "
             f"nl2sql_provider={self.nl2sql_provider!r}, "
             f"nl2sql_api_keys={sorted(p for p, _ in self.nl2sql_api_keys)!r}, "
             f"nl2sql_model={self.nl2sql_model!r}, "
@@ -687,6 +706,40 @@ def load_settings(env: Mapping[str, str] | None = None) -> Settings:
             raise ConfigError("MCPG_REPLICA_URLS must not be blank when set")
         replica_urls = urls
 
+    # Multi-database selector (roadmap 13.1). Parse ``name=dsn`` entries,
+    # comma- or newline-separated. Names must be simple identifiers, unique,
+    # and not collide with the reserved ``primary`` id. DSNs get the same TLS
+    # enforcement as the primary further down (alongside the replica check).
+    secondary_database_urls: tuple[tuple[str, str], ...] = ()
+    if (raw := env.get("MCPG_SECONDARY_DATABASE_URLS")) is not None:
+        entries = [piece.strip() for piece in re.split(r"[,\n]", raw) if piece.strip()]
+        if not entries:
+            raise ConfigError("MCPG_SECONDARY_DATABASE_URLS must not be blank when set")
+        seen: set[str] = set()
+        pairs: list[tuple[str, str]] = []
+        for entry in entries:
+            name, sep, dsn = entry.partition("=")
+            name = name.strip()
+            dsn = dsn.strip()
+            if not sep:
+                raise ConfigError(f"MCPG_SECONDARY_DATABASE_URLS entry {entry!r} is not in name=dsn form")
+            if not name:
+                raise ConfigError(f"MCPG_SECONDARY_DATABASE_URLS entry {entry!r} has an empty name")
+            if not dsn:
+                raise ConfigError(f"MCPG_SECONDARY_DATABASE_URLS entry for {name!r} has an empty DSN")
+            if not _SECONDARY_DB_NAME.match(name):
+                raise ConfigError(
+                    f"MCPG_SECONDARY_DATABASE_URLS name {name!r} must match [a-z0-9_]+ "
+                    "(lowercase letters, digits, underscores)"
+                )
+            if name == "primary":
+                raise ConfigError("MCPG_SECONDARY_DATABASE_URLS name 'primary' is reserved for MCPG_DATABASE_URL")
+            if name in seen:
+                raise ConfigError(f"MCPG_SECONDARY_DATABASE_URLS has a duplicate name {name!r}")
+            seen.add(name)
+            pairs.append((name, dsn))
+        secondary_database_urls = tuple(pairs)
+
     nl2sql_provider: str | None = None
     if (raw := env.get("MCPG_NL2SQL_PROVIDER")) is not None:
         candidate = raw.strip().lower()
@@ -859,6 +912,8 @@ def load_settings(env: Mapping[str, str] | None = None) -> Settings:
         _require_tls_or_loopback("MCPG_DATABASE_URL", database_url)
         for idx, replica_dsn in enumerate(replica_urls):
             _require_tls_or_loopback(f"MCPG_REPLICA_URLS[{idx}]", replica_dsn)
+        for sec_name, sec_dsn in secondary_database_urls:
+            _require_tls_or_loopback(f"MCPG_SECONDARY_DATABASE_URLS[{sec_name}]", sec_dsn)
 
     statement_timeout_ms = 30000
     if (raw := env.get("MCPG_STATEMENT_TIMEOUT_MS")) is not None:
@@ -1081,6 +1136,7 @@ def load_settings(env: Mapping[str, str] | None = None) -> Settings:
         default_role=default_role,
         allowed_roles=allowed_roles,
         replica_urls=replica_urls,
+        secondary_database_urls=secondary_database_urls,
         nl2sql_provider=nl2sql_provider,
         nl2sql_api_keys=nl2sql_api_keys,
         nl2sql_model=nl2sql_model,

--- a/src/mcpg/database.py
+++ b/src/mcpg/database.py
@@ -7,13 +7,17 @@ typed errors, and async-context-manager support, so the server owns a single
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Sequence
 from types import TracebackType
 from typing import Any
 
 from mcpg._vendor.sql import DbConnPool, SqlDriver, obfuscate_password
 from mcpg.config import Settings
+from mcpg.multidb import PRIMARY_DATABASE_ID, make_read_only_driver
 from mcpg.replicas import ReplicaPool, RoutedSqlDriver, _make_driver_for_pool
+
+logger = logging.getLogger(__name__)
 
 
 class DatabaseError(Exception):
@@ -29,6 +33,7 @@ class Database:
         *,
         pool: DbConnPool | None = None,
         replica_pool: ReplicaPool | None = None,
+        secondary_pools: dict[str, DbConnPool] | None = None,
     ) -> None:
         self._settings = settings
         self._pool = (
@@ -53,6 +58,24 @@ class Database:
             )
         else:
             self._replica_pool = None
+        # Multi-database selector (roadmap 13.1). One read-only pool per
+        # configured secondary. Tests may inject pre-built pools via
+        # ``secondary_pools`` (keyed by name); otherwise we build one
+        # ``DbConnPool`` per ``MCPG_SECONDARY_DATABASE_URLS`` entry. A
+        # secondary that fails to connect at startup is marked unavailable
+        # (tracked in ``_secondary_available``) but does NOT abort startup.
+        if secondary_pools is not None:
+            self._secondary_pools: dict[str, DbConnPool] = dict(secondary_pools)
+        else:
+            self._secondary_pools = {
+                name: DbConnPool(
+                    dsn,
+                    min_size=settings.pool_min_size,
+                    max_size=settings.pool_max_size,
+                )
+                for name, dsn in settings.secondary_database_urls
+            }
+        self._secondary_available: dict[str, bool] = dict.fromkeys(self._secondary_pools, False)
         self._connected = False
 
     @property
@@ -77,12 +100,32 @@ class Database:
             # individually; they don't abort startup. See
             # ``ReplicaPool.connect``.
             await self._replica_pool.connect()
+        # Secondary databases (roadmap 13.1): a connect failure marks that
+        # secondary unavailable but does NOT abort startup — mirrors the
+        # replica-pool tolerance. ``list_databases`` surfaces the state.
+        for name, pool in self._secondary_pools.items():
+            try:
+                await pool.pool_connect()
+            except Exception as exc:
+                self._secondary_available[name] = False
+                logger.warning(
+                    "Secondary database %r failed to open: %s",
+                    name,
+                    obfuscate_password(str(exc)),
+                )
+            else:
+                self._secondary_available[name] = True
         self._connected = True
 
     async def close(self) -> None:
         """Close the connection pool. Safe to call when not connected."""
         if self._replica_pool is not None:
             await self._replica_pool.close()
+        for name, pool in self._secondary_pools.items():
+            try:
+                await pool.close()
+            except Exception as exc:
+                logger.warning("Error closing secondary database %r pool: %s", name, exc)
         await self._pool.close()
         self._connected = False
 
@@ -91,10 +134,21 @@ class Database:
         """The configured :class:`ReplicaPool`, or ``None`` when unset."""
         return self._replica_pool
 
-    def driver(self) -> SqlDriver:
-        """Return a SQL driver bound to the pool.
+    def driver(self, database_id: str | None = None) -> SqlDriver:
+        """Return a SQL driver bound to the selected database.
 
-        Composes three optional behaviours:
+        ``database_id`` selects which configured database to target:
+
+        * ``None`` or ``"primary"`` → the primary driver (UNCHANGED path —
+          composes tenancy + replica routing exactly as before).
+        * a configured secondary name → a **read-only** driver bound to that
+          secondary's pool. Read-only is PostgreSQL-enforced (every query
+          runs inside ``BEGIN TRANSACTION READ ONLY``; see
+          :class:`mcpg.multidb.ReadOnlySqlDriver`). No tenancy or replica
+          layering is applied to secondaries.
+        * an unknown name → :class:`DatabaseError` listing the valid ids.
+
+        The primary path composes three optional behaviours:
 
         * **Tenancy** — when ``settings.default_role`` or
           ``allowed_roles`` is set, the underlying driver is
@@ -113,6 +167,18 @@ class Database:
         """
         if not self._connected:
             raise DatabaseError("database is not connected; call connect() first")
+        # Secondary-database selector (roadmap 13.1). Any explicit, non-primary
+        # id routes to a read-only secondary driver; an unknown id is a hard
+        # error listing the valid ids so the agent can self-correct.
+        if database_id is not None and database_id != PRIMARY_DATABASE_ID:
+            pool = self._secondary_pools.get(database_id)
+            if pool is None:
+                raise DatabaseError(f"unknown database id {database_id!r}; valid ids: {', '.join(self.database_ids())}")
+            return make_read_only_driver(
+                pool,
+                statement_timeout_ms=self._settings.statement_timeout_ms,
+                lock_timeout_ms=self._settings.lock_timeout_ms,
+            )
         enable_tenancy = self._settings.default_role is not None or bool(self._settings.allowed_roles)
         primary = _make_driver_for_pool(
             self._pool,
@@ -141,6 +207,44 @@ class Database:
         )
         driver.settings = self._settings  # type: ignore[attr-defined]
         return driver
+
+    def database_ids(self) -> list[str]:
+        """Return every configured database id, primary first.
+
+        The primary's id is always :data:`mcpg.multidb.PRIMARY_DATABASE_ID`;
+        secondaries follow in ``MCPG_SECONDARY_DATABASE_URLS`` order.
+        """
+        return [PRIMARY_DATABASE_ID, *self._secondary_pools.keys()]
+
+    async def probe(self, database_id: str | None = None) -> tuple[bool, str | None]:
+        """Probe one database with ``SELECT 1``.
+
+        Returns ``(reachable, detail)`` — ``detail`` is an obfuscated error
+        string when the probe failed, else ``None``. An unknown id raises
+        :class:`DatabaseError` (same contract as :meth:`driver`).
+        """
+        try:
+            driver = self.driver(database_id)
+            await driver.execute_query("SELECT 1", force_readonly=True)
+        except DatabaseError:
+            raise
+        except Exception as exc:
+            return False, obfuscate_password(str(exc))
+        return True, None
+
+    async def describe_databases(self) -> list[tuple[str, bool, bool, bool, str | None]]:
+        """Describe every configured database for ``list_databases``.
+
+        Yields one ``(id, is_primary, read_only, reachable, detail)`` tuple
+        per database, primary first. ``reachable`` is a live ``SELECT 1``
+        probe; secondaries are always ``read_only=True``.
+        """
+        out: list[tuple[str, bool, bool, bool, str | None]] = []
+        for db_id in self.database_ids():
+            is_primary = db_id == PRIMARY_DATABASE_ID
+            reachable, detail = await self.probe(db_id)
+            out.append((db_id, is_primary, not is_primary, reachable, detail))
+        return out
 
     async def copy_from_stdin(self, sql: str, data: bytes) -> int:
         """Stream ``data`` into a ``COPY ... FROM STDIN`` statement.

--- a/src/mcpg/multidb.py
+++ b/src/mcpg/multidb.py
@@ -1,0 +1,139 @@
+"""Multi-database selector — named, read-only secondary databases (roadmap 13.1).
+
+One MCPg server can serve multiple databases. The primary
+(``MCPG_DATABASE_URL``) stays the default; additional named secondaries are
+configured via ``MCPG_SECONDARY_DATABASE_URLS`` and are **read-only, enforced
+at the PostgreSQL level**.
+
+Read-only enforcement
+---------------------
+
+:class:`ReadOnlySqlDriver` wraps a per-secondary pool and forces *every*
+query to execute inside a ``BEGIN TRANSACTION READ ONLY`` block (by always
+passing ``force_readonly=True`` down to the vendored driver, regardless of
+what the caller asked for). PostgreSQL then rejects any write or DDL with
+``ERROR: cannot execute … in a read-only transaction`` (SQLSTATE 25006). This
+makes the read-only boundary a server-side guarantee, not a convention — a
+stray ``INSERT`` routed at a secondary fails closed even if the calling tool
+forgot to mark itself read-only.
+
+This sidesteps per-database write/DDL/LISTEN gating entirely: the global
+write / DDL / shell / listen / migrate gates continue to apply only to the
+primary, and secondaries simply can't be written to.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from mcpg._vendor.sql import DbConnPool, SqlDriver
+
+# The implicit id of ``MCPG_DATABASE_URL``. Reserved (see config.py) so a
+# secondary can never shadow it.
+PRIMARY_DATABASE_ID = "primary"
+
+
+class ReadOnlySqlDriver(SqlDriver):
+    """SqlDriver that pins every query to a read-only transaction.
+
+    Used for secondary databases. Overrides :meth:`execute_query` so the
+    ``force_readonly`` flag is always ``True`` on the wire — the vendored
+    driver then opens a ``BEGIN TRANSACTION READ ONLY`` for every statement
+    and PostgreSQL rejects writes / DDL. Also applies the configured
+    statement / lock timeouts, mirroring the primary path.
+    """
+
+    def __init__(
+        self,
+        *args: Any,
+        statement_timeout_ms: int = 30000,
+        lock_timeout_ms: int = 5000,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._statement_timeout_ms = statement_timeout_ms
+        self._lock_timeout_ms = lock_timeout_ms
+
+    async def execute_query(
+        self,
+        query: Any,
+        params: list[Any] | None = None,
+        force_readonly: bool = False,
+    ) -> list[SqlDriver.RowResult] | None:
+        # Ignore the caller's flag — a secondary is read-only, full stop.
+        del force_readonly
+        return await super().execute_query(query, params, force_readonly=True)
+
+    async def _execute_with_connection(  # type: ignore[no-untyped-def]
+        self,
+        connection,
+        query,
+        params,
+        force_readonly,
+    ):
+        if not getattr(connection, "_timeouts_configured", False):
+            async with connection.cursor() as cursor:
+                await cursor.execute(
+                    f"SET statement_timeout = {self._statement_timeout_ms}; SET lock_timeout = {self._lock_timeout_ms}"
+                )
+            try:
+                connection._timeouts_configured = True
+            except AttributeError:
+                pass
+        return await super()._execute_with_connection(connection, query, params, force_readonly)
+
+
+# NOTE: these two return shapes intentionally avoid ``slots=True`` and field
+# defaults. FastMCP derives the tool ``outputSchema`` by running pydantic's
+# schema builder over the return annotation; a slotted dataclass with a
+# ``field(default_factory=...)`` trips pydantic's non-serializable-default
+# guard and silently drops the schema. The other nested-return shapes in the
+# codebase (``introspection.PartitionSet`` / ``PolicySet``) follow the same
+# all-required-fields, no-slots convention for exactly this reason.
+@dataclass(frozen=True)
+class DatabaseDescriptor:
+    """One configured database (primary or secondary) and its live health.
+
+    ``read_only`` is ``True`` for every secondary and ``False`` for the
+    primary. ``reachable`` is a per-call ``SELECT 1`` probe result;
+    ``detail`` carries an obfuscated error string when the probe failed.
+    """
+
+    id: str
+    is_primary: bool
+    read_only: bool
+    reachable: bool
+    detail: str | None
+
+
+@dataclass(frozen=True)
+class DatabaseList:
+    """Result of ``list_databases`` — every configured database id + health."""
+
+    primary_id: str
+    database_ids: list[str]
+    databases: list[DatabaseDescriptor]
+
+
+def make_read_only_driver(
+    pool: DbConnPool,
+    *,
+    statement_timeout_ms: int = 30000,
+    lock_timeout_ms: int = 5000,
+) -> ReadOnlySqlDriver:
+    """Build a read-only driver bound to a secondary's pool."""
+    return ReadOnlySqlDriver(
+        conn=pool,
+        statement_timeout_ms=statement_timeout_ms,
+        lock_timeout_ms=lock_timeout_ms,
+    )
+
+
+__all__ = [
+    "PRIMARY_DATABASE_ID",
+    "DatabaseDescriptor",
+    "DatabaseList",
+    "ReadOnlySqlDriver",
+    "make_read_only_driver",
+]

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -9,10 +9,11 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from dataclasses import asdict, dataclass
-from typing import Any, TypeVar, cast
+from typing import Annotated, Any, TypeVar, cast
 
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.session import ServerSession
+from pydantic import Field
 
 from mcpg import (
     __version__,
@@ -48,6 +49,7 @@ from mcpg import (
     migration_history,
     migration_ingestion,
     migrations,
+    multidb,
     naming,
     nl2sql,
     partman,
@@ -229,9 +231,25 @@ def _check_heavy_diagnostics(ctx: _Ctx, tool_name: str) -> None:
         )
 
 
-def _driver(ctx: _Ctx) -> SqlDriver:
-    """Return the SQL driver for the current request."""
-    return ctx.request_context.lifespan_context.database.driver()
+def _driver(ctx: _Ctx, database: str | None = None) -> SqlDriver:
+    """Return the SQL driver for the current request.
+
+    ``database`` selects which configured database to target: ``None`` /
+    ``"primary"`` → the primary (unchanged path); a configured secondary
+    name → a read-only driver bound to that secondary (roadmap 13.1).
+    """
+    return ctx.request_context.lifespan_context.database.driver(database)
+
+
+# Uniform, self-documenting type for the read-capable tools' optional
+# ``database`` selector parameter (roadmap 13.1). Every read tool threads a
+# ``database: _DatabaseArg = None`` argument to ``_driver`` so an agent can
+# target a configured read-only secondary; omitting it keeps the primary.
+_DATABASE_PARAM_DESC = (
+    "Optional: target a configured secondary (read-only) database by name; "
+    "omit for the primary. Call list_databases to see the configured ids."
+)
+_DatabaseArg = Annotated[str | None, Field(description=_DATABASE_PARAM_DESC)]
 
 
 def _register_server_info(server: FastMCP[AppContext]) -> None:
@@ -343,9 +361,11 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
             "list_schemas(include_system=false)",
         ),
     )
-    async def list_schemas(ctx: _Ctx, include_system: bool = False) -> list[introspection.SchemaInfo]:
+    async def list_schemas(
+        ctx: _Ctx, include_system: bool = False, database: _DatabaseArg = None
+    ) -> list[introspection.SchemaInfo]:
         async def _run() -> list[introspection.SchemaInfo]:
-            schemas = await introspection.list_schemas(_driver(ctx), include_system=include_system)
+            schemas = await introspection.list_schemas(_driver(ctx, database), include_system=include_system)
             return schemas
 
         return await _cached_call(ctx, "list_schemas", _run, include_system)
@@ -359,9 +379,9 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
             "list_tables(schema='public')",
         ),
     )
-    async def list_tables(ctx: _Ctx, schema: str) -> list[introspection.TableInfo]:
+    async def list_tables(ctx: _Ctx, schema: str, database: _DatabaseArg = None) -> list[introspection.TableInfo]:
         async def _run() -> list[introspection.TableInfo]:
-            tables = await introspection.list_tables(_driver(ctx), schema)
+            tables = await introspection.list_tables(_driver(ctx, database), schema)
             return tables
 
         return await _cached_call(ctx, "list_tables", _run, schema)
@@ -375,9 +395,11 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
             "describe_table(schema='public', table='users')",
         ),
     )
-    async def describe_table(ctx: _Ctx, schema: str, table: str) -> list[introspection.ColumnInfo]:
+    async def describe_table(
+        ctx: _Ctx, schema: str, table: str, database: _DatabaseArg = None
+    ) -> list[introspection.ColumnInfo]:
         async def _run() -> list[introspection.ColumnInfo]:
-            columns = await introspection.describe_table(_driver(ctx), schema, table)
+            columns = await introspection.describe_table(_driver(ctx, database), schema, table)
             return columns
 
         return await _cached_call(ctx, "describe_table", _run, schema, table)
@@ -392,9 +414,11 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
             "list_indexes(schema='public', table='users')",
         ),
     )
-    async def list_indexes(ctx: _Ctx, schema: str, table: str) -> list[introspection.IndexInfo]:
+    async def list_indexes(
+        ctx: _Ctx, schema: str, table: str, database: _DatabaseArg = None
+    ) -> list[introspection.IndexInfo]:
         async def _run() -> list[introspection.IndexInfo]:
-            indexes = await introspection.list_indexes(_driver(ctx), schema, table)
+            indexes = await introspection.list_indexes(_driver(ctx, database), schema, table)
             return indexes
 
         return await _cached_call(ctx, "list_indexes", _run, schema, table)
@@ -407,9 +431,11 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
             "list_constraints(schema='public', table='orders')",
         ),
     )
-    async def list_constraints(ctx: _Ctx, schema: str, table: str) -> list[introspection.ConstraintInfo]:
+    async def list_constraints(
+        ctx: _Ctx, schema: str, table: str, database: _DatabaseArg = None
+    ) -> list[introspection.ConstraintInfo]:
         async def _run() -> list[introspection.ConstraintInfo]:
-            constraints = await introspection.list_constraints(_driver(ctx), schema, table)
+            constraints = await introspection.list_constraints(_driver(ctx, database), schema, table)
             return constraints
 
         return await _cached_call(ctx, "list_constraints", _run, schema, table)
@@ -423,9 +449,11 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
             "list_foreign_keys(schema='public')",
         ),
     )
-    async def list_foreign_keys(ctx: _Ctx, schema: str) -> list[introspection.ForeignKeyInfo]:
+    async def list_foreign_keys(
+        ctx: _Ctx, schema: str, database: _DatabaseArg = None
+    ) -> list[introspection.ForeignKeyInfo]:
         async def _run() -> list[introspection.ForeignKeyInfo]:
-            fks = await introspection.list_foreign_keys(_driver(ctx), schema)
+            fks = await introspection.list_foreign_keys(_driver(ctx, database), schema)
             return fks
 
         return await _cached_call(ctx, "list_foreign_keys", _run, schema)
@@ -438,9 +466,9 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
             "(the SELECT SQL)."
         ),
     )
-    async def list_views(ctx: _Ctx, schema: str) -> list[introspection.ViewInfo]:
+    async def list_views(ctx: _Ctx, schema: str, database: _DatabaseArg = None) -> list[introspection.ViewInfo]:
         async def _run() -> list[introspection.ViewInfo]:
-            views = await introspection.list_views(_driver(ctx), schema)
+            views = await introspection.list_views(_driver(ctx, database), schema)
             return views
 
         return await _cached_call(ctx, "list_views", _run, schema)
@@ -454,9 +482,9 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
             "(plpgsql / sql / c / etc.)."
         ),
     )
-    async def list_functions(ctx: _Ctx, schema: str) -> list[introspection.FunctionInfo]:
+    async def list_functions(ctx: _Ctx, schema: str, database: _DatabaseArg = None) -> list[introspection.FunctionInfo]:
         async def _run() -> list[introspection.FunctionInfo]:
-            functions = await introspection.list_functions(_driver(ctx), schema)
+            functions = await introspection.list_functions(_driver(ctx, database), schema)
             return functions
 
         return await _cached_call(ctx, "list_functions", _run, schema)
@@ -469,9 +497,11 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
             "qualified name), and `definition` (the CREATE TRIGGER SQL)."
         ),
     )
-    async def list_triggers(ctx: _Ctx, schema: str, table: str) -> list[introspection.TriggerInfo]:
+    async def list_triggers(
+        ctx: _Ctx, schema: str, table: str, database: _DatabaseArg = None
+    ) -> list[introspection.TriggerInfo]:
         async def _run() -> list[introspection.TriggerInfo]:
-            triggers = await introspection.list_triggers(_driver(ctx), schema, table)
+            triggers = await introspection.list_triggers(_driver(ctx, database), schema, table)
             return triggers
 
         return await _cached_call(ctx, "list_triggers", _run, schema, table)
@@ -484,9 +514,11 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
             "or null), and `partitions` (a list of `{name, bounds}` for each partition)."
         ),
     )
-    async def list_partitions(ctx: _Ctx, schema: str, table: str) -> introspection.PartitionSet:
+    async def list_partitions(
+        ctx: _Ctx, schema: str, table: str, database: _DatabaseArg = None
+    ) -> introspection.PartitionSet:
         async def _run() -> introspection.PartitionSet:
-            partition_set = await introspection.list_partitions(_driver(ctx), schema, table)
+            partition_set = await introspection.list_partitions(_driver(ctx, database), schema, table)
             return partition_set
 
         return await _cached_call(ctx, "list_partitions", _run, schema, table)
@@ -500,9 +532,11 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
             "`can_login`, `replication`, `bypass_rls`, `connection_limit`, `member_of`."
         ),
     )
-    async def list_roles(ctx: _Ctx, include_system: bool = False) -> list[introspection.RoleInfo]:
+    async def list_roles(
+        ctx: _Ctx, include_system: bool = False, database: _DatabaseArg = None
+    ) -> list[introspection.RoleInfo]:
         async def _run() -> list[introspection.RoleInfo]:
-            roles = await introspection.list_roles(_driver(ctx), include_system=include_system)
+            roles = await introspection.list_roles(_driver(ctx, database), include_system=include_system)
             return roles
 
         return await _cached_call(ctx, "list_roles", _run, include_system)
@@ -516,9 +550,11 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
             "regrant), and `grantor`."
         ),
     )
-    async def list_grants(ctx: _Ctx, schema: str, table: str) -> list[introspection.GrantInfo]:
+    async def list_grants(
+        ctx: _Ctx, schema: str, table: str, database: _DatabaseArg = None
+    ) -> list[introspection.GrantInfo]:
         async def _run() -> list[introspection.GrantInfo]:
-            grants = await introspection.list_grants(_driver(ctx), schema, table)
+            grants = await introspection.list_grants(_driver(ctx, database), schema, table)
             return grants
 
         return await _cached_call(ctx, "list_grants", _run, schema, table)
@@ -532,9 +568,11 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
             "using_expression, check_expression}`."
         ),
     )
-    async def list_policies(ctx: _Ctx, schema: str, table: str) -> introspection.PolicySet:
+    async def list_policies(
+        ctx: _Ctx, schema: str, table: str, database: _DatabaseArg = None
+    ) -> introspection.PolicySet:
         async def _run() -> introspection.PolicySet:
-            policy_set = await introspection.list_policies(_driver(ctx), schema, table)
+            policy_set = await introspection.list_policies(_driver(ctx, database), schema, table)
             return policy_set
 
         return await _cached_call(ctx, "list_policies", _run, schema, table)
@@ -547,9 +585,9 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
             "`max_value`, `increment`, `cycle` (bool), `last_value`."
         ),
     )
-    async def list_sequences(ctx: _Ctx, schema: str) -> list[introspection.SequenceInfo]:
+    async def list_sequences(ctx: _Ctx, schema: str, database: _DatabaseArg = None) -> list[introspection.SequenceInfo]:
         async def _run() -> list[introspection.SequenceInfo]:
-            sequences = await introspection.list_sequences(_driver(ctx), schema)
+            sequences = await introspection.list_sequences(_driver(ctx, database), schema)
             return sequences
 
         return await _cached_call(ctx, "list_sequences", _run, schema)
@@ -562,9 +600,9 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
             "the order defined)."
         ),
     )
-    async def list_enums(ctx: _Ctx, schema: str) -> list[introspection.EnumInfo]:
+    async def list_enums(ctx: _Ctx, schema: str, database: _DatabaseArg = None) -> list[introspection.EnumInfo]:
         async def _run() -> list[introspection.EnumInfo]:
-            enums = await introspection.list_enums(_driver(ctx), schema)
+            enums = await introspection.list_enums(_driver(ctx, database), schema)
             return enums
 
         return await _cached_call(ctx, "list_enums", _run, schema)
@@ -577,9 +615,9 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
             "`constraints` (list of CHECK clauses)."
         ),
     )
-    async def list_domains(ctx: _Ctx, schema: str) -> list[introspection.DomainInfo]:
+    async def list_domains(ctx: _Ctx, schema: str, database: _DatabaseArg = None) -> list[introspection.DomainInfo]:
         async def _run() -> list[introspection.DomainInfo]:
-            domains = await introspection.list_domains(_driver(ctx), schema)
+            domains = await introspection.list_domains(_driver(ctx, database), schema)
             return domains
 
         return await _cached_call(ctx, "list_domains", _run, schema)
@@ -592,9 +630,11 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
             "`{name, data_type}` for each field)."
         ),
     )
-    async def list_composite_types(ctx: _Ctx, schema: str) -> list[introspection.CompositeTypeInfo]:
+    async def list_composite_types(
+        ctx: _Ctx, schema: str, database: _DatabaseArg = None
+    ) -> list[introspection.CompositeTypeInfo]:
         async def _run() -> list[introspection.CompositeTypeInfo]:
-            types = await introspection.list_composite_types(_driver(ctx), schema)
+            types = await introspection.list_composite_types(_driver(ctx, database), schema)
             return types
 
         return await _cached_call(ctx, "list_composite_types", _run, schema)
@@ -607,9 +647,11 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
             "`validator`, and `options` (dict of wrapper-specific options)."
         ),
     )
-    async def list_foreign_data_wrappers(ctx: _Ctx) -> list[introspection.ForeignDataWrapperInfo]:
+    async def list_foreign_data_wrappers(
+        ctx: _Ctx, database: _DatabaseArg = None
+    ) -> list[introspection.ForeignDataWrapperInfo]:
         async def _run() -> list[introspection.ForeignDataWrapperInfo]:
-            wrappers = await introspection.list_foreign_data_wrappers(_driver(ctx))
+            wrappers = await introspection.list_foreign_data_wrappers(_driver(ctx, database))
             return wrappers
 
         return await _cached_call(ctx, "list_foreign_data_wrappers", _run)
@@ -622,9 +664,9 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
             "`type`, `version`, and `options` (dict of server options)."
         ),
     )
-    async def list_foreign_servers(ctx: _Ctx) -> list[introspection.ForeignServerInfo]:
+    async def list_foreign_servers(ctx: _Ctx, database: _DatabaseArg = None) -> list[introspection.ForeignServerInfo]:
         async def _run() -> list[introspection.ForeignServerInfo]:
-            servers = await introspection.list_foreign_servers(_driver(ctx))
+            servers = await introspection.list_foreign_servers(_driver(ctx, database))
             return servers
 
         return await _cached_call(ctx, "list_foreign_servers", _run)
@@ -637,9 +679,11 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
             "and `options` (dict of per-table options)."
         ),
     )
-    async def list_foreign_tables(ctx: _Ctx, schema: str) -> list[introspection.ForeignTableInfo]:
+    async def list_foreign_tables(
+        ctx: _Ctx, schema: str, database: _DatabaseArg = None
+    ) -> list[introspection.ForeignTableInfo]:
         async def _run() -> list[introspection.ForeignTableInfo]:
-            tables = await introspection.list_foreign_tables(_driver(ctx), schema)
+            tables = await introspection.list_foreign_tables(_driver(ctx, database), schema)
             return tables
 
         return await _cached_call(ctx, "list_foreign_tables", _run, schema)
@@ -652,9 +696,9 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
             "(foreign-server name), and `options` (dict of mapping options, e.g. credentials)."
         ),
     )
-    async def list_user_mappings(ctx: _Ctx) -> list[introspection.UserMappingInfo]:
+    async def list_user_mappings(ctx: _Ctx, database: _DatabaseArg = None) -> list[introspection.UserMappingInfo]:
         async def _run() -> list[introspection.UserMappingInfo]:
-            mappings = await introspection.list_user_mappings(_driver(ctx))
+            mappings = await introspection.list_user_mappings(_driver(ctx, database))
             return mappings
 
         return await _cached_call(ctx, "list_user_mappings", _run)
@@ -668,9 +712,9 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
             "(bools), and `tables` (list of `schema.table` strings)."
         ),
     )
-    async def list_publications(ctx: _Ctx) -> list[introspection.PublicationInfo]:
+    async def list_publications(ctx: _Ctx, database: _DatabaseArg = None) -> list[introspection.PublicationInfo]:
         async def _run() -> list[introspection.PublicationInfo]:
-            publications = await introspection.list_publications(_driver(ctx))
+            publications = await introspection.list_publications(_driver(ctx, database))
             return publications
 
         return await _cached_call(ctx, "list_publications", _run)
@@ -679,9 +723,9 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
         name="list_subscriptions",
         description="List logical-replication subscriptions; requires superuser to see any rows.",
     )
-    async def list_subscriptions(ctx: _Ctx) -> list[introspection.SubscriptionInfo]:
+    async def list_subscriptions(ctx: _Ctx, database: _DatabaseArg = None) -> list[introspection.SubscriptionInfo]:
         async def _run() -> list[introspection.SubscriptionInfo]:
-            subscriptions = await introspection.list_subscriptions(_driver(ctx))
+            subscriptions = await introspection.list_subscriptions(_driver(ctx, database))
             return subscriptions
 
         return await _cached_call(ctx, "list_subscriptions", _run)
@@ -692,9 +736,9 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
             "List the extensions installed in the database. Returns a list of objects with `name` and `version`."
         ),
     )
-    async def list_extensions(ctx: _Ctx) -> list[introspection.ExtensionInfo]:
+    async def list_extensions(ctx: _Ctx, database: _DatabaseArg = None) -> list[introspection.ExtensionInfo]:
         async def _run() -> list[introspection.ExtensionInfo]:
-            extensions = await introspection.list_extensions(_driver(ctx))
+            extensions = await introspection.list_extensions(_driver(ctx, database))
             return extensions
 
         return await _cached_call(ctx, "list_extensions", _run)
@@ -707,9 +751,11 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
             "(null when not installed), and `installed` (bool)."
         ),
     )
-    async def list_available_extensions(ctx: _Ctx) -> list[introspection.AvailableExtension]:
+    async def list_available_extensions(
+        ctx: _Ctx, database: _DatabaseArg = None
+    ) -> list[introspection.AvailableExtension]:
         async def _run() -> list[introspection.AvailableExtension]:
-            extensions = await introspection.list_available_extensions(_driver(ctx))
+            extensions = await introspection.list_available_extensions(_driver(ctx, database))
             return extensions
 
         return await _cached_call(ctx, "list_available_extensions", _run)
@@ -726,9 +772,11 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
             "`expression`, `kind` ('stored' today; reserved for 'virtual')."
         ),
     )
-    async def list_generated_columns(ctx: _Ctx, schema: str) -> list[introspection.GeneratedColumnInfo]:
+    async def list_generated_columns(
+        ctx: _Ctx, schema: str, database: _DatabaseArg = None
+    ) -> list[introspection.GeneratedColumnInfo]:
         async def _run() -> list[introspection.GeneratedColumnInfo]:
-            cols = await introspection.list_generated_columns(_driver(ctx), schema)
+            cols = await introspection.list_generated_columns(_driver(ctx, database), schema)
             return cols
 
         return await _cached_call(ctx, "list_generated_columns", _run, schema)
@@ -744,8 +792,10 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
             "owning backend, and the first 200 chars of its query. Read-only."
         ),
     )
-    async def list_locks(ctx: _Ctx, limit: int = locks.DEFAULT_LOCK_LIMIT) -> list[locks.LockInfo]:
-        return await locks.list_locks(_driver(ctx), limit=limit)
+    async def list_locks(
+        ctx: _Ctx, limit: int = locks.DEFAULT_LOCK_LIMIT, database: _DatabaseArg = None
+    ) -> list[locks.LockInfo]:
+        return await locks.list_locks(_driver(ctx, database), limit=limit)
 
     @server.tool(
         name="find_blocking_chains",
@@ -756,8 +806,10 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
             "possible (A blocks B, B blocks A); render with care. Read-only."
         ),
     )
-    async def find_blocking_chains(ctx: _Ctx, limit: int = locks.DEFAULT_BLOCKING_LIMIT) -> list[locks.BlockingPair]:
-        return await locks.find_blocking_chains(_driver(ctx), limit=limit)
+    async def find_blocking_chains(
+        ctx: _Ctx, limit: int = locks.DEFAULT_BLOCKING_LIMIT, database: _DatabaseArg = None
+    ) -> list[locks.BlockingPair]:
+        return await locks.find_blocking_chains(_driver(ctx, database), limit=limit)
 
     @server.tool(
         name="walk_blocking_chains",
@@ -770,8 +822,10 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
             "with per-backend lock detail), and `mermaid` (the pre-rendered flowchart string)."
         ),
     )
-    async def walk_blocking_chains(ctx: _Ctx, limit: int = locks.DEFAULT_BLOCKING_LIMIT) -> locks.BlockingGraphReport:
-        return await locks.walk_blocking_chains(_driver(ctx), limit=limit)
+    async def walk_blocking_chains(
+        ctx: _Ctx, limit: int = locks.DEFAULT_BLOCKING_LIMIT, database: _DatabaseArg = None
+    ) -> locks.BlockingGraphReport:
+        return await locks.walk_blocking_chains(_driver(ctx, database), limit=limit)
 
     @server.tool(
         name="read_pg_stat_io",
@@ -784,8 +838,8 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
             "returns available=false and an empty list."
         ),
     )
-    async def read_pg_stat_io(ctx: _Ctx) -> io_stats.IOStatsReport:
-        return await io_stats.read_pg_stat_io(_driver(ctx))
+    async def read_pg_stat_io(ctx: _Ctx, database: _DatabaseArg = None) -> io_stats.IOStatsReport:
+        return await io_stats.read_pg_stat_io(_driver(ctx, database))
 
     @server.tool(
         name="read_pg_buffercache_summary",
@@ -795,8 +849,10 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
             "Requires the pg_buffercache extension. If not installed, returns available=false."
         ),
     )
-    async def read_pg_buffercache_summary(ctx: _Ctx) -> io_stats.BufferCacheSummaryReport:
-        return await io_stats.read_pg_buffercache_summary(_driver(ctx))
+    async def read_pg_buffercache_summary(
+        ctx: _Ctx, database: _DatabaseArg = None
+    ) -> io_stats.BufferCacheSummaryReport:
+        return await io_stats.read_pg_buffercache_summary(_driver(ctx, database))
 
     @server.tool(
         name="read_pg_buffercache_relations",
@@ -811,8 +867,9 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
         ctx: _Ctx,
         schema: str | None = None,
         limit: int = 100,
+        database: _DatabaseArg = None,
     ) -> io_stats.BufferCacheRelationsReport:
-        return await io_stats.read_pg_buffercache_relations(_driver(ctx), schema=schema, limit=limit)
+        return await io_stats.read_pg_buffercache_relations(_driver(ctx, database), schema=schema, limit=limit)
 
     @server.tool(
         name="read_pg_wal_records",
@@ -826,8 +883,9 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
         start_lsn: str,
         end_lsn: str | None = None,
         limit: int = 100,
+        database: _DatabaseArg = None,
     ) -> walinspect.WalRecordsReport:
-        return await walinspect.read_pg_wal_records(_driver(ctx), start_lsn, end_lsn, limit)
+        return await walinspect.read_pg_wal_records(_driver(ctx, database), start_lsn, end_lsn, limit)
 
     @server.tool(
         name="read_pg_wal_stats",
@@ -842,8 +900,9 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
         start_lsn: str,
         end_lsn: str | None = None,
         per_record: bool = False,
+        database: _DatabaseArg = None,
     ) -> walinspect.WalStatsReport:
-        return await walinspect.read_pg_wal_stats(_driver(ctx), start_lsn, end_lsn, per_record)
+        return await walinspect.read_pg_wal_stats(_driver(ctx, database), start_lsn, end_lsn, per_record)
 
     @server.tool(
         name="get_wal_archive_status",
@@ -866,8 +925,8 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
             "get_wal_archive_status()",
         ),
     )
-    async def get_wal_archive_status(ctx: _Ctx) -> wal_archive.WalArchiveStatus:
-        return await wal_archive.get_wal_archive_status(_driver(ctx))
+    async def get_wal_archive_status(ctx: _Ctx, database: _DatabaseArg = None) -> wal_archive.WalArchiveStatus:
+        return await wal_archive.get_wal_archive_status(_driver(ctx, database))
 
     @server.tool(
         name="check_pitr_readiness",
@@ -889,8 +948,8 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
             "check_pitr_readiness()",
         ),
     )
-    async def check_pitr_readiness(ctx: _Ctx) -> pitr.PitrReadinessReport:
-        return await pitr.check_pitr_readiness(_driver(ctx))
+    async def check_pitr_readiness(ctx: _Ctx, database: _DatabaseArg = None) -> pitr.PitrReadinessReport:
+        return await pitr.check_pitr_readiness(_driver(ctx, database))
 
     @server.tool(
         name="get_compact_schema",
@@ -899,9 +958,9 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
             "tables, columns, primary keys, nullability, and relations to save context window tokens."
         ),
     )
-    async def get_compact_schema(ctx: _Ctx, schema: str) -> str:
+    async def get_compact_schema(ctx: _Ctx, schema: str, database: _DatabaseArg = None) -> str:
         async def _run() -> str:
-            return await introspection.get_compact_schema(_driver(ctx), schema)
+            return await introspection.get_compact_schema(_driver(ctx, database), schema)
 
         return await _cached_call(ctx, "get_compact_schema", _run, schema)
 
@@ -918,8 +977,10 @@ def _register_introspection(server: FastMCP[AppContext]) -> None:
             "`{version_num}`; flyway has `{installed_rank, version, description, type, ...}`)."
         ),
     )
-    async def read_migration_history(ctx: _Ctx, schema: str | None = None) -> migration_history.MigrationHistoryReport:
-        return await migration_history.read_migration_history(_driver(ctx), schema=schema)
+    async def read_migration_history(
+        ctx: _Ctx, schema: str | None = None, database: _DatabaseArg = None
+    ) -> migration_history.MigrationHistoryReport:
+        return await migration_history.read_migration_history(_driver(ctx, database), schema=schema)
 
 
 def _register_diagrams(server: FastMCP[AppContext]) -> None:
@@ -933,11 +994,15 @@ def _register_diagrams(server: FastMCP[AppContext]) -> None:
             "generate_schema_diagram(schema='public', include_partitions=false)",
         ),
     )
-    async def generate_schema_diagram(ctx: _Ctx, schema: str, include_partitions: bool = False) -> str:
+    async def generate_schema_diagram(
+        ctx: _Ctx, schema: str, include_partitions: bool = False, database: _DatabaseArg = None
+    ) -> str:
         _check_heavy_diagnostics(ctx, "generate_schema_diagram")
 
         async def _run() -> str:
-            return await diagrams.generate_schema_diagram(_driver(ctx), schema, include_partitions=include_partitions)
+            return await diagrams.generate_schema_diagram(
+                _driver(ctx, database), schema, include_partitions=include_partitions
+            )
 
         return await _cached_call(ctx, "generate_schema_diagram", _run, schema, include_partitions)
 
@@ -956,11 +1021,13 @@ def _register_diagrams(server: FastMCP[AppContext]) -> None:
             "Returns the Mermaid `graph LR` diagram as a string."
         ),
     )
-    async def generate_fk_cascade_graph(ctx: _Ctx, schema: str, include_all: bool = False) -> str:
+    async def generate_fk_cascade_graph(
+        ctx: _Ctx, schema: str, include_all: bool = False, database: _DatabaseArg = None
+    ) -> str:
         _check_heavy_diagnostics(ctx, "generate_fk_cascade_graph")
 
         async def _run() -> str:
-            return await diagrams.generate_fk_cascade_graph(_driver(ctx), schema, include_all=include_all)
+            return await diagrams.generate_fk_cascade_graph(_driver(ctx, database), schema, include_all=include_all)
 
         return await _cached_call(ctx, "generate_fk_cascade_graph", _run, schema, include_all)
 
@@ -975,11 +1042,15 @@ def _register_diagrams(server: FastMCP[AppContext]) -> None:
             "generate_schema_docs(schema='public', include_samples=true)",
         ),
     )
-    async def generate_schema_docs(ctx: _Ctx, schema: str, include_samples: bool = False) -> str:
+    async def generate_schema_docs(
+        ctx: _Ctx, schema: str, include_samples: bool = False, database: _DatabaseArg = None
+    ) -> str:
         _check_heavy_diagnostics(ctx, "generate_schema_docs")
 
         async def _run() -> str:
-            return await schema_docs.generate_schema_docs(_driver(ctx), schema, include_samples=include_samples)
+            return await schema_docs.generate_schema_docs(
+                _driver(ctx, database), schema, include_samples=include_samples
+            )
 
         return await _cached_call(ctx, "generate_schema_docs", _run, schema, include_samples)
 
@@ -995,8 +1066,10 @@ def _register_schema_diff(server: FastMCP[AppContext]) -> None:
             "compare_schemas(left_schema='public', right_schema='staging')",
         ),
     )
-    async def compare_schemas(ctx: _Ctx, left_schema: str, right_schema: str) -> schema_diff.SchemaDiff:
-        diff = await schema_diff.compare_schemas(_driver(ctx), left_schema, right_schema)
+    async def compare_schemas(
+        ctx: _Ctx, left_schema: str, right_schema: str, database: _DatabaseArg = None
+    ) -> schema_diff.SchemaDiff:
+        diff = await schema_diff.compare_schemas(_driver(ctx, database), left_schema, right_schema)
         return diff
 
 
@@ -1031,9 +1104,10 @@ def _register_rag_efficiency(server: FastMCP[AppContext]) -> None:
         sample_size: int = 30,
         candidate_multipliers: list[int] | None = None,
         metric: str = "cosine",
+        database: _DatabaseArg = None,
     ) -> rag_efficiency.VectorEfficiencyReport:
         report = await rag_efficiency.analyze_vector_search_efficiency(
-            _driver(ctx),
+            _driver(ctx, database),
             schema,
             table,
             column,
@@ -1067,9 +1141,10 @@ def _register_rag_analytics(server: FastMCP[AppContext]) -> None:
         days: int = 7,
         model: str | None = None,
         retrieval_index: str | None = None,
+        database: _DatabaseArg = None,
     ) -> rag_efficiency.RerankerLiftReport:
         report = await rag_efficiency.analyze_reranker_lift(
-            _driver(ctx), days=days, model=model, retrieval_index=retrieval_index
+            _driver(ctx, database), days=days, model=model, retrieval_index=retrieval_index
         )
         return report
 
@@ -1091,9 +1166,10 @@ def _register_rag_analytics(server: FastMCP[AppContext]) -> None:
         k: int = 10,
         model: str | None = None,
         retrieval_index: str | None = None,
+        database: _DatabaseArg = None,
     ) -> rag_efficiency.TopKStabilityReport:
         report = await rag_efficiency.analyze_topk_stability(
-            _driver(ctx), days=days, k=k, model=model, retrieval_index=retrieval_index
+            _driver(ctx, database), days=days, k=k, model=model, retrieval_index=retrieval_index
         )
         return report
 
@@ -1116,9 +1192,10 @@ def _register_rag_analytics(server: FastMCP[AppContext]) -> None:
         model: str | None = None,
         retrieval_index: str | None = None,
         n_buckets: int = 20,
+        database: _DatabaseArg = None,
     ) -> rag_efficiency.RerankScoreDistributionReport:
         report = await rag_efficiency.analyze_rerank_score_distribution(
-            _driver(ctx),
+            _driver(ctx, database),
             days=days,
             model=model,
             retrieval_index=retrieval_index,
@@ -1145,9 +1222,10 @@ def _register_rag_analytics(server: FastMCP[AppContext]) -> None:
         k: int = 10,
         model: str | None = None,
         retrieval_index: str | None = None,
+        database: _DatabaseArg = None,
     ) -> rag_efficiency.NDCGReport:
         report = await rag_efficiency.analyze_rerank_ndcg(
-            _driver(ctx), days=days, k=k, model=model, retrieval_index=retrieval_index
+            _driver(ctx, database), days=days, k=k, model=model, retrieval_index=retrieval_index
         )
         return report
 
@@ -1167,9 +1245,10 @@ def _register_rag_analytics(server: FastMCP[AppContext]) -> None:
         ctx: _Ctx,
         days: int = 7,
         retrieval_index: str | None = None,
+        database: _DatabaseArg = None,
     ) -> rag_efficiency.RerankRecommendation:
         report = await rag_efficiency.recommend_rerank_strategy(
-            _driver(ctx), days=days, retrieval_index=retrieval_index
+            _driver(ctx, database), days=days, retrieval_index=retrieval_index
         )
         return report
 
@@ -1191,9 +1270,10 @@ def _register_vector_tuning(server: FastMCP[AppContext]) -> None:
         column: str,
         index_type: str = "hnsw",
         metric: str = "l2",
+        database: _DatabaseArg = None,
     ) -> vector_tuning.TuningRecommendation:
         result = await vector_tuning.tune_vector_index(
-            _driver(ctx), schema, table, column, index_type=index_type, metric=metric
+            _driver(ctx, database), schema, table, column, index_type=index_type, metric=metric
         )
         return result
 
@@ -1215,9 +1295,10 @@ def _register_vector_tuning(server: FastMCP[AppContext]) -> None:
         k: int = 10,
         sample_size: int = 20,
         metric: str = "l2",
+        database: _DatabaseArg = None,
     ) -> vector_tuning.RecallReport:
         report = await vector_tuning.vector_recall_at_k(
-            _driver(ctx),
+            _driver(ctx, database),
             schema,
             table,
             column,
@@ -1255,8 +1336,9 @@ def _register_vector_tuning(server: FastMCP[AppContext]) -> None:
         schema: str,
         table: str,
         column: str,
+        database: _DatabaseArg = None,
     ) -> vector_tuning.HalfvecMigrationPlan:
-        plan = await vector_tuning.migrate_vector_to_halfvec(_driver(ctx), schema, table, column)
+        plan = await vector_tuning.migrate_vector_to_halfvec(_driver(ctx, database), schema, table, column)
         return plan
 
     @server.tool(
@@ -1277,9 +1359,10 @@ def _register_vector_tuning(server: FastMCP[AppContext]) -> None:
         query_vector: list[float] | str,
         k: int = 10,
         metric: str = "l2",
+        database: _DatabaseArg = None,
     ) -> list[dict[str, Any]]:
         return await vector_tuner_advanced.analyze_hnsw_recall(
-            _driver(ctx),
+            _driver(ctx, database),
             schema,
             table,
             column,
@@ -1320,9 +1403,10 @@ def _register_vector_tuning(server: FastMCP[AppContext]) -> None:
         target_recall: float = 0.95,
         sample_queries: int = 10,
         metric: str = "l2",
+        database: _DatabaseArg = None,
     ) -> vector_tuner_advanced.HnswRecallRecommendation:
         result = await vector_tuner_advanced.recommend_hnsw_ef_search(
-            _driver(ctx),
+            _driver(ctx, database),
             schema,
             table,
             column,
@@ -1355,9 +1439,10 @@ def _register_vector_tuning(server: FastMCP[AppContext]) -> None:
         table: str,
         column: str,
         sample_size: int = vector_ops.DEFAULT_SAMPLE_SIZE,
+        database: _DatabaseArg = None,
     ) -> vector_ops.DistanceMetricRecommendation:
         result = await vector_ops.analyze_distance_metric(
-            _driver(ctx),
+            _driver(ctx, database),
             schema,
             table,
             column,
@@ -1395,9 +1480,10 @@ def _register_vector_tuning(server: FastMCP[AppContext]) -> None:
         target_embedding_column: str,
         k: int = vector_ops.DEFAULT_K,
         metric: str = "l2",
+        database: _DatabaseArg = None,
     ) -> vector_ops.CrossTableSimilarityResult:
         result = await vector_ops.cross_table_similarity(
-            _driver(ctx),
+            _driver(ctx, database),
             source_schema=source_schema,
             source_table=source_table,
             source_embedding_column=source_embedding_column,
@@ -1441,9 +1527,10 @@ def _register_vector_tuning(server: FastMCP[AppContext]) -> None:
         max_iterations: int = vector_ops.DEFAULT_MAX_ITERATIONS,
         metric: str = "l2",
         seed: int = 42,
+        database: _DatabaseArg = None,
     ) -> vector_ops.ClusterVectorsResult:
         result = await vector_ops.cluster_vectors(
-            _driver(ctx),
+            _driver(ctx, database),
             schema,
             table,
             embedding_column,
@@ -1492,9 +1579,10 @@ def _register_vector_tuning(server: FastMCP[AppContext]) -> None:
         metric: str = "l2",
         seed: int = 42,
         max_results: int = vector_ops.DEFAULT_OUTLIER_MAX_RESULTS,
+        database: _DatabaseArg = None,
     ) -> vector_ops.VectorOutlierResult:
         result = await vector_ops.detect_vector_outliers(
-            _driver(ctx),
+            _driver(ctx, database),
             schema,
             table,
             embedding_column,
@@ -1547,9 +1635,10 @@ def _register_vector_tuning(server: FastMCP[AppContext]) -> None:
         current_end: str,
         sample_size: int = vector_ops.DEFAULT_DRIFT_SAMPLE_SIZE,
         drift_threshold: float = vector_ops.DEFAULT_DRIFT_THRESHOLD,
+        database: _DatabaseArg = None,
     ) -> vector_ops.EmbeddingDriftReport:
         report = await vector_ops.monitor_embedding_drift(
-            _driver(ctx),
+            _driver(ctx, database),
             schema,
             table,
             embedding_column,
@@ -1576,8 +1665,8 @@ def _register_prisma(server: FastMCP[AppContext]) -> None:
             "Returns the rendered `schema.prisma` source as a single string."
         ),
     )
-    async def generate_prisma_schema(ctx: _Ctx, schema: str) -> str:
-        return await prisma.generate_prisma_schema(_driver(ctx), schema)
+    async def generate_prisma_schema(ctx: _Ctx, schema: str, database: _DatabaseArg = None) -> str:
+        return await prisma.generate_prisma_schema(_driver(ctx, database), schema)
 
     @server.tool(
         name="generate_drizzle_schema",
@@ -1591,8 +1680,8 @@ def _register_prisma(server: FastMCP[AppContext]) -> None:
             "Returns the rendered TypeScript `schema.ts` source as a single string."
         ),
     )
-    async def generate_drizzle_schema(ctx: _Ctx, schema: str) -> str:
-        return await drizzle.generate_drizzle_schema(_driver(ctx), schema)
+    async def generate_drizzle_schema(ctx: _Ctx, schema: str, database: _DatabaseArg = None) -> str:
+        return await drizzle.generate_drizzle_schema(_driver(ctx, database), schema)
 
     @server.tool(
         name="generate_diesel_schema",
@@ -1607,8 +1696,8 @@ def _register_prisma(server: FastMCP[AppContext]) -> None:
             "documented v1 gap."
         ),
     )
-    async def generate_diesel_schema(ctx: _Ctx, schema: str) -> str:
-        return await diesel.generate_diesel_schema(_driver(ctx), schema)
+    async def generate_diesel_schema(ctx: _Ctx, schema: str, database: _DatabaseArg = None) -> str:
+        return await diesel.generate_diesel_schema(_driver(ctx, database), schema)
 
     @server.tool(
         name="generate_jooq_config",
@@ -1629,9 +1718,10 @@ def _register_prisma(server: FastMCP[AppContext]) -> None:
         schema: str,
         target_package: str = "com.example.jooq",
         target_directory: str = "src/main/java",
+        database: _DatabaseArg = None,
     ) -> str:
         return await jooq.generate_jooq_config(
-            _driver(ctx),
+            _driver(ctx, database),
             schema,
             target_package=target_package,
             target_directory=target_directory,
@@ -1648,8 +1738,8 @@ def _register_prisma(server: FastMCP[AppContext]) -> None:
             "object {filename: source} so the agent can write each file."
         ),
     )
-    async def generate_ent_schemas(ctx: _Ctx, schema: str) -> dict[str, str]:
-        return await ent.generate_ent_schemas(_driver(ctx), schema)
+    async def generate_ent_schemas(ctx: _Ctx, schema: str, database: _DatabaseArg = None) -> dict[str, str]:
+        return await ent.generate_ent_schemas(_driver(ctx, database), schema)
 
     @server.tool(
         name="generate_ecto_schemas",
@@ -1663,8 +1753,10 @@ def _register_prisma(server: FastMCP[AppContext]) -> None:
             "object {filename: source} so the agent can write each file."
         ),
     )
-    async def generate_ecto_schemas(ctx: _Ctx, schema: str, app_module: str = "MyApp") -> dict[str, str]:
-        return await ecto.generate_ecto_schemas(_driver(ctx), schema, app_module=app_module)
+    async def generate_ecto_schemas(
+        ctx: _Ctx, schema: str, app_module: str = "MyApp", database: _DatabaseArg = None
+    ) -> dict[str, str]:
+        return await ecto.generate_ecto_schemas(_driver(ctx, database), schema, app_module=app_module)
 
     @server.tool(
         name="generate_sqlalchemy_models",
@@ -1679,8 +1771,8 @@ def _register_prisma(server: FastMCP[AppContext]) -> None:
             "Returns the rendered Python `models.py` source as a single string."
         ),
     )
-    async def generate_sqlalchemy_models(ctx: _Ctx, schema: str) -> str:
-        return await sqlalchemy_export.generate_sqlalchemy_models(_driver(ctx), schema)
+    async def generate_sqlalchemy_models(ctx: _Ctx, schema: str, database: _DatabaseArg = None) -> str:
+        return await sqlalchemy_export.generate_sqlalchemy_models(_driver(ctx, database), schema)
 
     @server.tool(
         name="generate_sqlc_schema",
@@ -1695,8 +1787,8 @@ def _register_prisma(server: FastMCP[AppContext]) -> None:
             "Returns the rendered `schema.sql` text as a single string."
         ),
     )
-    async def generate_sqlc_schema(ctx: _Ctx, schema: str) -> str:
-        return await sqlc.generate_sqlc_schema(_driver(ctx), schema)
+    async def generate_sqlc_schema(ctx: _Ctx, schema: str, database: _DatabaseArg = None) -> str:
+        return await sqlc.generate_sqlc_schema(_driver(ctx, database), schema)
 
 
 def _register_advisors(server: FastMCP[AppContext]) -> None:
@@ -1709,11 +1801,11 @@ def _register_advisors(server: FastMCP[AppContext]) -> None:
             "zone. Advisory only — no writes."
         ),
     )
-    async def run_advisors(ctx: _Ctx, schema: str) -> advisors.AdvisorReport:
+    async def run_advisors(ctx: _Ctx, schema: str, database: _DatabaseArg = None) -> advisors.AdvisorReport:
         _check_heavy_diagnostics(ctx, "run_advisors")
 
         async def _run() -> advisors.AdvisorReport:
-            report = await advisors.run_advisors(_driver(ctx), schema)
+            report = await advisors.run_advisors(_driver(ctx, database), schema)
             return report
 
         return await _cached_call(ctx, "run_advisors", _run, schema)
@@ -1732,11 +1824,13 @@ def _register_advisors(server: FastMCP[AppContext]) -> None:
             "and `indexes` (list of candidate indexes with size and definition)."
         ),
     )
-    async def find_unused_objects(ctx: _Ctx, schema: str) -> advisors.UnusedObjectsReport:
+    async def find_unused_objects(
+        ctx: _Ctx, schema: str, database: _DatabaseArg = None
+    ) -> advisors.UnusedObjectsReport:
         _check_heavy_diagnostics(ctx, "find_unused_objects")
 
         async def _run() -> advisors.UnusedObjectsReport:
-            report = await advisors.find_unused_objects(_driver(ctx), schema)
+            report = await advisors.find_unused_objects(_driver(ctx, database), schema)
             return report
 
         return await _cached_call(ctx, "find_unused_objects", _run, schema)
@@ -1757,11 +1851,13 @@ def _register_advisors(server: FastMCP[AppContext]) -> None:
             "category, confidence, matched_pattern}`) and `summary` counts by category."
         ),
     )
-    async def find_sensitive_columns(ctx: _Ctx, schema: str) -> advisors.SensitiveColumnsReport:
+    async def find_sensitive_columns(
+        ctx: _Ctx, schema: str, database: _DatabaseArg = None
+    ) -> advisors.SensitiveColumnsReport:
         _check_heavy_diagnostics(ctx, "find_sensitive_columns")
 
         async def _run() -> advisors.SensitiveColumnsReport:
-            report = await advisors.find_sensitive_columns(_driver(ctx), schema)
+            report = await advisors.find_sensitive_columns(_driver(ctx, database), schema)
             return report
 
         return await _cached_call(ctx, "find_sensitive_columns", _run, schema)
@@ -1782,11 +1878,11 @@ def _register_advisors(server: FastMCP[AppContext]) -> None:
             "non-conventional prefixes)."
         ),
     )
-    async def lint_naming_conventions(ctx: _Ctx, schema: str) -> naming.NamingReport:
+    async def lint_naming_conventions(ctx: _Ctx, schema: str, database: _DatabaseArg = None) -> naming.NamingReport:
         _check_heavy_diagnostics(ctx, "lint_naming_conventions")
 
         async def _run() -> naming.NamingReport:
-            report = await naming.lint_naming_conventions(_driver(ctx), schema)
+            report = await naming.lint_naming_conventions(_driver(ctx, database), schema)
             return report
 
         return await _cached_call(ctx, "lint_naming_conventions", _run, schema)
@@ -1803,12 +1899,17 @@ def _register_advisors(server: FastMCP[AppContext]) -> None:
         ),
     )
     async def test_rls_for_role(
-        ctx: _Ctx, schema: str, table: str, role: str, sample_size: int = rls.DEFAULT_RLS_SAMPLE_SIZE
+        ctx: _Ctx,
+        schema: str,
+        table: str,
+        role: str,
+        sample_size: int = rls.DEFAULT_RLS_SAMPLE_SIZE,
+        database: _DatabaseArg = None,
     ) -> rls.RLSTestResult:
         _check_heavy_diagnostics(ctx, "test_rls_for_role")
 
         async def _run() -> rls.RLSTestResult:
-            result = await rls.test_rls_for_role(_driver(ctx), schema, table, role, sample_size=sample_size)
+            result = await rls.test_rls_for_role(_driver(ctx, database), schema, table, role, sample_size=sample_size)
             return result
 
         return await _cached_call(ctx, "test_rls_for_role", _run, schema, table, role, sample_size)
@@ -1828,9 +1929,14 @@ def _register_advisors(server: FastMCP[AppContext]) -> None:
         ),
     )
     async def generate_test_data(
-        ctx: _Ctx, schema: str, table: str, rows: int = test_data.DEFAULT_ROW_COUNT, seed: int | None = None
+        ctx: _Ctx,
+        schema: str,
+        table: str,
+        rows: int = test_data.DEFAULT_ROW_COUNT,
+        seed: int | None = None,
+        database: _DatabaseArg = None,
     ) -> test_data.GeneratedDataset:
-        dataset = await test_data.generate_test_data(_driver(ctx), schema, table, rows=rows, seed=seed)
+        dataset = await test_data.generate_test_data(_driver(ctx, database), schema, table, rows=rows, seed=seed)
         return dataset
 
     @server.tool(
@@ -1858,10 +1964,11 @@ def _register_advisors(server: FastMCP[AppContext]) -> None:
         table: str,
         seed: int | None = None,
         follow_foreign_keys: bool = True,
+        database: _DatabaseArg = None,
     ) -> test_row_factory.GeneratedTestRow:
         async def _run() -> test_row_factory.GeneratedTestRow:
             row = await test_row_factory.generate_test_row_for(
-                _driver(ctx),
+                _driver(ctx, database),
                 schema,
                 table,
                 seed=seed,
@@ -1892,11 +1999,11 @@ def _register_advisors(server: FastMCP[AppContext]) -> None:
         ),
     )
     async def analyze_session_cost(
-        ctx: _Ctx, lookback_minutes: int = 60, hot_threshold: int = 10
+        ctx: _Ctx, lookback_minutes: int = 60, hot_threshold: int = 10, database: _DatabaseArg = None
     ) -> session_advisor.SessionCostAnalysis:
         async def _run() -> session_advisor.SessionCostAnalysis:
             result = await session_advisor.analyze_session_cost(
-                _driver(ctx), lookback_minutes=lookback_minutes, hot_threshold=hot_threshold
+                _driver(ctx, database), lookback_minutes=lookback_minutes, hot_threshold=hot_threshold
             )
             return result
 
@@ -1922,14 +2029,16 @@ def _register_advisors(server: FastMCP[AppContext]) -> None:
             "recommend_headline_tools(lookback_days=14, top_n=6)",
         ),
     )
-    async def recommend_headline_tools(ctx: _Ctx, lookback_days: int = 7, top_n: int = 6) -> dict[str, Any]:
+    async def recommend_headline_tools(
+        ctx: _Ctx, lookback_days: int = 7, top_n: int = 6, database: _DatabaseArg = None
+    ) -> dict[str, Any]:
         async def _run() -> dict[str, Any]:
             from mcpg.about import CAPABILITIES
             from mcpg.headline_curator import recommend_headline_tools as _recommend
 
             current = {cap.id: cap.headline_tools for cap in CAPABILITIES}
             report = await _recommend(
-                _driver(ctx),
+                _driver(ctx, database),
                 lookback_days=lookback_days,
                 top_n=top_n,
                 current_headlines=current,
@@ -1956,11 +2065,11 @@ def _register_advisors(server: FastMCP[AppContext]) -> None:
         ),
     )
     async def audit_sequences(
-        ctx: _Ctx, warning_pct: float = 80.0, critical_pct: float = 95.0
+        ctx: _Ctx, warning_pct: float = 80.0, critical_pct: float = 95.0, database: _DatabaseArg = None
     ) -> config_advisor.SequenceAuditResult:
         async def _run() -> config_advisor.SequenceAuditResult:
             result = await config_advisor.audit_sequences(
-                _driver(ctx), warning_pct=warning_pct, critical_pct=critical_pct
+                _driver(ctx, database), warning_pct=warning_pct, critical_pct=critical_pct
             )
             return result
 
@@ -1983,9 +2092,11 @@ def _register_advisors(server: FastMCP[AppContext]) -> None:
             "audit_settings(total_ram_mb=16384)",
         ),
     )
-    async def audit_settings(ctx: _Ctx, total_ram_mb: int | None = None) -> config_advisor.SettingsAuditResult:
+    async def audit_settings(
+        ctx: _Ctx, total_ram_mb: int | None = None, database: _DatabaseArg = None
+    ) -> config_advisor.SettingsAuditResult:
         async def _run() -> config_advisor.SettingsAuditResult:
-            result = await config_advisor.audit_settings(_driver(ctx), total_ram_mb=total_ram_mb)
+            result = await config_advisor.audit_settings(_driver(ctx, database), total_ram_mb=total_ram_mb)
             return result
 
         return await _cached_call(ctx, "audit_settings", _run, total_ram_mb)
@@ -2035,11 +2146,11 @@ def _register_advisors(server: FastMCP[AppContext]) -> None:
             "using EXPLAIN plan costs and index scans, returning an optimized version."
         ),
     )
-    async def optimize_query(ctx: _Ctx, sql: str) -> advisors.OptimizationResult:
+    async def optimize_query(ctx: _Ctx, sql: str, database: _DatabaseArg = None) -> advisors.OptimizationResult:
         _check_heavy_diagnostics(ctx, "optimize_query")
 
         async def _run() -> advisors.OptimizationResult:
-            res = await advisors.optimize_query(_driver(ctx), sql)
+            res = await advisors.optimize_query(_driver(ctx, database), sql)
             return res
 
         return await _cached_call(ctx, "optimize_query", _run, sql)
@@ -2058,8 +2169,10 @@ def _register_composite(server: FastMCP[AppContext]) -> None:
             "summarize_table(schema='public', table='users', sample_rows=5)",
         ),
     )
-    async def summarize_table(ctx: _Ctx, schema: str, table: str, sample_rows: int = 5) -> composite.TableSummary:
-        result = await composite.summarize_table(_driver(ctx), schema, table, sample_rows=sample_rows)
+    async def summarize_table(
+        ctx: _Ctx, schema: str, table: str, sample_rows: int = 5, database: _DatabaseArg = None
+    ) -> composite.TableSummary:
+        result = await composite.summarize_table(_driver(ctx, database), schema, table, sample_rows=sample_rows)
         return result
 
     @server.tool(
@@ -2075,11 +2188,11 @@ def _register_composite(server: FastMCP[AppContext]) -> None:
             "why_is_this_slow(sql='SELECT * FROM orders WHERE customer_id = 42')",
         ),
     )
-    async def why_is_this_slow(ctx: _Ctx, sql: str) -> composite.SlowQueryDiagnosis:
+    async def why_is_this_slow(ctx: _Ctx, sql: str, database: _DatabaseArg = None) -> composite.SlowQueryDiagnosis:
         _check_heavy_diagnostics(ctx, "why_is_this_slow")
 
         async def _run() -> composite.SlowQueryDiagnosis:
-            result = await composite.why_is_this_slow(_driver(ctx), sql)
+            result = await composite.why_is_this_slow(_driver(ctx, database), sql)
             return result
 
         return await _cached_call(ctx, "why_is_this_slow", _run, sql)
@@ -2096,9 +2209,13 @@ def _register_data_movement(server: FastMCP[AppContext]) -> None:
         ),
     )
     async def export_query(
-        ctx: _Ctx, sql: str, format: str = "csv", limit: int = data_movement.DEFAULT_EXPORT_LIMIT
+        ctx: _Ctx,
+        sql: str,
+        format: str = "csv",
+        limit: int = data_movement.DEFAULT_EXPORT_LIMIT,
+        database: _DatabaseArg = None,
     ) -> data_movement.ExportResult:
-        result = await data_movement.export_query(_driver(ctx), sql, format=format, limit=limit)
+        result = await data_movement.export_query(_driver(ctx, database), sql, format=format, limit=limit)
         return result
 
     @server.tool(
@@ -2116,8 +2233,9 @@ def _register_data_movement(server: FastMCP[AppContext]) -> None:
         table: str,
         format: str = "csv",
         limit: int = data_movement.DEFAULT_EXPORT_LIMIT,
+        database: _DatabaseArg = None,
     ) -> data_movement.ExportResult:
-        result = await data_movement.export_table(_driver(ctx), schema, table, format=format, limit=limit)
+        result = await data_movement.export_table(_driver(ctx, database), schema, table, format=format, limit=limit)
         return result
 
 
@@ -2418,8 +2536,8 @@ def _register_timescaledb_reads(server: FastMCP[AppContext]) -> None:
             "(list of `{schema, table, num_chunks, compression_enabled, total_size_bytes}`)."
         ),
     )
-    async def list_hypertables(ctx: _Ctx) -> timescaledb.HypertableListResult:
-        result = await timescaledb.list_hypertables(_driver(ctx))
+    async def list_hypertables(ctx: _Ctx, database: _DatabaseArg = None) -> timescaledb.HypertableListResult:
+        result = await timescaledb.list_hypertables(_driver(ctx, database))
         return result
 
     @server.tool(
@@ -2432,8 +2550,10 @@ def _register_timescaledb_reads(server: FastMCP[AppContext]) -> None:
             "(list of `{chunk_name, range_start, range_end, is_compressed, total_size_bytes}`)."
         ),
     )
-    async def list_chunks(ctx: _Ctx, schema: str, table: str) -> timescaledb.ChunkListResult:
-        result = await timescaledb.list_chunks(_driver(ctx), schema, table)
+    async def list_chunks(
+        ctx: _Ctx, schema: str, table: str, database: _DatabaseArg = None
+    ) -> timescaledb.ChunkListResult:
+        result = await timescaledb.list_chunks(_driver(ctx, database), schema, table)
         return result
 
 
@@ -2664,9 +2784,9 @@ def _register_audit_trail(server: FastMCP[AppContext]) -> None:
         ),
     )
     async def list_audit_events(
-        ctx: _Ctx, limit: int = 100, tool: str | None = None
+        ctx: _Ctx, limit: int = 100, tool: str | None = None, database: _DatabaseArg = None
     ) -> list[audit_trail.AuditTrailEntry]:
-        events = await audit_trail.list_audit_events(_driver(ctx), limit=limit, tool=tool)
+        events = await audit_trail.list_audit_events(_driver(ctx, database), limit=limit, tool=tool)
         return events
 
     @server.tool(
@@ -2678,10 +2798,10 @@ def _register_audit_trail(server: FastMCP[AppContext]) -> None:
             "pointing at where the chain broke."
         ),
     )
-    async def verify_audit_chain(ctx: _Ctx) -> dict[str, Any]:
+    async def verify_audit_chain(ctx: _Ctx, database: _DatabaseArg = None) -> dict[str, Any]:
         from mcpg.audit_integrity import verify_audit_chain as vac
 
-        return await vac(_driver(ctx))
+        return await vac(_driver(ctx, database))
 
 
 def _register_query(server: FastMCP[AppContext]) -> None:
@@ -2693,8 +2813,10 @@ def _register_query(server: FastMCP[AppContext]) -> None:
             "run_select(sql='SELECT id, email FROM users LIMIT 10', max_rows=1000)",
         ),
     )
-    async def run_select(ctx: _Ctx, sql: str, max_rows: int = query.DEFAULT_MAX_ROWS) -> query.QueryResult:
-        result = await query.run_select(_driver(ctx), sql, max_rows=max_rows)
+    async def run_select(
+        ctx: _Ctx, sql: str, max_rows: int = query.DEFAULT_MAX_ROWS, database: _DatabaseArg = None
+    ) -> query.QueryResult:
+        result = await query.run_select(_driver(ctx, database), sql, max_rows=max_rows)
         return result
 
     @server.tool(
@@ -2715,9 +2837,10 @@ def _register_query(server: FastMCP[AppContext]) -> None:
         statements: list[str],
         max_rows: int = query.DEFAULT_MAX_ROWS,
         parallel_limit: int = query.DEFAULT_PARALLEL_LIMIT,
+        database: _DatabaseArg = None,
     ) -> query.ParallelQueryResult:
         result = await query.run_select_parallel(
-            _driver(ctx),
+            _driver(ctx, database),
             statements,
             max_rows=max_rows,
             parallel_limit=parallel_limit,
@@ -2736,9 +2859,9 @@ def _register_query(server: FastMCP[AppContext]) -> None:
             "5-minute TTL clean up). Hard cap of 16 concurrent cursors."
         ),
     )
-    async def open_cursor(ctx: _Ctx, sql: str) -> dict[str, Any]:
+    async def open_cursor(ctx: _Ctx, sql: str, database: _DatabaseArg = None) -> dict[str, Any]:
         manager = ctx.request_context.lifespan_context.cursor_manager
-        info = await manager.open(_driver(ctx), sql)
+        info = await manager.open(_driver(ctx, database), sql)
         return asdict(info)
 
     @server.tool(
@@ -2800,8 +2923,10 @@ def _register_query(server: FastMCP[AppContext]) -> None:
             "explain_query(sql='SELECT * FROM orders WHERE customer_id = 42', io=true)",
         ),
     )
-    async def explain_query(ctx: _Ctx, sql: str, io: bool = False) -> query.ExplainResult:
-        result = await query.explain_query(_driver(ctx), sql, io=io)
+    async def explain_query(
+        ctx: _Ctx, sql: str, io: bool = False, database: _DatabaseArg = None
+    ) -> query.ExplainResult:
+        result = await query.explain_query(_driver(ctx, database), sql, io=io)
         return result
 
     @server.tool(
@@ -2817,8 +2942,10 @@ def _register_query(server: FastMCP[AppContext]) -> None:
             "analyze_query_plan(sql='SELECT * FROM orders WHERE customer_id = 42', io=true)",
         ),
     )
-    async def analyze_query_plan(ctx: _Ctx, sql: str, io: bool = False) -> query.QueryPlanAnalysis:
-        result = await query.analyze_query_plan(_driver(ctx), sql, io=io)
+    async def analyze_query_plan(
+        ctx: _Ctx, sql: str, io: bool = False, database: _DatabaseArg = None
+    ) -> query.QueryPlanAnalysis:
+        result = await query.analyze_query_plan(_driver(ctx, database), sql, io=io)
         return result
 
     @server.tool(
@@ -2854,6 +2981,7 @@ def _register_query(server: FastMCP[AppContext]) -> None:
         execute: bool = False,
         table_filter: list[str] | None = None,
         max_rows: int = query.DEFAULT_MAX_ROWS,
+        database: _DatabaseArg = None,
     ) -> nl2sql.TranslationResult:
         # All NL→SQL business logic — provider selection from request
         # arg / env default / configured keys, model + base_url override
@@ -2863,7 +2991,7 @@ def _register_query(server: FastMCP[AppContext]) -> None:
         params = nl2sql.resolve_provider_call_params(settings, provider)
         llm = nl2sql.build_provider(params.provider_name, params.api_key, base_url=params.base_url)
         result = await nl2sql.translate_nl_to_sql(
-            _driver(ctx),
+            _driver(ctx, database),
             provider=llm,
             model=params.model,
             question=question,
@@ -2887,8 +3015,42 @@ def _register_health(server: FastMCP[AppContext]) -> None:
             "check_database_health()",
         ),
     )
-    async def check_database_health(ctx: _Ctx) -> health.HealthReport:
-        return await health.check_database_health(_driver(ctx))
+    async def check_database_health(ctx: _Ctx, database: _DatabaseArg = None) -> health.HealthReport:
+        return await health.check_database_health(_driver(ctx, database))
+
+    @server.tool(
+        name="list_databases",
+        description=(
+            "List every database this MCPg server is configured to serve: the "
+            "primary (the default target of every tool) plus any read-only "
+            "secondaries from MCPG_SECONDARY_DATABASE_URLS. Read-capable tools "
+            "accept an optional `database` argument naming one of these ids; "
+            "omitting it targets the primary. Secondaries are read-only "
+            "(PostgreSQL-enforced) — writes / DDL / shell / migrate always run "
+            "against the primary. Returns an object with `primary_id`, "
+            "`database_ids` (primary first), and `databases` — a list of "
+            "objects with `id`, `is_primary`, `read_only`, `reachable` (a live "
+            "SELECT 1 probe), and `detail` (an error string when unreachable)."
+        ),
+    )
+    async def list_databases(ctx: _Ctx) -> multidb.DatabaseList:
+        database = ctx.request_context.lifespan_context.database
+        rows = await database.describe_databases()
+        descriptors = [
+            multidb.DatabaseDescriptor(
+                id=db_id,
+                is_primary=is_primary,
+                read_only=read_only,
+                reachable=reachable,
+                detail=detail,
+            )
+            for db_id, is_primary, read_only, reachable, detail in rows
+        ]
+        return multidb.DatabaseList(
+            primary_id=multidb.PRIMARY_DATABASE_ID,
+            database_ids=database.database_ids(),
+            databases=descriptors,
+        )
 
     @server.tool(
         name="audit_database",
@@ -2902,11 +3064,13 @@ def _register_health(server: FastMCP[AppContext]) -> None:
             "(per-area results), `top_issues`, `recommendations`, and `raw_stats_snapshot`."
         ),
     )
-    async def audit_database(ctx: _Ctx, schema: str, log_table: str | None = None) -> audit.AuditReport:
+    async def audit_database(
+        ctx: _Ctx, schema: str, log_table: str | None = None, database: _DatabaseArg = None
+    ) -> audit.AuditReport:
         _check_heavy_diagnostics(ctx, "audit_database")
 
         async def _run() -> audit.AuditReport:
-            report = await audit.audit_database(_driver(ctx), schema, log_table=log_table)
+            report = await audit.audit_database(_driver(ctx, database), schema, log_table=log_table)
             return report
 
         return await _cached_call(ctx, "audit_database", _run, schema, log_table)
@@ -2920,11 +3084,13 @@ def _register_health(server: FastMCP[AppContext]) -> None:
             "analyze_workload(limit=10)",
         ),
     )
-    async def analyze_workload(ctx: _Ctx, limit: int = workload.DEFAULT_LIMIT) -> workload.WorkloadReport:
+    async def analyze_workload(
+        ctx: _Ctx, limit: int = workload.DEFAULT_LIMIT, database: _DatabaseArg = None
+    ) -> workload.WorkloadReport:
         _check_heavy_diagnostics(ctx, "analyze_workload")
 
         async def _run() -> workload.WorkloadReport:
-            report = await workload.analyze_workload(_driver(ctx), limit=limit)
+            report = await workload.analyze_workload(_driver(ctx, database), limit=limit)
             return report
 
         return await _cached_call(ctx, "analyze_workload", _run, limit)
@@ -2950,12 +3116,13 @@ def _register_health(server: FastMCP[AppContext]) -> None:
         max_rows_per_call: float = workload.DEFAULT_MAX_ROWS_PER_CALL,
         min_total_ms: float = workload.DEFAULT_MIN_TOTAL_MS,
         limit: int = workload.DEFAULT_NPLUSONE_LIMIT,
+        database: _DatabaseArg = None,
     ) -> workload.NPlusOneReport:
         _check_heavy_diagnostics(ctx, "detect_n_plus_one")
 
         async def _run() -> workload.NPlusOneReport:
             report = await workload.detect_n_plus_one(
-                _driver(ctx),
+                _driver(ctx, database),
                 min_calls=min_calls,
                 max_rows_per_call=max_rows_per_call,
                 min_total_ms=min_total_ms,
@@ -2982,9 +3149,11 @@ def _register_health(server: FastMCP[AppContext]) -> None:
             "read_autovacuum_priority(limit=25)",
         ),
     )
-    async def read_autovacuum_priority(ctx: _Ctx, limit: int = 25) -> autovacuum.AutovacuumPriorityReport:
+    async def read_autovacuum_priority(
+        ctx: _Ctx, limit: int = 25, database: _DatabaseArg = None
+    ) -> autovacuum.AutovacuumPriorityReport:
         async def _run() -> autovacuum.AutovacuumPriorityReport:
-            report = await autovacuum.read_autovacuum_priority(_driver(ctx), limit=limit)
+            report = await autovacuum.read_autovacuum_priority(_driver(ctx, database), limit=limit)
             return report
 
         return await _cached_call(ctx, "read_autovacuum_priority", _run, limit)
@@ -2999,12 +3168,12 @@ def _register_health(server: FastMCP[AppContext]) -> None:
         ),
     )
     async def recommend_indexes(
-        ctx: _Ctx, min_live_tuples: int = indexing.DEFAULT_MIN_LIVE_TUPLES
+        ctx: _Ctx, min_live_tuples: int = indexing.DEFAULT_MIN_LIVE_TUPLES, database: _DatabaseArg = None
     ) -> list[indexing.IndexRecommendation]:
         _check_heavy_diagnostics(ctx, "recommend_indexes")
 
         async def _run() -> list[indexing.IndexRecommendation]:
-            recommendations = await indexing.recommend_indexes(_driver(ctx), min_live_tuples=min_live_tuples)
+            recommendations = await indexing.recommend_indexes(_driver(ctx, database), min_live_tuples=min_live_tuples)
             return recommendations
 
         return await _cached_call(ctx, "recommend_indexes", _run, min_live_tuples)
@@ -3036,12 +3205,13 @@ def _register_health(server: FastMCP[AppContext]) -> None:
         schema: str | None = None,
         min_index_size_bytes: int = indexing.DEFAULT_MIN_INDEX_SIZE_BYTES,
         low_scan_ratio: float = indexing.DEFAULT_LOW_SCAN_RATIO,
+        database: _DatabaseArg = None,
     ) -> list[indexing.IndexDropCandidate]:
         _check_heavy_diagnostics(ctx, "recommend_index_drops")
 
         async def _run() -> list[indexing.IndexDropCandidate]:
             candidates = await indexing.recommend_index_drops(
-                _driver(ctx),
+                _driver(ctx, database),
                 schema=schema,
                 min_index_size_bytes=min_index_size_bytes,
                 low_scan_ratio=low_scan_ratio,
@@ -3071,9 +3241,10 @@ def _register_health(server: FastMCP[AppContext]) -> None:
         mode: str = textsearch.DEFAULT_FUZZY_MODE,
         limit: int = textsearch.DEFAULT_LIMIT,
         threshold: float = textsearch.DEFAULT_THRESHOLD,
+        database: _DatabaseArg = None,
     ) -> textsearch.FuzzySearchResult:
         result = await textsearch.fuzzy_search(
-            _driver(ctx), schema, table, column, term, mode=mode, limit=limit, threshold=threshold
+            _driver(ctx, database), schema, table, column, term, mode=mode, limit=limit, threshold=threshold
         )
         return result
 
@@ -3096,9 +3267,10 @@ def _register_health(server: FastMCP[AppContext]) -> None:
         search_query: str,
         config: str = textsearch.DEFAULT_TEXT_CONFIG,
         limit: int = textsearch.DEFAULT_LIMIT,
+        database: _DatabaseArg = None,
     ) -> list[textsearch.FullTextMatch]:
         matches = await textsearch.full_text_search(
-            _driver(ctx), schema, table, column, search_query, config=config, limit=limit
+            _driver(ctx, database), schema, table, column, search_query, config=config, limit=limit
         )
         return matches
 
@@ -3120,9 +3292,10 @@ def _register_health(server: FastMCP[AppContext]) -> None:
         query_vector: list[float],
         metric: str = textsearch.DEFAULT_VECTOR_METRIC,
         limit: int = textsearch.DEFAULT_LIMIT,
+        database: _DatabaseArg = None,
     ) -> textsearch.VectorSearchResult:
         result = await textsearch.vector_search(
-            _driver(ctx), schema, table, column, query_vector, metric=metric, limit=limit
+            _driver(ctx, database), schema, table, column, query_vector, metric=metric, limit=limit
         )
         return result
 
@@ -3146,9 +3319,10 @@ def _register_health(server: FastMCP[AppContext]) -> None:
         max_distance: float,
         metric: str = textsearch.DEFAULT_VECTOR_METRIC,
         limit: int = textsearch.DEFAULT_LIMIT,
+        database: _DatabaseArg = None,
     ) -> textsearch.VectorSearchResult:
         result = await textsearch.vector_range_search(
-            _driver(ctx),
+            _driver(ctx, database),
             schema,
             table,
             column,
@@ -3187,9 +3361,10 @@ def _register_health(server: FastMCP[AppContext]) -> None:
         fetch_k: int | None = None,
         lambda_mult: float = textsearch.DEFAULT_MMR_LAMBDA,
         metric: str = textsearch.DEFAULT_VECTOR_METRIC,
+        database: _DatabaseArg = None,
     ) -> textsearch.MmrSearchResult:
         result = await textsearch.mmr_search(
-            _driver(ctx),
+            _driver(ctx, database),
             schema,
             table,
             column,
@@ -3230,9 +3405,10 @@ def _register_health(server: FastMCP[AppContext]) -> None:
         text_config: str = textsearch.DEFAULT_TEXT_CONFIG,
         limit: int = textsearch.DEFAULT_LIMIT,
         candidate_pool: int = 50,
+        database: _DatabaseArg = None,
     ) -> textsearch.HybridSearchResult:
         result = await textsearch.hybrid_search(
-            _driver(ctx),
+            _driver(ctx, database),
             schema,
             table,
             vector_column,
@@ -3258,8 +3434,10 @@ def _register_health(server: FastMCP[AppContext]) -> None:
             "wouldn't justify the migration."
         ),
     )
-    async def recommend_vector_quantization(ctx: _Ctx, schema: str) -> list[textsearch.QuantizationRecommendation]:
-        recommendations = await textsearch.recommend_vector_quantization(_driver(ctx), schema)
+    async def recommend_vector_quantization(
+        ctx: _Ctx, schema: str, database: _DatabaseArg = None
+    ) -> list[textsearch.QuantizationRecommendation]:
+        recommendations = await textsearch.recommend_vector_quantization(_driver(ctx, database), schema)
         return recommendations
 
     @server.tool(
@@ -3277,8 +3455,11 @@ def _register_health(server: FastMCP[AppContext]) -> None:
         longitude: float,
         latitude: float,
         limit: int = textsearch.DEFAULT_LIMIT,
+        database: _DatabaseArg = None,
     ) -> textsearch.GeoSearchResult:
-        result = await textsearch.geo_search(_driver(ctx), schema, table, column, longitude, latitude, limit=limit)
+        result = await textsearch.geo_search(
+            _driver(ctx, database), schema, table, column, longitude, latitude, limit=limit
+        )
         return result
 
 
@@ -3293,8 +3474,8 @@ def _register_liveops(server: FastMCP[AppContext]) -> None:
             "`blocked_by` (list of PIDs holding locks this backend is waiting on)."
         ),
     )
-    async def list_active_queries(ctx: _Ctx) -> list[liveops.ActiveQuery]:
-        return await liveops.list_active_queries(_driver(ctx))
+    async def list_active_queries(ctx: _Ctx, database: _DatabaseArg = None) -> list[liveops.ActiveQuery]:
+        return await liveops.list_active_queries(_driver(ctx, database))
 
     @server.tool(
         name="verify_connection_encryption",
@@ -3308,8 +3489,8 @@ def _register_liveops(server: FastMCP[AppContext]) -> None:
             "connection actually came up encrypted."
         ),
     )
-    async def verify_connection_encryption(ctx: _Ctx) -> liveops.ConnectionEncryption:
-        return await liveops.verify_connection_encryption(_driver(ctx))
+    async def verify_connection_encryption(ctx: _Ctx, database: _DatabaseArg = None) -> liveops.ConnectionEncryption:
+        return await liveops.verify_connection_encryption(_driver(ctx, database))
 
     @server.tool(
         name="monitor_index_build",
@@ -3327,8 +3508,8 @@ def _register_liveops(server: FastMCP[AppContext]) -> None:
             "`tuples_total`, and `progress_pct` (null when no denominator is reported)."
         ),
     )
-    async def monitor_index_build(ctx: _Ctx) -> list[liveops.IndexBuildProgress]:
-        return await liveops.monitor_index_build(_driver(ctx))
+    async def monitor_index_build(ctx: _Ctx, database: _DatabaseArg = None) -> list[liveops.IndexBuildProgress]:
+        return await liveops.monitor_index_build(_driver(ctx, database))
 
     @server.tool(
         name="list_replicas",
@@ -3354,8 +3535,8 @@ def _register_liveops(server: FastMCP[AppContext]) -> None:
             "List the pg_cron jobs registered in the database. Returns an empty list when pg_cron is not installed."
         ),
     )
-    async def list_cron_jobs(ctx: _Ctx) -> list[cron.CronJob]:
-        return await cron.list_cron_jobs(_driver(ctx))
+    async def list_cron_jobs(ctx: _Ctx, database: _DatabaseArg = None) -> list[cron.CronJob]:
+        return await cron.list_cron_jobs(_driver(ctx, database))
 
 
 def _register_turboquant_reads(server: FastMCP[AppContext]) -> None:
@@ -3370,8 +3551,8 @@ def _register_turboquant_reads(server: FastMCP[AppContext]) -> None:
             "pg_turboquant extension is not installed."
         ),
     )
-    async def list_turboquant_indexes(ctx: _Ctx) -> list[turboquant.TurboQuantIndexInfo]:
-        infos = await turboquant.list_turboquant_indexes(_driver(ctx))
+    async def list_turboquant_indexes(ctx: _Ctx, database: _DatabaseArg = None) -> list[turboquant.TurboQuantIndexInfo]:
+        infos = await turboquant.list_turboquant_indexes(_driver(ctx, database))
         return infos
 
     @server.tool(
@@ -3389,8 +3570,10 @@ def _register_turboquant_reads(server: FastMCP[AppContext]) -> None:
             "`raw_metadata` (full upstream payload)."
         ),
     )
-    async def get_turboquant_index_metadata(ctx: _Ctx, schema: str, index: str) -> turboquant.TurboQuantIndexInfo:
-        info = await turboquant.get_turboquant_index_metadata(_driver(ctx), schema, index)
+    async def get_turboquant_index_metadata(
+        ctx: _Ctx, schema: str, index: str, database: _DatabaseArg = None
+    ) -> turboquant.TurboQuantIndexInfo:
+        info = await turboquant.get_turboquant_index_metadata(_driver(ctx, database), schema, index)
         return info
 
     @server.tool(
@@ -3402,8 +3585,10 @@ def _register_turboquant_reads(server: FastMCP[AppContext]) -> None:
             "may add. Requires the pg_turboquant extension."
         ),
     )
-    async def get_turboquant_heap_stats(ctx: _Ctx, schema: str, index: str) -> turboquant.TurboQuantHeapStats:
-        stats = await turboquant.get_turboquant_heap_stats(_driver(ctx), schema, index)
+    async def get_turboquant_heap_stats(
+        ctx: _Ctx, schema: str, index: str, database: _DatabaseArg = None
+    ) -> turboquant.TurboQuantHeapStats:
+        stats = await turboquant.get_turboquant_heap_stats(_driver(ctx, database), schema, index)
         return stats
 
     @server.tool(
@@ -3416,8 +3601,10 @@ def _register_turboquant_reads(server: FastMCP[AppContext]) -> None:
             "has run on this connection yet."
         ),
     )
-    async def get_turboquant_last_scan_stats(ctx: _Ctx) -> turboquant.TurboQuantLastScanStats | None:
-        stats = await turboquant.get_turboquant_last_scan_stats(_driver(ctx))
+    async def get_turboquant_last_scan_stats(
+        ctx: _Ctx, database: _DatabaseArg = None
+    ) -> turboquant.TurboQuantLastScanStats | None:
+        stats = await turboquant.get_turboquant_last_scan_stats(_driver(ctx, database))
         return stats if stats is not None else None
 
     @server.tool(
@@ -3433,8 +3620,10 @@ def _register_turboquant_reads(server: FastMCP[AppContext]) -> None:
             "``pg_turboquant Indexes`` category in audit_database."
         ),
     )
-    async def recommend_turboquant_maintenance(ctx: _Ctx) -> list[turboquant.TurboQuantAdvisorFinding]:
-        findings = await turboquant.recommend_turboquant_maintenance(_driver(ctx))
+    async def recommend_turboquant_maintenance(
+        ctx: _Ctx, database: _DatabaseArg = None
+    ) -> list[turboquant.TurboQuantAdvisorFinding]:
+        findings = await turboquant.recommend_turboquant_maintenance(_driver(ctx, database))
         return findings
 
     @server.tool(
@@ -3463,9 +3652,10 @@ def _register_turboquant_reads(server: FastMCP[AppContext]) -> None:
         probes: int | None = None,
         oversample_factor: int | None = None,
         half_precision: bool = False,
+        database: _DatabaseArg = None,
     ) -> list[turboquant.TurboQuantCandidate]:
         candidates = await turboquant.turboquant_approx_candidates(
-            _driver(ctx),
+            _driver(ctx, database),
             schema,
             table,
             id_column,
@@ -3502,9 +3692,10 @@ def _register_turboquant_reads(server: FastMCP[AppContext]) -> None:
         probes: int | None = None,
         oversample_factor: int | None = None,
         half_precision: bool = False,
+        database: _DatabaseArg = None,
     ) -> list[turboquant.TurboQuantRerankedCandidate]:
         candidates = await turboquant.turboquant_rerank_candidates(
-            _driver(ctx),
+            _driver(ctx, database),
             schema,
             table,
             id_column,
@@ -3541,9 +3732,10 @@ def _register_turboquant_reads(server: FastMCP[AppContext]) -> None:
         index_schema: str | None = None,
         index_name: str | None = None,
         filter_selectivity: float | None = None,
+        database: _DatabaseArg = None,
     ) -> turboquant.TurboQuantQueryKnobs:
         knobs = await turboquant.recommend_turboquant_query_knobs(
-            _driver(ctx),
+            _driver(ctx, database),
             candidate_limit,
             final_limit=final_limit,
             index_schema=index_schema,
@@ -3568,8 +3760,8 @@ def _register_pg_search_reads(server: FastMCP[AppContext]) -> None:
             "is not installed."
         ),
     )
-    async def list_pg_search_indexes(ctx: _Ctx) -> list[pg_search.PgSearchIndexInfo]:
-        infos = await pg_search.list_pg_search_indexes(_driver(ctx))
+    async def list_pg_search_indexes(ctx: _Ctx, database: _DatabaseArg = None) -> list[pg_search.PgSearchIndexInfo]:
+        infos = await pg_search.list_pg_search_indexes(_driver(ctx, database))
         return infos
 
     @server.tool(
@@ -3585,8 +3777,10 @@ def _register_pg_search_reads(server: FastMCP[AppContext]) -> None:
             "and `index_options` (raw reloptions dict for forward-compat)."
         ),
     )
-    async def get_pg_search_index_metadata(ctx: _Ctx, schema: str, index: str) -> pg_search.PgSearchIndexInfo:
-        info = await pg_search.get_pg_search_index_metadata(_driver(ctx), schema, index)
+    async def get_pg_search_index_metadata(
+        ctx: _Ctx, schema: str, index: str, database: _DatabaseArg = None
+    ) -> pg_search.PgSearchIndexInfo:
+        info = await pg_search.get_pg_search_index_metadata(_driver(ctx, database), schema, index)
         return info
 
     @server.tool(
@@ -3604,8 +3798,10 @@ def _register_pg_search_reads(server: FastMCP[AppContext]) -> None:
             "``pg_search BM25 Indexes`` category in audit_database."
         ),
     )
-    async def recommend_pg_search_maintenance(ctx: _Ctx) -> list[pg_search.PgSearchAdvisorFinding]:
-        findings = await pg_search.recommend_pg_search_maintenance(_driver(ctx))
+    async def recommend_pg_search_maintenance(
+        ctx: _Ctx, database: _DatabaseArg = None
+    ) -> list[pg_search.PgSearchAdvisorFinding]:
+        findings = await pg_search.recommend_pg_search_maintenance(_driver(ctx, database))
         return findings
 
     @server.tool(
@@ -3640,9 +3836,10 @@ def _register_pg_search_reads(server: FastMCP[AppContext]) -> None:
         snippet_start_tag: str = "<b>",
         snippet_end_tag: str = "</b>",
         snippet_max_num_chars: int = 150,
+        database: _DatabaseArg = None,
     ) -> list[pg_search.PgSearchHit]:
         hits = await pg_search.pg_search_run(
-            _driver(ctx),
+            _driver(ctx, database),
             schema,
             table,
             query,
@@ -3688,9 +3885,10 @@ def _register_pg_search_reads(server: FastMCP[AppContext]) -> None:
         max_word_length: int | None = None,
         boost_factor: float | None = None,
         stop_words: list[str] | None = None,
+        database: _DatabaseArg = None,
     ) -> list[pg_search.PgSearchHit]:
         hits = await pg_search.pg_search_more_like_this(
-            _driver(ctx),
+            _driver(ctx, database),
             schema,
             table,
             document_id,
@@ -3724,9 +3922,10 @@ def _register_pg_search_reads(server: FastMCP[AppContext]) -> None:
         query_string: str,
         lenient: bool = False,
         conjunction_mode: bool = False,
+        database: _DatabaseArg = None,
     ) -> pg_search.PgSearchParsedQuery:
         parsed = await pg_search.pg_search_parse_query(
-            _driver(ctx),
+            _driver(ctx, database),
             query_string,
             lenient=lenient,
             conjunction_mode=conjunction_mode,
@@ -3767,9 +3966,10 @@ def _register_pg_search_reads(server: FastMCP[AppContext]) -> None:
         bm25_weight: float = pg_search.HYBRID_DEFAULT_WEIGHT,
         vector_weight: float = pg_search.HYBRID_DEFAULT_WEIGHT,
         per_leg_limit: int = pg_search.HYBRID_DEFAULT_PER_LEG_LIMIT,
+        database: _DatabaseArg = None,
     ) -> list[pg_search.HybridHit]:
         hits = await pg_search.hybrid_bm25_vector_search(
-            _driver(ctx),
+            _driver(ctx, database),
             schema,
             table,
             query_text=query_text,
@@ -3985,9 +4185,10 @@ def _register_rag_telemetry_efficiency_read(server: FastMCP[AppContext]) -> None
         backend: str | None = None,
         metric: str | None = None,
         k: int | None = None,
+        database: _DatabaseArg = None,
     ) -> rag_telemetry.EfficiencyThresholds:
         result = await rag_telemetry.recommend_efficiency_thresholds(
-            _driver(ctx),
+            _driver(ctx, database),
             days=days,
             backend=backend,
             metric=metric,
@@ -4176,9 +4377,11 @@ def _register_redis_fdw_reads(server: FastMCP[AppContext]) -> None:
             "list_redis_foreign_servers()",
         ),
     )
-    async def list_redis_foreign_servers(ctx: _Ctx) -> list[redis_fdw.RedisForeignServer]:
+    async def list_redis_foreign_servers(
+        ctx: _Ctx, database: _DatabaseArg = None
+    ) -> list[redis_fdw.RedisForeignServer]:
         async def _run() -> list[redis_fdw.RedisForeignServer]:
-            servers = await redis_fdw.list_redis_foreign_servers(_driver(ctx))
+            servers = await redis_fdw.list_redis_foreign_servers(_driver(ctx, database))
             return servers
 
         return await _cached_call(ctx, "list_redis_foreign_servers", _run)
@@ -4197,9 +4400,11 @@ def _register_redis_fdw_reads(server: FastMCP[AppContext]) -> None:
             "describe_redis_cache_table(schema='public', table='sessions_cache')",
         ),
     )
-    async def describe_redis_cache_table(ctx: _Ctx, schema: str, table: str) -> redis_fdw.RedisCacheTableInfo:
+    async def describe_redis_cache_table(
+        ctx: _Ctx, schema: str, table: str, database: _DatabaseArg = None
+    ) -> redis_fdw.RedisCacheTableInfo:
         async def _run() -> redis_fdw.RedisCacheTableInfo:
-            info = await redis_fdw.describe_redis_cache_table(_driver(ctx), schema, table)
+            info = await redis_fdw.describe_redis_cache_table(_driver(ctx, database), schema, table)
             return info
 
         return await _cached_call(ctx, "describe_redis_cache_table", _run, schema, table)
@@ -4217,9 +4422,9 @@ def _register_redis_fdw_reads(server: FastMCP[AppContext]) -> None:
             "get_redis_cache_stats(server='redis_primary')",
         ),
     )
-    async def get_redis_cache_stats(ctx: _Ctx, server: str) -> redis_fdw.RedisCacheStats:
+    async def get_redis_cache_stats(ctx: _Ctx, server: str, database: _DatabaseArg = None) -> redis_fdw.RedisCacheStats:
         async def _run() -> redis_fdw.RedisCacheStats:
-            stats = await redis_fdw.get_redis_cache_stats(_driver(ctx), server)
+            stats = await redis_fdw.get_redis_cache_stats(_driver(ctx, database), server)
             return stats
 
         return await _cached_call(ctx, "get_redis_cache_stats", _run, server)
@@ -4251,10 +4456,11 @@ def _register_redis_fdw_reads(server: FastMCP[AppContext]) -> None:
         min_reads_per_day: int = 1000,
         max_rows: int = 1_000_000,
         limit: int = 20,
+        database: _DatabaseArg = None,
     ) -> redis_fdw.RecommendRedisCacheTargetsResult:
         async def _run() -> redis_fdw.RecommendRedisCacheTargetsResult:
             result = await redis_fdw.recommend_redis_cache_targets(
-                _driver(ctx),
+                _driver(ctx, database),
                 server=server,
                 min_read_write_ratio=min_read_write_ratio,
                 min_reads_per_day=min_reads_per_day,
@@ -4500,9 +4706,9 @@ def _register_pgq_reads(server: FastMCP[AppContext]) -> None:
             "get_pgq_status()",
         ),
     )
-    async def get_pgq_status(ctx: _Ctx) -> pgq.PgqStatus:
+    async def get_pgq_status(ctx: _Ctx, database: _DatabaseArg = None) -> pgq.PgqStatus:
         async def _run() -> pgq.PgqStatus:
-            return await pgq.get_pgq_status(_driver(ctx))
+            return await pgq.get_pgq_status(_driver(ctx, database))
 
         return await _cached_call(ctx, "get_pgq_status", _run)
 
@@ -4520,9 +4726,9 @@ def _register_pgq_reads(server: FastMCP[AppContext]) -> None:
             "list_property_graphs()",
         ),
     )
-    async def list_property_graphs(ctx: _Ctx) -> list[pgq.PropertyGraphInfo]:
+    async def list_property_graphs(ctx: _Ctx, database: _DatabaseArg = None) -> list[pgq.PropertyGraphInfo]:
         async def _run() -> list[pgq.PropertyGraphInfo]:
-            return await pgq.list_property_graphs(_driver(ctx))
+            return await pgq.list_property_graphs(_driver(ctx, database))
 
         return await _cached_call(ctx, "list_property_graphs", _run)
 
@@ -4539,9 +4745,11 @@ def _register_pgq_reads(server: FastMCP[AppContext]) -> None:
             "describe_property_graph(schema='public', name='org_chart')",
         ),
     )
-    async def describe_property_graph(ctx: _Ctx, schema: str, name: str) -> pgq.PropertyGraphInfo:
+    async def describe_property_graph(
+        ctx: _Ctx, schema: str, name: str, database: _DatabaseArg = None
+    ) -> pgq.PropertyGraphInfo:
         async def _run() -> pgq.PropertyGraphInfo:
-            return await pgq.describe_property_graph(_driver(ctx), schema, name)
+            return await pgq.describe_property_graph(_driver(ctx, database), schema, name)
 
         return await _cached_call(ctx, "describe_property_graph", _run, schema, name)
 
@@ -4564,8 +4772,8 @@ def _register_pgq_reads(server: FastMCP[AppContext]) -> None:
             ),
         ),
     )
-    async def run_pgq(ctx: _Ctx, query: str, max_rows: int = 200) -> pgq.PgqRunResult:
-        return await pgq.run_pgq(_driver(ctx), query, max_rows=max_rows)
+    async def run_pgq(ctx: _Ctx, query: str, max_rows: int = 200, database: _DatabaseArg = None) -> pgq.PgqRunResult:
+        return await pgq.run_pgq(_driver(ctx, database), query, max_rows=max_rows)
 
 
 def _register_pgq_ddl(server: FastMCP[AppContext]) -> None:
@@ -4644,9 +4852,11 @@ def _register_pg_prewarm_reads(server: FastMCP[AppContext]) -> None:
             "get_prewarm_extension_status()",
         ),
     )
-    async def get_prewarm_extension_status(ctx: _Ctx) -> pg_prewarm.PrewarmExtensionStatus:
+    async def get_prewarm_extension_status(
+        ctx: _Ctx, database: _DatabaseArg = None
+    ) -> pg_prewarm.PrewarmExtensionStatus:
         async def _run() -> pg_prewarm.PrewarmExtensionStatus:
-            status = await pg_prewarm.get_prewarm_extension_status(_driver(ctx))
+            status = await pg_prewarm.get_prewarm_extension_status(_driver(ctx, database))
             return status
 
         return await _cached_call(ctx, "get_prewarm_extension_status", _run)
@@ -4669,9 +4879,10 @@ def _register_pg_prewarm_reads(server: FastMCP[AppContext]) -> None:
         ctx: _Ctx,
         schema: str | None = None,
         limit: int = 100,
+        database: _DatabaseArg = None,
     ) -> list[pg_prewarm.PrewarmedRelation]:
         async def _run() -> list[pg_prewarm.PrewarmedRelation]:
-            relations = await pg_prewarm.list_prewarmed_relations(_driver(ctx), schema=schema, limit=limit)
+            relations = await pg_prewarm.list_prewarmed_relations(_driver(ctx, database), schema=schema, limit=limit)
             return relations
 
         return await _cached_call(ctx, "list_prewarmed_relations", _run, schema, limit)
@@ -4703,10 +4914,11 @@ def _register_pg_prewarm_reads(server: FastMCP[AppContext]) -> None:
         min_heap_blks_read: int = 1000,
         limit: int = 20,
         prewarm_mode: str = "buffer",
+        database: _DatabaseArg = None,
     ) -> pg_prewarm.RecommendPrewarmTargetsResult:
         async def _run() -> pg_prewarm.RecommendPrewarmTargetsResult:
             result = await pg_prewarm.recommend_prewarm_targets(
-                _driver(ctx),
+                _driver(ctx, database),
                 shared_buffers_budget_pct=shared_buffers_budget_pct,
                 min_heap_blks_read=min_heap_blks_read,
                 limit=limit,
@@ -4735,9 +4947,9 @@ def _register_pg_prewarm_reads(server: FastMCP[AppContext]) -> None:
             "list_autowarm_jobs()",
         ),
     )
-    async def list_autowarm_jobs(ctx: _Ctx) -> list[pg_prewarm.AutowarmJob]:
+    async def list_autowarm_jobs(ctx: _Ctx, database: _DatabaseArg = None) -> list[pg_prewarm.AutowarmJob]:
         async def _run() -> list[pg_prewarm.AutowarmJob]:
-            jobs = await pg_prewarm.list_autowarm_jobs(_driver(ctx))
+            jobs = await pg_prewarm.list_autowarm_jobs(_driver(ctx, database))
             return jobs
 
         return await _cached_call(ctx, "list_autowarm_jobs", _run)
@@ -4867,11 +5079,11 @@ def _register_pg19_runtime_reads(server: FastMCP[AppContext]) -> None:
             "get_data_checksums_status()",
         ),
     )
-    async def get_data_checksums_status(ctx: _Ctx) -> pg19_runtime.DataChecksumsStatus:
+    async def get_data_checksums_status(ctx: _Ctx, database: _DatabaseArg = None) -> pg19_runtime.DataChecksumsStatus:
         # Live cluster setting — never cache (gemini-review pattern from
         # PR #141): an agent toggling checksums needs to see the
         # post-toggle state on the next probe.
-        return await pg19_runtime.get_data_checksums_status(_driver(ctx))
+        return await pg19_runtime.get_data_checksums_status(_driver(ctx, database))
 
     @server.tool(
         name="get_logical_replication_status",
@@ -4890,9 +5102,10 @@ def _register_pg19_runtime_reads(server: FastMCP[AppContext]) -> None:
     )
     async def get_logical_replication_status(
         ctx: _Ctx,
+        database: _DatabaseArg = None,
     ) -> pg19_runtime.LogicalReplicationStatus:
         # Live setting — never cache; status reflects post-toggle state.
-        return await pg19_runtime.get_logical_replication_status(_driver(ctx))
+        return await pg19_runtime.get_logical_replication_status(_driver(ctx, database))
 
 
 def _register_pg19_runtime_writes(server: FastMCP[AppContext]) -> None:
@@ -4977,14 +5190,14 @@ def _register_pg19_ddl_reads(server: FastMCP[AppContext]) -> None:
             "get_pg19_ddl_status()",
         ),
     )
-    async def get_pg19_ddl_status(ctx: _Ctx) -> pg19_ddl.Pg19DdlStatus:
+    async def get_pg19_ddl_status(ctx: _Ctx, database: _DatabaseArg = None) -> pg19_ddl.Pg19DdlStatus:
         # Catalog probe — never cache: an extension install / build flip
         # mid-session needs to be visible on the next call.
         # Returns the dataclass directly — FastMCP auto-derives the
         # outputSchema from the type annotation (PR-13: structured
         # tool outputs so LangChain / LangGraph clients can validate
         # responses against a Pydantic model).
-        return await pg19_ddl.get_pg19_ddl_status(_driver(ctx))
+        return await pg19_ddl.get_pg19_ddl_status(_driver(ctx, database))
 
     @server.tool(
         name="get_role_ddl",
@@ -5000,8 +5213,8 @@ def _register_pg19_ddl_reads(server: FastMCP[AppContext]) -> None:
             "get_role_ddl(role_name='app_user')",
         ),
     )
-    async def get_role_ddl(ctx: _Ctx, role_name: str) -> pg19_ddl.ObjectDdlResult:
-        return await pg19_ddl.get_role_ddl(_driver(ctx), role_name)
+    async def get_role_ddl(ctx: _Ctx, role_name: str, database: _DatabaseArg = None) -> pg19_ddl.ObjectDdlResult:
+        return await pg19_ddl.get_role_ddl(_driver(ctx, database), role_name)
 
     @server.tool(
         name="get_database_ddl",
@@ -5015,8 +5228,10 @@ def _register_pg19_ddl_reads(server: FastMCP[AppContext]) -> None:
             "get_database_ddl(database_name='analytics')",
         ),
     )
-    async def get_database_ddl(ctx: _Ctx, database_name: str) -> pg19_ddl.ObjectDdlResult:
-        return await pg19_ddl.get_database_ddl(_driver(ctx), database_name)
+    async def get_database_ddl(
+        ctx: _Ctx, database_name: str, database: _DatabaseArg = None
+    ) -> pg19_ddl.ObjectDdlResult:
+        return await pg19_ddl.get_database_ddl(_driver(ctx, database), database_name)
 
     @server.tool(
         name="get_tablespace_ddl",
@@ -5030,8 +5245,10 @@ def _register_pg19_ddl_reads(server: FastMCP[AppContext]) -> None:
             "get_tablespace_ddl(tablespace_name='fast_ssd')",
         ),
     )
-    async def get_tablespace_ddl(ctx: _Ctx, tablespace_name: str) -> pg19_ddl.ObjectDdlResult:
-        return await pg19_ddl.get_tablespace_ddl(_driver(ctx), tablespace_name)
+    async def get_tablespace_ddl(
+        ctx: _Ctx, tablespace_name: str, database: _DatabaseArg = None
+    ) -> pg19_ddl.ObjectDdlResult:
+        return await pg19_ddl.get_tablespace_ddl(_driver(ctx, database), tablespace_name)
 
 
 def _register_pg19_ddl_writes(server: FastMCP[AppContext]) -> None:
@@ -5089,10 +5306,10 @@ def _register_pg19_skip_scan_reads(server: FastMCP[AppContext]) -> None:
             "get_skip_scan_status()",
         ),
     )
-    async def get_skip_scan_status(ctx: _Ctx) -> pg19_skip_scan.SkipScanStatus:
+    async def get_skip_scan_status(ctx: _Ctx, database: _DatabaseArg = None) -> pg19_skip_scan.SkipScanStatus:
         # Live version probe — never cache. A server upgrade mid-session
         # needs to flip availability on the next call.
-        return await pg19_skip_scan.get_skip_scan_status(_driver(ctx))
+        return await pg19_skip_scan.get_skip_scan_status(_driver(ctx, database))
 
     @server.tool(
         name="recommend_skip_scan_indexes",
@@ -5116,11 +5333,11 @@ def _register_pg19_skip_scan_reads(server: FastMCP[AppContext]) -> None:
         ),
     )
     async def recommend_skip_scan_indexes(
-        ctx: _Ctx, max_leading_ndv: int = 1000
+        ctx: _Ctx, max_leading_ndv: int = 1000, database: _DatabaseArg = None
     ) -> list[pg19_skip_scan.SkipScanCandidate]:
         # Live catalog + stats walk — never cache. ANALYZE / index DDL
         # changes need to be visible on the next call.
-        return await pg19_skip_scan.recommend_skip_scan_indexes(_driver(ctx), max_leading_ndv=max_leading_ndv)
+        return await pg19_skip_scan.recommend_skip_scan_indexes(_driver(ctx, database), max_leading_ndv=max_leading_ndv)
 
 
 def _register_pg19_partitions_reads(server: FastMCP[AppContext]) -> None:
@@ -5138,10 +5355,12 @@ def _register_pg19_partitions_reads(server: FastMCP[AppContext]) -> None:
             "get_pg19_partitions_status()",
         ),
     )
-    async def get_pg19_partitions_status(ctx: _Ctx) -> pg19_partitions.Pg19PartitionsStatus:
+    async def get_pg19_partitions_status(
+        ctx: _Ctx, database: _DatabaseArg = None
+    ) -> pg19_partitions.Pg19PartitionsStatus:
         # Cluster version probe — never cache: a server upgrade mid-session
         # needs to flip availability on the next call.
-        return await pg19_partitions.get_pg19_partitions_status(_driver(ctx))
+        return await pg19_partitions.get_pg19_partitions_status(_driver(ctx, database))
 
 
 def _register_pg19_partitions_writes(server: FastMCP[AppContext]) -> None:
@@ -5252,11 +5471,11 @@ def _register_wait_for_lsn_reads(server: FastMCP[AppContext]) -> None:
             "get_wait_for_lsn_status()",
         ),
     )
-    async def get_wait_for_lsn_status(ctx: _Ctx) -> wait_for_lsn.WaitForLsnStatus:
+    async def get_wait_for_lsn_status(ctx: _Ctx, database: _DatabaseArg = None) -> wait_for_lsn.WaitForLsnStatus:
         # Live cluster state — never cache. is_in_recovery flips on
         # promotion / demotion and the agent needs to see the new
         # state on the next call.
-        return await wait_for_lsn.get_wait_for_lsn_status(_driver(ctx))
+        return await wait_for_lsn.get_wait_for_lsn_status(_driver(ctx, database))
 
     @server.tool(
         name="get_current_wal_lsn",
@@ -5273,10 +5492,10 @@ def _register_wait_for_lsn_reads(server: FastMCP[AppContext]) -> None:
             "get_current_wal_lsn()",
         ),
     )
-    async def get_current_wal_lsn(ctx: _Ctx) -> wait_for_lsn.CurrentWalLsnResult:
+    async def get_current_wal_lsn(ctx: _Ctx, database: _DatabaseArg = None) -> wait_for_lsn.CurrentWalLsnResult:
         # Snapshot — never cache; the LSN advances monotonically with
         # every WAL-emitting transaction.
-        return await wait_for_lsn.get_current_wal_lsn(_driver(ctx))
+        return await wait_for_lsn.get_current_wal_lsn(_driver(ctx, database))
 
     @server.tool(
         name="recommend_read_your_writes",
@@ -5296,9 +5515,10 @@ def _register_wait_for_lsn_reads(server: FastMCP[AppContext]) -> None:
     )
     async def recommend_read_your_writes(
         ctx: _Ctx,
+        database: _DatabaseArg = None,
     ) -> wait_for_lsn.ReadYourWritesRecommendation:
         # Live advisor — never cache. Lag and role change in real time.
-        return await wait_for_lsn.recommend_read_your_writes(_driver(ctx))
+        return await wait_for_lsn.recommend_read_your_writes(_driver(ctx, database))
 
 
 def _register_wait_for_lsn_writes(server: FastMCP[AppContext]) -> None:
@@ -5319,8 +5539,10 @@ def _register_wait_for_lsn_writes(server: FastMCP[AppContext]) -> None:
             "wait_for_lsn(lsn='0/1234ABCD', timeout_ms=5000)",
         ),
     )
-    async def wait_for_lsn_tool(ctx: _Ctx, lsn: str, timeout_ms: int = 0) -> wait_for_lsn.WaitForLsnResult:
-        return await wait_for_lsn.wait_for_lsn(_driver(ctx), lsn=lsn, timeout_ms=timeout_ms)
+    async def wait_for_lsn_tool(
+        ctx: _Ctx, lsn: str, timeout_ms: int = 0, database: _DatabaseArg = None
+    ) -> wait_for_lsn.WaitForLsnResult:
+        return await wait_for_lsn.wait_for_lsn(_driver(ctx, database), lsn=lsn, timeout_ms=timeout_ms)
 
 
 def _register_pg19_stats_reads(server: FastMCP[AppContext]) -> None:
@@ -5338,9 +5560,9 @@ def _register_pg19_stats_reads(server: FastMCP[AppContext]) -> None:
             "get_pg19_stats_status()",
         ),
     )
-    async def get_pg19_stats_status(ctx: _Ctx) -> pg19_stats.Pg19StatsStatus:
+    async def get_pg19_stats_status(ctx: _Ctx, database: _DatabaseArg = None) -> pg19_stats.Pg19StatsStatus:
         async def _run() -> pg19_stats.Pg19StatsStatus:
-            return await pg19_stats.get_pg19_stats_status(_driver(ctx))
+            return await pg19_stats.get_pg19_stats_status(_driver(ctx, database))
 
         return await _cached_call(ctx, "get_pg19_stats_status", _run)
 
@@ -5357,11 +5579,11 @@ def _register_pg19_stats_reads(server: FastMCP[AppContext]) -> None:
             "read_pg_stat_lock()",
         ),
     )
-    async def read_pg_stat_lock(ctx: _Ctx) -> list[pg19_stats.LockStatRow]:
+    async def read_pg_stat_lock(ctx: _Ctx, database: _DatabaseArg = None) -> list[pg19_stats.LockStatRow]:
         # Live counters — never cache (matches find_blocking_chains /
         # read_pg_stat_io pattern). Caching would return stale waits
         # during real-time incident response (gemini review on PR #141).
-        return await pg19_stats.read_pg_stat_lock(_driver(ctx))
+        return await pg19_stats.read_pg_stat_lock(_driver(ctx, database))
 
     @server.tool(
         name="read_pg_stat_recovery",
@@ -5377,10 +5599,10 @@ def _register_pg19_stats_reads(server: FastMCP[AppContext]) -> None:
             "read_pg_stat_recovery()",
         ),
     )
-    async def read_pg_stat_recovery(ctx: _Ctx) -> list[pg19_stats.RecoveryStatRow]:
+    async def read_pg_stat_recovery(ctx: _Ctx, database: _DatabaseArg = None) -> list[pg19_stats.RecoveryStatRow]:
         # Live replay state — never cache. Stale lag readings during
         # standby triage are worse than useless (gemini review on PR #141).
-        return await pg19_stats.read_pg_stat_recovery(_driver(ctx))
+        return await pg19_stats.read_pg_stat_recovery(_driver(ctx, database))
 
     @server.tool(
         name="analyze_lock_hotspots",
@@ -5398,11 +5620,11 @@ def _register_pg19_stats_reads(server: FastMCP[AppContext]) -> None:
             "analyze_lock_hotspots()",
         ),
     )
-    async def analyze_lock_hotspots(ctx: _Ctx) -> pg19_stats.LockHotspotsResult:
+    async def analyze_lock_hotspots(ctx: _Ctx, database: _DatabaseArg = None) -> pg19_stats.LockHotspotsResult:
         # Live advisor over live counters — never cache. Incident-response
         # callers need the current snapshot, not what we saw 60s ago
         # (gemini review on PR #141).
-        return await pg19_stats.analyze_lock_hotspots(_driver(ctx))
+        return await pg19_stats.analyze_lock_hotspots(_driver(ctx, database))
 
 
 def _register_aio_reads(server: FastMCP[AppContext]) -> None:
@@ -5421,9 +5643,9 @@ def _register_aio_reads(server: FastMCP[AppContext]) -> None:
             "get_aio_status()",
         ),
     )
-    async def get_aio_status(ctx: _Ctx) -> aio.AioStatus:
+    async def get_aio_status(ctx: _Ctx, database: _DatabaseArg = None) -> aio.AioStatus:
         async def _run() -> aio.AioStatus:
-            return await aio.get_aio_status(_driver(ctx))
+            return await aio.get_aio_status(_driver(ctx, database))
 
         return await _cached_call(ctx, "get_aio_status", _run)
 
@@ -5449,9 +5671,9 @@ def _register_aio_reads(server: FastMCP[AppContext]) -> None:
             "recommend_io_method()",
         ),
     )
-    async def recommend_io_method(ctx: _Ctx) -> aio.RecommendIoMethodResult:
+    async def recommend_io_method(ctx: _Ctx, database: _DatabaseArg = None) -> aio.RecommendIoMethodResult:
         async def _run() -> aio.RecommendIoMethodResult:
-            return await aio.recommend_io_method(_driver(ctx))
+            return await aio.recommend_io_method(_driver(ctx, database))
 
         return await _cached_call(ctx, "recommend_io_method", _run)
 
@@ -5472,9 +5694,9 @@ def _register_repack_reads(server: FastMCP[AppContext]) -> None:
             "get_repack_status()",
         ),
     )
-    async def get_repack_status(ctx: _Ctx) -> repack.RepackStatus:
+    async def get_repack_status(ctx: _Ctx, database: _DatabaseArg = None) -> repack.RepackStatus:
         async def _run() -> repack.RepackStatus:
-            return await repack.get_repack_status(_driver(ctx))
+            return await repack.get_repack_status(_driver(ctx, database))
 
         return await _cached_call(ctx, "get_repack_status", _run)
 
@@ -6006,9 +6228,9 @@ def _register_warehousepg_reads(server: FastMCP[AppContext]) -> None:
             "get_warehousepg_status()",
         ),
     )
-    async def get_warehousepg_status(ctx: _Ctx) -> warehousepg.WarehousePGStatus:
+    async def get_warehousepg_status(ctx: _Ctx, database: _DatabaseArg = None) -> warehousepg.WarehousePGStatus:
         async def _run() -> warehousepg.WarehousePGStatus:
-            return await warehousepg.get_warehousepg_status(_driver(ctx))
+            return await warehousepg.get_warehousepg_status(_driver(ctx, database))
 
         return await _cached_call(ctx, "get_warehousepg_status", _run)
 
@@ -6024,9 +6246,11 @@ def _register_warehousepg_reads(server: FastMCP[AppContext]) -> None:
             "list_distribution_policies(schema='public')",
         ),
     )
-    async def list_distribution_policies(ctx: _Ctx, schema: str | None = None) -> warehousepg.DistributionPolicyReport:
+    async def list_distribution_policies(
+        ctx: _Ctx, schema: str | None = None, database: _DatabaseArg = None
+    ) -> warehousepg.DistributionPolicyReport:
         async def _run() -> warehousepg.DistributionPolicyReport:
-            return await warehousepg.list_distribution_policies(_driver(ctx), schema=schema)
+            return await warehousepg.list_distribution_policies(_driver(ctx, database), schema=schema)
 
         return await _cached_call(ctx, "list_distribution_policies", _run, schema)
 
@@ -6043,9 +6267,9 @@ def _register_warehousepg_reads(server: FastMCP[AppContext]) -> None:
             "check_segment_health()",
         ),
     )
-    async def check_segment_health(ctx: _Ctx) -> warehousepg.SegmentHealthReport:
+    async def check_segment_health(ctx: _Ctx, database: _DatabaseArg = None) -> warehousepg.SegmentHealthReport:
         async def _run() -> warehousepg.SegmentHealthReport:
-            return await warehousepg.check_segment_health(_driver(ctx))
+            return await warehousepg.check_segment_health(_driver(ctx, database))
 
         return await _cached_call(ctx, "check_segment_health", _run)
 
@@ -6061,9 +6285,11 @@ def _register_warehousepg_reads(server: FastMCP[AppContext]) -> None:
             "describe_ao_table(schema='public', table='events_ao')",
         ),
     )
-    async def describe_ao_table(ctx: _Ctx, schema: str, table: str) -> warehousepg.AppendOptimizedTableInfo:
+    async def describe_ao_table(
+        ctx: _Ctx, schema: str, table: str, database: _DatabaseArg = None
+    ) -> warehousepg.AppendOptimizedTableInfo:
         async def _run() -> warehousepg.AppendOptimizedTableInfo:
-            return await warehousepg.describe_ao_table(_driver(ctx), schema, table)
+            return await warehousepg.describe_ao_table(_driver(ctx, database), schema, table)
 
         return await _cached_call(ctx, "describe_ao_table", _run, schema, table)
 
@@ -6080,9 +6306,9 @@ def _register_warehousepg_reads(server: FastMCP[AppContext]) -> None:
             "list_resource_groups()",
         ),
     )
-    async def list_resource_groups(ctx: _Ctx) -> warehousepg.ResourceGroupReport:
+    async def list_resource_groups(ctx: _Ctx, database: _DatabaseArg = None) -> warehousepg.ResourceGroupReport:
         async def _run() -> warehousepg.ResourceGroupReport:
-            return await warehousepg.list_resource_groups(_driver(ctx))
+            return await warehousepg.list_resource_groups(_driver(ctx, database))
 
         return await _cached_call(ctx, "list_resource_groups", _run)
 
@@ -6100,13 +6326,15 @@ def _register_warehousepg_reads(server: FastMCP[AppContext]) -> None:
             "analyze_mpp_query_plan(sql='SELECT * FROM big JOIN small ON big.k = small.k')",
         ),
     )
-    async def analyze_mpp_query_plan(ctx: _Ctx, sql: str) -> warehousepg.MppQueryPlanAnalysis:
+    async def analyze_mpp_query_plan(
+        ctx: _Ctx, sql: str, database: _DatabaseArg = None
+    ) -> warehousepg.MppQueryPlanAnalysis:
         # Deliberately NOT cached — matches the convention for
         # analyze_query_plan / explain_query: each EXPLAIN ANALYZE
         # call reflects the planner state + actual buffer cache at
         # invocation time. Caching by SQL text would hide regressions
         # the agent is calling this tool to detect.
-        return await warehousepg.analyze_mpp_query_plan(_driver(ctx), sql)
+        return await warehousepg.analyze_mpp_query_plan(_driver(ctx, database), sql)
 
     @server.tool(
         name="recommend_redistribute",
@@ -6122,9 +6350,11 @@ def _register_warehousepg_reads(server: FastMCP[AppContext]) -> None:
             "recommend_redistribute(schema='public', table='fact_sales')",
         ),
     )
-    async def recommend_redistribute(ctx: _Ctx, schema: str, table: str) -> warehousepg.RedistributeRecommendation:
+    async def recommend_redistribute(
+        ctx: _Ctx, schema: str, table: str, database: _DatabaseArg = None
+    ) -> warehousepg.RedistributeRecommendation:
         async def _run() -> warehousepg.RedistributeRecommendation:
-            return await warehousepg.recommend_redistribute(_driver(ctx), schema, table)
+            return await warehousepg.recommend_redistribute(_driver(ctx, database), schema, table)
 
         return await _cached_call(ctx, "recommend_redistribute", _run, schema, table)
 

--- a/tests/contract/test_tool_output_schemas.py
+++ b/tests/contract/test_tool_output_schemas.py
@@ -184,6 +184,8 @@ _TOOLS_WITH_STRUCTURED_OUTPUT: dict[str, frozenset[str]] = {
     "read_pg_wal_records": frozenset({"available", "records"}),
     "read_pg_wal_stats": frozenset({"available", "stats"}),
     "check_database_health": frozenset({"status", "checks"}),
+    # Multi-database selector (roadmap 13.1).
+    "list_databases": frozenset({"primary_id", "database_ids", "databases"}),
     "read_migration_history": frozenset(
         {"alembic", "flyway", "diesel", "django", "prisma", "golang_migrate", "goose", "sequelize"}
     ),
@@ -794,7 +796,7 @@ def test_converted_tool_count_grows_monotonically() -> None:
     never decrement it without a deliberate "we're rolling back
     structured output for tool X" conversation in the PR.
     """
-    floor = 194
+    floor = 195
     actual = len(_TOOLS_WITH_STRUCTURED_OUTPUT)
     assert actual >= floor, (
         f"structured-output manifest dropped from at-least-{floor} tools "

--- a/tests/contract/test_tool_return_shapes.py
+++ b/tests/contract/test_tool_return_shapes.py
@@ -78,6 +78,7 @@ _KNOWN_HELPER_MODULES = (
     "maintenance",
     "migration_history",
     "migrations",
+    "multidb",
     "naming",
     "nl2sql",
     "partman",

--- a/tests/contract/tool_return_shapes.snapshot.json
+++ b/tests/contract/tool_return_shapes.snapshot.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "schema_version": 1,
-    "tool_count": 245
+    "tool_count": 246
   },
   "tools": {
     "add_compression_policy": {
@@ -1062,6 +1062,9 @@
       "kind": "list"
     },
     "list_cursors": {
+      "kind": "opaque"
+    },
+    "list_databases": {
       "kind": "opaque"
     },
     "list_distribution_policies": {

--- a/tests/contract/tool_surface.snapshot.json
+++ b/tests/contract/tool_surface.snapshot.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "schema_version": 1,
-    "tool_count": 245
+    "tool_count": 246
   },
   "tools": [
     {
@@ -66,6 +66,19 @@
             "title": "Column",
             "type": "string"
           },
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "sample_size": {
             "default": 1000,
             "title": "Sample Size",
@@ -97,6 +110,19 @@
           "column": {
             "title": "Column",
             "type": "string"
+          },
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
           },
           "k": {
             "default": 10,
@@ -145,7 +171,21 @@
     {
       "description": "Rank PG 19 `pg_stat_lock` rows by wait dominance and surface stable reason codes. Read-only — never modifies state. Pair with `find_blocking_chains` for the active culprits on a specific hot lock_type. Returns an object with `available` (bool), `server_version_num`, `detail`, and `hotspots` — a list of objects with `lock_type`, `waits`, `wait_time_us`, `reason` (one of `contention_dominant` / `high_wait_time` / `high_wait_count` / `low_contention`), and `suggested_followup` (a human-readable next-step string).\n\nExample: `analyze_lock_hotspots()`",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "analyze_lock_hotspotsArguments",
         "type": "object"
       },
@@ -155,6 +195,19 @@
       "description": "Run `EXPLAIN (ANALYZE, FORMAT JSON)` on `sql` and roll up MPP-specific facts: slice count, motion nodes (`Redistribute Motion` / `Broadcast Motion` / `Gather Motion`), and per-motion metadata (senders, receivers, estimated rows). Uses the same safety pre-flight as `analyze_query_plan(io=True)` — writes / DDL stay rejected. `redistribute_count` flags 'data is not co-located with the join key'. On vanilla PG returns `available=false`.\n\nExample: `analyze_mpp_query_plan(sql='SELECT * FROM big JOIN small ON big.k = small.k')`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "sql": {
             "title": "Sql",
             "type": "string"
@@ -172,6 +225,19 @@
       "description": "Summarise a query's execution plan: total estimated cost, estimated rows, node types used, and any sequentially-scanned tables. Set `io=true` to run `EXPLAIN (ANALYZE, BUFFERS, TIMING)` instead of the plan-only variant — adds `actual_total_time_ms`, `shared_blocks_read/hit`, `io_read_time_ms`, `io_write_time_ms`, and (PG 19) `aio_read_blocks` / `aio_write_blocks` rolled up across the plan tree. Reasoning about AIO needs `io=true`.\n\nExample: `analyze_query_plan(sql='SELECT * FROM orders WHERE customer_id = 42', io=true)`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "io": {
             "default": false,
             "title": "Io",
@@ -194,6 +260,19 @@
       "description": "NDCG@k under bi-encoder ordering vs cross-encoder ordering, averaged across labeled queries (``ground_truth_relevance IS NOT NULL``). Reports the delta (cross - bi) — positive = the rerank is adding real ranking quality, negative = it's hurting. Surfaces ``rerank_hurts_ndcg`` (CRITICAL) or ``rerank_lifts_ndcg`` (GOOD evidence). Reads from mcpg_rag.rerank_events; returns zero counts when no labeled rows exist in the window.",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "days": {
             "default": 7,
             "title": "Days",
@@ -238,6 +317,19 @@
       "description": "Equal-width histogram of cross_encoder_score values over the window plus the top-decile share. Surfaces ``score_clustering`` (WARNING) when the reranker isn't discriminating (more than half of scores land in the top decile of the range). Reads from mcpg_rag.rerank_events. Returns an object with `window_days`, `event_count`, `histogram` (list of counts), `bucket_edges` (list of bucket boundaries), `top_decile_share`, and `findings` (list of advisory findings).",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "days": {
             "default": 7,
             "title": "Days",
@@ -282,6 +374,19 @@
       "description": "Per-query Spearman + Kendall correlation between bi-encoder and cross-encoder ranks, aggregated across queries in the window. Low correlation = the reranker is actively reordering (doing real work); high correlation = the reranker mostly confirms the bi-encoder order. Optional ``model`` / ``retrieval_index`` filters. Surfaces ``reranker_idle`` (WARNING) when the reranker rarely changes ordering. Reads from mcpg_rag.rerank_events; returns a report with zero counts when the table doesn't exist or the window is empty.",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "days": {
             "default": 7,
             "title": "Days",
@@ -321,6 +426,19 @@
       "description": "Surface hot-path inefficiencies from the audit log. Reads `mcpg_audit.events` over the last `lookback_minutes` (default 60, capped at 1440) and flags tools called more than `hot_threshold` times (default 10). Catalogue-listing tools (`list_tables` / `list_schemas` / `list_indexes` / etc.) get a `redundant_listing` finding pointing at `get_compact_schema`; other tools get a `hot_repeated_call` finding suggesting caching. Idle sessions get an `idle_session` finding. When `mcpg_audit.events` doesn't exist (audit subsystem off) returns `audit_table_present=False` with a diagnostic. Returns an object with `audit_table_present` (bool), `events_examined` (int), `lookback_minutes`, `findings` (list of objects with `reason`, `tool`, `call_count`, `suggestion`), and `detail`.\n\nExample: `analyze_session_cost(lookback_minutes=30, hot_threshold=15)`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "hot_threshold": {
             "default": 10,
             "title": "Hot Threshold",
@@ -341,6 +459,19 @@
       "description": "Jaccard overlap between top-K-by-bi-rank and top-K-by-cross-rank per query, aggregated. High mean Jaccard means the reranker isn't actually changing the top-K membership. Surfaces ``topk_stable`` (WARNING) when the rerank is barely earning its place at this K. Reads from mcpg_rag.rerank_events; returns a report with zero counts when the table doesn't exist or the window is empty.",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "days": {
             "default": 7,
             "title": "Days",
@@ -404,6 +535,19 @@
             "title": "Column",
             "type": "string"
           },
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "id_column": {
             "title": "Id Column",
             "type": "string"
@@ -459,6 +603,19 @@
       "description": "Return the slowest queries by mean execution time, via the pg_stat_statements extension. Reports availability=false if the extension is not installed.\n\nExample: `analyze_workload(limit=10)`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "limit": {
             "default": 10,
             "title": "Limit",
@@ -474,6 +631,19 @@
       "description": "Run a deep, comprehensive DBA-level database performance, logs, and health audit over the specified schema. Scans memory, checkpoints, temp file spills, contention locks, dead tuple cleanliness, and optionally scans custom logging tables. Returns an object with `timestamp`, `database`, `version`, `overall_health` ('GOOD' / 'WARNING' / 'CRITICAL'), `health_score` (int), `categories` (per-area results), `top_issues`, `recommendations`, and `raw_stats_snapshot`.",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "log_table": {
             "anyOf": [
               {
@@ -508,6 +678,19 @@
             "title": "Critical Pct",
             "type": "number"
           },
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "warning_pct": {
             "default": 80.0,
             "title": "Warning Pct",
@@ -523,6 +706,19 @@
       "description": "Sanity-sweep `postgresql.conf` via `pg_settings`. Flags dangerous toggles (`fsync=off`, `full_page_writes=off`, `autovacuum=off`, `synchronous_commit=off`), cross-setting issues (`maintenance_work_mem` < `work_mem`, tiny `shared_buffers`, low `checkpoint_completion_target`), and — when `total_ram_mb` is supplied — RAM-relative ratios for `shared_buffers` / `effective_cache_size` (PostgreSQL can't see host RAM itself). Pure read. Returns an object with `ram_aware` (bool), `examined_settings` (list), `detail`, and `findings` (tripped rules only — each with `code`, `setting`, `current`, `status`, `suggestion`).\n\nExample: `audit_settings(total_ram_mb=16384)`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "total_ram_mb": {
             "anyOf": [
               {
@@ -578,7 +774,21 @@
     {
       "description": "Run database health checks: connection utilisation, buffer cache hit ratio, tables needing vacuum, and invalid indexes. Returns an object with `status` ('ok' / 'warning' / 'critical') and `checks` (a list of `{name, status, detail}` per check).\n\nExample: `check_database_health()`",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "check_database_healthArguments",
         "type": "object"
       },
@@ -587,7 +797,21 @@
     {
       "description": "Assess whether the cluster is ready for point-in-time recovery (PITR) — the one-call 'could I actually recover to an arbitrary point right now, and if not what's missing?' check. Composes `get_wal_archive_status` (5.2) with the GUCs that gate PITR: continuous archiving must be healthy, `wal_level` >= replica, `max_wal_senders` >= 1 (so pg_basebackup can stream a base backup), and `full_page_writes` on (torn-page safety during replay). Read-only advisor — changes nothing, emits no secrets. Returns an object with `available`, `ready` (bool — true only when all gates pass), `wal_level`, `archiving_healthy`, `gates` (list of objects with `name`, `ok`, `observed`, `remediation`), `remediation` (ordered fixes for failing gates), and `detail`.\n\nExample: `check_pitr_readiness()`",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "check_pitr_readinessArguments",
         "type": "object"
       },
@@ -596,7 +820,21 @@
     {
       "description": "Walk `gp_segment_configuration` and surface MPP segment posture. Returns per-segment `status` ('u' = up), `mode` ('s' = sync / 'n' = not-in-sync / 'c' = changetracking), and `role` vs `preferred_role` to detect post-failover state. Top-level `unhealthy_count` + `out_of_sync_count` let agents branch without walking the segments array. Read-only. On vanilla PG returns `available=false`.\n\nExample: `check_segment_health()`",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "check_segment_healthArguments",
         "type": "object"
       },
@@ -623,6 +861,19 @@
       "description": "k-means cluster a pgvector column. Samples up to `sample_size` (default 5000) non-NULL rows of schema.table.embedding_column, runs Lloyd's algorithm with k-means++ seeding (`seed` for determinism), and returns `centroids` (one per cluster, with size) + `assignments` (per-row cluster index + distance). When `id_column` is set each assignment carries that column's value; otherwise the row's positional sample index. metric='l2' (default — squared Euclidean) or 'cosine' (vectors normalised; centroids re-normalised every iteration). `k` >= 2 and there must be at least 2k parseable rows. Reports available=false if pgvector is not installed.\n\nExample: `cluster_vectors(schema='public', table='docs', embedding_column='embedding', k=8, metric='cosine')`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "embedding_column": {
             "title": "Embedding Column",
             "type": "string"
@@ -687,6 +938,19 @@
       "description": "Return the structural diff between two schemas — tables/columns/indexes/constraints/foreign-keys added, removed, or changed. Base tables only; views and custom types are not compared. Renames surface as a paired add + remove.\n\nExample: `compare_schemas(left_schema='public', right_schema='staging')`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "left_schema": {
             "title": "Left Schema",
             "type": "string"
@@ -1365,6 +1629,19 @@
       "description": "Find the k rows in target_schema.target_table most similar to a specific row in source_schema.source_table. Locates the source row via source_id_column = source_id_value, reads its embedding from source_embedding_column, then issues a pgvector k-NN query against target_embedding_column. Both columns must be vector(N) of the same N — verified from the catalog up front so a mismatch fails with a clear error rather than a cast error. Useful for entity-resolution / linking across tables whose embeddings come from different models but share a dimension. Returns source_embedding_found=false when no row matches the id value. Reports available=false if pgvector is not installed.",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "k": {
             "default": 10,
             "title": "K",
@@ -1426,6 +1703,19 @@
       "description": "Describe append-optimized (AO) / append-optimized columnar (AO/CO) storage metadata for one table: row vs column orientation, `compression_type`, `compression_level`, `block_size`, `checksum`. Reads `pg_appendonly`. Returns `is_ao=false` cleanly when the table is a regular heap. Read-only. On vanilla PG returns `available=false`.\n\nExample: `describe_ao_table(schema='public', table='events_ao')`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "schema": {
             "title": "Schema",
             "type": "string"
@@ -1465,6 +1755,19 @@
       "description": "Describe one SQL/PGQ property graph by schema-qualified name. Requires PG 19+; raises an error otherwise. Useful when an agent has located a graph via `list_property_graphs` and needs the full membership before composing a `run_pgq` query. Returns an object with `schema`, `name`, `vertex_tables` (list of `schema.table` strings), and `edge_tables` (same shape).\n\nExample: `describe_property_graph(schema='public', name='org_chart')`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "name": {
             "title": "Name",
             "type": "string"
@@ -1487,6 +1790,19 @@
       "description": "Describe one foreign table backed by ``redis_fdw``: which server it's mapped to, the Redis-side key structure (`hash` / `list` / `string` / `set` / `zset`), key-prefix, TTL, and SQL-side column shape. Raises an error when the table doesn't exist or isn't backed by redis_fdw. Returns an object with `schema`, `name`, `server`, `key_type`, `key_prefix`, `ttl_seconds`, `columns` (list of `{name, data_type}`), and `options` (the full foreign-table options dict).\n\nExample: `describe_redis_cache_table(schema='public', table='sessions_cache')`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "schema": {
             "title": "Schema",
             "type": "string"
@@ -1518,6 +1834,19 @@
       "description": "Describe the columns of a table, in ordinal order. Returns a list of objects with `name`, `data_type`, `nullable`, `default`, and `vector_dimension` (set only for pgvector `vector(N)` columns).\n\nExample: `describe_table(schema='public', table='users')`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "schema": {
             "title": "Schema",
             "type": "string"
@@ -1557,6 +1886,19 @@
       "description": "Surface query templates in pg_stat_statements that look like an N+1 loop: hundreds of calls, each returning at most a row or two, with meaningful total wall-clock time spent. Returns the candidates sorted by total time descending so the worst offender appears first. Thresholds (min_calls, max_rows_per_call, min_total_ms) are tunable. Treat results as candidates for investigation, NOT verdicts — a hot cache-miss pattern on a primary-key lookup can trip the same shape. Reports availability=false if pg_stat_statements is not installed.",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "limit": {
             "default": 25,
             "title": "Limit",
@@ -1587,6 +1929,19 @@
       "description": "Flag pgvector rows whose embedding sits far from any cluster centroid. Samples up to `sample_size` (default 5000) non-NULL rows of schema.table.embedding_column, clusters them with k-means (same engine as `cluster_vectors`), then per cluster computes a z-score on the distance from each row to its centroid and flags rows whose z-score exceeds `zscore_threshold` (default 3.0). Per-cluster scoring catches rows that are weird-for-their-group rather than weird-overall, which is usually what 'find outliers' should mean. Returns `outliers` sorted by z-score descending (capped at `max_results`), `total_outliers` (the unclipped count), and `cluster_stats` (per-cluster mean / std of within-cluster distances). When `id_column` is set each outlier carries that column's value; otherwise the row's positional sample index. `k` >= 2 and there must be at least 2k parseable rows. Reports available=false if pgvector is not installed.",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "embedding_column": {
             "title": "Embedding Column",
             "type": "string"
@@ -1832,6 +2187,19 @@
       "description": "Return the PostgreSQL execution plan for a query. By default uses `EXPLAIN (FORMAT JSON)` — plan only, the query is not executed. Set `io=true` to switch to `EXPLAIN (ANALYZE, BUFFERS, TIMING)` — runs the query and includes buffer + I/O timing per node (PG 19 additionally surfaces asynchronous-I/O block counts). Validated by the same safety allowlist as `run_select`, so writes / DDL are rejected.\n\nExample: `explain_query(sql='SELECT * FROM orders WHERE customer_id = 42', io=true)`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "io": {
             "default": false,
             "title": "Io",
@@ -1854,6 +2222,19 @@
       "description": "Run a read-only SQL query and serialise its rows to CSV or JSON. Reuses the SQL-safety checks of run_select. Truncates at `limit` rows and flags it in the result so callers can paginate.\n\nExample: `export_query(sql='SELECT id, email FROM users', format='csv', limit=10000)`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "format": {
             "default": "csv",
             "title": "Format",
@@ -1881,6 +2262,19 @@
       "description": "Serialise every row in schema.table (up to `limit`) to CSV or JSON. Schema and table names must be plain identifiers. Returns an object with `format`, `row_count`, `truncated` (bool — true when the row count hit `limit`), and `content` (the serialised payload as a string).",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "format": {
             "default": "csv",
             "title": "Format",
@@ -1935,6 +2329,19 @@
       "description": "Return (blocked, blocking) backend pairs via pg_blocking_pids. Each row pairs a backend waiting on a Lock with one PID holding the lock that's preventing progress. Cycles are possible (A blocks B, B blocks A); render with care. Read-only.",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "limit": {
             "default": 50,
             "title": "Limit",
@@ -1950,6 +2357,19 @@
       "description": "Flag columns whose names or types look like they hold sensitive data (passwords, tokens, PII, financial info, health records). Pure heuristic — no row sampling, no value introspection. Categories: credential, financial, contact, identifier, health, government_id, location. Each finding carries a confidence (high / medium / low) so an agent can filter for a first review pass. Treat as a SIGNAL, not a verdict — a column named email_template_id matches the email pattern but isn't itself an email address. Returns an object with `findings` (list of `{schema, table, column, data_type, category, confidence, matched_pattern}`) and `summary` counts by category.",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "schema": {
             "title": "Schema",
             "type": "string"
@@ -1967,6 +2387,19 @@
       "description": "Find tables and indexes with zero scans since pg_stat was last reset — a strong signal of dead code, but NOT a verdict. Tables report seq+idx scan counts, write counts, and estimated row count; indexes report size and definition. Excludes PRIMARY KEY and UNIQUE indexes (PG needs those regardless of scans). Run this after the database has been hot for a meaningful period — fresh stats produce false positives. Returns an object with `tables` (list of candidate tables with their stats) and `indexes` (list of candidate indexes with size and definition).",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "schema": {
             "title": "Schema",
             "type": "string"
@@ -1992,6 +2425,19 @@
             "default": "english",
             "title": "Config",
             "type": "string"
+          },
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
           },
           "limit": {
             "default": 10,
@@ -2029,6 +2475,19 @@
           "column": {
             "title": "Column",
             "type": "string"
+          },
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
           },
           "limit": {
             "default": 10,
@@ -2073,6 +2532,19 @@
       "description": "Read a PostgreSQL schema and emit a Diesel ORM (Rust) schema.rs. One `table!` macro per table with column SQL types, `Nullable<T>` for nullable columns, plus `joinable!` declarations for single-column intra-schema FKs and an `allow_tables_to_appear_in_same_query!` macro so multi-table joins type-check. Enum types are emitted as Text-backed wrapper enums in a `pg_enum` module so the output works without `diesel_derive_enum`. Composite FKs are a documented v1 gap.",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "schema": {
             "title": "Schema",
             "type": "string"
@@ -2090,6 +2562,19 @@
       "description": "Read a PostgreSQL schema and emit a Drizzle ORM TypeScript schema string (drizzle-orm/pg-core). Covers tables, columns with PG-native types, primary/foreign keys, unique constraints, indexes, defaults, and enums. Single-column FKs emit column-level .references(); composite FKs are a documented v1 gap. Views, foreign tables, partitions, triggers, and functions are out of scope. Returns the rendered TypeScript `schema.ts` source as a single string.",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "schema": {
             "title": "Schema",
             "type": "string"
@@ -2112,6 +2597,19 @@
             "title": "App Module",
             "type": "string"
           },
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "schema": {
             "title": "Schema",
             "type": "string"
@@ -2129,6 +2627,19 @@
       "description": "Read a PostgreSQL schema and emit Ent (Go) Schema struct files — one .go file per table. Each file exports a struct that lists field.X(...) calls for every column, edge.To(...) for single-column intra-schema FKs, and field.Enum().Values() for enum-typed columns. Composite FKs are a documented v1 gap. Returns a JSON object {filename: source} so the agent can write each file.",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "schema": {
             "title": "Schema",
             "type": "string"
@@ -2146,6 +2657,19 @@
       "description": "Build a Mermaid graph LR of foreign-key cascade chains in a schema. Each edge runs from the referencing table to the referenced table, labelled with the cascade action(s) on DELETE / UPDATE. By default only FKs with at least one CASCADE / SET NULL / SET DEFAULT action are included — those are the ones that produce a write blast radius. Pass include_all=true to include NO ACTION / RESTRICT FKs too (full FK topology view). Cross-schema FK targets are rendered as separate nodes prefixed with their schema. Returns the Mermaid `graph LR` diagram as a string.",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "include_all": {
             "default": false,
             "title": "Include All",
@@ -2190,6 +2714,19 @@
       "description": "Read a PostgreSQL schema and emit a jooq-codegen configuration XML pointing at it. Unlike the other exporters, jOOQ generates Java code itself from a live database — the artefact here is the configuration file the user feeds to mvn jooq-codegen:generate (or the Gradle task). The XML lists every base table explicitly via an <includes> regex, excludes MCPg's bookkeeping tables, and emits a <forcedType> for every json / jsonb column so they map to org.jooq.JSON / org.jooq.JSONB out of the box. Default Java package is com.example.jooq; override via the target_package arg.",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "schema": {
             "title": "Schema",
             "type": "string"
@@ -2217,6 +2754,19 @@
       "description": "Read a PostgreSQL schema and emit a valid Prisma `.prisma` schema string (mirrors `prisma db pull`). Covers tables, columns, primary/foreign keys, unique constraints, indexes, and enums. Views, foreign tables, partitions, triggers, functions, and policies are out of scope; unmappable types fall back to `Unsupported(\"...\")`. Returns the rendered `schema.prisma` source as a single string.",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "schema": {
             "title": "Schema",
             "type": "string"
@@ -2234,6 +2784,19 @@
       "description": "Render a Mermaid ER diagram for a schema. Views and foreign tables are excluded; partitions are excluded by default — pass include_partitions=true to draw each partition as its own entity. Returns the Mermaid `erDiagram` as a string ready to paste into a Markdown block.\n\nExample: `generate_schema_diagram(schema='public', include_partitions=false)`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "include_partitions": {
             "default": false,
             "title": "Include Partitions",
@@ -2256,6 +2819,19 @@
       "description": "Generate a detailed Markdown reference of a schema's tables, columns, constraints, indexes, views, foreign tables, and custom enums along with comments / descriptions. Optional include_samples fetches a few distinct, non-null values for each column. Returns a single Markdown document as a string.\n\nExample: `generate_schema_docs(schema='public', include_samples=true)`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "include_samples": {
             "default": false,
             "title": "Include Samples",
@@ -2278,6 +2854,19 @@
       "description": "Read a PostgreSQL schema and emit a SQLAlchemy 2.0 declarative models file (DeclarativeBase + Mapped[T] + mapped_column). Covers tables, columns with PG-native types (incl. jsonb via sqlalchemy.dialects.postgresql.JSONB), primary keys, single-column FKs via ForeignKey(), unique constraints (column-level + composite via __table_args__), defaults, and enums (emitted as Python enum.Enum classes). Composite FKs are a documented v1 gap. Returns the rendered Python `models.py` source as a single string.",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "schema": {
             "title": "Schema",
             "type": "string"
@@ -2295,6 +2884,19 @@
       "description": "Read a PostgreSQL schema and emit a sqlc-friendly schema.sql (plain DDL). Order: CREATE SCHEMA, CREATE TYPE for each enum, CREATE TABLE statements (columns only), ALTER TABLE ADD CONSTRAINT (PK / unique / check / foreign key in that order), then CREATE INDEX for non-constraint indexes. The file replays cleanly against an empty database so FKs land after all referenced tables exist. In-process — no MCPG_ALLOW_SHELL needed. Returns the rendered `schema.sql` text as a single string.",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "schema": {
             "title": "Schema",
             "type": "string"
@@ -2312,6 +2914,19 @@
       "description": "Generate synthetic INSERT statements for a table — typed values respecting column type, NOT NULL, and DEFAULT. Returns the SQL as strings; does NOT execute it. Useful for seeding dev / staging environments. The generator is deterministic when a seed is provided. Foreign keys are NOT resolved — the caller must pre-seed referenced rows or drop the FK before applying. Hard cap of 10000 rows per call. Pure read (the actual writes go through run_write under unrestricted mode).",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "rows": {
             "default": 10,
             "title": "Rows",
@@ -2351,6 +2966,19 @@
       "description": "Generate ONE realistic test row for a table — catalogue-aware. Skips identity / generated columns (server fills them in), samples one existing row from each referenced table for FK columns (so the row inserts cleanly), and uses column-name heuristics (`*_email` → `user_N@example.com`, `*_url` → `https://example.com/r/N`, `*_at` → recent timestamp, etc.) to make values look like data. Sibling of `generate_test_data` (bulk) — designed for the shadow-migration workflow where a single realistic row matters more than volume. Returns an object with `insert_sql` (one ready-to-execute INSERT), `columns` (per-column ColumnFill with `sql_literal` + `heuristic` explanation), `schema`, `table`. Does NOT execute the INSERT — caller applies via `run_write` when ready.\n\nExample: `generate_test_row_for(schema='public', table='orders', seed=42)`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "follow_foreign_keys": {
             "default": true,
             "title": "Follow Foreign Keys",
@@ -2394,6 +3022,19 @@
             "title": "Column",
             "type": "string"
           },
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "latitude": {
             "title": "Latitude",
             "type": "number"
@@ -2431,7 +3072,21 @@
     {
       "description": "Report whether PG 19's async-I/O subsystem is usable. On PG < 19 returns `available=false` with a diagnostic pointing the agent at the existing `read_pg_stat_io` / `run_maintenance` tools. Never raises — driver-level errors during the version or settings probe also surface as `available=false`. Returns an object with `available` (bool), `server_version_num` (int), `server_version`, `io_method` ('sync' / 'worker' / 'io_uring' / null), `io_min_workers`, `io_max_workers`, and `detail` (a guidance string).\n\nExample: `get_aio_status()`",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "get_aio_statusArguments",
         "type": "object"
       },
@@ -2441,6 +3096,19 @@
       "description": "Return a highly condensed, token-efficient text summary of a schema's tables, columns, primary keys, nullability, and relations to save context window tokens.",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "schema": {
             "title": "Schema",
             "type": "string"
@@ -2457,7 +3125,21 @@
     {
       "description": "Return the current WAL LSN — write-side on a primary (`pg_current_wal_lsn()`) or replay-side on a standby (`pg_last_wal_replay_lsn()`). Natural pairing for the read-your-writes workflow: capture on the primary right after a write, then pass to `wait_for_lsn` on the standby session before the follow-up read. Works on every supported PG version. Returns an object with `role` (`'primary'` or `'standby'`) and `lsn` (PostgreSQL LSN literal, e.g. `'0/1234ABCD'`).\n\nExample: `get_current_wal_lsn()`",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "get_current_wal_lsnArguments",
         "type": "object"
       },
@@ -2466,7 +3148,21 @@
     {
       "description": "Report whether PG 19's online `data_checksums` toggle is usable + the current setting. Never raises — driver-level errors surface as `available=false`. On PG ≤ 18 reports `available=false` but still surfaces the current state (set at initdb time) so the agent has context, and points at the offline `pg_checksums` fallback. Returns an object with `available` (bool), `server_version_num` (int), `server_version`, `enabled` (bool / null), and `detail` (guidance string).\n\nExample: `get_data_checksums_status()`",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "get_data_checksums_statusArguments",
         "type": "object"
       },
@@ -2476,6 +3172,19 @@
       "description": "Return the `CREATE DATABASE` DDL for a named database using PG 19's `pg_get_databasedef(oid)` function. Returns `found=false` with an empty `ddl` when the database doesn't exist. Requires PG 19+. Returns an object with `object_type` (`'database'`), `object_name`, `found`, and `ddl`.\n\nExample: `get_database_ddl(database_name='analytics')`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "database_name": {
             "title": "Database Name",
             "type": "string"
@@ -2492,7 +3201,21 @@
     {
       "description": "Report whether PG 19's on-demand wal_level flip is usable, plus the configured `wal_level`, the new PG 19 `effective_wal_level` preset GUC, and `max_replication_slots`. When configured and effective diverge the agent can tell that an `ALTER SYSTEM` has been done but a reload is still pending. Never raises. Returns an object with `available` (bool), `server_version_num`, `server_version`, `wal_level`, `effective_wal_level`, `max_replication_slots`, and `detail`.\n\nExample: `get_logical_replication_status()`",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "get_logical_replication_statusArguments",
         "type": "object"
       },
@@ -2510,7 +3233,21 @@
     {
       "description": "Report whether PG 19's `pg_get_roledef()` / `pg_get_databasedef()` / `pg_get_tablespacedef()` DDL-dump functions are usable on this server. Never raises — driver-level errors surface as `available=false`. On PG ≤ 18 reports `available=false` and points the agent at `pg_dumpall --roles-only` / `--globals-only` / `--tablespaces-only` as the fallback. Returns an object with `available` (bool), `server_version_num` (int), `server_version`, `has_pg_get_roledef` (bool), `has_pg_get_databasedef` (bool), `has_pg_get_tablespacedef` (bool), and `detail` (guidance string).\n\nExample: `get_pg19_ddl_status()`",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "get_pg19_ddl_statusArguments",
         "type": "object"
       },
@@ -2519,7 +3256,21 @@
     {
       "description": "Report whether PG 19's `ALTER TABLE … MERGE PARTITIONS` and `ALTER TABLE … SPLIT PARTITION` forms are usable on this server. Never raises — driver-level errors surface as `available=false`. On PG ≤ 18 reports `available=false` and points the agent at the detach / create / attach fallback path. Returns an object with `available` (bool), `server_version_num` (int), `server_version`, and `detail` (guidance string).\n\nExample: `get_pg19_partitions_status()`",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "get_pg19_partitions_statusArguments",
         "type": "object"
       },
@@ -2528,7 +3279,21 @@
     {
       "description": "Report whether PG 19's `pg_stat_lock` and `pg_stat_recovery` views are usable on this server. Never raises — driver-level errors surface as `available=false`. On PG < 19 returns `available=false` with a diagnostic pointing the agent at `find_blocking_chains` / `pg_stat_replication`. Returns an object with `available` (bool), `server_version_num` (int), `server_version`, `has_pg_stat_lock` (bool), `has_pg_stat_recovery` (bool), and `detail` (guidance string).\n\nExample: `get_pg19_stats_status()`",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "get_pg19_stats_statusArguments",
         "type": "object"
       },
@@ -2538,6 +3303,19 @@
       "description": "Fetch the parsed reloptions for a single BM25 index (schema.index). Same shape as one entry of ``list_pg_search_indexes`` — typed accessors for the 13 documented options plus the raw ``index_options`` dict. Raises when the extension is not installed or no BM25 index by that name exists. Returns an object with `schema`, `index`, the typed option fields, and `index_options` (raw reloptions dict for forward-compat).",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "index": {
             "title": "Index",
             "type": "string"
@@ -2559,7 +3337,21 @@
     {
       "description": "Report whether SQL/PGQ (the SQL standard for property graph queries, new in PG 19) is usable on this server. SQL/PGQ coexists with the AGE-style `graph_operations` bucket — `get_pgq_status` is the agent's hint about which surface to reach for. Never raises; on PG < 19 reports `available=false` with a diagnostic pointing at `run_cypher`. Returns an object with `available` (bool), `server_version_num` (int), `server_version` (the human-readable string), and `detail` (a guidance string the agent can surface to the user).\n\nExample: `get_pgq_status()`",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "get_pgq_statusArguments",
         "type": "object"
       },
@@ -2568,7 +3360,21 @@
     {
       "description": "Report whether ``pg_prewarm`` (and the supporting ``pg_buffercache``) are installed, and whether ``pg_prewarm`` is listed in ``shared_preload_libraries`` (the autoprewarm worker requires it). Returns an object with `pg_prewarm_installed` (bool), `pg_buffercache_installed` (bool), `autoprewarm_libraries_present` (bool), and `shared_preload_libraries` (the raw setting).\n\nExample: `get_prewarm_extension_status()`",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "get_prewarm_extension_statusArguments",
         "type": "object"
       },
@@ -2578,6 +3384,19 @@
       "description": "Best-effort cache metrics for a redis_fdw server. redis_fdw does not ship a uniform stats SQL surface across versions, so the tool validates that the server exists and otherwise reports `available=false` with a diagnostic. Operators wanting live metrics should query Redis directly (INFO / DBSIZE). Returns an object with `server`, `available` (bool), `key_count`, `used_memory_bytes`, and `detail` (a human-readable note).\n\nExample: `get_redis_cache_stats(server='redis_primary')`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "server": {
             "title": "Server",
             "type": "string"
@@ -2594,7 +3413,21 @@
     {
       "description": "Report whether PG 19's in-server `REPACK` command is usable. On PG < 19 returns `available=false` with a diagnostic pointing the agent at the long-standing pg_repack extension shell-out path so the fallback is clear. The in-server `REPACK CONCURRENTLY` is the headline PG 19 operational win — online table rebuild with no blocking writers. Returns an object with `available` (bool), `server_version_num` (int), `server_version` (the human-readable string), and `detail` (a guidance string the agent can surface to the user).\n\nExample: `get_repack_status()`",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "get_repack_statusArguments",
         "type": "object"
       },
@@ -2604,6 +3437,19 @@
       "description": "Return the `CREATE ROLE` DDL for a named role using PG 19's `pg_get_roledef(oid)` function — no shell-out to `pg_dumpall --roles-only` required. Returns `found=false` with an empty `ddl` when the role doesn't exist. Requires PG 19+; raises on older servers (pair with `get_pg19_ddl_status` to feature-detect). Returns an object with `object_type` (`'role'`), `object_name`, `found` (bool), and `ddl` (the verbatim CREATE statement).\n\nExample: `get_role_ddl(role_name='app_user')`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "role_name": {
             "title": "Role Name",
             "type": "string"
@@ -2629,7 +3475,21 @@
     {
       "description": "Report whether PG 19's B-tree skip-scan optimisation is the planner default on this server. Never raises — driver-level errors surface as `available=false`. On PG ≤ 18 reports `available=false` and points the agent at the standard 'add a dedicated single-column index' fallback. Returns an object with `available` (bool), `server_version_num` (int), `server_version`, and `detail` (guidance string).\n\nExample: `get_skip_scan_status()`",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "get_skip_scan_statusArguments",
         "type": "object"
       },
@@ -2639,6 +3499,19 @@
       "description": "Return the `CREATE TABLESPACE` DDL for a named tablespace using PG 19's `pg_get_tablespacedef(oid)` function. Returns `found=false` with an empty `ddl` when the tablespace doesn't exist. Requires PG 19+. Returns an object with `object_type` (`'tablespace'`), `object_name`, `found`, and `ddl`.\n\nExample: `get_tablespace_ddl(tablespace_name='fast_ssd')`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "tablespace_name": {
             "title": "Tablespace Name",
             "type": "string"
@@ -2656,6 +3529,19 @@
       "description": "Return the exact heap row count tq_index_heap_stats() reports for a single turboquant index (schema.index). The raw upstream payload is preserved in ``raw`` for any extra counters upstream may add. Requires the pg_turboquant extension.",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "index": {
             "title": "Index",
             "type": "string"
@@ -2678,6 +3564,19 @@
       "description": "Fetch the tq_index_metadata payload for a single turboquant index (schema.index). Documented fields are surfaced as typed attributes; the full upstream payload is preserved in ``raw_metadata`` so advisors can reach unanticipated fields. Raises when the extension is not installed or no turboquant index by that name exists. Returns an object with `schema`, `index`, `algorithm_version`, `quantizer_family`, `residual_sketch_kind`, `fast_path_eligible`, `capability_flags`, `delta_state`, `maintenance_recommended`, and `raw_metadata` (full upstream payload).",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "index": {
             "title": "Index",
             "type": "string"
@@ -2699,7 +3598,21 @@
     {
       "description": "Return the backend-local JSON tq_last_scan_stats() reports for the most recent turboquant scan: score_mode, simd_kernel, pages_scanned, pages_pruned, plus the raw payload. Returns ``null`` when the extension is absent or no turboquant scan has run on this connection yet.",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "get_turboquant_last_scan_statsArguments",
         "type": "object"
       },
@@ -2708,7 +3621,21 @@
     {
       "description": "Report whether PG 19's `WAIT FOR LSN` is usable on this server. Also reports whether the current backend is a standby (the only context where the wait does meaningful work). Never raises. On PG ≤ 18 returns `available=false` and points at the poll-loop fallback. Returns an object with `available` (bool), `server_version_num` (int), `server_version`, `is_in_recovery` (bool), and `detail`.\n\nExample: `get_wait_for_lsn_status()`",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "get_wait_for_lsn_statusArguments",
         "type": "object"
       },
@@ -2717,7 +3644,21 @@
     {
       "description": "Report WAL-archiving health from `pg_stat_archiver` + the archive-mode GUCs — the early-warning signal for a failing `archive_command` / `archive_library` (full archive volume, bad object-store credentials, network partition), which otherwise silently accumulates WAL in `pg_wal/` until the volume fills. Companion to `read_pg_wal_records` (which inspects WAL *records*); this covers the WAL *archive*. Read-only; never raises. The `archive_command` string is NOT echoed (it can embed credentials) — only a boolean `archive_command_set`. Returns an object with `available`, `archiving_enabled`, `archive_mode`, `archive_command_set`, `archived_count`, `last_archived_wal`, `last_archived_time`, `failed_count`, `last_failed_wal`, `last_failed_time`, `stats_reset`, `healthy` (bool — false when archiving is on and the latest attempt failed), and `detail`.\n\nExample: `get_wal_archive_status()`",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "get_wal_archive_statusArguments",
         "type": "object"
       },
@@ -2726,7 +3667,21 @@
     {
       "description": "Probe the connected server for the WarehousePG (Greenplum-derived MPP) signature. Reports `available=true` only when BOTH the version string mentions WarehousePG / Greenplum AND the `gp_segment_configuration` catalog view exists. Surfaces `coordinator_role`, `segment_count` (primary segments only), and `mirroring` (bool). On vanilla PostgreSQL clusters returns `available=false` with a clean diagnostic — the rest of the `mcpg.warehousepg.*` family advertise themselves inert via this probe. Read-only; never raises.\n\nExample: `get_warehousepg_status()`",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "get_warehousepg_statusArguments",
         "type": "object"
       },
@@ -2755,6 +3710,19 @@
             "default": 1.0,
             "title": "Bm25 Weight",
             "type": "number"
+          },
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
           },
           "distance_op": {
             "default": "<=>",
@@ -2837,6 +3805,19 @@
             "default": 50,
             "title": "Candidate Pool",
             "type": "integer"
+          },
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
           },
           "limit": {
             "default": 10,
@@ -3041,6 +4022,19 @@
       "description": "Lint table / column / index naming in a schema. Detects the majority case style (snake_case / camelCase / PascalCase / SCREAMING_SNAKE) per schema and per table, then flags outliers. Also flags indexes whose names do not start with a conventional prefix (idx_, ix_, pk_, uq_, fk_ by default). Findings carry the offender's style and the detected majority — agents can use the style field to filter for renames vs accept-as-is. Pure read. Returns an object with `schema_style` (detected majority), `findings` (list of style outliers), and `index_prefix_findings` (indexes with non-conventional prefixes).",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "schema": {
             "title": "Schema",
             "type": "string"
@@ -3057,7 +4051,21 @@
     {
       "description": "List the queries currently running on the server, with each backend's wait event, duration, and the PIDs blocking it. Returns a list of objects with `pid`, `username`, `application`, `state`, `wait_event` (null when not waiting), `duration_seconds`, `query`, and `blocked_by` (list of PIDs holding locks this backend is waiting on).",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "list_active_queriesArguments",
         "type": "object"
       },
@@ -3067,6 +4075,19 @@
       "description": "List recent rows from mcpg_audit.events (newest first). Returns an empty list when MCPG_AUDIT_PERSIST has never been turned on (no audit table yet). Optionally filter by tool name.",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "limit": {
             "default": 100,
             "title": "Limit",
@@ -3093,7 +4114,21 @@
     {
       "description": "List the pg_cron jobs MCPg registered for autowarm (``jobname LIKE 'mcpg_autowarm%'``). Returns an empty list when ``pg_cron`` is not installed. Returns a list of objects with `jobid`, `jobname`, `schedule` (the cron expression), and `command` (the SELECT the job runs).\n\nExample: `list_autowarm_jobs()`",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "list_autowarm_jobsArguments",
         "type": "object"
       },
@@ -3102,7 +4137,21 @@
     {
       "description": "List every extension available to the database, with whether it is installed. Returns a list of objects with `name`, `default_version`, `installed_version` (null when not installed), and `installed` (bool).",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "list_available_extensionsArguments",
         "type": "object"
       },
@@ -3112,6 +4161,19 @@
       "description": "List the chunks of a TimescaleDB hypertable with each chunk's range_start / range_end and whether it has been compressed. Empty list when the table is not a hypertable. Returns an object with `available` (bool) and `chunks` (list of `{chunk_name, range_start, range_end, is_compressed, total_size_bytes}`).",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "schema": {
             "title": "Schema",
             "type": "string"
@@ -3134,6 +4196,19 @@
       "description": "List the standalone composite types in a schema with their attributes. Returns a list of objects with `name` and `attributes` (list of `{name, data_type}` for each field).",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "schema": {
             "title": "Schema",
             "type": "string"
@@ -3151,6 +4226,19 @@
       "description": "List a table's constraints — primary/foreign keys, unique, check, exclusion. Returns a list of objects with `name`, `type`, and `definition` (the constraint SQL).\n\nExample: `list_constraints(schema='public', table='orders')`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "schema": {
             "title": "Schema",
             "type": "string"
@@ -3172,7 +4260,21 @@
     {
       "description": "List the pg_cron jobs registered in the database. Returns an empty list when pg_cron is not installed.",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "list_cron_jobsArguments",
         "type": "object"
       },
@@ -3188,9 +4290,31 @@
       "name": "list_cursors"
     },
     {
+      "description": "List every database this MCPg server is configured to serve: the primary (the default target of every tool) plus any read-only secondaries from MCPG_SECONDARY_DATABASE_URLS. Read-capable tools accept an optional `database` argument naming one of these ids; omitting it targets the primary. Secondaries are read-only (PostgreSQL-enforced) — writes / DDL / shell / migrate always run against the primary. Returns an object with `primary_id`, `database_ids` (primary first), and `databases` — a list of objects with `id`, `is_primary`, `read_only`, `reachable` (a live SELECT 1 probe), and `detail` (an error string when unreachable).",
+      "inputSchema": {
+        "properties": {},
+        "title": "list_databasesArguments",
+        "type": "object"
+      },
+      "name": "list_databases"
+    },
+    {
       "description": "List the data-distribution policy for each table in a WarehousePG schema (`HASH(col,...)`, `RANDOM`, or `REPLICATED`). Joins `gp_distribution_policy` to `pg_attribute` for the distribution-key column names in catalog order. `schema=None` returns every non-system schema. Read-only. On vanilla PG returns `available=false` with a diagnostic.\n\nExample: `list_distribution_policies(schema='public')`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "schema": {
             "anyOf": [
               {
@@ -3213,6 +4337,19 @@
       "description": "List the domain types in a schema, with base type, default, and check constraints. Returns a list of objects with `name`, `base_type`, `nullable`, `default`, and `constraints` (list of CHECK clauses).",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "schema": {
             "title": "Schema",
             "type": "string"
@@ -3230,6 +4367,19 @@
       "description": "List the enum types in a schema, with their labels in sort order. Returns a list of objects with `name` and `values` (list of label strings, in the order defined).",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "schema": {
             "title": "Schema",
             "type": "string"
@@ -3246,7 +4396,21 @@
     {
       "description": "List the extensions installed in the database. Returns a list of objects with `name` and `version`.",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "list_extensionsArguments",
         "type": "object"
       },
@@ -3255,7 +4419,21 @@
     {
       "description": "List the foreign-data wrappers installed in the database. Returns a list of objects with `name`, `handler` (qualified function name), `validator`, and `options` (dict of wrapper-specific options).",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "list_foreign_data_wrappersArguments",
         "type": "object"
       },
@@ -3265,6 +4443,19 @@
       "description": "List foreign keys in a schema, resolved to columns and referenced table. Returns a list of objects with `name`, `from_table`, `from_columns`, `to_schema`, `to_table`, `to_columns`.\n\nExample: `list_foreign_keys(schema='public')`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "schema": {
             "title": "Schema",
             "type": "string"
@@ -3281,7 +4472,21 @@
     {
       "description": "List the foreign servers defined in the database, with their FDW and options. Returns a list of objects with `name`, `wrapper` (foreign-data wrapper name), `type`, `version`, and `options` (dict of server options).",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "list_foreign_serversArguments",
         "type": "object"
       },
@@ -3291,6 +4496,19 @@
       "description": "List the foreign tables in a schema, with their server and options. Returns a list of objects with `name`, `server` (foreign-server name), and `options` (dict of per-table options).",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "schema": {
             "title": "Schema",
             "type": "string"
@@ -3308,6 +4526,19 @@
       "description": "List the functions and procedures defined in a schema. Returns a list of objects with `name`, `kind` ('function' or 'procedure'), `arguments` (signature string), `returns` (return-type string), and `language` (plpgsql / sql / c / etc.).",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "schema": {
             "title": "Schema",
             "type": "string"
@@ -3325,6 +4556,19 @@
       "description": "List every GENERATED ALWAYS AS (...) STORED column in a schema, with its data type, the underlying expression, and whether it's stored or virtual. PostgreSQL today supports only the stored form; the kind field is reported anyway so the response shape is forward-compatible when PG adds virtual columns. Returns a list of objects with `schema`, `table`, `column`, `data_type`, `expression`, `kind` ('stored' today; reserved for 'virtual').",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "schema": {
             "title": "Schema",
             "type": "string"
@@ -3342,6 +4586,19 @@
       "description": "List the privileges granted on a table — who may do what to it. Returns a list of objects with `grantee`, `privilege` (SELECT / INSERT / UPDATE / DELETE / TRUNCATE / REFERENCES / TRIGGER), `grantable` (bool — may the grantee regrant), and `grantor`.",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "schema": {
             "title": "Schema",
             "type": "string"
@@ -3372,7 +4629,21 @@
     {
       "description": "List every TimescaleDB hypertable visible to the current role, with chunk count, compression flag, and total size. Reports available=false when the timescaledb extension is not installed. Returns an object with `available` (bool) and `hypertables` (list of `{schema, table, num_chunks, compression_enabled, total_size_bytes}`).",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "list_hypertablesArguments",
         "type": "object"
       },
@@ -3382,6 +4653,19 @@
       "description": "List the indexes defined on a table. Returns a list of objects with `name`, `method` (btree / gin / gist / brin / hash / spgist / hnsw / ivfflat / …), `definition` (the CREATE INDEX statement), and `partitioned`.\n\nExample: `list_indexes(schema='public', table='users')`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "schema": {
             "title": "Schema",
             "type": "string"
@@ -3404,6 +4688,19 @@
       "description": "List currently-held and waiting locks, joined with backend state from pg_stat_activity. Ordered by (granted ASC, pid) so waiting locks float to the top. Returns lock type, mode, qualified relation name when applicable, transaction / virtualxid, the application_name + state + wait event of the owning backend, and the first 200 chars of its query. Read-only.",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "limit": {
             "default": 100,
             "title": "Limit",
@@ -3428,6 +4725,19 @@
       "description": "Describe how a table is partitioned (strategy and bounds) and list its partitions. Returns an object with `partitioned` (bool), `strategy` ('range' / 'list' / 'hash' or null), and `partitions` (a list of `{name, bounds}` for each partition).",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "schema": {
             "title": "Schema",
             "type": "string"
@@ -3458,7 +4768,21 @@
     {
       "description": "List every pg_search BM25 index in the database along with the parsed reloptions (the ``WITH (...)`` config) for each. Surfaces the 13 documented bm25 options (key_field, the six *_fields jsonb configs, layer_sizes, background_layer_sizes, target_segment_count, mutable_segment_rows, sort_by, search_tokenizer). The full parsed dict is preserved in ``index_options`` so unsurfaced or future options stay reachable. Returns an empty list when the pg_search extension is not installed.",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "list_pg_search_indexesArguments",
         "type": "object"
       },
@@ -3468,6 +4792,19 @@
       "description": "List the Row-Level-Security policies on a table, and whether row security is enabled. Returns an object with `rls_enabled` (bool) and `policies` — a list of `{name, command (SELECT/INSERT/UPDATE/DELETE/ALL), permissive (bool), roles, using_expression, check_expression}`.",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "schema": {
             "title": "Schema",
             "type": "string"
@@ -3490,6 +4827,19 @@
       "description": "Report current shared-buffer residency per relation, ranked by blocks-cached descending. Requires the ``pg_buffercache`` extension; returns an empty list when it's missing. Returns a list of objects with `schema`, `table`, `blocks_cached` (8 KiB pages currently in shared buffers), `total_blocks` (the relation's on-disk size in the same unit), `pct_cached` (the residency ratio rounded to 2 decimals), and `dirty_blocks` (pages with pending writes).\n\nExample: `list_prewarmed_relations(schema='public', limit=50)`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "limit": {
             "default": 100,
             "title": "Limit",
@@ -3516,7 +4866,21 @@
     {
       "description": "List SQL/PGQ property graphs defined in the database (reads `information_schema.sql_property_graphs`). Returns an empty list on PG < 19 or when the catalog view is missing (early Beta builds may not expose it yet — pair with `get_pgq_status` to disambiguate). Returns a list of objects with `schema`, `name`, `vertex_tables` (list of `schema.table` strings), and `edge_tables` (same shape).\n\nExample: `list_property_graphs()`",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "list_property_graphsArguments",
         "type": "object"
       },
@@ -3525,7 +4889,21 @@
     {
       "description": "List logical-replication publications with the tables and operations they include. Returns a list of objects with `name`, `owner`, `all_tables` (bool), `publishes_insert` / `publishes_update` / `publishes_delete` / `publishes_truncate` (bools), and `tables` (list of `schema.table` strings).",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "list_publicationsArguments",
         "type": "object"
       },
@@ -3534,7 +4912,21 @@
     {
       "description": "List the foreign servers backed by ``redis_fdw`` — the FDW that exposes a Redis instance as SQL-queryable foreign tables. Reports each server's connection address, port, database, TLS posture, and whether a user mapping (credential) is configured. Returns an empty list when the redis_fdw extension is not installed. Returns a list of objects with `name`, `address`, `port`, `database`, `tls` (bool), `password_configured` (bool), and `options` (the full server-options dict).\n\nExample: `list_redis_foreign_servers()`",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "list_redis_foreign_serversArguments",
         "type": "object"
       },
@@ -3552,7 +4944,21 @@
     {
       "description": "List configured WarehousePG resource groups + their utilisation. Reads `gp_toolkit.gp_resgroup_status` for `concurrency`, `cpu_max_percent`, `cpu_weight`, `memory_limit`, `memory_shared_quota`, plus live `num_running` / `num_queueing`. Pairs with `analyze_workload` for 'where's my workload time going' diagnosis. Read-only. On vanilla PG returns `available=false`.\n\nExample: `list_resource_groups()`",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "list_resource_groupsArguments",
         "type": "object"
       },
@@ -3562,6 +4968,19 @@
       "description": "List the database roles and their attributes, excluding PostgreSQL's own roles unless include_system is true. Returns a list of objects with `name`, `superuser`, `create_role`, `create_db`, `can_login`, `replication`, `bypass_rls`, `connection_limit`, `member_of`.",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "include_system": {
             "default": false,
             "title": "Include System",
@@ -3577,6 +4996,19 @@
       "description": "List database schemas, excluding PostgreSQL's own schemas unless include_system is true. Returns a list of objects with `name`.\n\nExample: `list_schemas(include_system=false)`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "include_system": {
             "default": false,
             "title": "Include System",
@@ -3592,6 +5024,19 @@
       "description": "List the sequences defined in a schema, with their range, increment, and last value. Returns a list of objects with `name`, `data_type`, `start_value`, `min_value`, `max_value`, `increment`, `cycle` (bool), `last_value`.",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "schema": {
             "title": "Schema",
             "type": "string"
@@ -3608,7 +5053,21 @@
     {
       "description": "List logical-replication subscriptions; requires superuser to see any rows.",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "list_subscriptionsArguments",
         "type": "object"
       },
@@ -3618,6 +5077,19 @@
       "description": "List the tables and views in a schema, flagging partitioned tables and partitions. Returns a list of objects with `name`, `type` ('table' or 'view'), `partitioned`, `is_partition`.\n\nExample: `list_tables(schema='public')`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "schema": {
             "title": "Schema",
             "type": "string"
@@ -3635,6 +5107,19 @@
       "description": "List the user-defined triggers on a table. Returns a list of objects with `name`, `function` (the called function's qualified name), and `definition` (the CREATE TRIGGER SQL).",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "schema": {
             "title": "Schema",
             "type": "string"
@@ -3656,7 +5141,21 @@
     {
       "description": "List every pg_turboquant ANN index in the database along with the metadata payload that tq_index_metadata() reports for it: algorithm_version, quantizer_family, residual_sketch_kind, fast_path_eligible, capability_flags, delta_state, and maintenance_recommended. Returns an empty list when the pg_turboquant extension is not installed.",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "list_turboquant_indexesArguments",
         "type": "object"
       },
@@ -3699,7 +5198,21 @@
     {
       "description": "List role-to-foreign-server mappings; the catch-all appears as user='public'. Returns a list of objects with `user` (role name or 'public'), `server` (foreign-server name), and `options` (dict of mapping options, e.g. credentials).",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "list_user_mappingsArguments",
         "type": "object"
       },
@@ -3709,6 +5222,19 @@
       "description": "List the views and materialized views in a schema, with their definitions. Returns a list of objects with `name`, `materialized` (bool), and `definition` (the SELECT SQL).",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "schema": {
             "title": "Schema",
             "type": "string"
@@ -3882,6 +5408,19 @@
             "title": "Column",
             "type": "string"
           },
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "schema": {
             "title": "Schema",
             "type": "string"
@@ -3908,6 +5447,19 @@
           "column": {
             "title": "Column",
             "type": "string"
+          },
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
           },
           "fetch_k": {
             "anyOf": [
@@ -3983,6 +5535,19 @@
             "title": "Current Start",
             "type": "string"
           },
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "drift_threshold": {
             "default": 0.05,
             "title": "Drift Threshold",
@@ -4028,7 +5593,21 @@
     {
       "description": "Surface every active CREATE INDEX and its progress from pg_stat_progress_create_index (PG12+, no extension). One row per build with pid, schema.relation.index_name, the command, phase label, blocks_done/total, tuples_done/total, and a computed progress_pct (blocks first, tuples as fallback, null when neither phase reports a denominator). Useful next to list_active_queries when an HNSW / IVFFlat build on a big table is taking longer than expected. Returns a list of objects with `pid`, `schema`, `relation`, `index_name`, `command`, `phase`, `blocks_done`, `blocks_total`, `tuples_done`, `tuples_total`, and `progress_pct` (null when no denominator is reported).",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "monitor_index_buildArguments",
         "type": "object"
       },
@@ -4038,6 +5617,19 @@
       "description": "Open a server-side cursor for a SELECT query. The cursor holds the result set on the server side so an agent can page through millions of rows without loading them all. SQL is validated by the same safety allowlist as run_select. Returns the cursor_id; fetch the rows with fetch_cursor and close with close_cursor (or let the 5-minute TTL clean up). Hard cap of 16 concurrent cursors.",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "sql": {
             "title": "Sql",
             "type": "string"
@@ -4055,6 +5647,19 @@
       "description": "Analyze a SQL query for syntax anti-patterns and performance issues using EXPLAIN plan costs and index scans, returning an optimized version.",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "sql": {
             "title": "Sql",
             "type": "string"
@@ -4164,6 +5769,19 @@
             ],
             "default": null,
             "title": "Boost Factor"
+          },
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
           },
           "document_id": {
             "title": "Document Id"
@@ -4306,6 +5924,19 @@
             "title": "Conjunction Mode",
             "type": "boolean"
           },
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "lenient": {
             "default": false,
             "title": "Lenient",
@@ -4342,6 +5973,19 @@
             ],
             "default": null,
             "title": "Columns"
+          },
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
           },
           "key_field": {
             "title": "Key Field",
@@ -4550,6 +6194,19 @@
       "description": "Return the tables most urgently needing autovacuum, ranked by how close their dead-tuple count is to the per-table autovacuum threshold (`autovacuum_vacuum_threshold + autovacuum_vacuum_scale_factor * reltuples`, honouring per-table `reloptions` overrides). Each row carries `priority` ('overdue' if past the threshold, 'watchlist' if within 50%, 'borderline' otherwise) plus the inputs (`n_dead_tup`, `vacuum_threshold`, `last_autovacuum`, `autovacuum_enabled`) so the agent can explain *why* a table landed on the shortlist. Top-level `overdue_count` lets an agent branch without walking the list. Read-only catalog query.\n\nExample: `read_autovacuum_priority(limit=25)`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "limit": {
             "default": 25,
             "title": "Limit",
@@ -4565,6 +6222,19 @@
       "description": "Query and summarize historical migrations applied to the database by popular migration frameworks (Alembic, Flyway, Diesel, Django, Prisma, Golang Migrate, Goose, Sequelize). Allows filtering by schema. Returns an object with one optional list per detected framework: `alembic`, `flyway`, `diesel`, `django`, `prisma`, `golang_migrate`, `goose`, `sequelize`. Each entry is null when the framework's table isn't present; otherwise it carries the framework-specific row shape (e.g. alembic has `{version_num}`; flyway has `{installed_rank, version, description, type, ...}`).",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "schema": {
             "anyOf": [
               {
@@ -4587,6 +6257,19 @@
       "description": "Read the list of database relations taking up the most space in the PostgreSQL shared buffer cache. Reports buffered size, percentage of shared buffers, percent of relation buffered, average usage count, and dirty pages. Allows filtering by schema. Requires the pg_buffercache extension. If not installed, returns available=false.",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "limit": {
             "default": 100,
             "title": "Limit",
@@ -4613,7 +6296,21 @@
     {
       "description": "Read a high-level summary of the PostgreSQL shared buffer cache usage. Reports total buffers, free/used buffers, dirty buffers, and average usage count. Requires the pg_buffercache extension. If not installed, returns available=false.",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "read_pg_buffercache_summaryArguments",
         "type": "object"
       },
@@ -4622,7 +6319,21 @@
     {
       "description": "Read the pg_stat_io view (PostgreSQL 16+). Reports per (backend_type, object, context) cumulative I/O activity — reads, writes, extends, evictions, hits, fsyncs. Useful for spotting buffer-cache misses and write amplification. On PostgreSQL 14 / 15 the view doesn't exist, so the tool returns available=false and an empty list.",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "read_pg_stat_ioArguments",
         "type": "object"
       },
@@ -4631,7 +6342,21 @@
     {
       "description": "Return every row from PG 19's `pg_stat_lock` view (per-lock-type acquire / wait / wait-time counters since the most recent `pg_stat_reset`). Empty list on PG < 19 or when the view isn't present. Returns a list of objects with `lock_type` (relation / page / tuple / xid / virtualxid / advisory / ...), `acquires`, `waits`, and `wait_time_us`.\n\nExample: `read_pg_stat_lock()`",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "read_pg_stat_lockArguments",
         "type": "object"
       },
@@ -4640,7 +6365,21 @@
     {
       "description": "Return rows from PG 19's `pg_stat_recovery` view — replay progress, lag, and startup state for a standby. Empty list on PG < 19, when the view isn't present, or when the server isn't in recovery (a primary running standalone returns no rows). Returns a list of objects with `replay_lsn`, `replay_lag_seconds`, `last_replayed_at`, and `startup_state` (any of which may be null when not applicable).\n\nExample: `read_pg_stat_recovery()`",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "read_pg_stat_recoveryArguments",
         "type": "object"
       },
@@ -4650,6 +6389,19 @@
       "description": "Read Write-Ahead Log (WAL) records information over a specified LSN range. Requires the pg_walinspect extension. If not installed, returns available=false.",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "end_lsn": {
             "anyOf": [
               {
@@ -4684,6 +6436,19 @@
       "description": "Read Write-Ahead Log (WAL) record statistics over a specified LSN range, grouped by resource manager or record type. Requires the pg_walinspect extension. If not installed, returns available=false.",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "end_lsn": {
             "anyOf": [
               {
@@ -4730,6 +6495,19 @@
             "default": null,
             "title": "Backend"
           },
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "days": {
             "default": 30,
             "title": "Days",
@@ -4769,6 +6547,19 @@
       "description": "Empirically curate `describe_self`'s per-bucket `headline_tools` from the audit log. Reads `mcpg_audit.events` over the last `lookback_days` (default 7, capped at 90), groups successful calls by capability bucket, and reports the top-`top_n` (default 6) tools per bucket with `newcomers` (recommended but not in the hand-curated current list) and `departures` (currently headlined but not in the recommendation). The output is a REVIEWABLE recommendation, not an auto-applied override — operators decide whether to update `mcpg.about.CAPABILITIES`. Returns `audit_table_present=False` with a diagnostic when the audit subsystem is off. Returns an object with `audit_table_present`, `lookback_days`, `top_n`, `events_examined`, `detail`, and `buckets` (list of objects with `bucket_id`, `current`, `recommended`, `newcomers`, `departures`, `call_counts`).\n\nExample: `recommend_headline_tools(lookback_days=14, top_n=6)`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "lookback_days": {
             "default": 7,
             "title": "Lookback Days",
@@ -4792,6 +6583,19 @@
           "column": {
             "title": "Column",
             "type": "string"
+          },
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
           },
           "k": {
             "default": 10,
@@ -4836,6 +6640,19 @@
       "description": "Sibling of `recommend_indexes` for indexes to remove. Walks `pg_stat_user_indexes` + `pg_stat_user_tables` for existing indexes that look like pure cost — large on disk but never (or barely) scanned. Three reason codes, descending strength: `never_used` (no recorded idx_scans since the last stats reset — candidate for drop, but verify before removal), `scan_no_fetch` (planner picks it but it returns no rows — usually existence-check pattern), `rarely_used` (scan rate below `low_scan_ratio` of the table's total scan activity). Primary-key / unique / exclusion-constraint indexes are excluded (dropping those would be a schema change, not a performance win); indexes below `min_index_size_bytes` are skipped too. Returns a ready-to-run `DROP INDEX CONCURRENTLY` statement per candidate. Read-only advisor — execution is on the operator.\n\nExample: `recommend_index_drops(schema='public', min_index_size_bytes=1000000, low_scan_ratio=0.01)`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "low_scan_ratio": {
             "default": 0.01,
             "title": "Low Scan Ratio",
@@ -4868,6 +6685,19 @@
       "description": "Recommend tables that may benefit from indexing — large tables read mostly by sequential scan. Returns a list of objects with `schema`, `table`, `live_tuples`, `sequential_scans`, `index_scans`, and a `reason` explaining why the table is a candidate.\n\nExample: `recommend_indexes(min_live_tuples=10000)`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "min_live_tuples": {
             "default": 10000,
             "title": "Min Live Tuples",
@@ -4882,7 +6712,21 @@
     {
       "description": "Recommend a PG 19 `io_method` ('sync' / 'worker' / 'io_uring') for the current workload. Reads `pg_stat_database` aggregates (blks_read / blks_hit / stats_reset) and the current setting, then maps the workload signals to one of: `high_concurrent_read_load` (→ io_uring), `bursty_io_with_cache_pressure` (→ worker), `low_io_pressure` (→ sync), `current_setting_optimal` (no change), or `insufficient_stats` (window too short). Read-only — never invokes ALTER SYSTEM; emits a ready_to_run_sql snippet the operator can paste when the recommendation differs from the current setting. Returns an object with `available` (bool), `server_version_num`, `detail`, and `recommendations` — a list of objects with `recommended_method`, `reason`, `current_method`, `cache_miss_ratio`, `reads_per_second`, `stats_window_seconds`, and `ready_to_run_sql` (null when no change suggested).\n\nExample: `recommend_io_method()`",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "recommend_io_methodArguments",
         "type": "object"
       },
@@ -4891,7 +6735,21 @@
     {
       "description": "Walk every pg_search BM25 index and emit advisor findings. Rules currently surfaced: ``missing_key_field`` (CRITICAL — the key_field reloption is required by upstream; an index without it can't satisfy queries) and ``no_field_configs`` (WARNING — none of the six *_fields reloptions are set, so the index falls back to default tokenization for every indexed column). Each finding carries a ready-to-run ``suggested_action`` SQL statement. Returns an empty list when the extension is not installed. Also feeds the ``pg_search BM25 Indexes`` category in audit_database.",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "recommend_pg_search_maintenanceArguments",
         "type": "object"
       },
@@ -4945,6 +6803,19 @@
       "description": "Recommend relations whose first-query latency would benefit from ``pg_prewarm``. Inspects ``pg_stat_user_tables`` + ``pg_statio_user_tables`` to find high cold-miss-rate / seq_scan-dominant relations, and caps the cumulative cost at ``shared_buffers_budget_pct`` * ``shared_buffers`` so the recommendation never silently exceeds shared_buffers. The advisor is read-only — never invokes pg_prewarm itself. Returns an object with `shared_buffers_blocks` (configured shared_buffers in 8 KiB pages), `budget_blocks` (the cap), `total_cost_blocks` (sum of recommendations actually returned), and `candidates` — a list of objects with `schema`, `relation`, `reason` (`seq_scan_dominant` / `high_cold_miss_rate` / `small_hot_relation_uncached` / `index_in_critical_path`), `prewarm_mode`, `estimated_buffer_cost`, `heap_blks_read`, `heap_blks_hit`, `cache_miss_ratio`, and `ready_to_run_sql`.\n\nExample: `recommend_prewarm_targets(shared_buffers_budget_pct=60.0, limit=10)`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "limit": {
             "default": 20,
             "title": "Limit",
@@ -4974,7 +6845,21 @@
     {
       "description": "Advise whether the caller should use `WAIT FOR LSN` for read-your-writes consistency. Combines server role (primary vs standby), replay lag, and PG version into a structured recommendation. Never raises. `reason` is one of `primary_no_wait_needed`, `standby_no_lag`, `standby_lag_unknown`, `standby_with_lag`, `standby_pg18_or_older`, `unavailable`. Returns an object with `recommend_use` (bool), `reason`, `is_in_recovery`, `server_version_num`, `current_lag_bytes` (int / null), and `detail`.\n\nExample: `recommend_read_your_writes()`",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "recommend_read_your_writesArguments",
         "type": "object"
       },
@@ -4984,6 +6869,19 @@
       "description": "Recommend tables that would benefit from a Redis cache layer. Inspects ``pg_stat_user_tables`` for read-heavy, low-write relations whose working set fits comfortably in Redis (default: read/write ratio ≥ 10, ≥ 1000 reads, ≤ 1M rows). When ``server`` is provided the generated ``ready_to_run_sql`` stub targets that server name; otherwise the stub uses a placeholder operators must substitute. Advisor is read-only — never touches Redis itself. Returns an object with `server` and `candidates` — a list of objects with `schema`, `table`, `reads`, `writes`, `read_write_ratio`, `estimated_row_count`, `reason` (`read_only_lookup_table` / `small_hot_relation` / `read_heavy_low_write` / `moderate_read_dominant`), and `ready_to_run_sql` (a CREATE FOREIGN TABLE stub).\n\nExample: `recommend_redis_cache_targets(server='redis_primary', limit=10)`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "limit": {
             "default": 20,
             "title": "Limit",
@@ -5026,6 +6924,19 @@
       "description": "Distribution-skew advisor for a hash-distributed table. Reads `pg_stats.n_distinct` for every column on the table and suggests a better hash key when the current one is low-cardinality. Pure catalog read — no per-segment scans. Returns ranked `candidates`, optional `recommendation`, and ready-to-review `suggested_ddl` (`ALTER TABLE … SET WITH (REORGANIZE=TRUE) DISTRIBUTED BY (col)`). Diagnosis-only — never executes. On vanilla PG returns `available=false`.\n\nExample: `recommend_redistribute(schema='public', table='fact_sales')`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "schema": {
             "title": "Schema",
             "type": "string"
@@ -5048,6 +6959,19 @@
       "description": "Roll-up advisor over the four analytics for one window. Returns a single headline ``summary`` + the full list of findings. Built from whichever combination of ``reranker_idle`` / ``topk_stable`` / ``score_clustering`` / ``rerank_hurts_ndcg`` / ``rerank_lifts_ndcg`` fires. Also feeds the ``RAG Reranker Pipeline`` category in audit_database. Reads from mcpg_rag.rerank_events.",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "days": {
             "default": 7,
             "title": "Days",
@@ -5075,6 +6999,19 @@
       "description": "Find composite B-tree indexes whose leading column has low NDV — these are the ones PG 19's skip-scan optimisation unlocks. Each candidate's trailing columns can now be served by the composite index alone, so any dedicated single-column indexes on those trailing columns become review candidates for `recommend_index_drops`. Returns an empty list on PG ≤ 18 or driver failure — pair with `get_skip_scan_status` for the diagnostic. `max_leading_ndv` (default 1000) caps the leading-column NDV that's considered low enough for skip-scan to be profitable. Returns a list of objects with `schema`, `table`, `index_name`, `leading_column`, `trailing_columns` (list of strings), `estimated_leading_ndv` (int), and `rationale` (human-readable explanation).\n\nExample: `recommend_skip_scan_indexes()`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "max_leading_ndv": {
             "default": 1000,
             "title": "Max Leading Ndv",
@@ -5089,7 +7026,21 @@
     {
       "description": "Walk every pg_turboquant index and emit advisor findings. Rules currently surfaced: ``prerequisites_unmet`` (CRITICAL — pgvector is missing) and ``delta_tier_large`` (WARNING — upstream's own ``delta_health.merge_recommended=true`` advisory, emits a ``tq_maintain_index`` suggested_action). Each finding carries a ready-to-run ``suggested_action`` SQL statement. Returns an empty list when the extension is not installed. Also feeds the ``pg_turboquant Indexes`` category in audit_database.",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "recommend_turboquant_maintenanceArguments",
         "type": "object"
       },
@@ -5102,6 +7053,19 @@
           "candidate_limit": {
             "title": "Candidate Limit",
             "type": "integer"
+          },
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
           },
           "filter_selectivity": {
             "anyOf": [
@@ -5164,6 +7128,19 @@
       "description": "Scan a schema for `vector(N)` columns whose storage could be halved by switching to pgvector v0.7+'s `halfvec(N)` type (16-bit float). Returns one recommendation per qualifying column with current vs suggested bytes, the savings ratio, and a one-line rationale. Skips columns that are already non-`vector` and small tables where the absolute saving wouldn't justify the migration.",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "schema": {
             "title": "Schema",
             "type": "string"
@@ -5425,6 +7402,19 @@
       "description": "Run a set of catalog-driven advisor rules against a schema and return the aggregated findings. Rules cover missing primary keys, unindexed foreign keys, duplicate indexes, and nullable timestamps without time zone. Advisory only — no writes.",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "schema": {
             "title": "Schema",
             "type": "string"
@@ -5532,6 +7522,19 @@
       "description": "Execute a SQL/PGQ `SELECT ... GRAPH_TABLE` query and return the rows. The query must be a single `SELECT` (or `WITH ... SELECT`) statement that references `GRAPH_TABLE` — anything else is refused at the boundary (use `run_select` for non-graph reads). `max_rows` caps the result set; when the cap is hit, `truncated=true`. Requires PG 19+. Returns an object with `columns` (list of column names from the query's `COLUMNS (...)` clause), `rows` (list of dicts keyed by those columns), `row_count`, and `truncated` (bool).\n\nExample: `run_pgq(query=\"SELECT * FROM GRAPH_TABLE (org_chart MATCH (e:Employee)-[:REPORTS_TO]->(m:Manager) COLUMNS (e.name AS employee, m.name AS manager))\", max_rows=50)`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "max_rows": {
             "default": 200,
             "title": "Max Rows",
@@ -5554,6 +7557,19 @@
       "description": "Validate and run a read-only SQL query. Writes, DDL, and other unsafe statements are rejected before execution.\n\nExample: `run_select(sql='SELECT id, email FROM users LIMIT 10', max_rows=1000)`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "max_rows": {
             "default": 1000,
             "title": "Max Rows",
@@ -5576,6 +7592,19 @@
       "description": "Run up to parallel_limit read-only SELECTs concurrently. Each statement is validated by the same safety allowlist as run_select; one bad query does not abort the others — its error is captured in its own outcome slot. Useful for dashboard-style fan-out where round-trip latency dominates (e.g. fetching counters / aggregates from several tables at once). Each outcome includes an index so the caller can correlate results without relying on ordering.",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "max_rows": {
             "default": 1000,
             "title": "Max Rows",
@@ -5859,6 +7888,19 @@
       "description": "Return a one-stop snapshot of a table: columns, primary key, foreign keys, every other constraint, indexes, storage + row-count + last-vacuum/analyze stats, and (optionally) a short sample of rows. Replaces what would otherwise be 4-5 individual tool calls. Set sample_rows=0 on wide / jsonb-heavy tables where the sample isn't useful.\n\nExample: `summarize_table(schema='public', table='users', sample_rows=5)`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "sample_rows": {
             "default": 5,
             "title": "Sample Rows",
@@ -5903,6 +7945,19 @@
       "description": "Test what an RLS-bound role can read from a table. Reports whether RLS is enabled on the table, lists the policies that apply to the given role, counts the rows the role can read, and returns up to sample_size rows so the agent can inspect them. Runs as the target role inside a READ ONLY transaction — no writes can leak. Pure read.",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "role": {
             "title": "Role",
             "type": "string"
@@ -5935,6 +7990,19 @@
       "description": "Translate a natural-language question into a read-only PostgreSQL query against `schema`. The LLM provider (anthropic / openai / gemini) sees a compact brief of the schema (tables, columns, foreign keys) and is instructed to return JSON with `sql` and `explanation`. When execute=true, the generated SQL goes through the SAME safety allowlist as run_select before running — writes / DDL / multi-statement input are rejected even if the model produced them. Returns the SQL, model rationale, and (when executed) rows / columns / row_count. table_filter narrows the brief to a known subset when the question is clearly scoped. `provider`, when supplied, selects which configured LLM provider to call (use this to route between anthropic / openai / gemini per-call when multiple are configured); when omitted, MCPg uses the default (MCPG_NL2SQL_PROVIDER, otherwise the first available in preference order anthropic → openai → gemini). Call get_server_info to see which providers are configured.\n\nExample: `translate_nl_to_sql(question='top 10 customers by revenue last month', schema='public', execute=true)`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "execute": {
             "default": false,
             "title": "Execute",
@@ -5998,6 +8066,19 @@
             "title": "Column",
             "type": "string"
           },
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "index_type": {
             "default": "hnsw",
             "title": "Index Type",
@@ -6034,6 +8115,19 @@
           "candidate_limit": {
             "title": "Candidate Limit",
             "type": "integer"
+          },
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
           },
           "embedding_column": {
             "title": "Embedding Column",
@@ -6120,6 +8214,19 @@
           "candidate_limit": {
             "title": "Candidate Limit",
             "type": "integer"
+          },
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
           },
           "embedding_column": {
             "title": "Embedding Column",
@@ -6342,6 +8449,19 @@
             "title": "Column",
             "type": "string"
           },
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "limit": {
             "default": 10,
             "title": "Limit",
@@ -6392,6 +8512,19 @@
             "title": "Column",
             "type": "string"
           },
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "id_column": {
             "title": "Id Column",
             "type": "string"
@@ -6439,6 +8572,19 @@
             "title": "Column",
             "type": "string"
           },
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "limit": {
             "default": 10,
             "title": "Limit",
@@ -6479,7 +8625,21 @@
     {
       "description": "Verify the HMAC-SHA256 signature chain of persisted audit events in mcpg_audit.events. Returns an object with `verified` (bool), `events_checked` (int), the `first_event_id` and `last_event_id` covered by the walk, and (on failure) `error` and `first_invalid_id` pointing at where the chain broke.",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "verify_audit_chainArguments",
         "type": "object"
       },
@@ -6488,7 +8648,21 @@
     {
       "description": "Report whether MCPg's own connection to PostgreSQL is TLS-encrypted, including the negotiated protocol version, cipher, and key bits (from pg_stat_ssl). Also returns a cluster-wide tally of encrypted vs unencrypted backends (a lower bound under non-superuser privileges). Complements the startup TLS-enforcement check by confirming the live connection actually came up encrypted.",
       "inputSchema": {
-        "properties": {},
+        "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          }
+        },
         "title": "verify_connection_encryptionArguments",
         "type": "object"
       },
@@ -6498,6 +8672,19 @@
       "description": "Issue `WAIT FOR LSN '<lsn>' TIMEOUT <ms>` and block until WAL replay catches up on the connected backend. `timeout_ms` defaults to 0 (wait indefinitely); a positive value bounds the wait — on timeout the helper returns `timed_out=true` rather than raising so the caller can decide whether to retry or fall through. LSN format is strictly validated (`hex/hex`) before any SQL is composed. Requires PG 19+; raises on older servers with the poll-loop fallback in the message. Returns an object with `lsn`, `timeout_ms` (int), `timed_out` (bool), and `wait_sql` (the rendered statement).\n\nExample: `wait_for_lsn(lsn='0/1234ABCD', timeout_ms=5000)`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "lsn": {
             "title": "Lsn",
             "type": "string"
@@ -6520,6 +8707,19 @@
       "description": "Walk and reconstruct the lock-wait graph of the database. Detects deadlock cycles, traces linear blocking paths to their root blockers, and renders a Mermaid flowchart representing the lock dependency graph. Read-only. Returns an object with `cycles` (list of detected cycle PID lists), `paths` (linear blocking paths as PID lists), `roots` (root blocker PIDs), `nodes` (dict keyed by PID with per-backend lock detail), and `mermaid` (the pre-rendered flowchart string).",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "limit": {
             "default": 50,
             "title": "Limit",
@@ -6535,6 +8735,19 @@
       "description": "Diagnose why a SQL query might be slow, in one call. Runs EXPLAIN (FORMAT JSON) — does NOT execute the query — walks the plan tree, snapshots concurrent active queries + blocking lock pairs, reads the cluster-wide cache hit ratio, and produces categorised suggestions (plan / contention / cache / maintenance). Read-only; safe to run on a statement the agent doesn't want to materialise yet.\n\nExample: `why_is_this_slow(sql='SELECT * FROM orders WHERE customer_id = 42')`",
       "inputSchema": {
         "properties": {
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids.",
+            "title": "Database"
+          },
           "sql": {
             "title": "Sql",
             "type": "string"

--- a/tests/unit/_fakes.py
+++ b/tests/unit/_fakes.py
@@ -119,7 +119,12 @@ class FakeDatabase:
     async def close(self) -> None:
         self.is_connected = False
 
-    def driver(self) -> FakeDriver:
+    def driver(self, database_id: str | None = None) -> FakeDriver:
+        # ``database_id`` mirrors the real ``Database.driver`` signature
+        # (multi-database selector, roadmap 13.1). The fake ignores it and
+        # always returns the single canned driver; tests asserting selector
+        # behaviour use a real ``Database`` with injected pools instead.
+        del database_id
         return self._driver
 
     async def run_unmanaged(self, sql: str) -> None:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -519,6 +519,116 @@ def test_replica_repr_obfuscates_passwords() -> None:
     assert "supersecret" not in rendered
 
 
+# ---------------------------------------------------------------------------
+# Multi-database selector — MCPG_SECONDARY_DATABASE_URLS (roadmap 13.1)
+# ---------------------------------------------------------------------------
+
+
+def test_secondary_database_urls_default_empty() -> None:
+    assert load_settings({"MCPG_DATABASE_URL": _DB_URL}).secondary_database_urls == ()
+
+
+def test_secondary_database_urls_parses_name_dsn_pairs() -> None:
+    settings = load_settings(
+        {
+            "MCPG_DATABASE_URL": _DB_URL,
+            "MCPG_SECONDARY_DATABASE_URLS": (
+                "analytics=postgresql://u:p@localhost/an, reporting=postgresql://u:p@localhost/rep"
+            ),
+        }
+    )
+    assert settings.secondary_database_urls == (
+        ("analytics", "postgresql://u:p@localhost/an"),
+        ("reporting", "postgresql://u:p@localhost/rep"),
+    )
+
+
+def test_secondary_database_urls_accepts_newline_separator() -> None:
+    settings = load_settings(
+        {
+            "MCPG_DATABASE_URL": _DB_URL,
+            "MCPG_SECONDARY_DATABASE_URLS": "a=postgresql://u:p@localhost/a\nb=postgresql://u:p@localhost/b",
+        }
+    )
+    assert [name for name, _ in settings.secondary_database_urls] == ["a", "b"]
+
+
+def test_secondary_database_urls_blank_raises() -> None:
+    with pytest.raises(ConfigError, match="MCPG_SECONDARY_DATABASE_URLS must not be blank"):
+        load_settings({"MCPG_DATABASE_URL": _DB_URL, "MCPG_SECONDARY_DATABASE_URLS": "  ,  "})
+
+
+def test_secondary_database_urls_missing_equals_raises() -> None:
+    with pytest.raises(ConfigError, match="not in name=dsn form"):
+        load_settings({"MCPG_DATABASE_URL": _DB_URL, "MCPG_SECONDARY_DATABASE_URLS": "justaname"})
+
+
+def test_secondary_database_urls_empty_dsn_raises() -> None:
+    with pytest.raises(ConfigError, match="empty DSN"):
+        load_settings({"MCPG_DATABASE_URL": _DB_URL, "MCPG_SECONDARY_DATABASE_URLS": "a="})
+
+
+def test_secondary_database_urls_duplicate_name_raises() -> None:
+    with pytest.raises(ConfigError, match="duplicate name 'a'"):
+        load_settings(
+            {
+                "MCPG_DATABASE_URL": _DB_URL,
+                "MCPG_SECONDARY_DATABASE_URLS": ("a=postgresql://u:p@localhost/x,a=postgresql://u:p@localhost/y"),
+            }
+        )
+
+
+def test_secondary_database_urls_reserved_primary_name_raises() -> None:
+    with pytest.raises(ConfigError, match="'primary' is reserved"):
+        load_settings(
+            {
+                "MCPG_DATABASE_URL": _DB_URL,
+                "MCPG_SECONDARY_DATABASE_URLS": "primary=postgresql://u:p@localhost/x",
+            }
+        )
+
+
+def test_secondary_database_urls_bad_identifier_raises() -> None:
+    with pytest.raises(ConfigError, match=r"must match \[a-z0-9_\]"):
+        load_settings(
+            {
+                "MCPG_DATABASE_URL": _DB_URL,
+                "MCPG_SECONDARY_DATABASE_URLS": "Bad-Name=postgresql://u:p@localhost/x",
+            }
+        )
+
+
+def test_secondary_database_urls_enforces_tls_like_primary() -> None:
+    with pytest.raises(ConfigError, match=r"MCPG_SECONDARY_DATABASE_URLS\[an\].*sslmode"):
+        load_settings(
+            {
+                "MCPG_DATABASE_URL": _DB_URL,
+                "MCPG_SECONDARY_DATABASE_URLS": "an=postgresql://u:p@remote.example/db?sslmode=disable",
+            }
+        )
+
+
+def test_secondary_database_urls_tls_bypass_with_allow_insecure() -> None:
+    settings = load_settings(
+        {
+            "MCPG_DATABASE_URL": _DB_URL,
+            "MCPG_ALLOW_INSECURE_TLS": "true",
+            "MCPG_SECONDARY_DATABASE_URLS": "an=postgresql://u:p@remote.example/db?sslmode=disable",
+        }
+    )
+    assert settings.secondary_database_urls == (("an", "postgresql://u:p@remote.example/db?sslmode=disable"),)
+
+
+def test_secondary_database_urls_repr_obfuscates_passwords() -> None:
+    settings = load_settings(
+        {
+            "MCPG_DATABASE_URL": _DB_URL,
+            "MCPG_SECONDARY_DATABASE_URLS": "an=postgresql://u:supersecret@localhost/an",
+        }
+    )
+    assert "supersecret" not in repr(settings)
+
+
 # --- OIDC auth (Shortlist 6.5) -------------------------------------------
 
 

--- a/tests/unit/test_multidb.py
+++ b/tests/unit/test_multidb.py
@@ -1,0 +1,302 @@
+"""Tests for the multi-database selector (roadmap 13.1).
+
+Covers:
+
+* :class:`ReadOnlySqlDriver` — every query runs inside ``BEGIN TRANSACTION
+  READ ONLY`` regardless of the caller's ``force_readonly`` flag, and a write
+  is rejected by the (simulated) PostgreSQL read-only transaction.
+* :class:`mcpg.database.Database` multi-pool construction, the
+  ``driver(database_id=…)`` selector (primary unchanged, secondary read-only,
+  unknown id error), ``database_ids()`` ordering, and ``describe_databases``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+from _fakes import FakePool
+
+from mcpg._vendor.sql import SqlDriver
+from mcpg.config import load_settings
+from mcpg.database import Database, DatabaseError
+from mcpg.multidb import (
+    PRIMARY_DATABASE_ID,
+    DatabaseList,
+    ReadOnlySqlDriver,
+    make_read_only_driver,
+)
+from mcpg.replicas import TimeoutSqlDriver
+
+_PRIMARY = "postgresql://u:p@localhost/db"
+
+
+# ---------------------------------------------------------------------------
+# Fake psycopg connection that simulates a read-only transaction.
+# ---------------------------------------------------------------------------
+
+
+class _ReadOnlyError(Exception):
+    """Stand-in for psycopg's read-only-transaction error (SQLSTATE 25006)."""
+
+
+class _FakeCursor:
+    """Records statements; enforces read-only once BEGIN READ ONLY is seen."""
+
+    def __init__(self, conn: _FakeConnection, *, rows: list[dict[str, object]]) -> None:
+        self._conn = conn
+        self._rows = rows
+        self.description: object | None = None
+
+    async def __aenter__(self) -> _FakeCursor:
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        return None
+
+    async def execute(self, query: str, params: object = None) -> None:
+        self._conn.executed.append(query)
+        upper = query.strip().upper()
+        if upper.startswith("BEGIN TRANSACTION READ ONLY"):
+            self._conn.read_only = True
+            return
+        if upper in {"COMMIT", "ROLLBACK"}:
+            self._conn.read_only = False
+            return
+        if upper.startswith("SET "):
+            return
+        # A data-modifying statement inside a read-only tx is rejected,
+        # exactly as PostgreSQL would (cannot execute … in a read-only
+        # transaction).
+        if self._conn.read_only and upper.split()[0] in {"INSERT", "UPDATE", "DELETE", "CREATE", "DROP", "ALTER"}:
+            raise _ReadOnlyError("cannot execute in a read-only transaction")
+        # A SELECT returns rows.
+        if upper.startswith("SELECT"):
+            self.description = [("col",)]
+
+    def nextset(self) -> bool:
+        return False
+
+    async def fetchall(self) -> list[dict[str, object]]:
+        return self._rows
+
+
+class _FakeConnection:
+    def __init__(self, *, rows: list[dict[str, object]] | None = None) -> None:
+        self.executed: list[str] = []
+        self.read_only = False
+        self._rows = rows or [{"col": 1}]
+
+    def cursor(self, *args: object, **kwargs: object) -> _FakeCursor:
+        return _FakeCursor(self, rows=self._rows)
+
+    async def rollback(self) -> None:
+        self.read_only = False
+
+
+def _read_only_driver_over(conn: _FakeConnection) -> ReadOnlySqlDriver:
+    """A ReadOnlySqlDriver whose execute path uses ``conn`` directly."""
+    driver = ReadOnlySqlDriver(conn=conn)
+    # Bypass the pool branch: point the driver at the fake connection.
+    driver.conn = conn
+    driver.is_pool = False
+    return driver
+
+
+# ---------------------------------------------------------------------------
+# ReadOnlySqlDriver
+# ---------------------------------------------------------------------------
+
+
+async def test_read_only_driver_wraps_every_query_in_read_only_tx() -> None:
+    conn = _FakeConnection()
+    driver = _read_only_driver_over(conn)
+
+    # Caller asks for a NON-readonly query — the driver must still pin it
+    # to a read-only transaction.
+    await driver.execute_query("SELECT 1", force_readonly=False)
+
+    assert "BEGIN TRANSACTION READ ONLY" in conn.executed
+    assert "ROLLBACK" in conn.executed  # read-only path rolls back, never commits
+
+
+async def test_read_only_driver_rejects_a_write_against_a_secondary() -> None:
+    conn = _FakeConnection()
+    driver = _read_only_driver_over(conn)
+
+    with pytest.raises(_ReadOnlyError, match="read-only"):
+        await driver.execute_query("INSERT INTO t VALUES (1)", force_readonly=False)
+
+    # The BEGIN READ ONLY was issued before the write was attempted.
+    assert "BEGIN TRANSACTION READ ONLY" in conn.executed
+    begin_idx = conn.executed.index("BEGIN TRANSACTION READ ONLY")
+    write_idx = next(i for i, q in enumerate(conn.executed) if q.startswith("INSERT"))
+    assert begin_idx < write_idx
+
+
+async def test_make_read_only_driver_builds_a_read_only_driver() -> None:
+    pool = FakePool()
+    driver = make_read_only_driver(pool)  # type: ignore[arg-type]
+    assert isinstance(driver, ReadOnlySqlDriver)
+
+
+# ---------------------------------------------------------------------------
+# Database multi-pool selector
+# ---------------------------------------------------------------------------
+
+
+def _settings_with_secondaries() -> object:
+    return load_settings(
+        {
+            "MCPG_DATABASE_URL": _PRIMARY,
+            "MCPG_SECONDARY_DATABASE_URLS": (
+                "analytics=postgresql://u:p@localhost/an,reporting=postgresql://u:p@localhost/rep"
+            ),
+        }
+    )
+
+
+async def test_connect_opens_primary_and_secondary_pools() -> None:
+    settings = _settings_with_secondaries()
+    primary = FakePool()
+    analytics = FakePool()
+    reporting = FakePool()
+    db = Database(
+        settings,  # type: ignore[arg-type]
+        pool=primary,  # type: ignore[arg-type]
+        secondary_pools={"analytics": analytics, "reporting": reporting},  # type: ignore[arg-type]
+    )
+    await db.connect()
+
+    assert primary.connect_calls == 1
+    assert analytics.connect_calls == 1
+    assert reporting.connect_calls == 1
+    assert db.is_connected is True
+
+
+async def test_secondary_connect_failure_does_not_abort_startup() -> None:
+    settings = _settings_with_secondaries()
+    db = Database(
+        settings,  # type: ignore[arg-type]
+        pool=FakePool(),  # type: ignore[arg-type]
+        secondary_pools={"analytics": FakePool(fail=True), "reporting": FakePool()},  # type: ignore[arg-type]
+    )
+    # Must NOT raise even though one secondary fails to open.
+    await db.connect()
+    assert db.is_connected is True
+
+
+async def test_database_ids_lists_primary_first() -> None:
+    settings = _settings_with_secondaries()
+    db = Database(
+        settings,  # type: ignore[arg-type]
+        pool=FakePool(),  # type: ignore[arg-type]
+        secondary_pools={"analytics": FakePool(), "reporting": FakePool()},  # type: ignore[arg-type]
+    )
+    assert db.database_ids() == [PRIMARY_DATABASE_ID, "analytics", "reporting"]
+
+
+async def test_driver_for_secondary_is_read_only() -> None:
+    settings = _settings_with_secondaries()
+    db = Database(
+        settings,  # type: ignore[arg-type]
+        pool=FakePool(),  # type: ignore[arg-type]
+        secondary_pools={"analytics": FakePool()},  # type: ignore[arg-type]
+    )
+    await db.connect()
+    driver = db.driver("analytics")
+    assert isinstance(driver, ReadOnlySqlDriver)
+
+
+async def test_driver_for_primary_is_unchanged_path() -> None:
+    settings = _settings_with_secondaries()
+    db = Database(
+        settings,  # type: ignore[arg-type]
+        pool=FakePool(),  # type: ignore[arg-type]
+        secondary_pools={"analytics": FakePool()},  # type: ignore[arg-type]
+    )
+    await db.connect()
+    # None and "primary" both resolve to the primary driver — NOT read-only.
+    for db_id in (None, "primary"):
+        driver = db.driver(db_id)
+        assert isinstance(driver, TimeoutSqlDriver)
+        assert not isinstance(driver, ReadOnlySqlDriver)
+
+
+async def test_driver_unknown_id_raises_listing_valid_ids() -> None:
+    settings = _settings_with_secondaries()
+    db = Database(
+        settings,  # type: ignore[arg-type]
+        pool=FakePool(),  # type: ignore[arg-type]
+        secondary_pools={"analytics": FakePool()},  # type: ignore[arg-type]
+    )
+    await db.connect()
+    with pytest.raises(DatabaseError, match=r"unknown database id 'nope'.*analytics"):
+        db.driver("nope")
+
+
+async def test_primary_only_has_no_secondaries() -> None:
+    """Zero behaviour change when MCPG_SECONDARY_DATABASE_URLS is unset."""
+    settings = load_settings({"MCPG_DATABASE_URL": _PRIMARY})
+    db = Database(settings, pool=FakePool())  # type: ignore[arg-type]
+    await db.connect()
+    assert db.database_ids() == [PRIMARY_DATABASE_ID]
+    assert not isinstance(db.driver(), ReadOnlySqlDriver)
+
+
+# ---------------------------------------------------------------------------
+# describe_databases / list_databases payload
+# ---------------------------------------------------------------------------
+
+
+async def test_describe_databases_probes_each_db() -> None:
+    settings = _settings_with_secondaries()
+    db = Database(
+        settings,  # type: ignore[arg-type]
+        pool=FakePool(),  # type: ignore[arg-type]
+        secondary_pools={"analytics": FakePool()},  # type: ignore[arg-type]
+    )
+    await db.connect()
+
+    # Patch driver() so the SELECT 1 probe returns cleanly without a real pool.
+    class _OkDriver:
+        async def execute_query(self, *a: object, **k: object) -> list[SqlDriver.RowResult]:
+            return [SqlDriver.RowResult(cells={"?column?": 1})]
+
+    db.driver = lambda database_id=None: _OkDriver()  # type: ignore[assignment,return-value]
+
+    rows = await db.describe_databases()
+    ids = [r[0] for r in rows]
+    assert ids == [PRIMARY_DATABASE_ID, "analytics"]
+    primary_row = rows[0]
+    assert primary_row[1] is True  # is_primary
+    assert primary_row[2] is False  # read_only
+    secondary_row = rows[1]
+    assert secondary_row[1] is False  # is_primary
+    assert secondary_row[2] is True  # read_only (secondary)
+    assert all(r[3] is True for r in rows)  # reachable
+
+
+async def test_probe_surfaces_unreachable_detail() -> None:
+    settings = _settings_with_secondaries()
+    db = Database(
+        settings,  # type: ignore[arg-type]
+        pool=FakePool(),  # type: ignore[arg-type]
+        secondary_pools={"analytics": FakePool()},  # type: ignore[arg-type]
+    )
+    await db.connect()
+
+    class _FailDriver:
+        async def execute_query(self, *a: object, **k: object) -> list[SqlDriver.RowResult]:
+            raise RuntimeError("connection refused for host=secret")
+
+    db.driver = lambda database_id=None: _FailDriver()  # type: ignore[assignment,return-value]
+    reachable, detail = await db.probe("analytics")
+    assert reachable is False
+    assert detail is not None
+
+
+def test_database_list_is_a_frozen_dataclass() -> None:
+    payload = DatabaseList(primary_id="primary", database_ids=["primary"], databases=[])
+    with pytest.raises(FrozenInstanceError):
+        payload.primary_id = "x"  # type: ignore[misc]

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -193,6 +193,138 @@ async def test_get_server_info_is_callable_from_an_mcp_client() -> None:
     assert result.structuredContent["database_connected"] is True
 
 
+async def test_list_databases_primary_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With no secondaries, list_databases reports just the primary."""
+    from mcpg._vendor.sql import SqlDriver
+
+    db = Database(_SETTINGS, pool=FakePool())  # type: ignore[arg-type]
+
+    class _OkDriver:
+        async def execute_query(self, *a: Any, **k: Any) -> list[SqlDriver.RowResult]:
+            return [SqlDriver.RowResult(cells={"?column?": 1})]
+
+    monkeypatch.setattr(db, "driver", lambda database_id=None: _OkDriver())
+    server = create_server(_SETTINGS, database=db)
+
+    async with create_connected_server_and_client_session(server) as client:
+        result = await client.call_tool("list_databases", {})
+
+    assert result.isError is False
+    content = result.structuredContent
+    assert content is not None
+    assert content["primary_id"] == "primary"
+    assert content["database_ids"] == ["primary"]
+    assert len(content["databases"]) == 1
+    assert content["databases"][0]["is_primary"] is True
+    assert content["databases"][0]["read_only"] is False
+
+
+async def test_list_databases_lists_secondaries(monkeypatch: pytest.MonkeyPatch) -> None:
+    from mcpg._vendor.sql import SqlDriver
+
+    settings = load_settings(
+        {
+            "MCPG_DATABASE_URL": "postgresql://u:p@localhost/db",
+            "MCPG_SECONDARY_DATABASE_URLS": "analytics=postgresql://u:p@localhost/an",
+        }
+    )
+    db = Database(
+        settings,
+        pool=FakePool(),  # type: ignore[arg-type]
+        secondary_pools={"analytics": FakePool()},  # type: ignore[arg-type]
+    )
+
+    class _OkDriver:
+        async def execute_query(self, *a: Any, **k: Any) -> list[SqlDriver.RowResult]:
+            return [SqlDriver.RowResult(cells={"?column?": 1})]
+
+    monkeypatch.setattr(db, "driver", lambda database_id=None: _OkDriver())
+    server = create_server(settings, database=db)
+
+    async with create_connected_server_and_client_session(server) as client:
+        result = await client.call_tool("list_databases", {})
+
+    content = result.structuredContent
+    assert content is not None
+    assert content["database_ids"] == ["primary", "analytics"]
+    secondary = next(d for d in content["databases"] if d["id"] == "analytics")
+    assert secondary["read_only"] is True
+    assert secondary["is_primary"] is False
+
+
+async def test_list_databases_surfaces_unreachable_secondary(monkeypatch: pytest.MonkeyPatch) -> None:
+    from mcpg._vendor.sql import SqlDriver
+
+    settings = load_settings(
+        {
+            "MCPG_DATABASE_URL": "postgresql://u:p@localhost/db",
+            "MCPG_SECONDARY_DATABASE_URLS": "analytics=postgresql://u:p@localhost/an",
+        }
+    )
+    db = Database(
+        settings,
+        pool=FakePool(),  # type: ignore[arg-type]
+        secondary_pools={"analytics": FakePool()},  # type: ignore[arg-type]
+    )
+
+    class _OkDriver:
+        async def execute_query(self, *a: Any, **k: Any) -> list[SqlDriver.RowResult]:
+            return [SqlDriver.RowResult(cells={"?column?": 1})]
+
+    class _FailDriver:
+        async def execute_query(self, *a: Any, **k: Any) -> list[SqlDriver.RowResult]:
+            raise RuntimeError("connection refused")
+
+    def _driver(database_id: str | None = None) -> Any:
+        return _FailDriver() if database_id == "analytics" else _OkDriver()
+
+    monkeypatch.setattr(db, "driver", _driver)
+    server = create_server(settings, database=db)
+
+    async with create_connected_server_and_client_session(server) as client:
+        result = await client.call_tool("list_databases", {})
+
+    content = result.structuredContent
+    assert content is not None
+    secondary = next(d for d in content["databases"] if d["id"] == "analytics")
+    assert secondary["reachable"] is False
+    assert secondary["detail"] is not None
+
+
+async def test_read_tool_threads_database_param_to_driver(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A read tool's ``database`` arg must select the secondary's driver."""
+    from mcpg._vendor.sql import SqlDriver
+
+    settings = load_settings(
+        {
+            "MCPG_DATABASE_URL": "postgresql://u:p@localhost/db",
+            "MCPG_SECONDARY_DATABASE_URLS": "analytics=postgresql://u:p@localhost/an",
+        }
+    )
+    db = Database(
+        settings,
+        pool=FakePool(),  # type: ignore[arg-type]
+        secondary_pools={"analytics": FakePool()},  # type: ignore[arg-type]
+    )
+    seen: list[str | None] = []
+
+    class _OkDriver:
+        async def execute_query(self, *a: Any, **k: Any) -> list[SqlDriver.RowResult]:
+            return []
+
+    def _driver(database_id: str | None = None) -> Any:
+        seen.append(database_id)
+        return _OkDriver()
+
+    monkeypatch.setattr(db, "driver", _driver)
+    server = create_server(settings, database=db)
+
+    async with create_connected_server_and_client_session(server) as client:
+        await client.call_tool("list_schemas", {"database": "analytics"})
+
+    assert "analytics" in seen
+
+
 def _server_for(access_mode: AccessMode) -> object:
     settings = load_settings(
         {


### PR DESCRIPTION
## Summary

Implements roadmap **13.1** — one MCPg server can now serve **multiple
databases**. The primary (`MCPG_DATABASE_URL`) stays the default; additional
**named, read-only** secondaries are configured via a new env var, and every
read-capable tool gains an optional `database` selector.

### Design: secondaries are read-only, enforced by PostgreSQL
The key boundary that keeps this scope safe: **secondary databases are
read-only**, enforced server-side. `ReadOnlySqlDriver` forces every query into
a `BEGIN TRANSACTION READ ONLY` block (always passes `force_readonly=True`
down to the vendored driver), so a stray write/DDL routed at a secondary fails
closed with SQLSTATE 25006 — a guarantee, not a convention. This sidesteps
per-DB write/DDL/LISTEN gating: the global write/DDL/shell/listen/migrate gates
continue to apply only to the primary, and secondaries simply can't be written.

### What changed
- **Config** (`config.py`): new `MCPG_SECONDARY_DATABASE_URLS` — `name=dsn`
  entries (comma/newline separated), parsed into
  `Settings.secondary_database_urls`. Each name is a simple identifier
  (`[a-z0-9_]+`), unique, not the reserved `primary`; each DSN gets the same
  TLS enforcement as the primary. Passwords obfuscated in `repr`.
- **`multidb.py`** (new): `ReadOnlySqlDriver` + `make_read_only_driver`, and
  the `DatabaseDescriptor` / `DatabaseList` typed return shapes.
- **`database.py`**: per-secondary pool dict; `connect()`/`close()` manage all
  pools (a secondary connect failure marks it unavailable, never aborts
  startup — mirrors replica tolerance); `driver(database_id=None)` keeps the
  primary path **byte-for-byte unchanged**, routes a known secondary to a
  read-only driver, and raises a clear error (listing valid ids) on an unknown
  id. New `database_ids()` / `probe()` / `describe_databases()`.
- **`tools.py`**: `_driver(ctx, database=None)`; new READ tool
  **`list_databases`** (typed → `outputSchema`; routed to
  `operations_and_health`); optional `database: str | None = None` swept onto
  **168 read-capable handlers** and threaded to `_driver`. Write/DDL/shell/
  listen/migrate tools are untouched (verified in the surface snapshot:
  `run_select`/`list_schemas`/`describe_table` carry the param, `run_write`
  does not).

### Behavior when unconfigured
With `MCPG_SECONDARY_DATABASE_URLS` unset, behavior is **exactly as before** —
the `database` param defaults to the primary and the primary driver path is
unchanged.

### Tests
- Config parse/validation (dup names, reserved `primary`, bad identifier, TLS).
- Multi-pool construction; **a write against a secondary is rejected**;
  unknown-id error; `list_databases` (primary-only, secondaries listed,
  unreachable secondary surfaced).
- Contract snapshots regenerated; output-schema manifest floor 194 → 195 for
  the new typed `list_databases`; return-shape coverage floor unchanged.
- Full suite: **2552 passed, 110 skipped**. ruff + ruff format + mypy clean.

## Roadmap linkage

Advances roadmap row: 13.1

## Checklist

- [x] Tests added/updated first (TDD); suite passes locally (2552 passed)
- [x] `ruff`, `ruff format`, and `mypy src/mcpg` pass
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Roadmap row cited above; row 13.1 marked ✅ in this PR
- [x] No hand-edits to `src/mcpg/_vendor/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_