### PR TITLE
docs(changelog): fold GHCR container images into [0.6.5]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,6 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- **Container images on GHCR.** The release workflow now builds the
-  `Dockerfile` and pushes it to `ghcr.io/devopam/mcpg` on every tagged
-  release (`:<version>` + `:latest`), so container users can
-  `docker pull ghcr.io/devopam/mcpg:latest` instead of building from
-  source. The push runs only after the human-approved PyPI publish
-  succeeds, so the image tracks the approved release; it authenticates
-  with the built-in `GITHUB_TOKEN` (no new secrets).
-
 ### Changed
 
 ### Fixed
@@ -23,6 +15,14 @@ adheres to [Semantic Versioning](https://semver.org/).
 ## [0.6.5] - 2026-06-30
 
 ### Added
+
+- **Container images on GHCR.** The release workflow now builds the
+  `Dockerfile` and pushes it to `ghcr.io/devopam/mcpg` on every tagged
+  release (`:<version>` + `:latest`), so container users can
+  `docker pull ghcr.io/devopam/mcpg:latest` instead of building from
+  source. The push runs only after the human-approved PyPI publish
+  succeeds, so the image tracks the approved release; it authenticates
+  with the built-in `GITHUB_TOKEN` (no new secrets).
 
 - **Multi-database selector with read-only secondaries** (roadmap
   **13.1**). One MCPg server can now serve multiple databases. The

--- a/docs/release-notes-0.6.5.md
+++ b/docs/release-notes-0.6.5.md
@@ -46,6 +46,21 @@ not the reserved `primary`; and a secondary that fails to open at
 startup is marked unavailable (surfaced by `list_databases`) rather than
 aborting startup — mirroring the existing read-replica tolerance.
 
+## Also in this release: container images on GHCR
+
+Pre-built images now publish to the GitHub Container Registry on every
+tagged release, so container users can pull instead of building from
+source:
+
+```bash
+docker pull ghcr.io/devopam/mcpg:0.6.5   # or :latest
+```
+
+The image build is the same production-grade multi-stage `Dockerfile`
+(non-root `uid 10001`, slim runtime). The push runs only after the
+maintainer-approved PyPI publish, so the container tracks the approved
+release.
+
 ## Upgrade
 
 ```bash


### PR DESCRIPTION
## Summary

The "Container images on GHCR" entry (#201) merged after the 0.6.5
release cut, so it landed in `[Unreleased]`. Since the GHCR push first
happens **when `v0.6.5` is tagged**, the change ships *as part of*
v0.6.5 — so this moves the entry into the `[0.6.5]` section (leaving
`[Unreleased]` empty) and adds a matching note to
`docs/release-notes-0.6.5.md`.

This keeps the tagged release's notes self-consistent: the
`github-release` workflow job extracts the `[0.6.5]` CHANGELOG section as
the GitHub Release body, so the container-images line will now appear
there too.

Docs-only; no code change.

## Roadmap linkage

Advances roadmap row: N/A — release-notes housekeeping

## Checklist

- [x] Tests added/updated first (TDD); suite passes locally (docs-only)
- [x] `ruff`, `ruff format`, and `mypy src/mcpg` pass (no source touched)
- [x] `CHANGELOG.md` updated (`[Unreleased]` → `[0.6.5]`)
- [x] Roadmap row cited above (N/A)
- [x] No hand-edits to `src/mcpg/_vendor/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Documentation:
- Document GHCR container image publishing as part of the 0.6.5 release in both CHANGELOG and version-specific release notes.