### PR TITLE
docs(roadmap): fix 13.1 shipped-marker placement so linkage tool reads it

### DIFF
--- a/docs/feature-shortlist.md
+++ b/docs/feature-shortlist.md
@@ -178,7 +178,7 @@ documented return conditions.
 
 | # | Item | Effort | Value | Notes |
 |---|---|---|---|---|
-| 13.1 | One MCPg server, multiple `MCPG_DATABASE_URL`s — tool-level db selector | L | Medium | ✅ Shipped. `MCPG_SECONDARY_DATABASE_URLS` adds named, **read-only** secondary databases; every read-capable tool takes an optional `database` arg, `list_databases` discovers them. Read-only is PostgreSQL-enforced (every secondary query runs in a `READ ONLY` transaction), which sidesteps per-DB write/DDL gating — writes / DDL / shell / migrate stay primary-only. |
+| 13.1 | ✅ **Shipped.** One MCPg server, multiple `MCPG_DATABASE_URL`s — tool-level db selector | L | Medium | `MCPG_SECONDARY_DATABASE_URLS` adds named, **read-only** secondary databases; every read-capable tool takes an optional `database` arg, `list_databases` discovers them. Read-only is PostgreSQL-enforced (every secondary query runs in a `READ ONLY` transaction), which sidesteps per-DB write/DDL gating — writes / DDL / shell / migrate stay primary-only. |
 
 ## 14. Release engineering & hygiene
 


### PR DESCRIPTION
## Summary

Row 13.1's `✅ Shipped` marker was placed in the **Notes** column, but
`tools/roadmap_linkage.py` infers status from the **start of the Item
cell**. As a result `roadmap_linkage.py list` reported the already-shipped
13.1 (merged in #196) as still `open`. This moves the marker to the Item
cell — matching every other shipped row — and drops the now-redundant
prefix from Notes.

After this, `roadmap_linkage.py list` correctly shows only the two
deliberately-deferred BM25 rows (12.2 / 12.3) as open.

Docs-only; no code change.

## Roadmap linkage

Advances roadmap row: N/A — bookkeeping fix for the already-shipped 13.1 marker

## Checklist

- [x] Tests added/updated first (TDD); suite passes locally (docs-only)
- [x] `ruff`, `ruff format`, and `mypy src/mcpg` pass (no source touched)
- [x] `CHANGELOG.md` — N/A (internal roadmap doc)
- [x] Roadmap row cited above (or `N/A`)
- [x] No hand-edits to `src/mcpg/_vendor/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Documentation:
- Update the feature shortlist roadmap entry for item 13.1 to place the shipped marker in the Item column and clean up the Notes text.