### PR TITLE
fix(liveops): stop replica-routing PID-targeted backend actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,18 @@ adheres to [Semantic Versioning](https://semver.org/).
   lingering backends via `pg_terminate_backend` followed by a plain
   `DROP DATABASE`, preserving the original FORCE intent without needing the
   syntax.
+- **`cancel_query` / `terminate_backend` could be replica-routed to the
+  wrong server.** Both sent their `pg_cancel_backend(pid)` /
+  `pg_terminate_backend(pid)` signal with `force_readonly=True`, which
+  marks a query "safe to route to a read replica" — but a PID names a
+  specific backend process on whichever physical server it lives on, not
+  something portable across a replica. With `MCPG_REPLICA_URLS`
+  configured, this could silently target the wrong server (a PID not found
+  there just returns `succeeded=False`; a coincidentally-matching PID
+  would be cancelled/terminated instead, with no error at all). Dropped
+  the flag from both calls in `mcpg.liveops` — a PID-targeted admin
+  signal is a primary-only action by nature, never eligible for replica
+  routing.
 - **MCP Registry publish step failing silently on every release since
   0.6.1.** `server.json` (the manifest `mcp-publisher` reads) was checked in
   with a fixed `version: "0.6.1"` at registry launch and never bumped again,

--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -303,13 +303,13 @@ query, so this is cheap and side-effect-free. (Distinct from the existing
 **Effort:** small (one pre-flight helper + wiring into
 `translate_nl_to_sql` + 4-6 tests).
 
-### ⬜ Pin PID-targeted backend actions to the primary (never replica-routed)
-**Problem.** `mcpg.liveops.cancel_query` / `terminate_backend` send
-`pg_cancel_backend(pid)` / `pg_terminate_backend(pid)` via
+### ✅ Pin PID-targeted backend actions to the primary (never replica-routed)
+**Shipped.** **Problem.** `mcpg.liveops.cancel_query` / `terminate_backend`
+sent `pg_cancel_backend(pid)` / `pg_terminate_backend(pid)` via
 `driver.execute_query(..., force_readonly=True)`. That flag is meant to
 mark a query as *safe to route to a read replica* — but a PID is scoped to
 whichever physical server process it names, not portable across servers.
-When `MCPG_REPLICA_URLS` is configured, `RoutedSqlDriver` can send a
+When `MCPG_REPLICA_URLS` is configured, `RoutedSqlDriver` could send a
 cancel/terminate signal to a **different backend on a replica** than the
 one the caller actually intended (sourced from `list_active_queries`,
 `pg_stat_activity`, or an operator's own knowledge of the primary) —
@@ -318,23 +318,22 @@ silently: a PID that doesn't exist on the routed-to server just returns
 different, unrelated backend) would be cancelled/terminated instead, with
 no error at all. Surfaced 2026-07-01 during review of an unrelated PR
 (`force_readonly=True` on a `pg_terminate_backend` call in test cleanup
-code, fixed there; this is the equivalent, pre-existing issue in the real
+code, fixed there; this was the equivalent, pre-existing issue in the real
 product tools).
 
-**Solution.** Drop `force_readonly=True` from both calls in
+**Solution.** Dropped `force_readonly=True` from both calls in
 `mcpg.liveops` — a PID-targeted admin signal is a primary-only action by
 nature (same category as DDL/write tools), not a "safe to read from a
-replica" query, so it should never be eligible for replica routing
-regardless of what a future caller passes. If replica-side PID actions are
-ever genuinely wanted, that should be an explicit, opt-in target
-(consistent with the `database` selector pattern from roadmap 13.1), not
-implicit routing via a flag whose real purpose is unrelated.
+replica" query, so it's never eligible for replica routing regardless of
+replica config. If replica-side PID actions are ever genuinely wanted,
+that should be an explicit, opt-in target (consistent with the `database`
+selector pattern from roadmap 13.1), not implicit routing via a flag whose
+real purpose is unrelated.
 
-**Env vars to add:** none (removes an incorrect flag; no new surface).
+**Env vars to add:** none (removed an incorrect flag; no new surface).
 
-**Effort:** small (two-line change + a regression test asserting
-`force_readonly` is not passed, or that the call always targets the
-primary driver regardless of replica config).
+**Effort:** small — two-line change in `mcpg.liveops` + two regression
+tests asserting the calls are never marked `force_readonly`.
 
 ---
 

--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -303,6 +303,39 @@ query, so this is cheap and side-effect-free. (Distinct from the existing
 **Effort:** small (one pre-flight helper + wiring into
 `translate_nl_to_sql` + 4-6 tests).
 
+### ⬜ Pin PID-targeted backend actions to the primary (never replica-routed)
+**Problem.** `mcpg.liveops.cancel_query` / `terminate_backend` send
+`pg_cancel_backend(pid)` / `pg_terminate_backend(pid)` via
+`driver.execute_query(..., force_readonly=True)`. That flag is meant to
+mark a query as *safe to route to a read replica* — but a PID is scoped to
+whichever physical server process it names, not portable across servers.
+When `MCPG_REPLICA_URLS` is configured, `RoutedSqlDriver` can send a
+cancel/terminate signal to a **different backend on a replica** than the
+one the caller actually intended (sourced from `list_active_queries`,
+`pg_stat_activity`, or an operator's own knowledge of the primary) —
+silently: a PID that doesn't exist on the routed-to server just returns
+`succeeded=False`, and a PID that *coincidentally* exists there (a
+different, unrelated backend) would be cancelled/terminated instead, with
+no error at all. Surfaced 2026-07-01 during review of an unrelated PR
+(`force_readonly=True` on a `pg_terminate_backend` call in test cleanup
+code, fixed there; this is the equivalent, pre-existing issue in the real
+product tools).
+
+**Solution.** Drop `force_readonly=True` from both calls in
+`mcpg.liveops` — a PID-targeted admin signal is a primary-only action by
+nature (same category as DDL/write tools), not a "safe to read from a
+replica" query, so it should never be eligible for replica routing
+regardless of what a future caller passes. If replica-side PID actions are
+ever genuinely wanted, that should be an explicit, opt-in target
+(consistent with the `database` selector pattern from roadmap 13.1), not
+implicit routing via a flag whose real purpose is unrelated.
+
+**Env vars to add:** none (removes an incorrect flag; no new surface).
+
+**Effort:** small (two-line change + a regression test asserting
+`force_readonly` is not passed, or that the call always targets the
+primary driver regardless of replica config).
+
 ---
 
 ## Posture summary

--- a/src/mcpg/liveops.py
+++ b/src/mcpg/liveops.py
@@ -83,11 +83,16 @@ async def cancel_query(driver: SqlDriver, pid: int) -> BackendActionResult:
 
     Sends a cancel signal via ``pg_cancel_backend``; the connection itself
     stays open. ``succeeded`` is ``False`` if no such backend exists.
+
+    Deliberately NOT ``force_readonly`` — a PID names a specific backend
+    process on whichever physical server it lives on, which isn't portable
+    across a read replica. Marking this "safe to replica-route" could send
+    the signal to the wrong server, silently no-op'ing (PID not found there)
+    or, worse, hitting an unrelated backend that happens to share the PID.
     """
     rows = await driver.execute_query(
         "SELECT pg_cancel_backend(%s) AS ok",
         params=[pid],
-        force_readonly=True,
     )
     succeeded = bool((rows or [])[0].cells["ok"])
     return BackendActionResult(pid=pid, action="cancel_query", succeeded=succeeded)
@@ -98,11 +103,12 @@ async def terminate_backend(driver: SqlDriver, pid: int) -> BackendActionResult:
 
     Sends a terminate signal via ``pg_terminate_backend``. ``succeeded`` is
     ``False`` if no such backend exists.
+
+    Deliberately NOT ``force_readonly`` — see :func:`cancel_query`.
     """
     rows = await driver.execute_query(
         "SELECT pg_terminate_backend(%s) AS ok",
         params=[pid],
-        force_readonly=True,
     )
     succeeded = bool((rows or [])[0].cells["ok"])
     return BackendActionResult(pid=pid, action="terminate_backend", succeeded=succeeded)

--- a/tests/unit/test_liveops.py
+++ b/tests/unit/test_liveops.py
@@ -87,10 +87,29 @@ async def test_cancel_query_reports_the_signal_outcome() -> None:
     assert driver.calls[0][1] == [4242]
 
 
+async def test_cancel_query_never_marks_the_call_force_readonly() -> None:
+    # A PID names a backend on a specific physical server; force_readonly
+    # would make this eligible for replica routing, which could target the
+    # wrong server. Must always go through the primary-bound path.
+    driver = FakeDriver([{"ok": True}])
+
+    await cancel_query(driver, 4242)
+
+    assert driver.calls[0][2] is False
+
+
 async def test_cancel_query_reports_failure_for_an_unknown_backend() -> None:
     result = await cancel_query(FakeDriver([{"ok": False}]), 999999)
 
     assert result.succeeded is False
+
+
+async def test_terminate_backend_never_marks_the_call_force_readonly() -> None:
+    driver = FakeDriver([{"ok": True}])
+
+    await terminate_backend(driver, 7000)
+
+    assert driver.calls[0][2] is False
 
 
 async def test_terminate_backend_reports_the_signal_outcome() -> None:


### PR DESCRIPTION
## Summary

Originally opened as a docs-only backlog entry; on reflection the fix
itself is small and well-understood, so implementing it directly instead
of just tracking it.

`mcpg.liveops.cancel_query` / `terminate_backend` sent
`pg_cancel_backend(pid)` / `pg_terminate_backend(pid)` via
`driver.execute_query(..., force_readonly=True)`. That flag marks a query
"safe to route to a read replica" — but a PID names a specific backend
process on whichever physical server it lives on, not something portable
across a replica. With `MCPG_REPLICA_URLS` configured, `RoutedSqlDriver`
could send the signal to the **wrong server**, silently: a PID not found
there just returns `succeeded=False`, and a PID that *coincidentally*
exists there (an unrelated backend) would be cancelled/terminated instead
— with no error at all.

Found while reviewing #212: the same pattern in test cleanup code was
flagged by Gemini and fixed there; this is the equivalent, pre-existing
issue in the real product tools.

## Fix

- Dropped `force_readonly=True` from both `pg_cancel_backend` and
  `pg_terminate_backend` calls in `mcpg.liveops` — a PID-targeted admin
  signal is a primary-only action by nature, never eligible for replica
  routing regardless of config.
- Two regression tests assert the calls are never marked
  `force_readonly`.
- `docs/security-hardening.md`'s backlog entry flipped from pending (`⬜`)
  to shipped (`✅`).

## Tests
Full suite: **2623 passed, 110 skipped, 0 failed.** `ruff` + `ruff format`
+ `mypy src/mcpg` clean.

## Roadmap linkage

Advances roadmap row: N/A — security fix (tracked in security-hardening.md, not the feature roadmap)

## Checklist

- [x] Tests added/updated first (TDD); suite passes locally (2623 passed)
- [x] `ruff`, `ruff format`, and `mypy src/mcpg` pass
- [x] `CHANGELOG.md` updated under `[Unreleased] → Fixed`
- [x] Roadmap row cited above (N/A)
- [x] No hand-edits to `src/mcpg/_vendor/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)