### PR TITLE
Automate Smithery publishing + document the full registry-listing map

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -285,3 +285,39 @@ jobs:
           # Skip the buildkit provenance attestation so the package page
           # shows a single clean manifest rather than an unknown/unknown pair.
           provenance: false
+
+  publish-smithery:
+    name: Publish → Smithery
+    # Opt-in: inert until the maintainer adds a SMITHERY_API_KEY repo
+    # secret. Smithery lists MCPg as a local stdio server that launches
+    # via `uvx mcpg`, so the listing already tracks the latest PyPI
+    # release regardless — re-publishing here keeps the listing's
+    # declared version/metadata current with each release. Non-gating.
+    needs: publish-pypi
+    if: ${{ vars.PUBLISH_SMITHERY == 'true' }}
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+      - name: Build the Smithery bundle
+        # Smithery's bundle parser doesn't understand the canonical
+        # bundle's `uv` server type, so we derive a python/uvx variant
+        # from the same source of truth (packaging/mcpb) — see
+        # packaging/smithery/build.py. Sync the version first, exactly
+        # like the .mcpb and server.json steps.
+        run: |
+          VER="${GITHUB_REF_NAME#v}"
+          python packaging/mcpb/sync_version.py "$VER"
+          python packaging/smithery/build.py smithery-bundle
+          npx --yes @anthropic-ai/mcpb validate smithery-bundle/manifest.json
+          npx --yes @anthropic-ai/mcpb pack smithery-bundle "mcpg-${VER}-smithery.mcpb"
+      - name: Publish to Smithery
+        env:
+          SMITHERY_API_KEY: ${{ secrets.SMITHERY_API_KEY }}
+        run: |
+          VER="${GITHUB_REF_NAME#v}"
+          npx --yes @smithery/cli@latest namespace use devopam
+          npx --yes @smithery/cli@latest mcp publish "mcpg-${VER}-smithery.mcpb" -n devopam/mcpg

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -662,8 +662,8 @@ release that changes the tool surface or the `.mcpb` in a way worth
 re-listing:
 
 1. Grab the new `mcpg-<version>.mcpb` from the GitHub release.
-2. Re-submit via the desktop-extension form
-   (`https://clau.de/desktop-extention-submission`).
+2. Re-submit via the desktop-extension form linked from the
+   [connectors submission docs](https://claude.com/docs/connectors/building/submission).
 3. Track status in Claude's submissions dashboard; escalate to
    `mcp-review@anthropic.com` if stuck.
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -606,6 +606,73 @@ If the workflow already started, cancel it from **Actions → publish.yml
 
 ---
 
+## 8b. Registry & directory listings
+
+Where MCPg is listed, and what a release does to each — so nothing is
+silently stale and the few manual steps aren't forgotten. **Most of
+this is automatic**; the publish workflow fans a tagged release out to
+every machine-updatable surface.
+
+| Listing | Update mechanism | Per-release action |
+|---|---|---|
+| **PyPI** | `publish-pypi` job (OIDC, maintainer-gated) | Automatic |
+| **GHCR** (`ghcr.io/devopam/mcpg`) | `publish-ghcr` job | Automatic |
+| **GitHub Releases** (+ `.mcpb` asset) | `github-release` job | Automatic |
+| **Official MCP Registry** | `publish-mcp-registry` job (`server.json`, version-synced) | Automatic |
+| **PulseMCP** | Ingests the MCP Registry daily | Automatic (transitive) |
+| **mcp.so / mcpservers.org / Glama** | Scrape GitHub + the registry | Automatic (transitive) |
+| **Smithery** (`devopam/mcpg`) | `publish-smithery` job (opt-in) | Automatic *once enabled* — see below |
+| **Claude connectors directory** | Review portal, no API | **Manual** — see below |
+
+### Copy that lives in `server.json` (drives the registry-fed listings)
+
+The MCP Registry — and everything that ingests it (PulseMCP, aggregators)
+— sources its blurb from `server.json`'s `description` (≤100 chars,
+enforced by the registry schema). It is **not** auto-generated, so when
+the tool count or positioning changes, edit `server.json` and it
+propagates on the next release.
+
+### Enabling the Smithery auto-publish
+
+The `publish-smithery` job is inert until you switch it on:
+
+1. Create a Smithery API key at **smithery.ai** → account → API Keys.
+2. Add it as a repo **secret** named `SMITHERY_API_KEY`
+   (`Settings → Secrets and variables → Actions → Secrets`).
+3. Add a repo **variable** `PUBLISH_SMITHERY` = `true`
+   (same page → Variables).
+
+The job derives a Smithery-compatible bundle from `packaging/mcpb` via
+`packaging/smithery/build.py` (Smithery doesn't understand the canonical
+bundle's `uv` server type, so the variant uses `python` + a direct
+`uvx mcpg` launch) and publishes it. Because the listing launches
+`uvx mcpg` (always latest), it already tracks PyPI between releases —
+the job just keeps the declared version and metadata current.
+
+> **First-time Smithery listing** is done by hand (`smithery mcp publish`);
+> the job maintains it thereafter. The listing's **description and icon**
+> aren't set by bundle-publish — set those once in Smithery's web
+> server-card settings (they persist across re-publishes).
+
+### The one genuinely manual listing: Claude connectors directory
+
+The Claude directory is a **reviewed** submission portal with no
+publish API, so releases can't push to it automatically. After a
+release that changes the tool surface or the `.mcpb` in a way worth
+re-listing:
+
+1. Grab the new `mcpg-<version>.mcpb` from the GitHub release.
+2. Re-submit via the desktop-extension form
+   (`https://clau.de/desktop-extention-submission`).
+3. Track status in Claude's submissions dashboard; escalate to
+   `mcp-review@anthropic.com` if stuck.
+
+Because the bundle installs `mcpg` from PyPI (always the pinned release
+at install time), a listed extension keeps working across patch
+releases without re-submission — re-submit only for material changes.
+
+---
+
 ## 9. Recurring chores
 
 Quarterly housekeeping items that don't block a release but keep the
