### PR TITLE
Move the runtime to Python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           enable-cache: true
       - run: uv sync --frozen
       - name: ruff (lint)
@@ -37,7 +37,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           enable-cache: true
       - run: uv sync --frozen
       # pip-audit consults the PyPI advisory DB + OSV.dev for known
@@ -191,7 +191,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           enable-cache: true
       - run: uv sync --frozen
       # Runs unit, vendored-kernel, and integration suites with the coverage
@@ -200,38 +200,3 @@ jobs:
         env:
           MCPG_TEST_DATABASE_URL: postgresql://${{ env.DB_USER }}:postgres@localhost:5432/mcpg_test
         run: uv run pytest -q --cov
-
-  test-python314:
-    name: Tests (Python 3.14, PG 17) — experimental
-    runs-on: ubuntu-latest
-    # Exploratory lane: proves out the dependency stack (psycopg[binary],
-    # pglast, cryptography — the compiled ones) under the next CPython
-    # release before anything commits to it. CI only ever installs 3.13
-    # elsewhere (see the ``test`` job above, ``lint``, ``security``); this
-    # is deliberately non-gating (continue-on-error) — a failure here is a
-    # signal to investigate, not a merge blocker. One PG version is enough
-    # since the point is Python-level compatibility, not another full PG
-    # matrix sweep.
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v7
-      - name: Start PostgreSQL (pgvector + PostGIS)
-        run: |
-          docker build -f .github/ci-postgres.Dockerfile --build-arg PG_MAJOR=17 -t mcpg-ci-db-py314 .
-          docker run -d --name mcpg-db-py314 -p 5432:5432 \
-            -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres \
-            -e POSTGRES_DB=mcpg_test mcpg-ci-db-py314
-          for _ in $(seq 1 30); do
-            docker exec mcpg-db-py314 pg_isready -U postgres && break
-            sleep 2
-          done
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          python-version: "3.14"
-          enable-cache: true
-      - run: uv sync --frozen
-      - name: pytest
-        env:
-          MCPG_TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/mcpg_test
-        run: uv run pytest -q

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v7
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           enable-cache: true
       - run: uv sync --frozen
       - name: Sanity check — tag matches pyproject version
@@ -74,11 +74,11 @@ jobs:
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v7
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           enable-cache: true
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - name: Install runtime deps from real PyPI (anti-confusion)
         # TestPyPI is a public sandbox; combining its index with
         # ``--extra-index-url=pypi`` lets an attacker shadow our

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- **Runtime moves to Python 3.14.** The Docker image, CI (`lint`,
+  `security`, and the full PG 14-19 + WarehousePG test matrix), and the
+  publish workflow all now build/run on Python 3.14 (previously 3.13).
+  `pyproject.toml` still declares `requires-python = ">=3.12"` and
+  classifies 3.12/3.13/3.14 as supported — this is a change to which
+  version *we* build and test with, not a narrowing of what versions
+  `pip install mcpg` accepts.
+
 ### Fixed
 
 ## [0.6.6] - 2026-07-01

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # --- Stage 1: Build virtual environment ---
-FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim AS builder
+FROM ghcr.io/astral-sh/uv:python3.14-bookworm-slim AS builder
 
 WORKDIR /app
 
@@ -9,7 +9,7 @@ COPY src ./src
 RUN uv sync --frozen --no-dev
 
 # --- Stage 2: Runtime environment ---
-FROM python:3.13-slim-bookworm AS runtime
+FROM python:3.14-slim-bookworm AS runtime
 
 WORKDIR /app
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: SQL",
     "Topic :: Database",
     "Topic :: Database :: Database Engines/Servers",
@@ -180,7 +181,7 @@ select = ["E", "F", "I", "B", "W", "N", "UP", "RUF"]
 known-first-party = ["mcpg"]
 
 [tool.mypy]
-python_version = "3.13"
+python_version = "3.14"
 strict = true
 # Vendored code keeps its own (looser) typing; do not gate on it.
 exclude = ["src/mcpg/_vendor/", "tests/vendor/", "scratch/"]


### PR DESCRIPTION
## Summary

Follow-up to #218 (the experimental `test-python314` CI lane), which passed cleanly on its first real run — proving the compiled deps (`psycopg[binary]`, `pglast==7.14`, `cryptography` via `pyjwt[crypto]`) all work under Python 3.14. This PR follows through and makes 3.14 the mainline version everywhere we build/test:

- **`Dockerfile`**: both `FROM` lines (builder + runtime stages) now pull the 3.14 base images.
- **`ci.yml`**: `lint`, `security`, and the main PG 14-19 + WarehousePG test matrix all install Python 3.14 instead of 3.13. Removed the now-redundant `test-python314` experimental job — its whole purpose was proving 3.14 out before committing to it, which is done, so keeping it around would just be duplicate work against the same mainline version.
- **`publish.yml`**: same bump across all three `python-version` pins (`build`, and `smoke-testpypi`'s two setup steps).
- **`pyproject.toml`**: `mypy`'s `python_version` target moves to `3.14` (matches what CI actually runs now); added the `Programming Language :: Python :: 3.14` classifier alongside the existing 3.12/3.13 ones.
  - `requires-python` stays `>=3.12` — this is a change to what *we* build/test with, not a narrowing of what `pip install mcpg` accepts.
  - `ruff`'s `target-version` stays `"py312"` for the same reason — it governs the minimum-syntax floor for consumers, not the dev/CI interpreter.
- **`CHANGELOG.md`**: noted under `[Unreleased] / Changed`.

## Test plan

- [x] `uv run ruff format --check .` / `uv run ruff check .` — clean.
- [x] `uv run mypy src/mcpg` — clean, now simulating the 3.14 stdlib/typeshed.
- [x] `uv run pytest -q -m "not integration"` — 2624 passed.
- [x] YAML-validated both workflow files (`python3 -c "import yaml; ..."` confirms the job lists: `ci.yml` → `lint`, `security`, `test`; `publish.yml` unchanged job list).
- [ ] The actual PG 14-19 + WarehousePG matrix running on Python 3.14 for real is what this PR's own CI run will exercise.


---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_