### PR TITLE
fix(publish): sync server.json version to the release tag in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -167,6 +167,29 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+      - name: Sync server.json version to the release tag
+        # server.json is checked in with a fixed version (bumped manually at
+        # the 0.6.1 registry launch and never since — every subsequent
+        # release silently re-submitted "0.6.1" and the registry rejected it
+        # as a duplicate). Deriving the version from the tag here means this
+        # step can never go stale again, the same way the sdist/wheel build
+        # derives its version from pyproject.toml rather than a hand-maintained
+        # constant.
+        run: |
+          VER="${GITHUB_REF_NAME#v}"
+          python3 -c "
+          import json
+          path = 'server.json'
+          with open(path) as f:
+              data = json.load(f)
+          data['version'] = '$VER'
+          for pkg in data.get('packages', []):
+              pkg['version'] = '$VER'
+          with open(path, 'w') as f:
+              json.dump(data, f, indent=2)
+              f.write('\n')
+          "
+          cat server.json
       - name: Install mcp-publisher
         run: |
           curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,19 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **MCP Registry publish step failing silently on every release since
+  0.6.1.** `server.json` (the manifest `mcp-publisher` reads) was checked in
+  with a fixed `version: "0.6.1"` at registry launch and never bumped again,
+  so every subsequent release re-submitted "0.6.1" and the registry
+  correctly rejected it as a duplicate version — while PyPI / GHCR / the
+  GitHub Release all kept succeeding, so the failure went unnoticed. The
+  `publish-mcp-registry` job now patches `server.json`'s `version` (and
+  `packages[].version`) to the release tag before calling `mcp-publisher
+  publish`, the same way the sdist/wheel build derives its version from
+  `pyproject.toml` rather than a hand-maintained constant — this can't go
+  stale again. The checked-in `server.json` is also bumped to `0.6.5` to
+  match current state.
+
 ## [0.6.5] - 2026-06-30
 
 ### Added

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.devopam/mcpg",
-  "version": "0.6.1",
+  "version": "0.6.5",
   "description": "A production-grade PostgreSQL Model Context Protocol (MCP) server.",
   "repository": {
     "url": "https://github.com/devopam/MCPg",
@@ -12,7 +12,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "mcpg",
-      "version": "0.6.1",
+      "version": "0.6.5",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary

The `v0.6.5` release run's `Publish to MCP Registry` job failed with:
```
Error: publish failed: server returned status 400: {"errors":[{"message":"invalid version: cannot publish duplicate version"}]}
```

Root cause: `server.json` (the manifest `mcp-publisher` reads to know what to
publish) was checked in with a fixed `"version": "0.6.1"` when the registry
integration first landed (#82) and **has never been bumped since**. Every
release from 0.6.2 onward has been silently re-submitting `"0.6.1"` to the
registry, which correctly rejects it as a duplicate — while PyPI, GHCR, and
the GitHub Release all kept succeeding in the same workflow run, so the
failure went unnoticed release after release.

## Fix

- Added a `Sync server.json version to the release tag` step to the
  `publish-mcp-registry` job, right before `mcp-publisher publish` runs. It
  patches `server.json`'s `version` and every `packages[].version` to
  `${GITHUB_REF_NAME#v}` — the same tag-derives-the-version pattern the
  `build` job already uses to sanity-check `pyproject.toml`. This can't go
  stale again; there's no more hand-maintained version constant to forget.
- Bumped the checked-in `server.json` to `0.6.5` so the file reflects
  current state for anyone browsing the repo.

## Note on the v0.6.5 registry entry itself

This fix lands **after** the `v0.6.5` tag was already pushed, so the
already-completed workflow run for that tag won't pick it up (a re-run of a
completed job replays the workflow file as it existed at trigger time, not
`main`'s current version). PyPI / GHCR / the GitHub Release for 0.6.5 all
succeeded, so the release itself is unaffected — the MCP Registry will
simply pick up the fix cleanly starting with the next tagged release.

Infra-only; no `src/mcpg` change.

## Roadmap linkage

Advances roadmap row: N/A — CI/release-infra bug fix

## Checklist

- [x] Tests added/updated first (TDD); suite passes locally (no `src/mcpg` touched; no test covers `server.json`)
- [x] `ruff`, `ruff format`, and `mypy src/mcpg` pass (no source touched)
- [x] `CHANGELOG.md` updated under `[Unreleased] → Fixed`
- [x] Roadmap row cited above (N/A)
- [x] No hand-edits to `src/mcpg/_vendor/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_