### PR TITLE
docs(readme): refresh stale facts (PG 19, tool count, tests) + drop redundant 'Featured In'

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **A production-grade [Model Context Protocol](https://modelcontextprotocol.io)
 server for PostgreSQL.** Lets AI agents safely inspect, query, operate, and
-tune a Postgres database — over 100 tools spanning catalog introspection,
+tune a Postgres database — over 240 tools spanning catalog introspection,
 query intelligence, natural-language SQL, structural diffs, hybrid search,
 graph queries, data movement, live ops, and more.
 
@@ -17,7 +17,7 @@ graph queries, data movement, live ops, and more.
 
 ### 📍 Listed On
 
-- **[Official MCP Registry](https://registry.modelcontextprotocol.io/v0.1/servers/io.github.devopam%2Fmcpg/versions/0.6.1)**  
+- **[Official MCP Registry](https://registry.modelcontextprotocol.io/v0.1/servers/io.github.devopam%2Fmcpg/versions/0.6.5)**  
 - **[mcp.so](https://mcp.so/server/mcpg---production-grade-postgresql-mcp-server/Devopam%20Mittra)**  
 - **[mcpservers.org](https://mcpservers.org/servers/devopam/mcpg)**
 - **[![Glama](https://glama.ai/mcp/servers/devopam/MCPg/badges/score.svg)](https://glama.ai/mcp/servers/devopam/MCPg)**
@@ -28,7 +28,7 @@ graph queries, data movement, live ops, and more.
 | Safety              | Read-only default + AST validation |
 | Transport           | stdio + HTTP/SSE                  |
 | Install             | `pip install mcpg`                |
-| Postgres Versions   | 14–18                             |
+| Postgres Versions   | 14–19                             |
 | Key Differentiator  | Production observability + multi-tenancy |
 
 ## Why MCPg
@@ -58,17 +58,12 @@ graph queries, data movement, live ops, and more.
   HTTP transport surfaces `mcpg_tool_calls_total{tool,status}` +
   `mcpg_tool_duration_seconds`. Every tool call records a structured
   audit event with credential-redacted arguments.
-- **Test-driven, multi-version.** 800+ unit tests plus an integration
+- **Test-driven, multi-version.** 2,500+ unit tests plus an integration
   suite that runs against a real PostgreSQL container in CI — matrix
   covers PG **14, 15, 16, 17, 18** on every push, plus PG **19 (beta)**
   as an experimental (non-blocking) entry tracked under issue #120.
 
 ---
-
-### Featured In
-- mcp.so  
-- mcpservers.org  
-- Official MCP Registry (coming soon)
 
 ## Install
 


### PR DESCRIPTION
## Summary

README had drifted behind the codebase. This refreshes the stale facts
and removes a redundant section:

- **Postgres Versions** in the quick-facts table: `14–18` → **`14–19`**
  (PG 19 coverage; the features section already mentioned PG 19).
- **Intro**: "over 100 tools" → **"over 240 tools"** (actual surface is 246).
- **Features**: "800+ unit tests" → **"2,500+ unit tests"**.
- **MCP Registry link**: stale `…/versions/0.6.1` → **`0.6.5`**.
- **Removed the "Featured In" block** — it duplicated *and contradicted*
  the "📍 Listed On" section above (which already lists the **live**
  registry, mcp.so, mcpservers.org, and the Glama badge), where
  "Featured In" still said the registry was "coming soon".

### Note on github.io sync
GitHub Pages serves Jekyll from `main`/root (`README.md` → homepage,
`docs/` auto-rendered per `_config.yml`), so the published site isn't a
separate copy that drifts — it rebuilds from `main`. This refresh
therefore brings https://devopam.github.io/MCPg/ back in sync on merge;
no separate docs-site action is needed.

Docs-only; no code change. (The Docker section's `docker pull` update is
intentionally left to the separate ghcr.io publishing PR.)

## Roadmap linkage

Advances roadmap row: N/A — documentation refresh

## Checklist

- [x] Tests added/updated first (TDD); suite passes locally (docs-only)
- [x] `ruff`, `ruff format`, and `mypy src/mcpg` pass (no source touched)
- [x] `CHANGELOG.md` — N/A (README/docs only)
- [x] Roadmap row cited above (N/A)
- [x] No hand-edits to `src/mcpg/_vendor/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Refresh README to align documented capabilities with current MCPg features and registry status.

Documentation:
- Update README quick-facts and feature descriptions for current Postgres version support, tool count, and test coverage.
- Refresh Official MCP Registry link in README to point to the latest published version entry.
- Remove the redundant and outdated 'Featured In' section from the README.