### PR TITLE
Directory readiness: one-click .mcpb install, tool titles, destructiveHint

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -162,6 +162,38 @@ jobs:
         with:
           name: dist
           path: dist/
+      - name: Build the Claude Desktop extension (.mcpb)
+        # One-click-install bundle for Claude Desktop. server.type "uv"
+        # keeps it tiny (~2 kB): the host resolves the mcpg==VER pin
+        # from PyPI at install time, so one bundle covers every
+        # platform/arch. Versions are synced from the release tag the
+        # same way server.json is — the checked-in files carry the
+        # previous release's pin and are patched here, so the bundle
+        # can never ship stale.
+        run: |
+          VER="${GITHUB_REF_NAME#v}"
+          python3 - "$VER" <<'EOF'
+          import json
+          import re
+          import sys
+
+          ver = sys.argv[1]
+          with open("packaging/mcpb/manifest.json") as f:
+              manifest = json.load(f)
+          manifest["version"] = ver
+          with open("packaging/mcpb/manifest.json", "w") as f:
+              json.dump(manifest, f, indent=2)
+              f.write("\n")
+          path = "packaging/mcpb/pyproject.toml"
+          with open(path) as f:
+              text = f.read()
+          text = re.sub(r'version = "[^"]+"', f'version = "{ver}"', text)
+          text = re.sub(r"mcpg==[0-9][^\"',\s]*", f"mcpg=={ver}", text)
+          with open(path, "w") as f:
+              f.write(text)
+          EOF
+          npx --yes @anthropic-ai/mcpb validate packaging/mcpb/manifest.json
+          npx --yes @anthropic-ai/mcpb pack packaging/mcpb "dist/mcpg-${VER}.mcpb"
       - name: Cut release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -172,26 +172,7 @@ jobs:
         # can never ship stale.
         run: |
           VER="${GITHUB_REF_NAME#v}"
-          python3 - "$VER" <<'EOF'
-          import json
-          import re
-          import sys
-
-          ver = sys.argv[1]
-          with open("packaging/mcpb/manifest.json") as f:
-              manifest = json.load(f)
-          manifest["version"] = ver
-          with open("packaging/mcpb/manifest.json", "w") as f:
-              json.dump(manifest, f, indent=2)
-              f.write("\n")
-          path = "packaging/mcpb/pyproject.toml"
-          with open(path) as f:
-              text = f.read()
-          text = re.sub(r'version = "[^"]+"', f'version = "{ver}"', text)
-          text = re.sub(r"mcpg==[0-9][^\"',\s]*", f"mcpg=={ver}", text)
-          with open(path, "w") as f:
-              f.write(text)
-          EOF
+          python3 packaging/mcpb/sync_version.py "$VER"
           npx --yes @anthropic-ai/mcpb validate packaging/mcpb/manifest.json
           npx --yes @anthropic-ai/mcpb pack packaging/mcpb "dist/mcpg-${VER}.mcpb"
       - name: Cut release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **One-click Claude Desktop install (`.mcpb`)** — every release now
