### PR TITLE
ci(publish): publish container image to GHCR on tagged releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -175,3 +175,47 @@ jobs:
         run: mcp-publisher login github-oidc
       - name: Publish server to MCP Registry
         run: mcp-publisher publish
+
+  publish-ghcr:
+    name: Publish container → GHCR
+    # Runs only after the human-approved PyPI publish succeeds, so the
+    # container release tracks the approved PyPI release exactly — if the
+    # maintainer cancels at the PyPI approval gate, no image is pushed.
+    needs: publish-pypi
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v7
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Compute image tags
+        id: tags
+        # ``:<version>`` (e.g. 0.6.5) plus ``:latest``. The image name is
+        # lowercased because GHCR rejects uppercase path components.
+        run: |
+          VER="${GITHUB_REF_NAME#v}"
+          IMAGE="ghcr.io/devopam/mcpg"
+          echo "tags=${IMAGE}:${VER},${IMAGE}:latest" >> "$GITHUB_OUTPUT"
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          # OCI labels so the package page links back to the repo + release.
+          labels: |
+            org.opencontainers.image.source=https://github.com/devopam/MCPg
+            org.opencontainers.image.version=${{ github.ref_name }}
+            org.opencontainers.image.licenses=MIT
+            org.opencontainers.image.description=Production-grade PostgreSQL MCP server
+          # Skip the buildkit provenance attestation so the package page
+          # shows a single clean manifest rather than an unknown/unknown pair.
+          provenance: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Container images on GHCR.** The release workflow now builds the
+  `Dockerfile` and pushes it to `ghcr.io/devopam/mcpg` on every tagged
+  release (`:<version>` + `:latest`), so container users can
+  `docker pull ghcr.io/devopam/mcpg:latest` instead of building from
+  source. The push runs only after the human-approved PyPI publish
+  succeeds, so the image tracks the approved release; it authenticates
+  with the built-in `GITHUB_TOKEN` (no new secrets).
+
 ### Changed
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -88,12 +88,22 @@ mcpg --version
 
 ### Docker
 
+Pull the pre-built image from the GitHub Container Registry (published
+on every tagged release — `:latest` tracks the newest, or pin a version
+like `:0.6.5`):
+
 ```bash
-docker build -t mcpg https://github.com/devopam/MCPg.git
+docker pull ghcr.io/devopam/mcpg:latest
 docker run --rm -p 8000:8000 \
     -e MCPG_DATABASE_URL=postgresql://user:pass@host:5432/db \
     -e MCPG_ACCESS_MODE=read-only \
-    mcpg
+    ghcr.io/devopam/mcpg:latest
+```
+
+Or build it yourself from source:
+
+```bash
+docker build -t mcpg https://github.com/devopam/MCPg.git
 ```
 
 Multi-stage image: runtime stage drops the build toolchain, runs as


### PR DESCRIPTION
## Summary

Publishes MCPg's container image to the **GitHub Container Registry** so
users can `docker pull ghcr.io/devopam/mcpg:latest` instead of building
from source. (Exclusive PR for the ghcr.io question — no unrelated changes.)

### Why it's a good fit
- The `Dockerfile` is already production-grade (multi-stage, non-root
  `uid 10001`, slim runtime) — nothing about the image needs to change.
- **No new secrets**: GHCR authenticates with the built-in
  `GITHUB_TOKEN` (`packages: write`).
- The release workflow already fires on `v*.*.*` tags, so the new job
  slots in naturally.

### What it does
A new `publish-ghcr` job in `publish.yml`:
- Builds the existing `Dockerfile` and pushes to
  `ghcr.io/devopam/mcpg` with `:<version>` (e.g. `0.6.5`) + `:latest`.
- **`needs: publish-pypi`** — runs only *after* the human-approved PyPI
  publish succeeds, so the container release tracks the approved release
  exactly. If the maintainer cancels at the PyPI approval gate, no image
  is pushed.
- Adds OCI labels (source / version / license / description) so the
  package page links back to the repo, and sets `provenance: false` for
  a clean single-manifest package page.

### Docs
- README Docker section now leads with `docker pull ghcr.io/devopam/mcpg`
  (build-from-source kept as the alternative).
- `CHANGELOG.md` `[Unreleased]` notes the new distribution channel.

### Follow-ups (intentionally out of scope)
- **Multi-arch (arm64)** — kept to `linux/amd64` for v1 to keep the
  release pipeline fast/reliable; arm64 via QEMU/buildx is an easy
  follow-up if there's demand.
- First push happens when the next `v*.*.*` tag is created (e.g. when you
  tag `v0.6.5`). One-time: the GHCR package defaults to private — set it
  public in the repo's *Packages* settings after the first publish.

## Roadmap linkage

Advances roadmap row: N/A — packaging / distribution infrastructure

## Checklist

- [x] Tests added/updated first (TDD); suite passes locally (CI/docs only, no `src/` change)
- [x] `ruff`, `ruff format`, and `mypy src/mcpg` pass (no source touched)
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Roadmap row cited above (N/A)
- [x] No hand-edits to `src/mcpg/_vendor/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Add automated publishing of the existing Docker container image to GitHub Container Registry on tagged releases and document the new distribution channel.

New Features:
- Publish the Docker image to ghcr.io/devopam/mcpg with versioned and latest tags as part of the tagged release workflow.
- Document usage of the pre-built GHCR image in the README and note the new container distribution channel in the changelog.

CI:
- Extend the publish workflow with a GHCR job that builds and pushes the Docker image after a successful, human-approved PyPI publish, using GitHub-provided credentials.