### PR TITLE
release: cut v0.6.6 — roadmap completion + reliability fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [0.6.6] - 2026-07-01
+
+### Added
+
 - **`generate_graph_projection`** — relational → Apache AGE graph-projection
   mapper (roadmap **2.10**). Given a schema (and optional table subset), emits
   the openCypher `CREATE` / `MERGE` statements that project rows→vertices (one

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,6 +48,7 @@ them" — pick the section that matches what you're trying to do.
   retrospectives.
 - [**Progress log**](PROGRESS.md) — chronological build log.
 - Release notes:
+  [v0.6.6](release-notes-0.6.6.md) ·
   [v0.6.5](release-notes-0.6.5.md) ·
   [v0.6.4](release-notes-0.6.4.md) ·
   [v0.6.0](release-notes-0.6.0.md) ·

--- a/docs/release-notes-0.6.6.md
+++ b/docs/release-notes-0.6.6.md
@@ -1,0 +1,91 @@
+# MCPg v0.6.6 — release notes
+
+**Released:** 2026-07-01
+**Tool surface:** **252** tools across 19 capability buckets
+**Tests:** 2623 pass (PG 14 / 15 / 16 / 17 / 18 / 19 / WarehousePG)
+**CI:** PG 14-19 + a now-fully-passing WarehousePG lane
+
+This is a **patch-level bump (0.6.5 → 0.6.6)**. It completes the entire
+feature roadmap tracked in `docs/feature-shortlist.md` — six new
+read-capable tools spanning live-ops, vector retrieval, and graph
+projection — plus a set of real reliability fixes surfaced by finally
+getting the WarehousePG CI lane to run against a genuine server. Every
+addition is backward-compatible and additive.
+
+## New tools
+
+**Live database operations**
+- **`analyze_table_bloat`** — per-table *and* per-index estimated bloat %
+  (catalog estimate by default; precise `pgstattuple`/`pgstatindex` mode
+  when installed), sorted worst-first, so VACUUM/REPACK can be targeted
+  precisely instead of guessed at.
+- **`dry_run_ddl`** — runs a proposed `ALTER TABLE` / non-concurrent
+  `CREATE INDEX` under a tight `lock_timeout`, captures the lock mode
+  held, wall-clock duration, and WAL bytes generated, then **always rolls
+  back**. `CREATE INDEX CONCURRENTLY` and other non-transactional DDL are
+  rejected up front as ineligible, since they can't run inside the
+  wrapping transaction.
+- **`run_select_tuned`** — runs a read-only SELECT with an elevated,
+  bounded `work_mem` (hard-capped at 2 GiB) scoped to that single
+  statement, for analytical queries that would otherwise spill to disk.
+
+**Retrieval & vector**
+- **`retrieve_with_context`** — "one-shot RAG": a pgvector k-NN search
+  that also expands each hit one hop along foreign keys (parent + child
+  rows), packing the match and its relational context into a single
+  response.
+- **`recommend_ivfflat_probes`** — the IVFFlat counterpart to the
+  existing `recommend_hnsw_ef_search`: sweeps `probes`, measures
+  recall@k and latency, and recommends the smallest value clearing a
+  target recall.
+
+**Graph**
+- **`generate_graph_projection`** — projects a relational schema into an
+  Apache AGE property graph by generating the openCypher `CREATE`/`MERGE`
+  statements (rows→vertices, FKs→edges) **for review, never executed** —
+  the same pattern as `generate_test_data` and `recommend_redistribute`.
+
+## Enhancements
+
+- **`audit_database`** now folds in sequence-exhaustion and
+  `postgresql.conf`-sanity checks as two additional scorecard categories,
+  so the comprehensive scan surfaces at-risk sequences and dangerous GUCs
+  directly — no separate `audit_sequences`/`audit_settings` call needed.
+- **`dump_database`** gains an optional `schemas` parameter to scope a
+  `pg_dump` to specific schemas instead of the whole database. Purely
+  additive — omitting it is byte-for-byte unchanged.
+
+## Reliability fixes
+
+- **The `warehousepg-latest` CI lane is now genuinely green** — for the
+  first time. It had been failing since the day it was added: the pinned
+  image never existed on Docker Hub, so the build failed before a single
+  test ever ran, silently, for every PR. Repointed at a real published
+  image, corrected its connection wiring, and fixed three real
+  Greenplum/WarehousePG dialect incompatibilities the working lane then
+  surfaced (distribution-key-aware uniqueness constraints, a PG13+-only
+  `DROP DATABASE` flag, a default-schema collision in dump/restore).
+- **`cancel_query` / `terminate_backend` could target the wrong server.**
+  Both were marked "safe to route to a read replica," but a PID names a
+  process on one specific physical server — with `MCPG_REPLICA_URLS`
+  configured, the signal could silently miss or hit the wrong backend.
+  Fixed: these are primary-only actions now, always.
+- **The MCP Registry publish step had been silently failing since
+  0.6.1** — the version it submitted was never bumped past the original
+  registry-launch value, so every later release was rejected as a
+  duplicate while PyPI/GHCR/GitHub Releases kept succeeding unnoticed.
+  It now derives the version from the release tag automatically.
+
+## Upgrade
+
+```bash
+pip install --upgrade mcpg   # once published to PyPI
+docker pull ghcr.io/devopam/mcpg:0.6.6   # or :latest
+```
+
+No configuration changes required.
+
+## Full changelog
+
+See [`../CHANGELOG.md`](../CHANGELOG.md) `[0.6.6]` for the complete
+itemised list.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcpg"
-version = "0.6.5"
+version = "0.6.6"
 description = "A production-grade PostgreSQL Model Context Protocol (MCP) server."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/mcpg/__init__.py
+++ b/src/mcpg/__init__.py
@@ -1,3 +1,3 @@
 """MCPg — a PostgreSQL Model Context Protocol server."""
 
-__version__ = "0.6.5"
+__version__ = "0.6.6"

--- a/uv.lock
+++ b/uv.lock
@@ -988,7 +988,7 @@ cli = [
 
 [[package]]
 name = "mcpg"
-version = "0.6.5"
+version = "0.6.6"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Cuts **v0.6.6** — a patch-level bump (0.6.5 → 0.6.6), matching the
version you already tagged. Bumps `pyproject.toml` + `src/mcpg/__init__.py`
+ `uv.lock` to `0.6.6` and folds `[Unreleased]` into
`[0.6.6] - 2026-07-01` in `CHANGELOG.md`.

This completes the entire feature roadmap: six new tools
(`analyze_table_bloat`, `dry_run_ddl`, `run_select_tuned`,
`retrieve_with_context`, `recommend_ivfflat_probes`,
`generate_graph_projection`), two enhancements (`audit_database`'s
sequence/settings fold-in, `dump_database`'s `schemas` param), and three
real reliability fixes (the `warehousepg-latest` CI lane is now
genuinely green for the first time, `cancel_query`/`terminate_backend`
can no longer be replica-routed, and the MCP Registry publish step
self-heals instead of silently duplicate-rejecting every release).

Adds `docs/release-notes-0.6.6.md`; links it from `docs/index.md`.

**Tool surface:** 252 tools · **Tests:** 2623 pass.

## ⚠️ About the existing `v0.6.6` tag

The `v0.6.6` tag already exists (you created it before this PR), pointing
at the **old** commit where `pyproject.toml` was still `0.6.5` — which is
exactly why the publish workflow's "tag must match `pyproject.toml`
version" sanity check failed. **Once this PR merges, the tag needs to be
moved** to the new commit (I can't push tags from this environment —
the git relay blocks it). From your machine:

```bash
git fetch origin main
git tag -f v0.6.6 <new-main-HEAD-after-merge>
git push origin v0.6.6 --force
```

(`git push --force` on a **tag** ref only, not a branch — safe here since
the old tag's workflow run already failed and produced nothing.)

## Roadmap linkage

Advances roadmap row: N/A — release-cut PR (ships already-merged work)

## Checklist

- [x] Tests added/updated first (TDD); suite passes locally (2623 pass)
- [x] `ruff`, `ruff format`, and `mypy src/mcpg` pass
- [x] `CHANGELOG.md` updated (`[Unreleased]` → `[0.6.6]`)
- [x] Roadmap row cited above (N/A — release cut)
- [x] No hand-edits to `src/mcpg/_vendor/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_