+  attaches a `mcpg-<version>.mcpb` desktop-extension bundle. It uses
+  the MCPB `uv` server type, so the bundle is ~2 kB and works on every
+  platform/architecture: Claude Desktop resolves the pinned `mcpg`
+  release from PyPI at install time. The connection URL is declared
+  `sensitive` (OS-keychain storage) and access mode defaults to
+  read-only. Bundle sources live in `packaging/mcpb/`; versions are
+  synced from the release tag by the publish workflow (same
+  never-goes-stale pattern as `server.json`).
+- **Human-readable titles on all 252 tools** — auto-derived from the
+  snake_case name with an acronym/product-name table (`run_ddl` →
+  "Run DDL", `recommend_ivfflat_probes` → "Recommend IVFFlat probes"),
+  filling the one remaining metadata gap for connector-directory
+  listings. Explicit per-registration titles still win.
+- **Explicit `destructiveHint` on every write-capable tool** — the 67
+  write tools are now classified by a curated destructive (18) /
+  non-destructive (49) partition instead of relying on the implicit
+  MCP default. A contract test requires the partition to cover the
+  write surface exactly, so a new write tool cannot ship unclassified.
+- **`PRIVACY.md`** — states the self-hosted/no-telemetry posture, the
+  single documented external call (`translate_nl_to_sql` → your
+  configured LLM provider), and credential-handling guarantees.
+
 ### Changed
 
 ### Fixed

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,45 @@
+# Privacy policy
+
+MCPg is a **self-hosted** MCP server. You run it; your data stays with
+you.
+
+## What MCPg does with your data
+
+- **Your database contents never leave your infrastructure.** Every
+  tool talks only to the PostgreSQL server(s) you configure via
+  `MCPG_DATABASE_URL` (and optional replica/secondary DSNs). Query
+  results are returned to *your* MCP client and nowhere else.
+- **No telemetry, no phone-home.** MCPg collects no usage analytics,
+  sends no crash reports, and makes no network calls you didn't
+  configure. The optional Prometheus `/metrics` endpoint and
+  OpenTelemetry export are off by default and, when enabled, ship
+  metrics/traces only to endpoints you specify.
+- **One documented exception — NL→SQL.** The `translate_nl_to_sql`
+  tool sends your natural-language question plus relevant schema
+  context (table/column names, not row data) to the LLM provider whose
+  API key *you* configured (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` /
+  `GEMINI_API_KEY`). It is the only tool that contacts an external
+  service, it is flagged `openWorldHint: true` in its MCP annotations,
+  and it does nothing until you both set a key and call it.
+
+## Credentials
+
+- Database connection strings are read from environment variables and
+  are never logged in full — the audit trail and log output redact
+  passwords.
+- When installed as a Claude Desktop extension (`.mcpb`), the
+  connection URL is declared `sensitive` in the manifest, so the host
+  application stores it in the operating system's keychain rather than
+  in plain-text configuration.
+
+## Audit trail
+
+When `MCPG_AUDIT_PERSIST` is enabled, MCPg writes tool-call audit
+events to a table **inside your own database** (`mcpg_audit.events`),
+with credential-redacting argument capture. That data is yours; the
+`prune_audit_events` tool deletes it on your schedule.
+
+## Questions
+
+Open an issue at <https://github.com/devopam/MCPg/issues> or see
+[SECURITY.md](SECURITY.md) for vulnerability reporting.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -19,8 +19,8 @@ you.
   context (table/column names, not row data) to the LLM provider whose
   API key *you* configured (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` /
   `GEMINI_API_KEY`). It is the only tool that contacts an external
