### PR TITLE
Silence pydantic's benign "schema field shadows BaseModel" startup warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,14 @@ asyncio_default_fixture_loop_scope = "function"
 markers = [
     "integration: requires a live PostgreSQL (set MCPG_TEST_DATABASE_URL)",
 ]
+filterwarnings = [
+    # pytest resets warnings.filters per test, so the runtime filter
+    # mcpg/__init__.py installs (same pattern, kept in sync manually)
+    # doesn't survive into test collection — repeat it here so the ~180
+    # tool-return dataclasses with a `schema` field don't spam every test
+    # that touches Tool.output_schema.
+    'ignore:Field name ".*" in ".*" shadows an attribute in parent "BaseModel":UserWarning',
+]
 
 [tool.coverage.run]
 source = ["src/mcpg"]

--- a/src/mcpg/__init__.py
+++ b/src/mcpg/__init__.py
@@ -1,3 +1,23 @@
 """MCPg — a PostgreSQL Model Context Protocol server."""
 
+import warnings
+
 __version__ = "0.6.6"
+
+# ``schema`` is the natural field name for "which Postgres schema" across
+# ~180 tool-return dataclasses. The ``mcp`` SDK dynamically builds a
+# pydantic model from each of those dataclasses to publish an output
+# schema (mcp.server.fastmcp.utilities.func_metadata), and pydantic's
+# BaseModel still carries a deprecated v1-compat ``.schema()`` method —
+# so every one of those dataclasses trips this warning the first time a
+# client calls ``tools/list``. Renaming the field would break the JSON
+# shape of every affected tool's output; suppressing this specific,
+# known-benign message is the narrower fix. Exported so the regression
+# test can apply the exact same pattern rather than a hand-copied one.
+PYDANTIC_SCHEMA_FIELD_SHADOW_WARNING = r'Field name ".*" in ".*" shadows an attribute in parent "BaseModel"'
+
+warnings.filterwarnings(
+    "ignore",
+    message=PYDANTIC_SCHEMA_FIELD_SHADOW_WARNING,
+    category=UserWarning,
+)

--- a/tests/contract/test_tool_output_schemas.py
+++ b/tests/contract/test_tool_output_schemas.py
@@ -30,6 +30,8 @@ field on the helper is caught by *both* tests in concert.
 
 from __future__ import annotations
 
+import warnings
+
 from mcp.server.fastmcp import FastMCP
 
 from mcpg.config import load_settings
@@ -832,6 +834,35 @@ def test_converted_tools_output_schemas_carry_expected_fields() -> None:
         + "\n  ".join(drift)
         + "\nUpdate the manifest if the rename is intentional; otherwise revert the helper change."
     )
+
+
+def test_output_schema_build_emits_no_pydantic_schema_field_shadow_warnings() -> None:
+    """Building every tool's output_schema must not leak pydantic's
+    "Field name ... shadows an attribute in parent BaseModel" warning.
+
+    Every dataclass with a ``schema`` field (the natural name for "which
+    Postgres schema") trips this the moment pydantic dynamically builds a
+    model from it — ``mcpg.PYDANTIC_SCHEMA_FIELD_SHADOW_WARNING`` filters
+    it at import time. This applies that exact pattern fresh (pytest
+    resets ``warnings.filters`` per test) against the full tool surface,
+    so a future pydantic wording change or an uncovered attribute name
+    would show up here instead of leaking to users at runtime.
+    """
+    import mcpg
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        warnings.filterwarnings(
+            "ignore",
+            message=mcpg.PYDANTIC_SCHEMA_FIELD_SHADOW_WARNING,
+            category=UserWarning,
+        )
+        server = _build_maximal_server()
+        for tool in server._tool_manager.list_tools():
+            _ = tool.output_schema
+
+    shadow_warnings = [w for w in caught if "shadows an attribute in parent" in str(w.message)]
+    assert not shadow_warnings, [str(w.message) for w in shadow_warnings]
 
 
 def test_converted_tool_count_grows_monotonically() -> None:


### PR DESCRIPTION
## Summary

- Running MCPg surfaced a wall of `UserWarning: Field name "schema" in "..." shadows an attribute in parent "BaseModel"` warnings from pydantic on startup / first `tools/list`.
- Root cause: the `mcp` SDK's `func_metadata.py` dynamically builds a pydantic model from each tool's return-type dataclass to publish its `outputSchema`. Pydantic's `BaseModel` still carries a deprecated v1-compat `.schema()` method, and any dataclass field literally named `schema` (the natural name for "which Postgres schema", used across ~180 tool-return dataclasses in this codebase) collides with it. It's lazy — the warning only fires the first time `Tool.output_schema` (a `cached_property`) is accessed, i.e. the first `tools/list` call, which is why it shows up as soon as a client connects.
- Renaming the field isn't a reasonable fix here — it would change the JSON key in every affected tool's response, a breaking change to the public tool contract, just to quiet a cosmetic startup warning from a deprecated pydantic v1 shim nobody uses.
- Fix: suppress the specific, known-benign message via a scoped `warnings.filterwarnings(...)` at package import time (`src/mcpg/__init__.py`), matching only this exact pydantic message pattern (not a blanket `UserWarning` silence). Also added the same pattern to `pyproject.toml`'s pytest `filterwarnings`, since pytest resets `warnings.filters` per test and the runtime filter alone doesn't survive into test collection — without it, the same warning was showing up in every test that touches `Tool.output_schema` (31+ occurrences in `test_tool_surface_snapshot.py` alone).

## Test plan

- [x] Added `test_output_schema_build_emits_no_pydantic_schema_field_shadow_warnings` in `tests/contract/test_tool_output_schemas.py`, which builds the full maximal-flag tool surface fresh inside its own `catch_warnings` block (pytest resets filters per test, so this re-applies the exact same pattern `mcpg` exports) and asserts zero shadow warnings.
- [x] Reproduced the warning directly against a real `FastMCP` server + `register_tools()` + `list_tools()` before the fix (18 occurrences), confirmed 0 after.
- [x] `uv run pytest -q -m "not integration"` — 2624 passed, only one unrelated pre-existing warning (`StarletteDeprecationWarning`) left in the summary.
- [x] `uv run ruff format --check .` / `uv run ruff check .` / `uv run mypy src/mcpg` — all clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_