### PR TITLE
Fix release-notes extraction: every release body was the stub

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -171,7 +171,20 @@ jobs:
           # release body. Falls back to a stub if the section is
           # missing so the release still ships — the maintainer can
           # edit the body afterwards on the GitHub side.
-          awk "/^## \[${VER}\]/,/^## \[/" CHANGELOG.md | sed '$d' > /tmp/notes.md
+          #
+          # NOT an awk range pattern: GNU awk treats a line matching
+          # both endpoints as a single-line range, and "## [X.Y.Z]"
+          # matches both /^## \[X.Y.Z\]/ and /^## \[/ — so the old
+          # range-based extraction returned only the header line and
+          # every release body silently fell back to the stub
+          # (observed on v0.6.7 and all earlier releases). A flag
+          # variable sidesteps that; index() avoids regex-escaping
+          # the dots in the version.
+          awk -v ver="$VER" '
+            index($0, "## [" ver "]") == 1 { in_section = 1; next }
+            in_section && /^## \[/ { exit }
+            in_section
+          ' CHANGELOG.md > /tmp/notes.md
           [ -s /tmp/notes.md ] || echo "See CHANGELOG.md" > /tmp/notes.md
           gh release create "$GITHUB_REF_NAME" dist/* \
             --title "MCPg ${GITHUB_REF_NAME}" \


### PR DESCRIPTION
## Summary

Spotted while verifying the v0.6.7 release: the GitHub Release body was the `See CHANGELOG.md` fallback stub instead of the changelog section — and it turns out **every release since the `github-release` job was added has shipped the stub**.

Root cause: the job extracted the section with an awk **range pattern** (`awk "/^## \[${VER}\]/,/^## \[/"`), but GNU awk treats a line matching *both* endpoints as a single-line range — and `## [0.6.7]` matches both `/^## \[0.6.7\]/` and `/^## \[/`. So the extraction returned only the header line, the trailing `sed '$d'` deleted it, `/tmp/notes.md` came out empty, and the fallback kicked in silently on every run.

Fix: replace the range with an explicit flag variable (`in_section`), and match the header with `index()` so the version's dots don't need regex escaping:

```awk
index($0, "## [" ver "]") == 1 { in_section = 1; next }
in_section && /^## \[/ { exit }
in_section
```

Verified against the real CHANGELOG locally: the old command produces **0 lines** for `0.6.7`; the new one produces the full **63-line** section. The stub fallback stays for genuinely missing sections.

Note: this only fixes releases going forward. Existing release bodies (v0.6.7 and earlier) can be hand-edited on GitHub if desired — the v0.6.7 section text is in `CHANGELOG.md` under `[0.6.7] - 2026-07-03`.

## Test plan

- [x] Ran both the old and new awk commands against the checked-in `CHANGELOG.md` for `VER=0.6.7`: old → 0 lines (bug reproduced), new → 63 lines (full section, both bounding headers excluded).
- [x] YAML-validated the workflow file.
- [ ] Fully exercised on the next tagged release (the job only runs on tag pushes).


---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Fix release note extraction in the publish workflow so GitHub releases use the correct changelog section instead of a fallback stub.

Bug Fixes:
- Correct release-notes extraction so the GitHub release body is populated from the matching changelog section rather than defaulting to a stub when the header matches both awk range endpoints.

CI:
- Update the publish GitHub Actions workflow to use a more robust awk script with a state flag for selecting the correct changelog section when generating release notes.