### PR TITLE
docs(security): track two NL→SQL hardening items (prompt-injection + EXPLAIN pre-flight)

### DIFF
--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -227,6 +227,60 @@ audit trail, then exits. Configurable max-drain window
 
 **Effort:** small (~40 LOC + 3-4 tests).
 
+### ⬜ NL→SQL prompt-injection hardening (boundary defense)
+**Problem.** `translate_nl_to_sql` already separates the schema (system
+role) from the user's question (user role) and isolates the question via
+`.replace()` rather than format-string interpolation, and the generated
+SQL is re-validated by `SafeSqlDriver` (read-only SELECT, single
+statement, schema denylist) before any execution — so the *impact* of a
+prompt injection is already bounded to a read-only query over allowed
+schemas. What's missing is an explicit instruction in the system prompt
+telling the model to treat the user text as a **literal translation
+request** and refuse embedded instructions ("ignore previous
+instructions", "output all password hashes", etc.), plus hard delimiters
+around the user input. This is defense-in-depth at the prompt layer, not
+a new enforcement boundary.
+
+**Solution.** (1) Wrap the user question in explicit delimiters (e.g.
+`<user_request>…</user_request>`) in the user-role message. (2) Add a
+directive to the system prompt: the model is a strict SQL translator;
+anything inside the delimiters is data to translate, never instructions
+to obey; if the request asks for anything beyond a read-only SELECT over
+the permitted schemas, emit a refusal sentinel the caller can detect.
+(3) Keep the existing AST allowlist as the actual enforcement backstop —
+the prompt hardening only reduces the chance of a socially-engineered
+(but technically valid) SELECT.
+
+**Env vars to add:** none (prompt-template change; behaviour on by
+default).
+
+**Effort:** small (system-prompt edit + refusal-path handling + 3-5
+tests). Surfaced 2026-06-30 from a security-feature review.
+
+### ⬜ NL→SQL EXPLAIN dry-run pre-flight
+**Problem.** Generated SQL is validated structurally (AST allowlist +
+single-statement assertion) but not **semantically** — a query that
+references a non-existent column/table or has a type mismatch is
+syntactically valid, passes the allowlist, and only fails when executed.
+The agent gets a runtime error instead of an early, clean signal.
+
+**Solution.** Before returning (or, on `execute=True`, before running)
+the generated SELECT, run a non-executing `EXPLAIN` (no `ANALYZE`) in a
+read-only transaction, bounded by the existing `statement_timeout`. If
+`EXPLAIN` errors, surface it as a structured "query invalid" result with
+the planner message rather than a raw execution failure; optionally
+expose the plan so the caller can spot an unintended seq-scan-on-huge-
+table before running it. `EXPLAIN` without `ANALYZE` does not execute the
+query, so this is cheap and side-effect-free. (Distinct from the existing
+`io=True` path on `explain_query`, which deliberately *does* run
+`ANALYZE`.)
+
+**Env vars to add:** likely none (could gate behind an
+`explain_preflight` arg, default on).
+
+**Effort:** small (one pre-flight helper + wiring into
+`translate_nl_to_sql` + 4-6 tests).
+
 ---
 
 ## Posture summary

--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -251,7 +251,16 @@ the permitted schemas, emit a refusal sentinel the caller can detect.
 the prompt hardening only reduces the chance of a socially-engineered
 (but technically valid) SELECT.
 
-**Env vars to add:** none (prompt-template change; behaviour on by
+**Implementation note — refusal sentinel.** Pin the sentinel once so
+handling stays consistent: the model must emit a single line
+`-- MCPG_REFUSED: <reason>` (and nothing else) when it declines. The
+translator detects that exact prefix, returns a typed
+`Nl2SqlResult(refused=True, reason=…, sql=None)` (never passes the text
+on to `SafeSqlDriver`), and the tool surfaces it as a structured refusal
+rather than an error. Defining the sentinel + the result field up front
+avoids each provider branch inventing its own ad-hoc handling.
+
+**Env vars to add:** none (prompt-template change; behaviour is on by
 default).
 
 **Effort:** small (system-prompt edit + refusal-path handling + 3-5
@@ -274,6 +283,19 @@ table before running it. `EXPLAIN` without `ANALYZE` does not execute the
 query, so this is cheap and side-effect-free. (Distinct from the existing
 `io=True` path on `explain_query`, which deliberately *does* run
 `ANALYZE`.)
+
+**Implementation notes — permissions & cost.**
+- *Permissions:* `EXPLAIN` (no `ANALYZE`) needs the same `SELECT`
+  privileges the query itself needs, so any role that could run the
+  generated SELECT can plan it — no extra grant. Treat a permission
+  error from the pre-flight as "not authorised", surfaced like any other
+  planner error, not as a hard failure of the tool.
+- *Cost / configurability:* planning is normally sub-millisecond, but a
+  query over many partitions or a deeply-nested view can take longer, so
+  the pre-flight inherits the existing `statement_timeout` and must
+  degrade gracefully (treat a pre-flight timeout as "skipped, proceed"
+  rather than blocking). Make it bypassable via the `explain_preflight`
+  arg (default on) for callers that don't want the extra round trip.
 
 **Env vars to add:** likely none (could gate behind an
 `explain_preflight` arg, default on).


### PR DESCRIPTION
## Summary

Records the two genuinely-new items from the security-feature review as
**pending (`⬜`)** entries in `docs/security-hardening.md`. Design notes
only — **no implementation** (per request).

1. **NL→SQL prompt-injection hardening (boundary defense)** — add an
   explicit "literal SQL translator, ignore embedded instructions"
   directive to the system prompt + hard delimiters around the user
   question. Defense-in-depth on top of the *existing* role separation
   and `SafeSqlDriver` AST allowlist (which already bound a successful
   injection to a read-only SELECT over allowed schemas).
2. **NL→SQL EXPLAIN dry-run pre-flight** — run a non-executing `EXPLAIN`
   (no `ANALYZE`, timeout-bounded) on generated SQL to catch *semantic*
   errors (bad column/table, type mismatch) before returning/executing,
   instead of surfacing a raw runtime error.

### Why only these two
The review proposed ~12 ideas; the rest were verified against the code as
**already shipped** — `pg_sleep` rejection (not in the SafeSql function
allowlist), statement/lock timeouts (`MCPG_STATEMENT_TIMEOUT_MS` 30s /
`MCPG_LOCK_TIMEOUT_MS` 5s), NL→SQL system/user role separation, PID kill
switches (`cancel_query` / `terminate_backend`, audited), AST rejection
of DROP/TRUNCATE/ALTER/GRANT/COPY, and `SET LOCAL ROLE` RBAC — or judged
**not worth the false-positive cost** (Cartesian-join / recursive-CTE AST
rules, and a keyword/intent classifier, all of which `statement_timeout`
+ the AST allowlist already mitigate). Enforced `$1/$2` parameterization
was a deliberate design difference (MCPg inlines literals and validates
the whole statement), not a gap.

Docs-only; no code change.

## Roadmap linkage

Advances roadmap row: N/A — security backlog bookkeeping

## Checklist

- [x] Tests added/updated first (TDD); suite passes locally (docs-only)
- [x] `ruff`, `ruff format`, and `mypy src/mcpg` pass (no source touched)
- [x] `CHANGELOG.md` — N/A (internal security doc)
- [x] Roadmap row cited above (N/A)
- [x] No hand-edits to `src/mcpg/_vendor/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Document planned NL→SQL security hardening for prompt-injection defenses and EXPLAIN-based pre-flight validation, without implementing any code changes.

Documentation:
- Add a pending documentation item for strengthening NL→SQL prompt-injection defenses via stricter translation directives and input delimiting.
- Add a pending documentation item for introducing an EXPLAIN-based dry-run pre-flight check for generated SQL to catch semantic issues before execution.