@@ -621,6 +688,9 @@ publishing surface healthy:
   — make sure the only owner is the maintainer's account.
 - **Re-run `pip-audit`** on the last shipped requirements set; if a
   CVE has landed since release, cut a patch.
+- **Rotate the `SMITHERY_API_KEY`** secret if it's ever been exposed
+  (e.g. pasted into a chat/issue); regenerate at smithery.ai and update
+  the repo secret.
 
 ---
 

--- a/packaging/smithery/build.py
+++ b/packaging/smithery/build.py
@@ -1,0 +1,78 @@
+"""Derive a Smithery-publishable bundle from the canonical MCPB bundle.
+
+Smithery's `mcp publish` accepts an ``.mcpb`` but its parser only knows
+the older MCPB runtimes (``python`` / ``node`` / ``binary``) — it does
+**not** recognise the ``uv`` server type our canonical Claude Desktop
+bundle uses. Rather than maintain a second hand-written manifest (which
+would drift), this transforms the one source of truth
+(``packaging/mcpb``) into a Smithery-compatible variant:
+
+- ``server.type: "uv"`` → ``"python"`` (a runtime Smithery understands;
+  MCPg *is* a Python package, so the label is honest).
+- ``server.mcp_config`` → launch via ``uvx mcpg`` directly. This is the
+  right local-launch form for Smithery's registry (no bundle unpack
+  needed), and because ``uvx mcpg`` always resolves the latest published
+  release, the Smithery listing tracks PyPI without a per-release
+  re-publish being strictly required.
+
+Everything else — name, version, ``user_config`` (which Smithery turns
+into the connection config schema), icon, privacy policies — is carried
+across unchanged. The version is expected to already be synced into
+``packaging/mcpb`` (via ``sync_version.py``) before this runs.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_CANONICAL = _HERE.parent / "mcpb"
+
+
+def smithery_manifest(canonical: dict) -> dict:
+    """Transform the canonical MCPB manifest into a Smithery-compatible one.
+
+    Pure and deterministic — the whole point is that this is testable
+    without a network or the packing toolchain.
+    """
+    manifest = json.loads(json.dumps(canonical))  # deep copy
+    server = manifest["server"]
+    server["type"] = "python"
+    server["mcp_config"] = {
+        "command": "uvx",
+        "args": ["mcpg"],
+        "env": {
+            "MCPG_DATABASE_URL": "${user_config.database_url}",
+            "MCPG_ACCESS_MODE": "${user_config.access_mode}",
+        },
+    }
+    return manifest
+
+
+def build(out_dir: Path) -> Path:
+    """Assemble a ready-to-pack Smithery bundle directory.
+
+    Copies the canonical bundle's payload (server sources, icon,
+    pyproject) and writes the transformed manifest over it. Returns the
+    output directory so the caller can ``mcpb pack`` it.
+    """
+    if out_dir.exists():
+        shutil.rmtree(out_dir)
+    shutil.copytree(_CANONICAL, out_dir, ignore=shutil.ignore_patterns("__pycache__"))
+
+    canonical = json.loads((_CANONICAL / "manifest.json").read_text(encoding="utf-8"))
+    (out_dir / "manifest.json").write_text(
+        json.dumps(smithery_manifest(canonical), indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return out_dir
+
+
+if __name__ == "__main__":
+    target = Path(sys.argv[1]) if len(sys.argv) > 1 else _HERE / "build"
+    result = build(target)
+    version = json.loads((result / "manifest.json").read_text(encoding="utf-8"))["version"]
+    print(f"Built Smithery bundle dir at {result} (mcpg {version})")

--- a/tests/unit/test_smithery_build.py
+++ b/tests/unit/test_smithery_build.py
@@ -61,3 +61,17 @@ def test_build_assembles_a_complete_bundle_dir(tmp_path: Path) -> None:
     assert (out / manifest["icon"]).is_file()
     assert (out / manifest["server"]["entry_point"]).is_file()
     assert (out / "pyproject.toml").is_file()
+
+
+def test_build_clears_stale_files_from_an_existing_target(tmp_path: Path) -> None:
+    # build() rebuilds from scratch, so a prior run's leftovers (e.g. a
+    # renamed icon) must not survive into the packed bundle.
+    target = tmp_path / "smithery"
+    target.mkdir()
+    stale = target / "leftover-from-a-previous-build.txt"
+    stale.write_text("stale", encoding="utf-8")
+
+    out = build(target)
+
+    assert not stale.exists()
+    assert (out / "manifest.json").is_file()

--- a/tests/unit/test_smithery_build.py
+++ b/tests/unit/test_smithery_build.py
@@ -1,0 +1,63 @@
+"""Tests for the Smithery bundle transform (packaging/smithery/build.py).
+
+The Smithery listing is derived from the canonical MCPB bundle by a
+pure transform. These pin the transform's contract so the derived
+bundle can't silently stop being Smithery-publishable (wrong runtime
+type) or lose the config schema Smithery builds from ``user_config``.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_ROOT / "packaging" / "smithery"))
+from build import build, smithery_manifest  # noqa: E402
+
+_CANONICAL = json.loads((_ROOT / "packaging" / "mcpb" / "manifest.json").read_text(encoding="utf-8"))
+
+
+def test_transform_uses_a_runtime_smithery_recognises() -> None:
+    # Smithery's bundle parser only accepts python/node/binary — never
+    # the canonical bundle's "uv" type. This is the whole reason the
+    # transform exists.
+    assert _CANONICAL["server"]["type"] == "uv"  # guards the premise
+    out = smithery_manifest(_CANONICAL)
+    assert out["server"]["type"] == "python"
+
+
+def test_transform_launches_via_uvx_mcpg() -> None:
+    out = smithery_manifest(_CANONICAL)
+    cfg = out["server"]["mcp_config"]
+    assert cfg["command"] == "uvx"
+    assert cfg["args"] == ["mcpg"]
+    # The connection URL + access mode must still flow from user_config.
+    assert cfg["env"]["MCPG_DATABASE_URL"] == "${user_config.database_url}"
+    assert cfg["env"]["MCPG_ACCESS_MODE"] == "${user_config.access_mode}"
+
+
+def test_transform_preserves_the_listing_metadata() -> None:
+    out = smithery_manifest(_CANONICAL)
+    # Version, config schema source, icon, and privacy policy must carry
+    # across unchanged — Smithery builds the config schema from
+    # user_config and the directory-style metadata from the rest.
+    assert out["version"] == _CANONICAL["version"]
+    assert out["user_config"] == _CANONICAL["user_config"]
+    assert out["icon"] == _CANONICAL["icon"]
+    assert out["privacy_policies"] == _CANONICAL["privacy_policies"]
+
+
+def test_transform_does_not_mutate_the_canonical_manifest() -> None:
+    before = json.dumps(_CANONICAL, sort_keys=True)
+    smithery_manifest(_CANONICAL)
+    assert json.dumps(_CANONICAL, sort_keys=True) == before
+
+
+def test_build_assembles_a_complete_bundle_dir(tmp_path: Path) -> None:
+    out = build(tmp_path / "smithery")
+    manifest = json.loads((out / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["server"]["type"] == "python"
+    # Payload the packer needs must be present.
+    assert (out / manifest["icon"]).is_file()
+    assert (out / manifest["server"]["entry_point"]).is_file()
+    assert (out / "pyproject.toml").is_file()


### PR DESCRIPTION
## Summary

Answers "how do we auto-update the registries on each release?" — with the honest finding that **most of it already is**:

| Listing | Mechanism | Status |
|---|---|---|
| PyPI, GHCR, GitHub Release + `.mcpb`, MCP Registry | existing `publish.yml` jobs | ✅ automatic |
| PulseMCP, mcp.so, mcpservers.org, Glama | ingest the MCP Registry / scrape GitHub | ✅ automatic (transitive) |
| **Smithery** | published by hand until now | ⬆️ **automated in this PR** |
| **Claude connectors directory** | reviewed portal, no publish API | 📝 documented as manual |

### Smithery automation

- **`packaging/smithery/build.py`** — derives a Smithery-publishable bundle from the canonical `packaging/mcpb` via a pure, tested transform. Smithery's parser doesn't understand MCPB's newer `uv` server type, so the variant uses `python` + a direct `uvx mcpg` launch (the correct local-launch form for Smithery's registry, and version-independent since `uvx` always resolves the latest PyPI release). Single source of truth — no second hand-maintained manifest to drift.
- **`publish-smithery` job** — opt-in and inert until enabled: gated on a `PUBLISH_SMITHERY` repo variable + `SMITHERY_API_KEY` secret, `needs: publish-pypi`, `continue-on-error`. Syncs version, builds+packs the variant, publishes to `devopam/mcpg`.
- The listing was created by hand this session (`devopam/mcpg` is live); this job **maintains** it going forward.

### Docs

`docs/release-process.md` gains a **"Registry & directory listings"** section: the full auto-vs-manual table, how `server.json`'s description drives the registry-fed blurbs, exact steps to enable the Smithery job, and the one genuinely manual listing (Claude directory re-submission — only needed for material changes, since the `.mcpb` installs the pinned PyPI release at install time). Plus a recurring chore to rotate the Smithery key if exposed.

## Test plan

- [x] `tests/unit/test_smithery_build.py` (5 tests): transform emits a Smithery-recognised runtime, launches via `uvx mcpg`, preserves the `user_config`-derived config schema + icon + privacy policies + version, doesn't mutate the canonical manifest, and `build()` assembles a complete packable dir.
- [x] Ran `build.py` end-to-end: output validates with the official `mcpb validate`.
- [x] Verified the real publish path this session — `devopam/mcpg` is live on Smithery (local stdio, correct config schema).
- [x] `ruff format --check` / `ruff check` clean; `publish.yml` YAML-validated (8 jobs).


---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Automate publishing of a Smithery-compatible bundle as part of the release workflow and document how all registry and directory listings are kept up to date.

New Features:
- Add a Smithery-specific bundle build script that derives a compatible manifest from the canonical MCPB bundle.
- Introduce an opt-in GitHub Actions job to build, validate, package, and publish the Smithery bundle on release.

Enhancements:
- Document all registry and directory listings, clarifying which are auto-updated vs manual and how server.json drives registry-fed descriptions.
- Add guidance and a recurring chore for managing and rotating the Smithery API key.

Tests:
- Add unit tests to pin the Smithery bundle transform behavior and ensure the derived bundle remains valid and complete.