### PR TITLE
README: correct the headline tool count (240 → 252)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **A production-grade [Model Context Protocol](https://modelcontextprotocol.io)
 server for PostgreSQL.** Lets AI agents safely inspect, query, operate, and
-tune a Postgres database — over 240 tools spanning catalog introspection,
+tune a Postgres database — 252 tools spanning catalog introspection,
 query intelligence, natural-language SQL, structural diffs, hybrid search,
 graph queries, data movement, live ops, and more.
 


### PR DESCRIPTION
## Summary

Finishing the Smithery setup surfaced a stale number: the Smithery listing auto-enriched its description from the repo README, whose **opening line still said "over 240 tools"** while every other surface says 252. One-line fix at the source — it corrects the Smithery listing (on next re-scrape), the GitHub landing page, and the PyPI long-description simultaneously.

Docs-only.


---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Documentation:
- Correct the headline tool count in the README from 240 to 252 to keep documentation consistent across surfaces.