### PR TITLE
Cut v0.6.8 — the adoption release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,30 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [0.6.8] - 2026-07-05
+
+### Added
+
 - **One-click installs for Cursor and VS Code + a client integration
   guide** — README install badges using the official HTTPS deeplink
   endpoints (`cursor.com/install-mcp`, `vscode.dev/redirect`; GitHub
   strips custom URL schemes from READMEs, so the raw `cursor://` /
   `vscode:` forms would render dead). The VS Code install uses a
   masked `promptString` input for the connection URL, so it never
-  lands in plain-text settings. New `docs/integrations.md` covers
-  Cursor, VS Code, Claude Desktop/Code, Windsurf, JetBrains AI
-  Assistant, Cline/Roo, Zed, Continue, and generic HTTP clients.
+  lands in plain-text settings. New `docs/integrations.md` covers 14
+  clients: Cursor, VS Code (GitHub Copilot agent mode), Claude
+  Desktop/Code, Windsurf, JetBrains AI Assistant, Cline/Roo, Zed,
+  Google Antigravity (+ Gemini CLI), Qwen Code, Perplexity, ChatGPT
+  (remote connectors), Microsoft Copilot Studio, Continue, and
+  generic HTTP clients — plus an honest "not yet coverable" section
+  for Aider (no native MCP support upstream) and DeepSeek (a model
+  provider, not a client). Badge payloads are pinned by a unit test
+  that decodes them out of both README and docs and asserts
+  cross-file consistency.
 - **One-click Claude Desktop install (`.mcpb`)** — every release now
   attaches a `mcpg-<version>.mcpb` desktop-extension bundle. It uses
   the MCPB `uv` server type, so the bundle is ~2 kB and works on every
