### PR TITLE
Add one-click Cursor/VS Code installs + client integrations guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- **One-click installs for Cursor and VS Code + a client integrations
+- **One-click installs for Cursor and VS Code + a client integration
   guide** — README install badges using the official HTTPS deeplink
   endpoints (`cursor.com/install-mcp`, `vscode.dev/redirect`; GitHub
   strips custom URL schemes from READMEs, so the raw `cursor://` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **One-click installs for Cursor and VS Code + a client integrations
+  guide** — README install badges using the official HTTPS deeplink
+  endpoints (`cursor.com/install-mcp`, `vscode.dev/redirect`; GitHub
+  strips custom URL schemes from READMEs, so the raw `cursor://` /
+  `vscode:` forms would render dead). The VS Code install uses a
+  masked `promptString` input for the connection URL, so it never
+  lands in plain-text settings. New `docs/integrations.md` covers
+  Cursor, VS Code, Claude Desktop/Code, Windsurf, JetBrains AI
+  Assistant, Cline/Roo, Zed, Continue, and generic HTTP clients.
 - **One-click Claude Desktop install (`.mcpb`)** — every release now
   attaches a `mcpg-<version>.mcpb` desktop-extension bundle. It uses
   the MCPB `uv` server type, so the bundle is ~2 kB and works on every

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ More detail in the [Installation Guide](https://github.com/devopam/MCPg/blob/mai
 [![Add to Cursor](https://img.shields.io/badge/Add_to-Cursor-000000?logo=cursor)](https://cursor.com/install-mcp?name=mcpg&config=eyJjb21tYW5kIjoidXZ4IiwiYXJncyI6WyJtY3BnIl0sImVudiI6eyJNQ1BHX0RBVEFCQVNFX1VSTCI6InBvc3RncmVzcWw6Ly91c2VyOnBhc3NAbG9jYWxob3N0OjU0MzIvbXlkYiJ9fQ%3D%3D)
 [![Install in VS Code](https://img.shields.io/badge/Install_in-VS_Code-0098FF?logo=githubcopilot)](https://vscode.dev/redirect?url=vscode%3Amcp%2Finstall%3F%257B%2522name%2522%253A%2522mcpg%2522%252C%2522command%2522%253A%2522uvx%2522%252C%2522args%2522%253A%255B%2522mcpg%2522%255D%252C%2522env%2522%253A%257B%2522MCPG_DATABASE_URL%2522%253A%2522%2524%257Binput%253Adatabase_url%257D%2522%257D%252C%2522inputs%2522%253A%255B%257B%2522type%2522%253A%2522promptString%2522%252C%2522id%2522%253A%2522database_url%2522%252C%2522description%2522%253A%2522PostgreSQL%2520connection%2520URL%2520%2528postgresql%253A%252F%252Fuser%253Apass%2540host%253A5432%252Fdb%2529%2522%252C%2522password%2522%253Atrue%257D%255D%257D)
 [![Claude Desktop](https://img.shields.io/badge/Claude_Desktop-.mcpb-D97757?logo=claude)](https://github.com/devopam/MCPg/releases/latest)
-— setup for Windsurf, JetBrains, Zed, Cline, Continue, and HTTP
+— setup for Windsurf, JetBrains, Zed, Cline, Antigravity, Continue, and HTTP
 clients in the [integrations guide](docs/integrations.md).
 
 ### One-click install in Claude Desktop (.mcpb)

--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ More detail in the [Installation Guide](https://github.com/devopam/MCPg/blob/mai
 [![Add to Cursor](https://img.shields.io/badge/Add_to-Cursor-000000?logo=cursor)](https://cursor.com/install-mcp?name=mcpg&config=eyJjb21tYW5kIjoidXZ4IiwiYXJncyI6WyJtY3BnIl0sImVudiI6eyJNQ1BHX0RBVEFCQVNFX1VSTCI6InBvc3RncmVzcWw6Ly91c2VyOnBhc3NAbG9jYWxob3N0OjU0MzIvbXlkYiJ9fQ%3D%3D)
 [![Install in VS Code](https://img.shields.io/badge/Install_in-VS_Code-0098FF?logo=githubcopilot)](https://vscode.dev/redirect?url=vscode%3Amcp%2Finstall%3F%257B%2522name%2522%253A%2522mcpg%2522%252C%2522command%2522%253A%2522uvx%2522%252C%2522args%2522%253A%255B%2522mcpg%2522%255D%252C%2522env%2522%253A%257B%2522MCPG_DATABASE_URL%2522%253A%2522%2524%257Binput%253Adatabase_url%257D%2522%257D%252C%2522inputs%2522%253A%255B%257B%2522type%2522%253A%2522promptString%2522%252C%2522id%2522%253A%2522database_url%2522%252C%2522description%2522%253A%2522PostgreSQL%2520connection%2520URL%2520%2528postgresql%253A%252F%252Fuser%253Apass%2540host%253A5432%252Fdb%2529%2522%252C%2522password%2522%253Atrue%257D%255D%257D)
 [![Claude Desktop](https://img.shields.io/badge/Claude_Desktop-.mcpb-D97757?logo=claude)](https://github.com/devopam/MCPg/releases/latest)
-— setup for Windsurf, JetBrains, Zed, Cline, Antigravity, Continue, and HTTP
+— setup for Windsurf, JetBrains, Zed, Cline, Antigravity, Perplexity,
+ChatGPT, Copilot Studio, Continue, and HTTP
 clients in the [integrations guide](docs/integrations.md).
 
 ### One-click install in Claude Desktop (.mcpb)

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ More detail in the [Installation Guide](https://github.com/devopam/MCPg/blob/mai
 [![Add to Cursor](https://img.shields.io/badge/Add_to-Cursor-000000?logo=cursor)](https://cursor.com/install-mcp?name=mcpg&config=eyJjb21tYW5kIjoidXZ4IiwiYXJncyI6WyJtY3BnIl0sImVudiI6eyJNQ1BHX0RBVEFCQVNFX1VSTCI6InBvc3RncmVzcWw6Ly91c2VyOnBhc3NAbG9jYWxob3N0OjU0MzIvbXlkYiJ9fQ%3D%3D)
 [![Install in VS Code](https://img.shields.io/badge/Install_in-VS_Code-0098FF?logo=githubcopilot)](https://vscode.dev/redirect?url=vscode%3Amcp%2Finstall%3F%257B%2522name%2522%253A%2522mcpg%2522%252C%2522command%2522%253A%2522uvx%2522%252C%2522args%2522%253A%255B%2522mcpg%2522%255D%252C%2522env%2522%253A%257B%2522MCPG_DATABASE_URL%2522%253A%2522%2524%257Binput%253Adatabase_url%257D%2522%257D%252C%2522inputs%2522%253A%255B%257B%2522type%2522%253A%2522promptString%2522%252C%2522id%2522%253A%2522database_url%2522%252C%2522description%2522%253A%2522PostgreSQL%2520connection%2520URL%2520%2528postgresql%253A%252F%252Fuser%253Apass%2540host%253A5432%252Fdb%2529%2522%252C%2522password%2522%253Atrue%257D%255D%257D)
 [![Claude Desktop](https://img.shields.io/badge/Claude_Desktop-.mcpb-D97757?logo=claude)](https://github.com/devopam/MCPg/releases/latest)
-— setup for Windsurf, JetBrains, Zed, Cline, Antigravity, Perplexity,
+— setup for Windsurf, JetBrains, Zed, Cline, Antigravity, Qwen Code, Perplexity,
 ChatGPT, Copilot Studio, Continue, and HTTP
 clients in the [integrations guide](docs/integrations.md).
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,13 @@ More detail in the [Installation Guide](https://github.com/devopam/MCPg/blob/mai
 
 ## Quick start
 
+**One-click installs:**
+[![Add to Cursor](https://img.shields.io/badge/Add_to-Cursor-000000?logo=cursor)](https://cursor.com/install-mcp?name=mcpg&config=eyJjb21tYW5kIjoidXZ4IiwiYXJncyI6WyJtY3BnIl0sImVudiI6eyJNQ1BHX0RBVEFCQVNFX1VSTCI6InBvc3RncmVzcWw6Ly91c2VyOnBhc3NAbG9jYWxob3N0OjU0MzIvbXlkYiJ9fQ%3D%3D)
+[![Install in VS Code](https://img.shields.io/badge/Install_in-VS_Code-0098FF?logo=githubcopilot)](https://vscode.dev/redirect?url=vscode%3Amcp%2Finstall%3F%257B%2522name%2522%253A%2522mcpg%2522%252C%2522command%2522%253A%2522uvx%2522%252C%2522args%2522%253A%255B%2522mcpg%2522%255D%252C%2522env%2522%253A%257B%2522MCPG_DATABASE_URL%2522%253A%2522%2524%257Binput%253Adatabase_url%257D%2522%257D%252C%2522inputs%2522%253A%255B%257B%2522type%2522%253A%2522promptString%2522%252C%2522id%2522%253A%2522database_url%2522%252C%2522description%2522%253A%2522PostgreSQL%2520connection%2520URL%2520%2528postgresql%253A%252F%252Fuser%253Apass%2540host%253A5432%252Fdb%2529%2522%252C%2522password%2522%253Atrue%257D%255D%257D)
+[![Claude Desktop](https://img.shields.io/badge/Claude_Desktop-.mcpb-D97757?logo=claude)](https://github.com/devopam/MCPg/releases/latest)
+— setup for Windsurf, JetBrains, Zed, Cline, Continue, and HTTP
+clients in the [integrations guide](docs/integrations.md).
+
 ### One-click install in Claude Desktop (.mcpb)
 
 Download `mcpg-<version>.mcpb` from the

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ them" — pick the section that matches what you're trying to do.
   Docker image, and what the environment variables mean.
 - [**Client integrations**](integrations.md) — one-click installs for
   Cursor / VS Code / Claude Desktop, plus setup for Windsurf,
-  JetBrains, Zed, Cline, Antigravity, Perplexity, ChatGPT, Copilot
+  JetBrains, Zed, Cline, Antigravity, Qwen Code, Perplexity, ChatGPT, Copilot
   Studio, Continue, and HTTP clients.
 - [**Demo dataset**](demo.md) — `mcpg --demo` seeds a curated
   playground schema; a captured walkthrough shows the pivotal tools

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ them" — pick the section that matches what you're trying to do.
   Docker image, and what the environment variables mean.
 - [**Client integrations**](integrations.md) — one-click installs for
   Cursor / VS Code / Claude Desktop, plus setup for Windsurf,
-  JetBrains, Zed, Cline, Continue, and HTTP clients.
+  JetBrains, Zed, Cline, Antigravity, Continue, and HTTP clients.
 - [**Demo dataset**](demo.md) — `mcpg --demo` seeds a curated
   playground schema; a captured walkthrough shows the pivotal tools
   finding its planted flaws.

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,8 @@ them" — pick the section that matches what you're trying to do.
   Docker image, and what the environment variables mean.
 - [**Client integrations**](integrations.md) — one-click installs for
   Cursor / VS Code / Claude Desktop, plus setup for Windsurf,
-  JetBrains, Zed, Cline, Antigravity, Continue, and HTTP clients.
+  JetBrains, Zed, Cline, Antigravity, Perplexity, ChatGPT, Copilot
+  Studio, Continue, and HTTP clients.
 - [**Demo dataset**](demo.md) — `mcpg --demo` seeds a curated
   playground schema; a captured walkthrough shows the pivotal tools
   finding its planted flaws.

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,9 @@ them" — pick the section that matches what you're trying to do.
 
 - [**Installation**](installation.md) — `pip install mcpg`, the
   Docker image, and what the environment variables mean.
+- [**Client integrations**](integrations.md) — one-click installs for
+  Cursor / VS Code / Claude Desktop, plus setup for Windsurf,
+  JetBrains, Zed, Cline, Continue, and HTTP clients.
 - [**Demo dataset**](demo.md) — `mcpg --demo` seeds a curated
   playground schema; a captured walkthrough shows the pivotal tools
   finding its planted flaws.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -5,8 +5,10 @@ MCPg speaks all three MCP transports (`stdio`, `streamable-http`,
 fastest install path per client. Everything below assumes `uv` is
 installed (`pipx install uv` or see [astral.sh/uv](https://docs.astral.sh/uv/));
 `uvx mcpg` fetches and runs the latest release with no separate
-install step. Replace the connection URL with your own — remote hosts
-need `?sslmode=require`.
+install step. Every snippet below uses the same **local-only example
+DSN** (`postgresql://user:pass@localhost:5432/mydb`) — replace it with
+your own; remote hosts require `?sslmode=require` (or stronger), which
+MCPg enforces at startup.
 
 > **Safe by default everywhere**: whatever the client, MCPg starts in
 > read-only mode and every tool carries MCP `readOnlyHint` /

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -185,6 +185,43 @@ mcpServers:
       MCPG_DATABASE_URL: postgresql://user:pass@localhost:5432/mydb
 ```
 
+## Perplexity (Mac app, paid plans)
+
+Perplexity's desktop app runs local MCP servers through a helper
+process: Settings → **Connectors** → install the *PerplexityXPC*
+helper → **Add Connector**. Use the *Advanced* tab and paste the same
+`mcpServers` JSON shown for Windsurf above (the *Simple* tab's single
+command field can't carry the `MCPG_DATABASE_URL` environment
+variable). Once the connector shows *Running*, toggle it on under
+*Sources* on the home screen.
+
+## ChatGPT (remote connector — developer mode)
+
+ChatGPT connects to **remote** MCP servers only: HTTPS required, no
+localhost, OAuth or no-auth connectors. Run MCPg's `streamable-http`
+transport on a reachable host (see the HTTP section below), then in
+ChatGPT: Settings → Apps → Advanced settings → **Developer mode**
+(Pro/Plus/Business/Enterprise, web) → add a connector with your
+server URL.
+
+Auth caveat, stated plainly: ChatGPT's connector options don't include
+static bearer headers, so either front MCPg with an OAuth-terminating
+gateway or run a no-auth connector **only** on a private network
+against a **read-only, non-production** database — never expose an
+unauthenticated database tool surface to the public internet.
+
+## Microsoft Copilot
+
+- **GitHub Copilot (VS Code agent mode)** — that's the
+  [VS Code section above](#vs-code-copilot-agent-mode); the one-click
+  badge covers it.
+- **Microsoft 365 Copilot / Copilot Studio** — Copilot Studio agents
+  connect to remote MCP servers: deploy MCPg's `streamable-http`
+  transport on an HTTPS endpoint and register it as an MCP tool/custom
+  connector in Copilot Studio. Same read-only-by-default posture
+  applies; use `MCPG_AUTH_MODE=oidc` with your Entra ID issuer for
+  enterprise-grade auth.
+
 ## Anything that speaks HTTP (LangGraph, custom agents, web apps)
 
 Run MCPg as a server and point the client at it:
@@ -201,6 +238,20 @@ Then connect any MCP-over-HTTP client to `http://localhost:8000` with
 the bearer token. For OIDC/JWT auth, rate limiting, and TLS options,
 see the [installation guide](installation.md) and
 [cookbook](cookbook.md).
+
+---
+
+## Asked about, not (yet) coverable
+
+- **Aider** — no native MCP client support as of mid-2026 (tracked
+  upstream in [Aider-AI/aider#4506](https://github.com/aider-ai/aider/issues/4506));
+  community bridges like `mcpm-aider` exist but aren't stable enough
+  for us to document. This section will gain a real config the moment
+  native support lands.
+- **DeepSeek** — a model provider, not an MCP client. DeepSeek models
+  drive MCPg just fine *through* the clients above (e.g. Cline or
+  Cursor with `deepseek-v4-pro` selected — note the pure-reasoning R1
+  models can't call tools).
 
 ---
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,0 +1,182 @@
+# Client integrations — wire MCPg into your editor or agent
+
+MCPg speaks all three MCP transports (`stdio`, `streamable-http`,
+`sse`), so it works with every major MCP client. This page gives the
+fastest install path per client. Everything below assumes `uv` is
+installed (`pipx install uv` or see [astral.sh/uv](https://docs.astral.sh/uv/));
+`uvx mcpg` fetches and runs the latest release with no separate
+install step. Replace the connection URL with your own — remote hosts
+need `?sslmode=require`.
+
+> **Safe by default everywhere**: whatever the client, MCPg starts in
+> read-only mode and every tool carries MCP `readOnlyHint` /
+> `destructiveHint` annotations, so clients that support them can
+> auto-approve reads and gate writes.
+
+## Claude Desktop
+
+**One-click**: download `mcpg-<version>.mcpb` from the
+[latest release](https://github.com/devopam/MCPg/releases/latest) and
+double-click it. You'll be prompted for the connection URL (stored in
+the OS keychain). Manual config alternative in the
+[installation guide](installation.md#claude-desktop-stdio-manual-config).
+
+## Claude Code (CLI)
+
+```bash
+claude mcp add mcpg --env MCPG_DATABASE_URL=postgresql://user:pass@localhost:5432/mydb -- uvx mcpg
+```
+
+## Cursor
+
+**One-click**: [Add to Cursor](https://cursor.com/install-mcp?name=mcpg&config=eyJjb21tYW5kIjoidXZ4IiwiYXJncyI6WyJtY3BnIl0sImVudiI6eyJNQ1BHX0RBVEFCQVNFX1VSTCI6InBvc3RncmVzcWw6Ly91c2VyOnBhc3NAbG9jYWxob3N0OjU0MzIvbXlkYiJ9fQ%3D%3D)
+(then edit the placeholder connection URL under Settings → MCP).
+
+Manual — `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (per-project):
+
+```json
+{
+  "mcpServers": {
+    "mcpg": {
+      "command": "uvx",
+      "args": ["mcpg"],
+      "env": {
+        "MCPG_DATABASE_URL": "postgresql://user:pass@localhost:5432/mydb"
+      }
+    }
+  }
+}
+```
+
+## VS Code (Copilot agent mode)
+
+**One-click**: [Install in VS Code](https://vscode.dev/redirect?url=vscode%3Amcp%2Finstall%3F%257B%2522name%2522%253A%2522mcpg%2522%252C%2522command%2522%253A%2522uvx%2522%252C%2522args%2522%253A%255B%2522mcpg%2522%255D%252C%2522env%2522%253A%257B%2522MCPG_DATABASE_URL%2522%253A%2522%2524%257Binput%253Adatabase_url%257D%2522%257D%252C%2522inputs%2522%253A%255B%257B%2522type%2522%253A%2522promptString%2522%252C%2522id%2522%253A%2522database_url%2522%252C%2522description%2522%253A%2522PostgreSQL%2520connection%2520URL%2520%2528postgresql%253A%252F%252Fuser%253Apass%2540host%253A5432%252Fdb%2529%2522%252C%2522password%2522%253Atrue%257D%255D%257D)
+· [Install in VS Code Insiders](https://insiders.vscode.dev/redirect?url=vscode-insiders%3Amcp%2Finstall%3F%257B%2522name%2522%253A%2522mcpg%2522%252C%2522command%2522%253A%2522uvx%2522%252C%2522args%2522%253A%255B%2522mcpg%2522%255D%252C%2522env%2522%253A%257B%2522MCPG_DATABASE_URL%2522%253A%2522%2524%257Binput%253Adatabase_url%257D%2522%257D%252C%2522inputs%2522%253A%255B%257B%2522type%2522%253A%2522promptString%2522%252C%2522id%2522%253A%2522database_url%2522%252C%2522description%2522%253A%2522PostgreSQL%2520connection%2520URL%2520%2528postgresql%253A%252F%252Fuser%253Apass%2540host%253A5432%252Fdb%2529%2522%252C%2522password%2522%253Atrue%257D%255D%257D)
+
+The one-click install prompts for your connection URL as a masked
+input — it never lands in plain-text settings.
+
+Manual — `.vscode/mcp.json` in your workspace:
+
+```json
+{
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "database_url",
+      "description": "PostgreSQL connection URL",
+      "password": true
+    }
+  ],
+  "servers": {
+    "mcpg": {
+      "command": "uvx",
+      "args": ["mcpg"],
+      "env": {
+        "MCPG_DATABASE_URL": "${input:database_url}"
+      }
+    }
+  }
+}
+```
+
+## Windsurf
+
+`~/.codeium/windsurf/mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "mcpg": {
+      "command": "uvx",
+      "args": ["mcpg"],
+      "env": {
+        "MCPG_DATABASE_URL": "postgresql://user:pass@localhost:5432/mydb"
+      }
+    }
+  }
+}
+```
+
+## JetBrains IDEs (AI Assistant)
+
+Settings → Tools → AI Assistant → Model Context Protocol (MCP) →
+Add → *As JSON*, then paste the same `mcpServers` block shown for
+Windsurf above. Available in AI Assistant 2025.1+ across IntelliJ
+IDEA, PyCharm, DataGrip, and the rest of the family.
+
+## Cline / Roo Code (VS Code extensions)
+
+MCP Servers panel → Configure MCP Servers, or edit
+`cline_mcp_settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "mcpg": {
+      "command": "uvx",
+      "args": ["mcpg"],
+      "env": {
+        "MCPG_DATABASE_URL": "postgresql://user:pass@localhost:5432/mydb"
+      }
+    }
+  }
+}
+```
+
+## Zed
+
+`settings.json` (⌘, / Ctrl-,):
+
+```json
+{
+  "context_servers": {
+    "mcpg": {
+      "command": {
+        "path": "uvx",
+        "args": ["mcpg"],
+        "env": {
+          "MCPG_DATABASE_URL": "postgresql://user:pass@localhost:5432/mydb"
+        }
+      }
+    }
+  }
+}
+```
+
+## Continue
+
+`~/.continue/config.yaml`:
+
+```yaml
+mcpServers:
+  - name: mcpg
+    command: uvx
+    args:
+      - mcpg
+    env:
+      MCPG_DATABASE_URL: postgresql://user:pass@localhost:5432/mydb
+```
+
+## Anything that speaks HTTP (LangGraph, custom agents, web apps)
+
+Run MCPg as a server and point the client at it:
+
+```bash
+MCPG_DATABASE_URL=postgresql://user:pass@localhost:5432/mydb \
+MCPG_TRANSPORT=streamable-http \
+MCPG_HTTP_PORT=8000 \
+MCPG_HTTP_AUTH_TOKEN=change-me \
+mcpg
+```
+
+Then connect any MCP-over-HTTP client to `http://localhost:8000` with
+the bearer token. For OIDC/JWT auth, rate limiting, and TLS options,
+see the [installation guide](installation.md) and
+[cookbook](cookbook.md).
+
+---
+
+**No interesting data to point at?** Seed the
+[demo dataset](demo.md) first: `mcpg --demo` plants a curated schema
+that gives every tool above something real to find.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -185,6 +185,30 @@ mcpServers:
       MCPG_DATABASE_URL: postgresql://user:pass@localhost:5432/mydb
 ```
 
+## Qwen Code (CLI)
+
+`~/.qwen/settings.json` (global) or `.qwen/settings.json` in your
+project — the top-level `mcpServers` object:
+
+```json
+{
+  "mcpServers": {
+    "mcpg": {
+      "command": "uvx",
+      "args": ["mcpg"],
+      "env": {
+        "MCPG_DATABASE_URL": "postgresql://user:pass@localhost:5432/mydb"
+      }
+    }
+  }
+}
+```
+
+`qwen mcp add` can write the entry for you, and the `/mcp` dialog
+inside an interactive session shows every configured server and its
+tools. Remote deployments can use `"httpUrl"` against MCPg's
+`streamable-http` transport instead of `command`.
+
 ## Perplexity (Mac app, paid plans)
 
 Perplexity's desktop app runs local MCP servers through a helper

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -146,6 +146,31 @@ MCP Servers panel → Configure MCP Servers, or edit
 }
 ```
 
+## Google Antigravity (and Gemini CLI)
+
+Antigravity's IDE and CLI share one MCP config —
+`~/.gemini/config/mcp_config.json` (also reachable in-app via
+*Manage MCP Servers → View raw config*; Antigravity reloads it
+automatically on save):
+
+```json
+{
+  "mcpServers": {
+    "mcpg": {
+      "command": "uvx",
+      "args": ["mcpg"],
+      "env": {
+        "MCPG_DATABASE_URL": "postgresql://user:pass@localhost:5432/mydb"
+      }
+    }
+  }
+}
+```
+
+For a remote/shared deployment, use `"serverUrl": "https://your-host:8000"`
+with MCPg running the `streamable-http` transport (see the HTTP
+section below).
+
 ## Continue
 
 `~/.continue/config.yaml`:

--- a/tests/unit/test_install_badges.py
+++ b/tests/unit/test_install_badges.py
@@ -1,0 +1,53 @@
+"""Consistency tests for the one-click install deeplinks.
+
+The encoded Cursor / VS Code install URLs appear in both README.md and
+docs/integrations.md. They're opaque blobs, so drift between the two
+copies — or a payload that silently stops decoding to a valid config —
+would never be caught by eye. These tests decode the payloads out of
+both committed files and pin their shape and equality.
+"""
+
+import base64
+import json
+import re
+import urllib.parse
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[2]
+
+_CURSOR_RE = re.compile(r"cursor\.com/install-mcp\?name=mcpg&config=([A-Za-z0-9%=+/]+)\)")
+_VSCODE_RE = re.compile(r"(?<!insiders\.)vscode\.dev/redirect\?url=([^)\s]+)\)")
+
+
+def _payloads(pattern: re.Pattern[str]) -> dict[str, str]:
+    found: dict[str, str] = {}
+    for rel in ("README.md", "docs/integrations.md"):
+        match = pattern.search((_ROOT / rel).read_text())
+        assert match, f"{rel}: no install link matching {pattern.pattern!r}"
+        found[rel] = match.group(1)
+    return found
+
+
+def test_cursor_deeplink_decodes_and_matches_across_files() -> None:
+    payloads = _payloads(_CURSOR_RE)
+    assert len(set(payloads.values())) == 1, f"Cursor configs drifted between files: {payloads}"
+    config = json.loads(base64.b64decode(urllib.parse.unquote(next(iter(payloads.values())))))
+    assert config["command"] == "uvx"
+    assert config["args"] == ["mcpg"]
+    assert "MCPG_DATABASE_URL" in config["env"]
+
+
+def test_vscode_deeplink_decodes_and_matches_across_files() -> None:
+    payloads = _payloads(_VSCODE_RE)
+    assert len(set(payloads.values())) == 1, f"VS Code configs drifted between files: {payloads}"
+    inner = urllib.parse.unquote(next(iter(payloads.values())))
+    assert inner.startswith("vscode:mcp/install?")
+    config = json.loads(urllib.parse.unquote(inner.split("?", 1)[1]))
+    assert config["name"] == "mcpg"
+    assert config["command"] == "uvx"
+    assert config["args"] == ["mcpg"]
+    # The connection URL must be a masked prompt, never a plain-text value.
+    assert config["env"]["MCPG_DATABASE_URL"] == "${input:database_url}"
+    (prompt,) = config["inputs"]
+    assert prompt["type"] == "promptString"
+    assert prompt["password"] is True


### PR DESCRIPTION
## Summary

Extends the one-click install story beyond Claude Desktop to the rest of the MCP client ecosystem. No server changes — MCPg already speaks stdio + streamable-HTTP + SSE, so this is pure last-mile install UX and documentation.

### One-click install badges (README quick start)

- **Add to Cursor** — via `https://cursor.com/install-mcp?name=mcpg&config=<base64>`; Cursor shows an approval dialog and writes `mcp.json`. Uses a placeholder DSN the user edits after install (Cursor deeplinks don't support prompted inputs).
- **Install in VS Code** — via `https://vscode.dev/redirect?url=vscode%3Amcp%2Finstall%3F...`; the payload declares the connection URL as a **masked `promptString` input**, so VS Code prompts for it on install and it never lands in plain-text settings.
- **Claude Desktop `.mcpb`** badge pointing at the latest release.

Why the HTTPS endpoints instead of raw `cursor://` / `vscode:` links: GitHub sanitizes custom URL schemes out of README markdown — the raw forms render as dead links (a known failure mode; the github-mcp-server repo hit exactly this). The official redirect endpoints are the documented workaround.

The badge payloads aren't hand-trusted: a verification step decodes them back out of the committed README and asserts the embedded JSON configs (command/args/inputs) round-trip correctly.

### `docs/integrations.md`

Fastest install path per client, each with a copy-paste config: Cursor, VS Code (Copilot agent mode), Claude Desktop (`.mcpb`) + Claude Code CLI, Windsurf, JetBrains AI Assistant (2025.1+), Cline/Roo Code, Zed, Continue, and generic streamable-HTTP clients (LangGraph, custom agents) with bearer auth. Each section defaults to read-only mode and the page cross-links `mcpg --demo` for users with no interesting data yet. Beyond install UX, each client section is a distinct search-traffic surface ("mcpg cursor", "postgres mcp windsurf", …).

Linked from the README quick start and the docs index.

## Test plan

- [x] Badge payloads decoded from the committed README and validated (Cursor base64 → `{"command":"uvx","args":["mcpg"],...}`; VS Code URL → `vscode:mcp/install?` + JSON with `password: true` input).
- [x] `ruff format --check` / `ruff check` clean; docs-only change otherwise (no code paths touched, tool surface unchanged).
- [ ] The badges themselves need a live click-test from a machine with Cursor/VS Code installed — @devopam, worth 60 seconds after merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Add one-click MCPg install badges for major editor clients and introduce a dedicated client integrations guide for streamlined setup across the MCP ecosystem.

Enhancements:
- Expose quick one-click install badges in the README for Cursor, VS Code, and Claude Desktop, linking to the new integrations guide.
- Update the docs index and changelog to highlight the new client integrations documentation and install paths.

Documentation:
- Document one-click install flows for Cursor, VS Code, and Claude Desktop alongside manual configuration snippets for other MCP-capable clients.
- Add a client integrations page linking editor/agent-specific setup to existing installation, demo, and cookbook docs.