-  service, it is flagged `openWorldHint: true` in its MCP annotations,
-  and it does nothing until you both set a key and call it.
+  service. It is flagged `openWorldHint: true` in its MCP annotations
+  and does nothing until you both set a key and call it.
 
 ## Credentials
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,17 @@ More detail in the [Installation Guide](https://github.com/devopam/MCPg/blob/mai
 
 ## Quick start
 
-### Wire MCPg into Claude Desktop (stdio transport)
+### One-click install in Claude Desktop (.mcpb)
+
+Download `mcpg-<version>.mcpb` from the
+[latest release](https://github.com/devopam/MCPg/releases/latest) and
+double-click it (or drag it into Claude Desktop's Settings →
+Extensions). You'll be prompted for your PostgreSQL connection URL —
+stored in the OS keychain — and an access mode (defaults to
+read-only). That's the whole install: the bundle is ~2 kB and the
+host resolves the pinned `mcpg` release from PyPI for your platform.
+
+### Or wire it up manually (stdio transport)
 
 Drop this into your `claude_desktop_config.json` (macOS:
 `~/Library/Application Support/Claude/claude_desktop_config.json`;

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -105,7 +105,24 @@ mcpg
 
 ## Wire it into an MCP client
 
-### Claude Desktop (`stdio`)
+### Claude Desktop — one-click extension (recommended)
+
+Download `mcpg-<version>.mcpb` from the
+[latest GitHub release](https://github.com/devopam/MCPg/releases/latest)
+and open it with Claude Desktop (double-click, or Settings →
+Extensions → drag it in). The install dialog prompts for:
+
+- **PostgreSQL connection URL** — stored in the operating system's
+  keychain (never in plain-text config).
+- **Access mode** — defaults to `read-only`.
+
+The bundle is a ~2 kB `uv`-type MCPB: Claude Desktop resolves the
+pinned `mcpg` release from PyPI for your platform at install time, so
+there is nothing else to install. Additional environment variables
+(replicas, capability gates, NL→SQL keys) can still be layered on via
+the manual config below if you need them.
+
+### Claude Desktop (`stdio`, manual config)
 
 `claude_desktop_config.json` (macOS:
 `~/Library/Application Support/Claude/claude_desktop_config.json`;

--- a/packaging/mcpb/manifest.json
+++ b/packaging/mcpb/manifest.json
@@ -1,0 +1,72 @@
+{
+  "manifest_version": "0.4",
+  "name": "mcpg",
+  "display_name": "MCPg — PostgreSQL",
+  "version": "0.6.7",
+  "description": "Production-grade PostgreSQL MCP server: 252 tools for querying, tuning, and operating Postgres — read-only by default.",
+  "long_description": "MCPg lets AI agents safely inspect, query, operate, and tune a PostgreSQL database. 252 tools spanning catalog introspection, query intelligence, natural-language SQL, structural diffs, hybrid search, graph queries, live ops, and more.\n\n**Safe by default**: read-only access mode, AST-validated SQL, and every tool publishes MCP annotations (`readOnlyHint`/`destructiveHint`) so the client knows exactly which calls are safe. Write, DDL, shell, and LISTEN capabilities stay off until explicitly enabled via environment variables.\n\nNo data yet? Run `mcpg --demo` against a scratch database to seed a curated demo dataset and take the tools for a spin — see the guided tour at https://github.com/devopam/MCPg/blob/main/docs/demo.md.",
+  "author": {
+    "name": "Devopam Mittra",
+    "email": "devopam@gmail.com",
+    "url": "https://github.com/devopam"
+  },
+  "homepage": "https://github.com/devopam/MCPg",
+  "documentation": "https://github.com/devopam/MCPg#documentation",
+  "support": "https://github.com/devopam/MCPg/issues",
+  "license": "MIT",
+  "keywords": [
+    "postgresql",
+    "postgres",
+    "database",
+    "sql",
+    "dba",
+    "pgvector",
+    "rag"
+  ],
+  "server": {
+    "type": "uv",
+    "entry_point": "server/main.py",
+    "mcp_config": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--directory",
+        "${__dirname}",
+        "server/main.py"
+      ],
+      "env": {
+        "MCPG_DATABASE_URL": "${user_config.database_url}",
+        "MCPG_ACCESS_MODE": "${user_config.access_mode}"
+      }
+    }
+  },
+  "user_config": {
+    "database_url": {
+      "type": "string",
+      "title": "PostgreSQL connection URL",
+      "description": "e.g. postgresql://user:password@localhost:5432/mydb — remote hosts need ?sslmode=require. Stored securely by the OS keychain.",
+      "sensitive": true,
+      "required": true
+    },
+    "access_mode": {
+      "type": "string",
+      "title": "Access mode",
+      "description": "read-only (default, safe) | restricted (allows write tools) | unrestricted (DBA surface; pair with MCPG_ALLOW_DDL etc. via env).",
+      "default": "read-only",
+      "required": false
+    }
+  },
+  "tools_generated": true,
+  "prompts_generated": true,
+  "compatibility": {
+    "claude_desktop": ">=0.10.0",
+    "platforms": [
+      "darwin",
+      "win32",
+      "linux"
+    ],
+    "runtimes": {
+      "python": ">=3.12,<4"
+    }
+  }
+}

--- a/packaging/mcpb/pyproject.toml
+++ b/packaging/mcpb/pyproject.toml
@@ -1,0 +1,13 @@
+# The MCPB bundle's project file. ``server.type: "uv"`` bundles declare
+# dependencies here and the host (Claude Desktop) resolves them from
+# PyPI at install time with uv — no vendored wheels, so one small
+# bundle works on every platform/architecture. The mcpg pin is synced
+# to the release tag by the publish workflow, exactly like server.json.
+[project]
+name = "mcpg-desktop-extension"
+version = "0.6.7"
+description = "MCPB launcher shim for the MCPg PostgreSQL MCP server."
+requires-python = ">=3.12"
+dependencies = [
+    "mcpg==0.6.7",
+]

--- a/packaging/mcpb/server/main.py
+++ b/packaging/mcpb/server/main.py
@@ -1,0 +1,14 @@
+"""MCPB entry point — a thin launcher around the installed mcpg package.
+
+The bundle's pyproject.toml pins the mcpg release; the host installs it
+with uv and runs this file. All real logic lives in the package —
+configuration arrives via the environment variables the manifest maps
+from user_config (MCPG_DATABASE_URL, MCPG_ACCESS_MODE).
+"""
+
+import sys
+
+from mcpg.__main__ import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packaging/mcpb/sync_version.py
+++ b/packaging/mcpb/sync_version.py
@@ -1,0 +1,42 @@
+"""Sync the MCPB bundle's pinned versions to a release version.
+
+Called by the publish workflow with the tag-derived version
+(``python3 packaging/mcpb/sync_version.py 1.2.3``) right before
+``mcpb pack``, so the checked-in bundle files — which carry the
+*previous* release's pin — can never ship stale. Same pattern as the
+``server.json`` sync step in publish.yml, extracted to a real file so
+it can be unit-tested instead of living inline in workflow YAML.
+
+Patches, in the directory this script lives in:
+
+- ``manifest.json``  → ``version``
+- ``pyproject.toml`` → ``[project] version`` and the ``mcpg==X.Y.Z`` pin
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+def sync(bundle_dir: Path, version: str) -> None:
+    """Rewrite the bundle's version pins in place."""
+    manifest_path = bundle_dir / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["version"] = version
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+
+    pyproject_path = bundle_dir / "pyproject.toml"
+    text = pyproject_path.read_text()
+    text = re.sub(r'version = "[^"]+"', f'version = "{version}"', text)
+    text = re.sub(r"mcpg==[0-9][^\"',\s]*", f"mcpg=={version}", text)
+    pyproject_path.write_text(text)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2 or not sys.argv[1]:
+        raise SystemExit("usage: sync_version.py <version>")
+    sync(Path(__file__).resolve().parent, sys.argv[1])
+    print(f"mcpb bundle pinned to {sys.argv[1]}")

--- a/src/mcpg/tools.py
+++ b/src/mcpg/tools.py
@@ -6726,41 +6726,192 @@ def _register_logical_replication_writes(server: FastMCP[AppContext]) -> None:
 # ``openWorldHint=False``; these are the exceptions (external LLM APIs).
 _OPEN_WORLD_TOOLS = frozenset({"translate_nl_to_sql"})
 
+# Per-tool destructiveness, spec sense: "may perform destructive
+# (irreversible / data-losing) updates", meaningful only for tools with
+# ``readOnlyHint=False``. The two sets below must exactly partition the
+# write-capable surface — a contract test enforces it — so adding a
+# write tool forces a conscious classification, and an unclassified new
+# tool defaults to the cautious reading (destructive) rather than
+# silently landing in the safe bucket.
+_DESTRUCTIVE_TOOLS = frozenset(
+    {
+        # Arbitrary/overwriting mutations.
+        "run_ddl",
+        "run_write",
+        "restore_database",
+        "complete_migration",  # executes migration SQL, which may drop/alter
+        "copy_table_between_databases",  # creates and force-drops databases
+        # Kills work in flight.
+        "cancel_query",
+        "terminate_backend",
+        # Removes objects or data.
+        "drop_graph",
+        "drop_property_graph",
+        "drop_publication",
+        "drop_subscription",
+        "partman_drop_partition",
+        "partman_run_maintenance",  # applies retention config: may detach/drop old partitions
+        "prune_audit_events",
+        "add_retention_policy",  # schedules future data deletion
+        "disable_data_checksums",  # removes a cluster integrity property
+        # Structural rewrites of existing partitions.
+        "merge_partitions",
+        "split_partition",
+    }
+)
+_NON_DESTRUCTIVE_WRITE_TOOLS = frozenset(
+    {
+        # Additive object creation (fails on conflict, destroys nothing).
+        "add_compression_policy",
+        "partman_create_parent",
+        "create_graph",
+        "create_hypertable",
+        "create_pg_search_index",
+        "create_property_graph",
+        "create_publication",
+        "create_redis_cache_server",
+        "create_redis_cache_table",
+        "create_redis_user_mapping",
+        "create_subscription",
+        "create_turboquant_index",
+        "enable_data_checksums",
+        "enable_extension",
+        "enable_logical_replication_on_demand",
+        "enable_redis_fdw",
+        # Additive data loads.
+        "import_csv",
+        "import_json",
+        "import_vectors",
+        "seed_table_with_sample_data",
+        # Maintenance: data preserved by design.
+        "maintain_turboquant_index",
+        "reindex_pg_search_index",
+        "reindex_turboquant_index",
+        "repack_table",
+        "run_maintenance",
+        "prewarm_recommended",
+        "prewarm_relation",
+        # Always rolls back.
+        "dry_run_ddl",
+        # Writes files / schedules, never touches table data.
+        "dump_database",
+        "schedule_logical_backup",
+        "schedule_autowarm",
+        "unschedule_autowarm",
+        "schedule_cron_job",
+        "unschedule_cron_job",
+        # Migration bookkeeping (no migration SQL is executed).
+        "prepare_migration",
+        "cancel_migration",
+        "validate_migration",
+        "validate_migration_schema",
+        "validate_check_constraint",
+        "list_pending_migrations",
+        "list_unapplied_migration_scripts",
+        # Telemetry / session-scoped state.
+        "log_rerank_event",
+        "record_efficiency_observation",
+        "setup_efficiency_observations",
+        "setup_rag_telemetry",
+        "subscribe_channel",
+        "unsubscribe_channel",
+        "poll_notifications",
+        "list_notification_subscriptions",
+    }
+)
 
-def _apply_tool_annotations(server: FastMCP[AppContext], read_only_names: set[str]) -> None:
-    """Stamp MCP ``ToolAnnotations`` derived from the capability gates.
+# Acronyms / product names the auto-derived titles must render properly;
+# any token not listed is used as-is (lowercase, sentence case overall).
+_TITLE_TOKENS: dict[str, str] = {
+    "sql": "SQL",
+    "ddl": "DDL",
+    "rls": "RLS",
+    "wal": "WAL",
+    "io": "IO",
+    "aio": "AIO",
+    "nl": "NL",
+    "lsn": "LSN",
+    "fdw": "FDW",
+    "fk": "FK",
+    "csv": "CSV",
+    "json": "JSON",
+    "bm25": "BM25",
+    "pgq": "PGQ",
+    "mpp": "MPP",
+    "rag": "RAG",
+    "pitr": "PITR",
+    "mmr": "MMR",
+    "ndcg": "NDCG",
+    "hnsw": "HNSW",
+    "ivfflat": "IVFFlat",
+    "ao": "AO",
+    "pg": "PG",
+    "pg19": "PG 19",
+    "select": "SELECT",
+    "topk": "top-k",
+    "postgres": "Postgres",
+    "redis": "Redis",
+    "prisma": "Prisma",
+    "drizzle": "Drizzle",
+    "diesel": "Diesel",
+    "ecto": "Ecto",
+    "ent": "Ent",
+    "jooq": "jOOQ",
+    "sqlalchemy": "SQLAlchemy",
+    "turboquant": "TurboQuant",
+    "warehousepg": "WarehousePG",
+    "cypher": "Cypher",
+}
+
+
+def _humanize_tool_name(name: str) -> str:
+    """``recommend_ivfflat_probes`` → ``Recommend IVFFlat probes``."""
+    words = [_TITLE_TOKENS.get(token, token) for token in name.split("_")]
+    title = " ".join(words)
+    return title[0].upper() + title[1:]
+
+
+def _apply_tool_wire_metadata(server: FastMCP[AppContext], read_only_names: set[str]) -> None:
+    """Stamp titles + MCP ``ToolAnnotations`` derived from the gates.
 
     MCPg already classifies every tool as READ / WRITE / DDL / SHELL /
     LISTEN via the registration gates in :func:`register_tools`; this
     puts that classification on the wire, where clients use it to
-    decide which calls to auto-approve (``readOnlyHint``) and whether
-    the tool leaves the database's closed world (``openWorldHint``).
-    Derived, not hand-written, so a tool moved between gates can never
-    ship a stale hint. ``destructiveHint`` is deliberately left unset
-    for non-read tools: the MCP default (true) is the cautious reading,
-    and MCPg doesn't currently track per-tool destructiveness more
-    precisely than the gate does.
+    decide which calls to auto-approve (``readOnlyHint``), how risky a
+    write is (``destructiveHint``, from the curated partition above),
+    and whether the tool leaves the database's closed world
+    (``openWorldHint``). Derived, not hand-written, so a tool moved
+    between gates can never ship a stale hint. Human-readable titles
+    are auto-derived from the snake_case name (directory listings —
+    e.g. the Claude connector directory — require one per tool).
 
     Uses the sync ``_tool_manager`` accessor for the same reason the
     session-intent filter does: this runs in synchronous startup code.
 
-    Merge semantics: annotations a registration set explicitly always
-    win — the derived values only fill fields that are still ``None``.
-    (No call site passes ``annotations=`` today, but a future per-tool
-    override — e.g. ``destructiveHint=False`` on a maintenance tool —
-    must not be silently clobbered by this sweep.)
+    Merge semantics: metadata a registration set explicitly always
+    wins — the derived values only fill fields that are still ``None``.
+    (No call site passes ``annotations=`` or ``title=`` today, but a
+    future per-tool override must not be silently clobbered.)
     """
     for tool in server._tool_manager.list_tools():
+        if tool.title is None:
+            tool.title = _humanize_tool_name(tool.name)
+        read_only = tool.name in read_only_names
         existing = tool.annotations
         if existing is None:
             tool.annotations = ToolAnnotations(
-                readOnlyHint=tool.name in read_only_names,
+                readOnlyHint=read_only,
+                # None (not False) for reads: the hint is only meaningful
+                # on write-capable tools per the MCP spec.
+                destructiveHint=None if read_only else tool.name not in _NON_DESTRUCTIVE_WRITE_TOOLS,
                 openWorldHint=tool.name in _OPEN_WORLD_TOOLS,
             )
             continue
         derived: dict[str, bool] = {}
         if existing.readOnlyHint is None:
-            derived["readOnlyHint"] = tool.name in read_only_names
+            derived["readOnlyHint"] = read_only
+        if not read_only and existing.destructiveHint is None:
+            derived["destructiveHint"] = tool.name not in _NON_DESTRUCTIVE_WRITE_TOOLS
         if existing.openWorldHint is None:
             derived["openWorldHint"] = tool.name in _OPEN_WORLD_TOOLS
         if derived:
@@ -6849,7 +7000,7 @@ def register_tools(server: FastMCP[AppContext], settings: Settings) -> None:
     if is_permitted(settings.access_mode, Capability.LISTEN) and settings.allow_listen:
         _register_listen(server)
 
-    _apply_tool_annotations(server, read_only_names)
+    _apply_tool_wire_metadata(server, read_only_names)
 
     # Session-intent surface filter (roadmap 8.8). Runs LAST so every
     # tool that would otherwise be registered has already been added —

--- a/tests/contract/test_tool_annotations.py
+++ b/tests/contract/test_tool_annotations.py
@@ -3,7 +3,7 @@
 MCPg's READ / WRITE / DDL / SHELL / LISTEN gating is its core safety
 story, but until the annotations sweep it never reached the wire — a
 client saw ``run_select`` and ``terminate_backend`` as equally opaque.
-These tests pin the derivation in ``tools._apply_tool_annotations``:
+These tests pin the derivation in ``tools._apply_tool_wire_metadata``:
 
 1. Every registered tool carries annotations with ``readOnlyHint`` set.
 2. The read-only set is exactly the surface reachable in read-only
@@ -12,6 +12,12 @@ These tests pin the derivation in ``tools._apply_tool_annotations``:
    tools always are.
 4. ``openWorldHint`` is False everywhere except the tools that reach
    external services (the NL→SQL provider call).
+5. Every write-capable tool carries an explicit ``destructiveHint``
+   backed by the curated destructive / non-destructive partition —
+   which must cover the write surface exactly, so a new write tool
+   can't ship unclassified.
+6. Every tool carries a human-readable title (directory listings —
+   e.g. the Claude connector directory — require one per tool).
 """
 
 from __future__ import annotations
@@ -119,7 +125,7 @@ def test_sweep_preserves_annotations_a_registration_set_explicitly() -> None:
     """
     from mcp.types import ToolAnnotations
 
-    from mcpg.tools import _apply_tool_annotations
+    from mcpg.tools import _apply_tool_wire_metadata
 
     server: FastMCP = FastMCP("mcpg-annotations-merge-fixture")
 
@@ -131,7 +137,7 @@ def test_sweep_preserves_annotations_a_registration_set_explicitly() -> None:
     def preexisting() -> str:
         return "x"
 
-    _apply_tool_annotations(server, read_only_names={"preexisting_annotated_tool"})
+    _apply_tool_wire_metadata(server, read_only_names={"preexisting_annotated_tool"})
 
     annotations = {t.name: t.annotations for t in server._tool_manager.list_tools()}["preexisting_annotated_tool"]
     assert annotations is not None
@@ -139,6 +145,59 @@ def test_sweep_preserves_annotations_a_registration_set_explicitly() -> None:
     assert annotations.destructiveHint is False  # preserved
     assert annotations.readOnlyHint is False  # explicit False beats the derived True
     assert annotations.openWorldHint is False  # unset -> filled by the derivation
+
+
+def test_destructive_partition_exactly_covers_the_write_surface() -> None:
+    """The destructive/non-destructive sets partition the write surface exactly.
+
+    The partition is hand-curated, so this is the drift guard: a new
+    write-capable tool fails here until someone consciously classifies
+    it, and a tool that stops existing can't linger in either set.
+    """
+    from mcpg.tools import _DESTRUCTIVE_TOOLS, _NON_DESTRUCTIVE_WRITE_TOOLS
+
+    overlap = _DESTRUCTIVE_TOOLS & _NON_DESTRUCTIVE_WRITE_TOOLS
+    assert not overlap, f"tools classified as both destructive and non-destructive: {sorted(overlap)}"
+
+    maximal = _build_server("unrestricted")
+    write_surface = {
+        t.name for t in maximal._tool_manager.list_tools() if t.annotations and t.annotations.readOnlyHint is False
+    }
+    classified = _DESTRUCTIVE_TOOLS | _NON_DESTRUCTIVE_WRITE_TOOLS
+    assert write_surface == classified, (
+        f"unclassified write tools (add to one of the partitions in tools.py): {sorted(write_surface - classified)}; "
+        f"classified but not registered as write tools: {sorted(classified - write_surface)}"
+    )
+
+
+def test_destructive_hint_is_explicit_on_writes_and_absent_on_reads() -> None:
+    from mcpg.tools import _DESTRUCTIVE_TOOLS
+
+    server = _build_server("unrestricted")
+    for tool in server._tool_manager.list_tools():
+        assert tool.annotations is not None
+        if tool.annotations.readOnlyHint:
+            # Meaningless for read-only tools per the MCP spec — stay unset.
+            assert tool.annotations.destructiveHint is None, tool.name
+        else:
+            expected = tool.name in _DESTRUCTIVE_TOOLS
+            assert tool.annotations.destructiveHint is expected, (
+                f"{tool.name}: destructiveHint={tool.annotations.destructiveHint}, expected {expected}"
+            )
+
+
+async def test_every_tool_has_a_human_readable_title() -> None:
+    server = _build_server("unrestricted")
+    wire_tools = await server.list_tools()
+    untitled = [t.name for t in wire_tools if not (t.title or "").strip()]
+    assert not untitled, f"tools without a title: {untitled}"
+    by_name = {t.name: t.title for t in wire_tools}
+    # Spot-check the acronym/product-name rendering.
+    assert by_name["run_ddl"] == "Run DDL"
+    assert by_name["translate_nl_to_sql"] == "Translate NL to SQL"
+    assert by_name["recommend_ivfflat_probes"] == "Recommend IVFFlat probes"
+    assert by_name["get_pg19_ddl_status"] == "Get PG 19 DDL status"
+    assert by_name["run_select"] == "Run SELECT"
 
 
 async def test_every_prompt_argument_has_a_description() -> None:

--- a/tests/unit/test_mcpb_bundle.py
+++ b/tests/unit/test_mcpb_bundle.py
@@ -1,0 +1,73 @@
+"""Tests for the MCPB desktop-extension bundle sources.
+
+The bundle in packaging/mcpb/ is packed and attached to every GitHub
+release by the publish workflow. These tests pin the two things that
+would break silently: the version-sync script the workflow runs, and
+the manifest invariants the Claude Desktop install experience relies
+on (sensitive connection URL, read-only default, uv server type).
+"""
+
+import json
+import shutil
+import sys
+from pathlib import Path
+
+_BUNDLE_DIR = Path(__file__).resolve().parents[2] / "packaging" / "mcpb"
+
+sys.path.insert(0, str(_BUNDLE_DIR))
+from sync_version import sync  # noqa: E402
+
+
+def test_sync_version_patches_every_pin(tmp_path: Path) -> None:
+    scratch = tmp_path / "mcpb"
+    shutil.copytree(_BUNDLE_DIR, scratch)
+
+    sync(scratch, "9.9.9")
+
+    manifest = json.loads((scratch / "manifest.json").read_text())
+    assert manifest["version"] == "9.9.9"
+    pyproject = (scratch / "pyproject.toml").read_text()
+    assert 'version = "9.9.9"' in pyproject
+    assert '"mcpg==9.9.9"' in pyproject
+    # No stale pin of any other version survives.
+    assert pyproject.count("mcpg==") == 1
+
+
+def test_manifest_invariants() -> None:
+    manifest = json.loads((_BUNDLE_DIR / "manifest.json").read_text())
+
+    # uv server type is what keeps the bundle tiny and cross-platform.
+    assert manifest["server"]["type"] == "uv"
+    entry_point = manifest["server"]["entry_point"]
+    assert (_BUNDLE_DIR / entry_point).is_file()
+
+    # The connection URL must be keychain-stored and mandatory; the
+    # access mode must default to MCPg's safe posture.
+    db = manifest["user_config"]["database_url"]
+    assert db["sensitive"] is True
+    assert db["required"] is True
+    assert manifest["user_config"]["access_mode"]["default"] == "read-only"
+
+    # The env plumbing the server actually reads.
+    env = manifest["server"]["mcp_config"]["env"]
+    assert env["MCPG_DATABASE_URL"] == "${user_config.database_url}"
+    assert env["MCPG_ACCESS_MODE"] == "${user_config.access_mode}"
+
+    # 252 tools are not enumerated by hand — the host derives them.
+    assert manifest["tools_generated"] is True
+    assert manifest["prompts_generated"] is True
+
+
+def test_bundle_pyproject_pins_the_current_release() -> None:
+    """The checked-in pin tracks mcpg's own version between releases.
+
+    The publish workflow re-syncs from the tag at release time, but
+    keeping the checked-in files current means a bundle packed from a
+    source checkout is never silently one release behind.
+    """
+    from mcpg import __version__
+
+    pyproject = (_BUNDLE_DIR / "pyproject.toml").read_text()
+    assert f"mcpg=={__version__}" in pyproject
+    manifest = json.loads((_BUNDLE_DIR / "manifest.json").read_text())
+    assert manifest["version"] == __version__


### PR DESCRIPTION
## Summary

The adoption-plan engineering item: everything the Claude connector directory review requires, plus the single biggest ease-of-adoption unlock — a one-click Claude Desktop install.

### One-click install: `.mcpb` desktop-extension bundle

- New `packaging/mcpb/` bundle using the MCPB **`uv` server type**: the bundle is **~2 kB** and works on every platform/architecture, because Claude Desktop resolves the pinned `mcpg` release from PyPI at install time (this is what sidesteps psycopg's platform-specific compiled wheels — no vendored `server/lib`).
- `user_config`: the connection URL is `sensitive: true` (stored in the OS keychain, never plain text); access mode defaults to **read-only**.
- The publish workflow gains a "Build the Claude Desktop extension" step in the `github-release` job: syncs the manifest + bundle-pyproject versions from the release tag (same never-goes-stale pattern we adopted for `server.json` after the MCP-registry incident), validates with the official `@anthropic-ai/mcpb` CLI, packs, and attaches `mcpg-<version>.mcpb` to the GitHub release alongside the wheel/sdist.
- **Verified locally with the official CLI**: `mcpb validate` passes, `mcpb pack` produces a 2.2 kB archive, and the version-sync script was exercised against a scratch copy (all three pinned fields patch correctly).

### Human-readable titles on all 252 tools

Auto-derived from the snake_case name in the same wire-metadata sweep as the annotations, with an acronym/product-name table so `run_ddl` → "Run DDL", `recommend_ivfflat_probes` → "Recommend IVFFlat probes", `get_pg19_ddl_status` → "Get PG 19 DDL status". Explicit per-registration titles still win (merge semantics unchanged). This was the one remaining connector-directory metadata gap after v0.6.7's annotations.

### Explicit `destructiveHint` on all 67 write-capable tools

Replaces the implicit MCP default with a curated partition: **18 destructive** (drops, `run_ddl`/`run_write`, `restore_database`, backend kills, retention-applying maintenance) / **49 non-destructive** (additive creates, data loads, maintenance that preserves data, `dry_run_ddl` which always rolls back, bookkeeping). Read-only tools keep `destructiveHint` unset, per the spec (it's only meaningful on writes).

The design guards itself: a contract test requires the two sets to **partition the write surface exactly**, so a new write tool fails CI until consciously classified — and defaults to the cautious bucket, not the safe one. The test earned its keep immediately: it caught `partman_run_maintenance` (applies retention config → can drop partitions → destructive) and `partman_create_parent` (additive) missing from my first pass.

### Supporting material

- **`PRIVACY.md`** (a directory-review requirement): self-hosted, no telemetry, the single documented external call (`translate_nl_to_sql` → your configured LLM provider), credential redaction + keychain storage.
- README and `docs/installation.md` gain the one-click install instructions.
- `_apply_tool_annotations` → `_apply_tool_wire_metadata` (it stamps titles now too).

## Test plan

- [x] 4 new/extended contract tests: every tool titled (with acronym spot-checks), destructive partition exactly covers the write surface (disjoint + complete), every write tool carries an explicit hint / reads carry none, existing preservation + wire-level tests updated.
- [x] Full unit + contract suites: **2,571 passed** locally; `ruff format --check` / `ruff check` / `mypy src/mcpg` (strict) clean. (Local Postgres in this sandbox died mid-run again — integration coverage is delegated to this PR's own CI matrix across PG 14–19, which is the gate that counts.)
- [x] `mcpb validate` + `mcpb pack` run against the real bundle; YAML-validated `publish.yml`.
- [ ] The release-attached `.mcpb` gets its first real exercise on the next tagged release.


---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Add a one-click Claude Desktop extension bundle and enrich MCP tool wire metadata for safer, directory-ready usage.

New Features:
- Provide a `.mcpb` Claude Desktop extension bundle using the MCPB `uv` server type, attached to each GitHub release.
- Auto-generate human-readable titles for all tools from their snake_case names with special handling for acronyms and product names.

Enhancements:
- Classify all write-capable tools with explicit `destructiveHint` values via curated destructive and non-destructive partitions, enforced by contract tests.
- Extend the tool metadata sweep to set both annotations and titles while preserving any explicitly registered overrides.
- Add privacy documentation describing data handling, external calls, credential storage, and audit behavior.

Build:
- Update the publish workflow to sync MCPB manifest and bundle pyproject versions from the release tag, validate via the official MCPB CLI, and pack the desktop bundle.

Documentation:
- Document one-click Claude Desktop installation in the README and installation guide.
- Introduce `PRIVACY.md` outlining self-hosted posture, telemetry behavior, and credential handling.

Tests:
- Add contract tests ensuring destructive/non-destructive partitions exactly cover the write surface, destructive hints are explicit on writes and absent on reads, and every tool has a human-readable title.