### PR TITLE
Add experimental Python 3.14 CI lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,3 +200,38 @@ jobs:
         env:
           MCPG_TEST_DATABASE_URL: postgresql://${{ env.DB_USER }}:postgres@localhost:5432/mcpg_test
         run: uv run pytest -q --cov
+
+  test-python314:
+    name: Tests (Python 3.14, PG 17) — experimental
+    runs-on: ubuntu-latest
+    # Exploratory lane: proves out the dependency stack (psycopg[binary],
+    # pglast, cryptography — the compiled ones) under the next CPython
+    # release before anything commits to it. CI only ever installs 3.13
+    # elsewhere (see the ``test`` job above, ``lint``, ``security``); this
+    # is deliberately non-gating (continue-on-error) — a failure here is a
+    # signal to investigate, not a merge blocker. One PG version is enough
+    # since the point is Python-level compatibility, not another full PG
+    # matrix sweep.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+      - name: Start PostgreSQL (pgvector + PostGIS)
+        run: |
+          docker build -f .github/ci-postgres.Dockerfile --build-arg PG_MAJOR=17 -t mcpg-ci-db-py314 .
+          docker run -d --name mcpg-db-py314 -p 5432:5432 \
+            -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres \
+            -e POSTGRES_DB=mcpg_test mcpg-ci-db-py314
+          for _ in $(seq 1 30); do
+            docker exec mcpg-db-py314 pg_isready -U postgres && break
+            sleep 2
+          done
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.14"
+          enable-cache: true
+      - run: uv sync --frozen
+      - name: pytest
+        env:
+          MCPG_TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/mcpg_test
+        run: uv run pytest -q


### PR DESCRIPTION
## Summary

- Docker's vulnerability-scan tooling nudges towards `python:3.14-slim-bookworm` as the runtime base image. Checked: both the 3.13 and 3.14 Docker Hub tags were rebuilt from the identical Debian bookworm base on the same day, so there's no OS-package CVE delta between them — any real difference is purely the CPython interpreter version, and 3.13 still gets genuine upstream security backports. This isn't a "stopgap for a known vulnerability," but it's still reasonable to move to the newer interpreter eventually.
- Before touching the `Dockerfile` or `pyproject.toml` classifiers, prove the dependency stack actually works on 3.14 first. CI has only ever installed Python 3.13 (`lint`, `security`, and the `test` matrix all pin `python-version: "3.13"`) — nothing has run the suite under 3.14.
- The compiled deps that would matter most (`psycopg[binary]`, `pglast==7.14`, `cryptography` via `pyjwt[crypto]`) all already ship `cp314` wheels on PyPI, so this is plausible, but "plausible" isn't the same as "actually run."

## What this adds

A new `test-python314` job in `ci.yml`:
- Installs Python 3.14 via `astral-sh/setup-uv`, `uv sync --frozen`, runs the full `pytest` suite against a single PG version (17 — chosen since this lane is about Python-level compatibility, not another full PG-version sweep).
- `continue-on-error: true` — non-gating. A failure here is a signal to investigate before a future Docker/classifier bump, not a merge blocker on this or any other PR.

## Next steps (not in this PR)

If this lane proves out green for a while, the follow-up is bumping `Dockerfile`'s two `FROM` lines (`ghcr.io/astral-sh/uv:python3.13-bookworm-slim` → `python3.14-bookworm-slim`, `python:3.13-slim-bookworm` → `python:3.14-slim-bookworm`) plus `pyproject.toml`'s `classifiers` list, together, once there's real CI evidence backing it.

## Test plan

- [x] YAML-validated the workflow file (`python3 -c "import yaml; ..."` confirms the job list is intact: `lint`, `security`, `test`, `test-python314`).
- [ ] The new job itself can only be exercised for real once this PR's CI actually runs — that's the point of adding it.


---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_