### PR TITLE
server.json: current, specific description for registry-driven listings

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.devopam/mcpg",
-  "version": "0.6.5",
-  "description": "A production-grade PostgreSQL Model Context Protocol (MCP) server.",
+  "version": "0.6.8",
+  "description": "Production-grade PostgreSQL MCP server \u2014 252 tools for query, tuning & ops, read-only by default.",
   "repository": {
     "url": "https://github.com/devopam/MCPg",
     "source": "github"
@@ -12,7 +12,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "mcpg",
-      "version": "0.6.5",
+      "version": "0.6.8",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary

While prepping the PulseMCP submission I found MCPg is *already* listed there — but with a stale **"100+ tools"** blurb (we're at 252). PulseMCP and similar directories (Glama, etc.) ingest their listing text from the **official MCP registry**, whose source is our `server.json` `description`. Ours was a generic one-liner (`"A production-grade PostgreSQL Model Context Protocol (MCP) server."`) that doesn't convey the tool count or the safety posture.

Replaced it with a current, differentiated description within the registry's **100-char limit** (verified against the schema):

> `Production-grade PostgreSQL MCP server — 252 tools for query, tuning & ops, read-only by default.` (97 chars)

Also bumped the checked-in `version` to `0.6.8` to match reality. The publish workflow re-syncs `version` (only) from the release tag at publish time and leaves `description` alone (verified), so this new description propagates to the registry — and downstream to PulseMCP — on the next release.

For an *immediate* PulseMCP refresh (not gated on a release), a note to `hello@pulsemcp.com` is the direct path — that's the manual step on my side.

## Test plan

- [x] `server.json` re-parses as valid JSON; description confirmed ≤100 chars against the `2025-12-11` registry schema (`ServerDetail.description.maxLength = 100`).
- [x] Confirmed the publish workflow's sync step patches only `version` / `packages[].version`, not `description`.


---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Update MCP server metadata to reflect current capabilities and version for registry-driven listings.

New Features:
- Provide a specific, registry-compliant server description highlighting tool count and default read-only posture.

Enhancements:
- Align the checked-in server version in server.json with the current release version so registry data stays accurate.