### PR TITLE
Add llms-install.md — agent-targeted install recipe for Cline

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -109,7 +109,10 @@ IDEA, PyCharm, DataGrip, and the rest of the family.
 
 ## Cline / Roo Code (VS Code extensions)
 
-MCP Servers panel → Configure MCP Servers, or edit
+Cline can install MCPg autonomously — ask it to "set up the MCP server
+at github.com/devopam/MCPg" and it follows
+[`llms-install.md`](../llms-install.md). Or configure it by hand: MCP
+Servers panel → Configure MCP Servers, or edit
 `cline_mcp_settings.json`:
 
 ```json

--- a/llms-install.md
+++ b/llms-install.md
@@ -17,7 +17,7 @@ uvx --version
 
 If that fails, install uv first:
 - macOS/Linux: `curl -LsSf https://astral.sh/uv/install.sh | sh`
-- Windows (PowerShell): `powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"`
+- Windows (PowerShell): `powershell -ExecutionPolicy Bypass -c "irm https://astral.sh/uv/install.ps1 | iex"`
 
 ## Step 1 — Get the database connection string from the user
 

--- a/llms-install.md
+++ b/llms-install.md
@@ -1,0 +1,104 @@
+# Installing MCPg — instructions for an AI coding agent
+
+You are an AI agent (Cline, Roo, or similar) setting up the **MCPg**
+PostgreSQL MCP server for a user. Follow these steps exactly. Do not
+consult README.md for install steps — it documents many paths; this
+file is the single canonical one.
+
+## Prerequisites
+
+MCPg runs via `uvx` (from [uv](https://docs.astral.sh/uv/)), which
+fetches and runs the published package with no separate install. Check
+whether `uv` is available:
+
+```bash
+uvx --version
+```
+
+If that fails, install uv first:
+- macOS/Linux: `curl -LsSf https://astral.sh/uv/install.sh | sh`
+- Windows (PowerShell): `powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"`
+
+## Step 1 — Get the database connection string from the user
+
+MCPg needs a PostgreSQL connection URL. **Ask the user for it** if you
+don't already have one. It looks like:
+
+```
+postgresql://USER:PASSWORD@HOST:5432/DBNAME
+```
+
+Rules to relay to the user:
+- A **remote** host requires `?sslmode=require` (or stronger) appended
+  — MCPg refuses insecure remote connections at startup.
+- `localhost` / `127.0.0.1` needs no sslmode.
+- If the user has no database to point at yet, tell them they can seed
+  a throwaway demo dataset after setup (see Step 4).
+
+Do **not** invent or hard-code credentials. Wait for the user's value.
+
+## Step 2 — Write the MCP server configuration
+
+Add this block to the user's Cline MCP settings
+(`cline_mcp_settings.json`), merging into any existing `mcpServers`
+object. Replace the placeholder URL with the value from Step 1:
+
+```json
+{
+  "mcpServers": {
+    "mcpg": {
+      "command": "uvx",
+      "args": ["mcpg"],
+      "env": {
+        "MCPG_DATABASE_URL": "postgresql://USER:PASSWORD@HOST:5432/DBNAME"
+      }
+    }
+  }
+}
+```
+
+Notes:
+- MCPg starts in **read-only** access mode by default — safe. Do not
+  add write/DDL/shell env vars unless the user explicitly asks; those
+  are `MCPG_ACCESS_MODE=unrestricted` plus `MCPG_ALLOW_DDL=true` etc.
+- No API keys are required for core use. (The optional natural-language
+  → SQL tool needs an LLM provider key, but everything else works
+  without one.)
+
+## Step 3 — Verify the connection
+
+After saving the config, MCPg should appear as a connected server in
+Cline's MCP panel with its tools listed. Confirm it works by calling
+the `list_schemas` tool (or ask: "list the schemas in the database").
+A successful response means setup is complete.
+
+If it fails to connect, the most common causes are:
+1. `uv` not on PATH → re-check the Prerequisites section above.
+2. Database unreachable / wrong credentials → verify the URL with the
+   user; check the host is running and reachable.
+3. Remote host without `?sslmode=require` → MCPg rejects it at startup;
+   append the sslmode parameter.
+
+## Step 4 — (Optional) Seed a demo dataset
+
+If the user has no interesting data to explore, they can populate a
+curated demo schema (400 customers, 3,000 orders, 900 reviews, with
+deliberately planted flaws for the analysis tools to find):
+
+```bash
+uvx mcpg --demo        # seed the mcpg_demo schema
+uvx mcpg --demo-drop   # remove it later
+```
+
+(Run with the same `MCPG_DATABASE_URL` set in the environment.) Then
+suggest they try: *"Why is this slow: SELECT * FROM mcpg_demo.orders
+WHERE customer_id = 42 ORDER BY order_date DESC"* — MCPg will find the
+missing index.
+
+## Done
+
+MCPg exposes 252 tools spanning catalog introspection, query
+intelligence, health checks, index tuning, hybrid search, and more —
+all read-only by default. Point the user at
+[docs/integrations.md](docs/integrations.md) and
+[docs/tour.md](docs/tour.md) for what to try next.

--- a/tests/unit/test_install_badges.py
+++ b/tests/unit/test_install_badges.py
@@ -22,7 +22,7 @@ _VSCODE_RE = re.compile(r"(?<!insiders\.)vscode\.dev/redirect\?url=([^)\s]+)\)")
 def _payloads(pattern: re.Pattern[str]) -> dict[str, str]:
     found: dict[str, str] = {}
     for rel in ("README.md", "docs/integrations.md"):
-        match = pattern.search((_ROOT / rel).read_text())
+        match = pattern.search((_ROOT / rel).read_text(encoding="utf-8"))
         assert match, f"{rel}: no install link matching {pattern.pattern!r}"
         found[rel] = match.group(1)
     return found

--- a/tests/unit/test_llms_install.py
+++ b/tests/unit/test_llms_install.py
@@ -11,7 +11,7 @@ import re
 from pathlib import Path
 
 _ROOT = Path(__file__).resolve().parents[2]
-_GUIDE = (_ROOT / "llms-install.md").read_text()
+_GUIDE = (_ROOT / "llms-install.md").read_text(encoding="utf-8")
 
 
 def test_the_config_block_is_valid_json_and_wires_the_real_command() -> None:
@@ -31,7 +31,7 @@ def test_guide_names_the_real_cli_and_demo_flags() -> None:
     # The demo commands it advertises must be the ones the CLI exposes.
     from mcpg import __main__
 
-    source = Path(__main__.__file__).read_text()
+    source = Path(__main__.__file__).read_text(encoding="utf-8")
     assert '"--demo"' in source and '"--demo-drop"' in source
     assert "mcpg --demo" in _GUIDE
     assert "mcpg --demo-drop" in _GUIDE
@@ -45,3 +45,10 @@ def test_guide_keeps_the_safe_default_posture() -> None:
     # gated behind an explicit user request, never the default recipe.
     if "unrestricted" in lowered:
         assert "explicitly" in lowered
+    # Two safety constraints the recipe must keep telling the agent, or
+    # an autonomous install silently loses them: never fabricate creds,
+    # and remote hosts need TLS. (Strip markdown emphasis so the phrase
+    # match doesn't hinge on **bold** markers.)
+    plain = lowered.replace("*", "")
+    assert "sslmode=require" in plain
+    assert "credential" in plain and ("do not invent" in plain or "hard-code" in plain)

--- a/tests/unit/test_llms_install.py
+++ b/tests/unit/test_llms_install.py
@@ -1,0 +1,47 @@
+"""Sanity checks for the Cline agent-install guide (llms-install.md).
+
+Cline (and similar agents) read llms-install.md to configure MCPg
+autonomously. If the recipe drifts from what MCPg actually accepts, an
+agent following it produces a broken config — and, unlike a human
+reader, it won't notice. These tests pin the load-bearing facts.
+"""
+
+import json
+import re
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[2]
+_GUIDE = (_ROOT / "llms-install.md").read_text()
+
+
+def test_the_config_block_is_valid_json_and_wires_the_real_command() -> None:
+    # Pull the mcpServers JSON block out of the guide and parse it.
+    block = re.search(r"```json\n(\{.*?\"mcpServers\".*?\})\n```", _GUIDE, re.DOTALL)
+    assert block, "llms-install.md must contain a fenced mcpServers JSON block"
+    config = json.loads(block.group(1))
+
+    server = config["mcpServers"]["mcpg"]
+    assert server["command"] == "uvx"
+    assert server["args"] == ["mcpg"]
+    # The one env var MCPg actually requires to start.
+    assert "MCPG_DATABASE_URL" in server["env"]
+
+
+def test_guide_names_the_real_cli_and_demo_flags() -> None:
+    # The demo commands it advertises must be the ones the CLI exposes.
+    from mcpg import __main__
+
+    source = Path(__main__.__file__).read_text()
+    assert '"--demo"' in source and '"--demo-drop"' in source
+    assert "mcpg --demo" in _GUIDE
+    assert "mcpg --demo-drop" in _GUIDE
+
+
+def test_guide_keeps_the_safe_default_posture() -> None:
+    # It must not instruct the agent to open write/DDL gates by default.
+    lowered = _GUIDE.lower()
+    assert "read-only" in lowered
+    # If it mentions the unrestricted escalation at all, it must be
+    # gated behind an explicit user request, never the default recipe.
+    if "unrestricted" in lowered:
+        assert "explicitly" in lowered

--- a/tests/unit/test_mcpb_bundle.py
+++ b/tests/unit/test_mcpb_bundle.py
@@ -24,9 +24,9 @@ def test_sync_version_patches_every_pin(tmp_path: Path) -> None:
 
     sync(scratch, "9.9.9")
 
-    manifest = json.loads((scratch / "manifest.json").read_text())
+    manifest = json.loads((scratch / "manifest.json").read_text(encoding="utf-8"))
     assert manifest["version"] == "9.9.9"
-    pyproject = (scratch / "pyproject.toml").read_text()
+    pyproject = (scratch / "pyproject.toml").read_text(encoding="utf-8")
     assert 'version = "9.9.9"' in pyproject
     assert '"mcpg==9.9.9"' in pyproject
     # No stale pin of any other version survives.
@@ -34,7 +34,7 @@ def test_sync_version_patches_every_pin(tmp_path: Path) -> None:
 
 
 def test_manifest_invariants() -> None:
-    manifest = json.loads((_BUNDLE_DIR / "manifest.json").read_text())
+    manifest = json.loads((_BUNDLE_DIR / "manifest.json").read_text(encoding="utf-8"))
 
     # uv server type is what keeps the bundle tiny and cross-platform.
     assert manifest["server"]["type"] == "uv"
@@ -77,7 +77,7 @@ def test_bundle_pyproject_pins_the_current_release() -> None:
     """
     from mcpg import __version__
 
-    pyproject = (_BUNDLE_DIR / "pyproject.toml").read_text()
+    pyproject = (_BUNDLE_DIR / "pyproject.toml").read_text(encoding="utf-8")
     assert f"mcpg=={__version__}" in pyproject
-    manifest = json.loads((_BUNDLE_DIR / "manifest.json").read_text())
+    manifest = json.loads((_BUNDLE_DIR / "manifest.json").read_text(encoding="utf-8"))
     assert manifest["version"] == __version__


### PR DESCRIPTION
## Summary

Cline (and similar agents) read **`llms-install.md`**, falling back to `README.md`, to configure an MCP server autonomously. Our README documents many install paths (PyPI, Docker, `.mcpb`, 14 clients) — great for humans, but it can send an install agent down the wrong branch. This file gives Cline **one unambiguous recipe**:

1. Check `uv` is available (with install commands per-OS).
2. Get the connection URL from the user — including the "remote needs `?sslmode=require`" rule, and "no DB? seed the demo" fallback. Explicitly tells the agent **not** to invent credentials.
3. Write the `mcpServers` block (`uvx mcpg` + `MCPG_DATABASE_URL`).
4. Verify via `list_schemas`, with a short troubleshooting list.
5. Optionally seed the demo dataset.

Read-only by default throughout — it never opens write/DDL/shell gates unless the user explicitly asks.

This is exactly the "optional file to help with complex setups" [Cline's marketplace docs recommend](https://github.com/cline/mcp-marketplace), and it directly strengthens the pending marketplace submission (the reviewer tests that Cline can install from the docs alone).

## Test plan

- [x] `tests/unit/test_llms_install.py` pins the load-bearing facts so the recipe can't silently drift: the JSON config block parses and wires `uvx mcpg` + `MCPG_DATABASE_URL`; the `--demo` / `--demo-drop` flags it advertises actually exist in `mcpg.__main__`; and it keeps the safe-default posture (any mention of `unrestricted` must be gated behind an explicit user request). 3/3 pass.
- [x] `ruff format --check` / `ruff check` clean; docs-only otherwise.
- [x] Linked from the integrations guide's Cline section.


---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Add an AI-agent-focused installation guide for MCPg and link it from the Cline integration docs, ensuring agents can autonomously configure the server safely in read-only mode.

Documentation:
- Introduce llms-install.md as the canonical, agent-targeted installation recipe for configuring MCPg with Cline and similar coding agents.
- Update the Cline integration section to describe autonomous MCPg setup via llms-install.md while retaining manual configuration instructions.

Tests:
- Add unit tests that validate the JSON config snippet in llms-install.md, confirm the documented demo CLI flags exist, and enforce that the guide maintains a safe read-only default posture.