### PR TITLE
release: cut v0.6.5 — multi-database selector (roadmap 13.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [0.6.5] - 2026-06-30
+
+### Added
+
 - **Multi-database selector with read-only secondaries** (roadmap
   **13.1**). One MCPg server can now serve multiple databases. The
   primary (`MCPG_DATABASE_URL`) stays the default target of every tool;

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,6 +48,7 @@ them" — pick the section that matches what you're trying to do.
   retrospectives.
 - [**Progress log**](PROGRESS.md) — chronological build log.
 - Release notes:
+  [v0.6.5](release-notes-0.6.5.md) ·
   [v0.6.4](release-notes-0.6.4.md) ·
   [v0.6.0](release-notes-0.6.0.md) ·
   [v0.5.0](release-notes-0.5.0.md) ·

--- a/docs/release-notes-0.6.5.md
+++ b/docs/release-notes-0.6.5.md
@@ -1,0 +1,62 @@
+# MCPg v0.6.5 — release notes
+
+**Released:** 2026-06-30
+**Tool surface:** **246** tools across 19 capability buckets
+**Tests:** 2552 pass (PG 14 / 15 / 16 / 17 / 18 / 19)
+**CI:** PG 14-19 + an experimental WarehousePG lane
+
+This is a **patch-level bump (0.6.4 → 0.6.5)** carrying a single
+headline feature — the multi-database selector (roadmap 13.1). Every
+addition is backward-compatible: the primary-only path is byte-for-byte
+unchanged when the new env var is unset, so existing deployments upgrade
+with no configuration changes.
+
+## Headline: one server, multiple databases (read-only secondaries)
+
+A single MCPg server can now serve **multiple databases**. The primary
+(`MCPG_DATABASE_URL`) stays the default target of every tool; additional
+named, **read-only** secondaries are configured via the new
+`MCPG_SECONDARY_DATABASE_URLS` env var — comma- or newline-separated
+`name=dsn` entries, e.g.
+`analytics=postgresql://…,reporting=postgresql://…`.
+
+Every **read-capable tool** gains an optional `database` argument that
+selects a secondary by name; omitting it targets the primary. The new
+**`list_databases`** READ tool discovers every configured database id,
+which one is primary, each `read_only` flag, and a live `SELECT 1`
+reachability probe.
+
+### Read-only is enforced by PostgreSQL, not by convention
+
+Secondaries are read-only at the server level: every query against a
+secondary runs inside a `BEGIN TRANSACTION READ ONLY`, so a stray write
+fails closed with SQLSTATE 25006 even if the calling tool forgot to mark
+itself read-only. This is the design boundary that keeps the feature
+safe — it sidesteps per-database write/DDL/LISTEN gating entirely:
+
+- **Write / DDL / shell / listen / migrate tools always target the
+  primary** — they never carry the `database` argument.
+- The global `MCPG_ACCESS_MODE` / `MCPG_ALLOW_DDL` / `MCPG_ALLOW_SHELL`
+  / `MCPG_ALLOW_LISTEN` gates continue to apply to the primary exactly
+  as before; secondaries simply can't be written to.
+
+Operational niceties: secondary DSNs get the same TLS enforcement as the
+primary; names must be simple identifiers (`[a-z0-9_]+`), unique, and
+not the reserved `primary`; and a secondary that fails to open at
+startup is marked unavailable (surfaced by `list_databases`) rather than
+aborting startup — mirroring the existing read-replica tolerance.
+
+## Upgrade
+
+```bash
+pip install --upgrade mcpg   # once published to PyPI
+```
+
+No configuration changes required. Multi-database support is opt-in —
+leave `MCPG_SECONDARY_DATABASE_URLS` unset and the server behaves
+exactly as in 0.6.4.
+
+## Full changelog
+
+See [`../CHANGELOG.md`](../CHANGELOG.md) `[0.6.5]` for the complete
+itemised list.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcpg"
-version = "0.6.4"
+version = "0.6.5"
 description = "A production-grade PostgreSQL Model Context Protocol (MCP) server."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/mcpg/__init__.py
+++ b/src/mcpg/__init__.py
@@ -1,3 +1,3 @@
 """MCPg — a PostgreSQL Model Context Protocol server."""
 
-__version__ = "0.6.4"
+__version__ = "0.6.5"

--- a/uv.lock
+++ b/uv.lock
@@ -988,7 +988,7 @@ cli = [
 
 [[package]]
 name = "mcpg"
-version = "0.6.4"
+version = "0.6.5"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Cuts **v0.6.5** — a patch-level bump (0.6.4 → 0.6.5) carrying a single
headline feature, the **multi-database selector** (roadmap 13.1). All
additions are backward-compatible: the primary-only path is unchanged
when `MCPG_SECONDARY_DATABASE_URLS` is unset.

- Bump `pyproject.toml` + `src/mcpg/__init__.py` + `uv.lock` to **0.6.5**.
- Fold `[Unreleased]` into `[0.6.5] - 2026-06-30` in `CHANGELOG.md`;
  leave a fresh empty `[Unreleased]`.
- Add `docs/release-notes-0.6.5.md`; link it from `docs/index.md`.

**Tool surface:** 246 tools · **Tests:** 2552 pass (PG 14–19).

The publish workflow's "tag must match pyproject version" guard will
pass (`0.6.5`). The `v0.6.5` tag that triggers the PyPI publish is
created **manually after merge**, per the established process.

## Roadmap linkage

Advances roadmap row: N/A — release-cut PR (ships the already-merged 13.1)

## Checklist

- [x] Tests added/updated first (TDD); suite passes locally (2552 pass)
- [x] `ruff`, `ruff format`, and `mypy src/mcpg` pass (no source touched)
- [x] `CHANGELOG.md` updated (`[Unreleased]` → `[0.6.5]`)
- [x] Roadmap row cited above (N/A — release cut)
- [x] No hand-edits to `src/mcpg/_vendor/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Cut v0.6.5 release for MCPg, documenting and packaging the new multi-database selector feature as a backward-compatible patch.

New Features:
- Introduce documented multi-database support with read-only secondary databases selectable per tool request.

Enhancements:
- Update project metadata and lockfile to version 0.6.5.
- Record the 0.6.5 changes in CHANGELOG and add dedicated release notes linked from the documentation index.

Documentation:
- Add v0.6.5 release notes describing the multi-database selector and upgrade path, and link them from the docs index.