### PR TITLE
Fix publish workflow: poll TestPyPI's simple index, not its JSON API

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -90,26 +90,43 @@ jobs:
             --format requirements-txt > /tmp/mcpg-deps.txt
           python -m pip install -r /tmp/mcpg-deps.txt
       - name: Wait for TestPyPI to index the upload
-        # Trusted Publishing returns 200 the moment the file lands,
-        # but the simple index is eventually consistent (~30s typical).
+        # Trusted Publishing returns 200 the moment the file lands, but the
+        # PEP 503 *simple index* pip actually installs from is a SEPARATE,
+        # independently-consistent system from the JSON API. Polling the
+        # JSON API (as this step used to) can report "ready" before the
+        # simple index has caught up — observed on the v0.6.6 release: the
+        # JSON check passed on its very first attempt, then the immediately
+        # following pip install 404'd because 0.6.6 wasn't in the simple
+        # index yet. Poll the simple index itself instead.
         run: |
           VER="${GITHUB_REF_NAME#v}"
-          for i in $(seq 1 12); do
-            if curl -fsSL "https://test.pypi.org/pypi/mcpg/${VER}/json" >/dev/null 2>&1; then
-              echo "TestPyPI sees mcpg==${VER}"
+          for i in $(seq 1 18); do
+            if curl -fsSL "https://test.pypi.org/simple/mcpg/" 2>/dev/null | grep -q "mcpg-${VER}"; then
+              echo "TestPyPI simple index sees mcpg==${VER}"
               exit 0
             fi
-            echo "TestPyPI not ready (attempt $i/12)..."
+            echo "TestPyPI simple index not ready (attempt $i/18)..."
             sleep 10
           done
-          echo "::error::TestPyPI never reported mcpg==${VER}"
+          echo "::error::TestPyPI simple index never listed mcpg==${VER}"
           exit 1
       - name: Install mcpg from TestPyPI (no deps)
+        # A short retry on the install itself too: even after the simple
+        # index origin has the version, a CDN edge cache in front of it can
+        # lag a few more seconds.
         run: |
           VER="${GITHUB_REF_NAME#v}"
-          python -m pip install --no-deps \
-            --index-url https://test.pypi.org/simple/ \
-            "mcpg==${VER}"
+          for i in 1 2 3; do
+            if python -m pip install --no-deps \
+                --index-url https://test.pypi.org/simple/ \
+                "mcpg==${VER}"; then
+              exit 0
+            fi
+            echo "pip install attempt $i/3 failed; retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::pip install mcpg==${VER} from TestPyPI failed after 3 attempts"
+          exit 1
       - name: Import + CLI smoke
         run: |
           python -c "import mcpg; print(mcpg.__version__)"


### PR DESCRIPTION
## Summary

- The v0.6.6 release's TestPyPI smoke-test step failed: `pip install mcpg==0.6.6` 404'd with 0.6.6 entirely absent from the reported "from versions" list, even though the preceding "wait for TestPyPI to index" check had already reported success.
- Root cause: TestPyPI's JSON API and the PEP 503 simple index that `pip install --index-url` actually queries are independently-consistent systems with different propagation lag. The old wait-loop polled the JSON API only, which can report a version "ready" before the simple index catches up.
- Fix: poll the simple index directly (`https://test.pypi.org/simple/mcpg/`) instead of the JSON API, and wrap the actual `pip install` in a short retry to absorb any residual CDN edge-cache lag in front of the simple-index origin.
- No functional change to what gets published — this only hardens the smoke-test verification step so a future release doesn't need a manual `rerun_failed_jobs` to get past it (as v0.6.6 did).

## Test plan

- [x] YAML-validated the edited workflow (`python3 -c "import yaml; yaml.safe_load(...)"`) to confirm the step list and structure are intact.
- [ ] Exercised for real on the next tagged release (`publish.yml` only triggers on `push: tags: ["v*.*.*"]`, so it can't be dry-run outside of an actual release).


---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_