@@ -40,9 +55,15 @@ adheres to [Semantic Versioning](https://semver.org/).
   single documented external call (`translate_nl_to_sql` → your
   configured LLM provider), and credential-handling guarantees.
 
-### Changed
-
 ### Fixed
+
+- **GitHub Release bodies were always the fallback stub.** The
+  release-notes extraction in the publish workflow used an awk range
+  pattern whose start line also matched its end pattern (GNU awk
+  collapses that to a single line), so every release since the job was
+  added shipped "See CHANGELOG.md" instead of the changelog section.
+  Replaced with an explicit flag-variable scan; this release is the
+  first to exercise it.
 
 ## [0.6.7] - 2026-07-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,9 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-### Added
-
-### Changed
-
-### Fixed
+Nothing yet — merged changes accumulate here until the next release is
+cut. (Add an `### Added` / `### Changed` / `### Fixed` heading along
+with the first entry of that kind.)
 
 ## [0.6.8] - 2026-07-05
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,6 +55,7 @@ them" — pick the section that matches what you're trying to do.
   retrospectives.
 - [**Progress log**](PROGRESS.md) — chronological build log.
 - Release notes:
+  [v0.6.8](release-notes-0.6.8.md) ·
   [v0.6.7](release-notes-0.6.7.md) ·
   [v0.6.6](release-notes-0.6.6.md) ·
   [v0.6.5](release-notes-0.6.5.md) ·

--- a/docs/release-notes-0.6.8.md
+++ b/docs/release-notes-0.6.8.md
@@ -1,0 +1,73 @@
+# MCPg v0.6.8 — release notes
+
+**Released:** 2026-07-05
+**Tool surface:** **252** tools across 19 capability buckets
+**Tests:** 2746 pass (PG 14 / 15 / 16 / 17 / 18 / 19 / WarehousePG)
+**Runtime:** Python 3.14
+
+This is a **patch-level bump (0.6.7 → 0.6.8)** focused entirely on
+adoption: installing MCPg into *any* MCP client is now a one-click or
+one-snippet affair. No tool signatures changed; everything is
+backward-compatible.
+
+## Headline: one-click installs, everywhere
+
+- **Claude Desktop** — this release attaches the first
+  **`mcpg-<version>.mcpb`** desktop-extension bundle: download,
+  double-click, paste your connection URL (stored in the OS keychain),
+  done. The bundle is ~2 kB and works on every platform/architecture —
+  it uses the MCPB `uv` server type, so Claude Desktop resolves the
+  pinned `mcpg` release from PyPI at install time. Access mode
+  defaults to read-only.
+- **Cursor** and **VS Code** — one-click install badges in the README,
+  via the official HTTPS deeplink endpoints. The VS Code install
+  prompts for the connection URL as a **masked input**, so it never
+  lands in plain-text settings.
+- **Everything else** — the new
+  [client integrations guide](integrations.md) covers 14 clients with
+  copy-paste configs: Windsurf, JetBrains AI Assistant, Cline/Roo
+  Code, Zed, Google Antigravity (+ Gemini CLI), Qwen Code, Perplexity,
+  ChatGPT (remote connectors), Microsoft Copilot Studio, Continue,
+  Claude Code CLI, and generic streamable-HTTP clients — plus a
+  straight answer on Aider (no native MCP support upstream yet) and
+  DeepSeek (a model provider whose models drive MCPg *through* these
+  clients).
+
+## Directory-ready metadata
+
+Rounding out v0.6.7's `readOnlyHint` work, every tool now also carries:
+
+- a **human-readable title**, auto-derived from the tool name with an
+  acronym/product-name table (`recommend_ivfflat_probes` →
+  "Recommend IVFFlat probes"), and
+- an explicit **`destructiveHint`** on all 67 write-capable tools,
+  from a curated destructive (18) / non-destructive (49) partition. A
+  contract test requires the partition to cover the write surface
+  exactly, so a new write tool cannot ship unclassified.
+
+Together with the new **`PRIVACY.md`** (self-hosted, no telemetry, one
+documented external call), MCPg now meets the published metadata
+requirements for connector-directory listings.
+
+## Also fixed
+
+- **GitHub Release bodies** had shipped the "See CHANGELOG.md" stub on
+  every release since automation was added — an awk range-pattern bug
+  in the extraction step. This release is the first with the fix in
+  effect; the body you're (hopefully) reading it in came from the
+  changelog.
+
+## Upgrade
+
+```bash
+pip install --upgrade mcpg
+docker pull ghcr.io/devopam/mcpg:0.6.8   # or :latest
+```
+
+Or grab `mcpg-0.6.8.mcpb` from this release and double-click it into
+Claude Desktop. No configuration changes required.
+
+## Full changelog
+
+See [`../CHANGELOG.md`](../CHANGELOG.md) `[0.6.8]` for the complete
+itemised list.

--- a/packaging/mcpb/manifest.json
+++ b/packaging/mcpb/manifest.json
@@ -1,10 +1,10 @@
 {
   "manifest_version": "0.4",
   "name": "mcpg",
-  "display_name": "MCPg — PostgreSQL",
-  "version": "0.6.7",
-  "description": "Production-grade PostgreSQL MCP server: 252 tools for querying, tuning, and operating Postgres — read-only by default.",
-  "long_description": "MCPg lets AI agents safely inspect, query, operate, and tune a PostgreSQL database. 252 tools spanning catalog introspection, query intelligence, natural-language SQL, structural diffs, hybrid search, graph queries, live ops, and more.\n\n**Safe by default**: read-only access mode, AST-validated SQL, and every tool publishes MCP annotations (`readOnlyHint`/`destructiveHint`) so the client knows exactly which calls are safe. Write, DDL, shell, and LISTEN capabilities stay off until explicitly enabled via environment variables.\n\nNo data yet? Run `mcpg --demo` against a scratch database to seed a curated demo dataset and take the tools for a spin — see the guided tour at https://github.com/devopam/MCPg/blob/main/docs/demo.md.",
+  "display_name": "MCPg \u2014 PostgreSQL",
+  "version": "0.6.8",
+  "description": "Production-grade PostgreSQL MCP server: 252 tools for querying, tuning, and operating Postgres \u2014 read-only by default.",
+  "long_description": "MCPg lets AI agents safely inspect, query, operate, and tune a PostgreSQL database. 252 tools spanning catalog introspection, query intelligence, natural-language SQL, structural diffs, hybrid search, graph queries, live ops, and more.\n\n**Safe by default**: read-only access mode, AST-validated SQL, and every tool publishes MCP annotations (`readOnlyHint`/`destructiveHint`) so the client knows exactly which calls are safe. Write, DDL, shell, and LISTEN capabilities stay off until explicitly enabled via environment variables.\n\nNo data yet? Run `mcpg --demo` against a scratch database to seed a curated demo dataset and take the tools for a spin \u2014 see the guided tour at https://github.com/devopam/MCPg/blob/main/docs/demo.md.",
   "author": {
     "name": "Devopam Mittra",
     "email": "devopam@gmail.com",
@@ -44,7 +44,7 @@
     "database_url": {
       "type": "string",
       "title": "PostgreSQL connection URL",
-      "description": "e.g. postgresql://user:password@localhost:5432/mydb — remote hosts need ?sslmode=require. Stored securely by the OS keychain.",
+      "description": "e.g. postgresql://user:password@localhost:5432/mydb \u2014 remote hosts need ?sslmode=require. Stored securely by the OS keychain.",
       "sensitive": true,
       "required": true
     },

--- a/packaging/mcpb/pyproject.toml
+++ b/packaging/mcpb/pyproject.toml
@@ -5,9 +5,9 @@
 # to the release tag by the publish workflow, exactly like server.json.
 [project]
 name = "mcpg-desktop-extension"
-version = "0.6.7"
+version = "0.6.8"
 description = "MCPB launcher shim for the MCPg PostgreSQL MCP server."
 requires-python = ">=3.12"
 dependencies = [
-    "mcpg==0.6.7",
+    "mcpg==0.6.8",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcpg"
-version = "0.6.7"
+version = "0.6.8"
 description = "A production-grade PostgreSQL Model Context Protocol (MCP) server."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/mcpg/__init__.py
+++ b/src/mcpg/__init__.py
@@ -2,7 +2,7 @@
 
 import warnings
 
-__version__ = "0.6.7"
+__version__ = "0.6.8"
 
 # ``schema`` is the natural field name for "which Postgres schema" across
 # ~180 tool-return dataclasses. The ``mcp`` SDK dynamically builds a

--- a/uv.lock
+++ b/uv.lock
@@ -988,7 +988,7 @@ cli = [
 
 [[package]]
 name = "mcpg"
-version = "0.6.7"
+version = "0.6.8"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Release cut for **v0.6.8** — everything merged since v0.6.7, all adoption-focused:

- **One-click Claude Desktop install**: this will be the **first release to attach `mcpg-0.6.8.mcpb`** (the publish workflow builds and attaches it automatically).
- **Cursor / VS Code one-click install badges** (click-tested by the maintainer) + the **14-client integrations guide**.
- **Tool titles + explicit `destructiveHint`** on all write-capable tools, completing connector-directory metadata readiness, plus **`PRIVACY.md`**.
- **Release-body extraction fix** — v0.6.8 is the first release where the GitHub Release body should render the actual changelog section instead of the stub. Worth eyeballing on the release page as the final verification of #222.

Mechanics: version bumped in `pyproject.toml`, `mcpg.__version__`, `uv.lock`, and the mcpb bundle pins (via `packaging/mcpb/sync_version.py` — the same script the workflow runs); CHANGELOG `[Unreleased]` folded into `[0.6.8] - 2026-07-05` (with the integration-guide entry updated to the final 14-client list and the #222 fix backfilled); `docs/release-notes-0.6.8.md` added and linked from the docs index.

## Test plan

- [x] `uv run pytest tests/unit tests/contract` — 2,576 passed (includes the bundle-pin consistency test now asserting 0.6.8 across manifest + pyproject).
- [x] `ruff format --check` / `ruff check` / `mypy src/mcpg` (strict) — clean.
- [x] Integration coverage via this PR's CI matrix (PG 14–19 + WarehousePG).

## After merge

Tagging is the manual step (I can't push tags from this environment):

```bash
git checkout main && git pull origin main
git tag v0.6.8
git push origin v0.6.8
```

The publish workflow then runs: build → TestPyPI → smoke test → **PyPI approval gate (your click)** → GitHub Release (+ first `.mcpb` attachment + first properly-rendered body) / MCP Registry / GHCR. Once live, the directory submissions (Claude connector directory, PulseMCP, Smithery, Cline marketplace) have a real artifact to point at.


---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Cut the v0.6.8 release, updating version metadata and changelog while focusing on easier adoption and correct release notes rendering.

New Features:
- Introduce one-click Claude Desktop installation via a bundled MCPB desktop extension attached to releases.
- Add Cursor and VS Code one-click install badges plus a comprehensive 14-client integration guide for MCPg.
- Complete directory-ready metadata by ensuring all tools expose human-readable titles and explicit destructive hints, supported by a new privacy description.

Bug Fixes:
- Fix GitHub Release body extraction so releases now include the actual changelog section instead of a stub message.

Build:
- Update project, desktop extension, and bundle manifest versions and pins from 0.6.7 to 0.6.8 to prepare the release.

Documentation:
- Add v0.6.8 release notes and link them from the docs index, including adoption-focused guidance and metadata details.