### PR TITLE
Publish MCP ToolAnnotations on every tool + cut v0.6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [0.6.7] - 2026-07-03
+
+### Added
+
 - **MCP `ToolAnnotations` on every tool** — all 252 tools now publish
   `readOnlyHint` (185 read-only / 67 write-capable) and `openWorldHint`
   on the wire, derived mechanically from the same READ / WRITE / DDL /
@@ -51,6 +59,22 @@ adheres to [Semantic Versioning](https://semver.org/).
   `pip install mcpg` accepts.
 
 ### Fixed
+
+- **Startup warning noise eliminated.** Running MCPg printed a wall of
+  benign pydantic `Field name "schema" ... shadows an attribute in
+  parent "BaseModel"` warnings on the first `tools/list` call (the
+  `mcp` SDK builds a pydantic model from each tool-return dataclass,
+  and `schema` — the natural name for "which Postgres schema" — collides
+  with a deprecated pydantic v1 shim). The specific message is now
+  suppressed at import time; renaming the field would have broken every
+  affected tool's JSON output shape. A contract test builds the full
+  tool surface and asserts zero shadow warnings leak.
+- **TestPyPI smoke-test race in the publish pipeline.** The
+  wait-for-indexing step polled TestPyPI's JSON API, which can report a
+  release "ready" before the PEP 503 simple index (what `pip install`
+  actually reads) catches up — observed on the v0.6.6 release, which
+  needed a manual re-run. The step now polls the simple index directly
+  and retry-wraps the install.
 
 ## [0.6.6] - 2026-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **MCP `ToolAnnotations` on every tool** — all 252 tools now publish
+  `readOnlyHint` (185 read-only / 67 write-capable) and `openWorldHint`
+  on the wire, derived mechanically from the same READ / WRITE / DDL /
+  SHELL / LISTEN capability gates that already enforce access, so a
+  moved tool can never ship a stale hint. Clients like Claude Desktop
+  use these to decide which calls to auto-approve — MCPg's safety
+  classification is now visible to them, not just internal.
+  `openWorldHint` is `false` everywhere except `translate_nl_to_sql`
+  (the one tool that calls an external LLM API). `destructiveHint` is
+  deliberately left unset for write-capable tools: the MCP default
+  (true) is the cautious reading. A contract test pins the derivation
+  exhaustively: the hinted read-only set must equal the surface
+  actually reachable in read-only access mode.
+- **Prompt argument descriptions** — all 7 arguments across the 3 MCP
+  prompts (`diagnose_slow_query`, `bisect_slow_migration`,
+  `review_rls_policy`) now carry wire-visible descriptions.
 - **`mcpg --demo` / `mcpg --demo-drop`** (roadmap **17.1**) — one-shot CLI
   commands that seed / remove a small, deterministic, curated e-commerce
   demo dataset (400 customers, 120 products, 3,000 orders, 900 reviews)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ graph queries, data movement, live ops, and more.
   `[A-Za-z_][A-Za-z0-9_]*` regex — a design constraint that means
   user input never reaches the database through string concatenation.
   Capabilities like DDL, shell, and `LISTEN/NOTIFY` are off until you
-  opt in.
+  opt in. Every tool publishes MCP `ToolAnnotations` (`readOnlyHint`,
+  `openWorldHint`) derived from those same gates, so clients can
+  auto-approve reads and gate writes without guessing.
 - **One server, broad surface.** Application data access (queries, search,
   cursors, NL→SQL) *and* DBA-grade operations (health checks, index tuning,
   EXPLAIN analysis, locks, vacuum, dumps, replicas, migrations) in a

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,6 +51,7 @@ them" — pick the section that matches what you're trying to do.
   retrospectives.
 - [**Progress log**](PROGRESS.md) — chronological build log.
 - Release notes:
+  [v0.6.7](release-notes-0.6.7.md) ·
   [v0.6.6](release-notes-0.6.6.md) ·
   [v0.6.5](release-notes-0.6.5.md) ·
   [v0.6.4](release-notes-0.6.4.md) ·

--- a/docs/release-notes-0.6.7.md
+++ b/docs/release-notes-0.6.7.md
@@ -1,0 +1,85 @@
+# MCPg v0.6.7 — release notes
+
+**Released:** 2026-07-03
+**Tool surface:** **252** tools across 19 capability buckets
+**Tests:** 2741 pass (PG 14 / 15 / 16 / 17 / 18 / 19 / WarehousePG)
+**Runtime:** Python 3.14
+
+This is a **patch-level bump (0.6.6 → 0.6.7)** focused on the client
+experience: the safety classification now reaches the wire, a curated
+demo dataset gives new users a rich first five minutes, and the runtime
+moves to Python 3.14. No tool signatures changed; everything is
+backward-compatible.
+
+## Headline: MCPg's safety model is now on the wire
+
+Every one of the 252 tools now publishes **MCP `ToolAnnotations`**:
+
+- **`readOnlyHint`** — `true` for the 185 read tools, `false` for the
+  67 write-capable ones. Derived mechanically from the same
+  READ / WRITE / DDL / SHELL / LISTEN capability gates that enforce
+  access, so a tool moved between gates can never ship a stale hint.
+  A contract test pins the derivation exhaustively: the hinted
+  read-only set must equal the tool surface actually reachable in
+  read-only access mode.
+- **`openWorldHint`** — `false` everywhere except `translate_nl_to_sql`
+  (the one tool that calls an external LLM API); everything else talks
+  only to the connected PostgreSQL server.
+- `destructiveHint` is deliberately left unset for write-capable tools:
+  the MCP default (true) is the cautious reading.
+
+Clients like Claude Desktop use these hints to decide which calls to
+auto-approve — until now MCPg's "safe by default" story was internal;
+now it's visible to every MCP client. The 3 MCP prompts' arguments all
+carry wire-visible descriptions too.
+
+## Try MCPg in two minutes: the demo dataset
+
+```bash
+MCPG_DATABASE_URL=postgresql://... mcpg --demo       # seed
+MCPG_DATABASE_URL=postgresql://... mcpg --demo-drop  # remove
+```
+
+`mcpg --demo` seeds a small, deterministic, **curated** e-commerce
+dataset (400 customers, 120 products, 3,000 orders, 900 reviews) into
+an `mcpg_demo` schema — engineered so the pivotal tools all have
+something real to find on first contact: an un-indexed foreign key for
+`analyze_query_plan` / `recommend_indexes`, PII-shaped columns for
+`find_sensitive_columns`, a camelCase naming violation, searchable
+review prose, and an optional pgvector embedding column when the
+extension is installed. The seed is a single transaction, re-seeding
+refuses rather than clobbers, and `--demo-drop` only removes a schema
+carrying the MCPg ownership marker.
+
+The companion [guided tour](demo.md) is *captured, not written* — every
+output block is a real tool run against the seeded dataset, and
+integration tests pin the planted findings so the walkthrough can't
+silently rot.
+
+## Also in this release
+
+- **Runtime moves to Python 3.14** — Docker image, the full CI matrix,
+  and the publish pipeline. `requires-python` stays `>=3.12`;
+  installing on 3.12/3.13 is unchanged.
+- **Startup warning noise eliminated** — the wall of benign pydantic
+  "Field name `schema` shadows an attribute in parent BaseModel"
+  warnings on first `tools/list` is suppressed (narrowly, by message
+  pattern), with a contract test guarding the full tool surface.
+- **Release-pipeline hardening** — the TestPyPI smoke test now polls
+  the PEP 503 simple index (what `pip install` actually reads) instead
+  of the JSON API, eliminating the propagation race that required a
+  manual re-run during the v0.6.6 release.
+
+## Upgrade
+
+```bash
+pip install --upgrade mcpg
+docker pull ghcr.io/devopam/mcpg:0.6.7   # or :latest
+```
+
+No configuration changes required.
+
+## Full changelog
+
+See [`../CHANGELOG.md`](../CHANGELOG.md) `[0.6.7]` for the complete
+itemised list.

--- a/docs/release-notes-0.6.7.md
+++ b/docs/release-notes-0.6.7.md
@@ -61,9 +61,9 @@ silently rot.
 - **Runtime moves to Python 3.14** — Docker image, the full CI matrix,
   and the publish pipeline. `requires-python` stays `>=3.12`;
   installing on 3.12/3.13 is unchanged.
-- **Startup warning noise eliminated** — the wall of benign pydantic
+- **Startup warning noise eliminated** — the benign pydantic
   "Field name `schema` shadows an attribute in parent BaseModel"
-  warnings on first `tools/list` is suppressed (narrowly, by message
+  warnings on first `tools/list` are suppressed (narrowly, by message
   pattern), with a contract test guarding the full tool surface.
 - **Release-pipeline hardening** — the TestPyPI smoke test now polls
   the PEP 503 simple index (what `pip install` actually reads) instead

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcpg"
-version = "0.6.6"
+version = "0.6.7"
 description = "A production-grade PostgreSQL Model Context Protocol (MCP) server."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/mcpg/__init__.py
+++ b/src/mcpg/__init__.py
@@ -2,7 +2,7 @@
 
 import warnings
 
-__version__ = "0.6.6"
+__version__ = "0.6.7"
 
 # ``schema`` is the natural field name for "which Postgres schema" across
 # ~180 tool-return dataclasses. The ``mcp`` SDK dynamically builds a

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -6743,12 +6743,28 @@ def _apply_tool_annotations(server: FastMCP[AppContext], read_only_names: set[st
 
     Uses the sync ``_tool_manager`` accessor for the same reason the
     session-intent filter does: this runs in synchronous startup code.
+
+    Merge semantics: annotations a registration set explicitly always
+    win — the derived values only fill fields that are still ``None``.
+    (No call site passes ``annotations=`` today, but a future per-tool
+    override — e.g. ``destructiveHint=False`` on a maintenance tool —
+    must not be silently clobbered by this sweep.)
     """
     for tool in server._tool_manager.list_tools():
-        tool.annotations = ToolAnnotations(
-            readOnlyHint=tool.name in read_only_names,
-            openWorldHint=tool.name in _OPEN_WORLD_TOOLS,
-        )
+        existing = tool.annotations
+        if existing is None:
+            tool.annotations = ToolAnnotations(
+                readOnlyHint=tool.name in read_only_names,
+                openWorldHint=tool.name in _OPEN_WORLD_TOOLS,
+            )
+            continue
+        derived: dict[str, bool] = {}
+        if existing.readOnlyHint is None:
+            derived["readOnlyHint"] = tool.name in read_only_names
+        if existing.openWorldHint is None:
+            derived["openWorldHint"] = tool.name in _OPEN_WORLD_TOOLS
+        if derived:
+            tool.annotations = existing.model_copy(update=derived)
 
 
 def register_tools(server: FastMCP[AppContext], settings: Settings) -> None:

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -13,6 +13,7 @@ from typing import Annotated, Any, TypeVar, cast
 
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.session import ServerSession
+from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from mcpg import (
@@ -6401,7 +6402,9 @@ def _register_prompts(server: FastMCP[AppContext]) -> None:
             "structured reporting checklist at the end."
         ),
     )
-    def diagnose_slow_query_prompt(sql: str) -> str:
+    def diagnose_slow_query_prompt(
+        sql: Annotated[str, Field(description="The slow SQL statement to investigate, verbatim.")],
+    ) -> str:
         return mcpg_prompts._build_diagnose_slow_query(sql)
 
     # ------------------------------------------------------------------
@@ -6419,9 +6422,15 @@ def _register_prompts(server: FastMCP[AppContext]) -> None:
         ),
     )
     def bisect_slow_migration_prompt(
-        migration_id: str,
-        baseline_schema: str,
-        current_schema: str,
+        migration_id: Annotated[
+            str, Field(description="Identifier of the suspect migration (as tracked by the migration tool in use).")
+        ],
+        baseline_schema: Annotated[
+            str, Field(description="Schema name representing the pre-migration (known-good) state.")
+        ],
+        current_schema: Annotated[
+            str, Field(description="Schema name representing the post-migration (regressed) state.")
+        ],
     ) -> str:
         return mcpg_prompts._build_bisect_slow_migration(migration_id, baseline_schema, current_schema)
 
@@ -6440,7 +6449,10 @@ def _register_prompts(server: FastMCP[AppContext]) -> None:
             "not apply them."
         ),
     )
-    def review_rls_policy_prompt(schema: str, table: str) -> str:
+    def review_rls_policy_prompt(
+        schema: Annotated[str, Field(description="Schema containing the table to audit.")],
+        table: Annotated[str, Field(description="Table whose row-level-security coverage should be reviewed.")],
+    ) -> str:
         return mcpg_prompts._build_review_rls_policy(schema, table)
 
 
@@ -6709,6 +6721,36 @@ def _register_logical_replication_writes(server: FastMCP[AppContext]) -> None:
         return result
 
 
+# Tools that reach outside the connected PostgreSQL server. Everything
+# else in MCPg talks to a closed domain (the database), so it gets
+# ``openWorldHint=False``; these are the exceptions (external LLM APIs).
+_OPEN_WORLD_TOOLS = frozenset({"translate_nl_to_sql"})
+
+
+def _apply_tool_annotations(server: FastMCP[AppContext], read_only_names: set[str]) -> None:
+    """Stamp MCP ``ToolAnnotations`` derived from the capability gates.
+
+    MCPg already classifies every tool as READ / WRITE / DDL / SHELL /
+    LISTEN via the registration gates in :func:`register_tools`; this
+    puts that classification on the wire, where clients use it to
+    decide which calls to auto-approve (``readOnlyHint``) and whether
+    the tool leaves the database's closed world (``openWorldHint``).
+    Derived, not hand-written, so a tool moved between gates can never
+    ship a stale hint. ``destructiveHint`` is deliberately left unset
+    for non-read tools: the MCP default (true) is the cautious reading,
+    and MCPg doesn't currently track per-tool destructiveness more
+    precisely than the gate does.
+
+    Uses the sync ``_tool_manager`` accessor for the same reason the
+    session-intent filter does: this runs in synchronous startup code.
+    """
+    for tool in server._tool_manager.list_tools():
+        tool.annotations = ToolAnnotations(
+            readOnlyHint=tool.name in read_only_names,
+            openWorldHint=tool.name in _OPEN_WORLD_TOOLS,
+        )
+
+
 def register_tools(server: FastMCP[AppContext], settings: Settings) -> None:
     """Register the MCP tools permitted by the configured access mode.
 
@@ -6757,6 +6799,9 @@ def register_tools(server: FastMCP[AppContext], settings: Settings) -> None:
         _register_wait_for_lsn_reads(server)
         _register_wait_for_lsn_writes(server)
         _register_warehousepg_reads(server)
+    # Everything registered so far sits behind (at most) the READ gate —
+    # this snapshot is what ``readOnlyHint=True`` is derived from below.
+    read_only_names = {tool.name for tool in server._tool_manager.list_tools()}
     if is_permitted(settings.access_mode, Capability.WRITE):
         _register_write(server)
         _register_maintenance(server)
@@ -6787,6 +6832,8 @@ def register_tools(server: FastMCP[AppContext], settings: Settings) -> None:
         _register_data_movement_shell(server)
     if is_permitted(settings.access_mode, Capability.LISTEN) and settings.allow_listen:
         _register_listen(server)
+
+    _apply_tool_annotations(server, read_only_names)
 
     # Session-intent surface filter (roadmap 8.8). Runs LAST so every
     # tool that would otherwise be registered has already been added —

--- a/tests/contract/test_tool_annotations.py
+++ b/tests/contract/test_tool_annotations.py
@@ -79,8 +79,10 @@ def test_spot_check_anchor_tools() -> None:
     server = _build_server("unrestricted")
     by_name = {t.name: t for t in server._tool_manager.list_tools()}
     for name in _MUST_BE_READ_ONLY:
+        assert name in by_name, f"anchor tool missing from the unrestricted surface: {name}"
         assert by_name[name].annotations is not None and by_name[name].annotations.readOnlyHint is True, name
     for name in _MUST_NOT_BE_READ_ONLY:
+        assert name in by_name, f"anchor tool missing from the unrestricted surface: {name}"
         assert by_name[name].annotations is not None and by_name[name].annotations.readOnlyHint is False, name
 
 
@@ -101,8 +103,42 @@ async def test_annotations_reach_the_wire_via_list_tools() -> None:
     sample = {t.name: t for t in wire_tools}
     assert sample["run_select"].annotations is not None
     assert sample["run_select"].annotations.readOnlyHint is True
+    assert sample["run_select"].annotations.openWorldHint is False
     assert sample["run_ddl"].annotations is not None
     assert sample["run_ddl"].annotations.readOnlyHint is False
+    assert sample["translate_nl_to_sql"].annotations is not None
+    assert sample["translate_nl_to_sql"].annotations.openWorldHint is True
+
+
+def test_sweep_preserves_annotations_a_registration_set_explicitly() -> None:
+    """Derived hints fill gaps; they must never clobber explicit ones.
+
+    No call site passes ``annotations=`` today, but a future per-tool
+    override (say ``destructiveHint=False`` on a maintenance tool) has
+    to survive the sweep — explicit beats derived, field by field.
+    """
+    from mcp.types import ToolAnnotations
+
+    from mcpg.tools import _apply_tool_annotations
+
+    server: FastMCP = FastMCP("mcpg-annotations-merge-fixture")
+
+    @server.tool(
+        name="preexisting_annotated_tool",
+        description="fixture",
+        annotations=ToolAnnotations(title="Keep me", destructiveHint=False, readOnlyHint=False),
+    )
+    def preexisting() -> str:
+        return "x"
+
+    _apply_tool_annotations(server, read_only_names={"preexisting_annotated_tool"})
+
+    annotations = {t.name: t.annotations for t in server._tool_manager.list_tools()}["preexisting_annotated_tool"]
+    assert annotations is not None
+    assert annotations.title == "Keep me"  # preserved
+    assert annotations.destructiveHint is False  # preserved
+    assert annotations.readOnlyHint is False  # explicit False beats the derived True
+    assert annotations.openWorldHint is False  # unset -> filled by the derivation
 
 
 async def test_every_prompt_argument_has_a_description() -> None:

--- a/tests/contract/test_tool_annotations.py
+++ b/tests/contract/test_tool_annotations.py
@@ -1,0 +1,115 @@
+"""Contract tests for MCP ``ToolAnnotations`` — the on-wire safety hints.
+
+MCPg's READ / WRITE / DDL / SHELL / LISTEN gating is its core safety
+story, but until the annotations sweep it never reached the wire — a
+client saw ``run_select`` and ``terminate_backend`` as equally opaque.
+These tests pin the derivation in ``tools._apply_tool_annotations``:
+
+1. Every registered tool carries annotations with ``readOnlyHint`` set.
+2. The read-only set is exactly the surface reachable in read-only
+   access mode (self-consistency: the gate IS the classification).
+3. Known-dangerous tools are never marked read-only; canonical read
+   tools always are.
+4. ``openWorldHint`` is False everywhere except the tools that reach
+   external services (the NL→SQL provider call).
+"""
+
+from __future__ import annotations
+
+from mcp.server.fastmcp import FastMCP
+
+from mcpg.config import load_settings
+from mcpg.tools import register_tools
+
+_FIXTURE_DB_URL = "postgresql://snapshot:snapshot@127.0.0.1:5432/snapshot"
+
+# Spot-check anchors. Not exhaustive — the mode-diff test below is the
+# exhaustive one — but these fail loudly with a readable message if the
+# derivation ever inverts.
+_MUST_BE_READ_ONLY = {"list_schemas", "run_select", "explain_query", "describe_table", "get_server_info"}
+_MUST_NOT_BE_READ_ONLY = {"run_ddl", "terminate_backend", "cancel_query", "restore_database", "complete_migration"}
+_OPEN_WORLD = {"translate_nl_to_sql"}
+
+
+def _build_server(access_mode: str) -> FastMCP:
+    settings = load_settings(
+        {
+            "MCPG_DATABASE_URL": _FIXTURE_DB_URL,
+            "MCPG_ACCESS_MODE": access_mode,
+            **(
+                {"MCPG_ALLOW_DDL": "true", "MCPG_ALLOW_SHELL": "true", "MCPG_ALLOW_LISTEN": "true"}
+                if access_mode == "unrestricted"
+                else {}
+            ),
+        }
+    )
+    server: FastMCP = FastMCP(f"mcpg-annotations-fixture-{access_mode}")
+    register_tools(server, settings)
+    return server
+
+
+def test_every_tool_carries_annotations_with_read_only_hint() -> None:
+    server = _build_server("unrestricted")
+    missing = [
+        t.name for t in server._tool_manager.list_tools() if t.annotations is None or t.annotations.readOnlyHint is None
+    ]
+    assert not missing, f"tools without a readOnlyHint annotation: {missing}"
+
+
+def test_read_only_hints_match_the_read_only_mode_surface() -> None:
+    """The exhaustive check: readOnlyHint=True ⟺ registered in read-only mode.
+
+    The access-mode gate is MCPg's actual enforcement boundary, so the
+    hint must agree with it exactly — a tool reachable in read-only mode
+    but hinted otherwise (or vice versa) means the derivation drifted.
+    """
+    maximal = _build_server("unrestricted")
+    read_only_surface = {t.name for t in _build_server("read-only")._tool_manager.list_tools()}
+
+    hinted_read_only = {
+        t.name for t in maximal._tool_manager.list_tools() if t.annotations and t.annotations.readOnlyHint
+    }
+    assert hinted_read_only == read_only_surface, (
+        f"hinted-but-not-gated: {sorted(hinted_read_only - read_only_surface)}; "
+        f"gated-but-not-hinted: {sorted(read_only_surface - hinted_read_only)}"
+    )
+
+
+def test_spot_check_anchor_tools() -> None:
+    server = _build_server("unrestricted")
+    by_name = {t.name: t for t in server._tool_manager.list_tools()}
+    for name in _MUST_BE_READ_ONLY:
+        assert by_name[name].annotations is not None and by_name[name].annotations.readOnlyHint is True, name
+    for name in _MUST_NOT_BE_READ_ONLY:
+        assert by_name[name].annotations is not None and by_name[name].annotations.readOnlyHint is False, name
+
+
+def test_open_world_hint_is_closed_except_external_service_tools() -> None:
+    server = _build_server("unrestricted")
+    for tool in server._tool_manager.list_tools():
+        assert tool.annotations is not None
+        expected = tool.name in _OPEN_WORLD
+        assert tool.annotations.openWorldHint is expected, (
+            f"{tool.name}: openWorldHint={tool.annotations.openWorldHint}, expected {expected}"
+        )
+
+
+async def test_annotations_reach_the_wire_via_list_tools() -> None:
+    """What the MCP client actually receives must carry the hints too."""
+    server = _build_server("unrestricted")
+    wire_tools = await server.list_tools()
+    sample = {t.name: t for t in wire_tools}
+    assert sample["run_select"].annotations is not None
+    assert sample["run_select"].annotations.readOnlyHint is True
+    assert sample["run_ddl"].annotations is not None
+    assert sample["run_ddl"].annotations.readOnlyHint is False
+
+
+async def test_every_prompt_argument_has_a_description() -> None:
+    server = _build_server("read-only")
+    prompts = await server.list_prompts()
+    assert prompts, "expected the prompt surface to be registered in read-only mode"
+    undescribed = [
+        f"{p.name}.{a.name}" for p in prompts for a in (p.arguments or []) if not (a.description or "").strip()
+    ]
+    assert not undescribed, f"prompt arguments without descriptions: {undescribed}"

--- a/uv.lock
+++ b/uv.lock
@@ -988,7 +988,7 @@ cli = [
 
 [[package]]
 name = "mcpg"
-version = "0.6.6"
+version = "0.6.7"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Two things in one PR (per the bundling preference): the wire-metadata sweep from the capabilities audit, and the v0.6.7 release fold.

### 1. MCP `ToolAnnotations` on all 252 tools

The audit found every tool shipping `annotations: None` — MCPg's READ/WRITE/DDL/SHELL/LISTEN safety classification never reached the wire, so clients like Claude Desktop saw `run_select` and `terminate_backend` as equally opaque when deciding what to auto-approve.

- **Derived, not hand-written**: `register_tools` snapshots the registered tool names at the READ-gate boundary, and `_apply_tool_annotations` stamps every tool afterwards — `readOnlyHint=True` for the 185 tools behind (at most) the READ gate, `False` for the 67 write-capable ones. A tool moved between gates can never ship a stale hint, and there are zero per-call-site edits.
- **`openWorldHint=False` everywhere except `translate_nl_to_sql`** — the one tool that calls an external LLM API; everything else talks only to the connected PostgreSQL server.
- **`destructiveHint` deliberately left unset** for write-capable tools: the MCP default (true) is the cautious reading, and the gates don't track per-tool destructiveness more precisely than that. Refining it per-tool is possible later without breaking anything.
- **Prompt arguments**: all 7 args across the 3 MCP prompts now carry wire-visible descriptions (via `Annotated[str, Field(description=...)]`, which the SDK lifts into `PromptArgument.description`).
- README's "Safe by default" bullet now mentions the hints.

### 2. Cut v0.6.7

- Version bump `0.6.6 → 0.6.7` in `pyproject.toml`, `mcpg.__version__`, `uv.lock`.
- CHANGELOG: `[Unreleased]` folded into `[0.6.7] - 2026-07-03`. Also backfilled two fixes that merged without changelog entries (the pydantic `schema`-shadow warning suppression from #217 and the TestPyPI simple-index race fix from #215).
- `docs/release-notes-0.6.7.md` + docs index link. Release contents: tool annotations (headline), `mcpg --demo` (#220), Python 3.14 runtime (#219), warning suppression (#217), publish-pipeline hardening (#215).

## Test plan

- [x] New contract suite `tests/contract/test_tool_annotations.py` (6 tests), including the exhaustive self-consistency check: **the hinted read-only set must equal the tool surface actually reachable in `MCPG_ACCESS_MODE=read-only`** — the gate is the classification, so drift fails the build. Plus spot-check anchors (`run_ddl`/`terminate_backend`/`cancel_query` never read-only; `run_select`/`list_schemas` always), the wire-level `list_tools()` check, and a no-undescribed-prompt-args check.
- [x] Re-ran the capabilities audit after the change: 252/252 tools annotated (185 read-only / 67 write-capable), `openWorld=['translate_nl_to_sql']`, 0 prompt args missing descriptions.
- [x] Locally: 2567 unit+contract passed (post-bump), 99 integration passed against a real PG 16, `ruff format --check` / `ruff check` / `mypy src/mcpg` (strict) clean. (One local full-suite run showed 111 integration errors — root-caused to the sandbox's local Postgres being killed mid-run, not the code; clean re-run passed.)

## After merge

I cannot push tags from this environment — tagging is the manual step, same as v0.6.6:

```bash
git checkout main && git pull origin main
git tag v0.6.7
git push origin v0.6.7
```

The publish workflow takes it from there (TestPyPI → smoke test → PyPI approval gate → GitHub Release + MCP Registry + GHCR), now with the simple-index race fix so no manual re-run should be needed.


---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Publish MCP ToolAnnotations for all tools and cut the v0.6.7 release.

New Features:
- Expose MCP ToolAnnotations (readOnlyHint and openWorldHint) for all registered tools, derived from existing capability gates.
- Add wire-visible descriptions for all MCP prompt arguments in diagnostic prompts.
- Add v0.6.7 release notes documentation and link it from the docs index.

Enhancements:
- Derive tool safety annotations centrally during tool registration to keep wire metadata consistent with access-mode gating.
- Document in the README that tools now publish ToolAnnotations to help clients auto-approve safe operations.

Build:
- Bump project version from 0.6.6 to 0.6.7 in packaging metadata and lockfile.

Documentation:
- Document the v0.6.7 release in CHANGELOG and dedicated release-notes file, including prior fixes that lacked entries.

Tests:
- Add contract tests to validate ToolAnnotations coverage, consistency with access modes, open-world hints, and prompt argument descriptions.