### PR TITLE
Pages site hygiene: exclude packaging/, fix a mangled Liquid expression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,10 @@ htmlcov/
 coverage.xml
 .mypy_cache/
 .ruff_cache/
+
+# Local GitHub Pages / Jekyll build artifacts (the site builds on GitHub;
+# `_config.yml` is the only tracked Pages input).
+_site/
+.sass-cache/
+.jekyll-cache/
+.jekyll-metadata

--- a/_config.yml
+++ b/_config.yml
@@ -48,6 +48,7 @@ optional_front_matter:
 # IDE/CI cruft don't belong on the documentation surface.
 exclude:
   - .github/
+  - packaging/
   - .gitignore
   - .pre-commit-config.yaml
   - .ruff_cache/

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -497,7 +497,7 @@ jobs:
           path: dist/
       - name: Cut release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
         run: |
           VER="${GITHUB_REF_NAME#v}"
           # Pull the matching section out of CHANGELOG.md as the


### PR DESCRIPTION
## Summary

Two real issues found while investigating the Pages failure — **neither is the cause of the failure** (the build succeeds and produces the `github-pages` artifact; the `actions/deploy-pages` *deploy* step is what fails, which is a repo Pages-settings issue). These are just genuine hygiene fixes surfaced along the way:

- **`_config.yml`**: exclude `packaging/` from the published site. The MCPB/Smithery build tooling (manifests, `build.py`, etc.) was leaking onto the docs site. Verified excluded after the change.
- **`docs/release-process.md`**: `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` was being consumed by Jekyll's Liquid parser and rendered as a broken `GH_TOKEN: $`. Wrapped in `{% raw %}` — verified via a local `github-pages` Jekyll build that it now renders the literal expression with no raw-tag leak.

## Test plan

- [x] Reproduced GitHub's Jekyll build locally (`github-pages-232` gem): builds clean before and after; `packaging/` now absent from output; `GH_TOKEN` line renders `${{ secrets.GITHUB_TOKEN }}` literally.


---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Exclude build tooling from the published Pages site and fix a Liquid expression so the GitHub token reference renders literally in the release docs.

Bug Fixes:
- Prevent the GH_TOKEN line in release-process documentation from being mangled by Jekyll's Liquid parser by rendering the secrets expression literally.

Enhancements:
- Exclude the packaging/ directory from the Jekyll build output to keep internal build tooling off the public documentation site.

Documentation:
- Update release-process documentation so the example GH_TOKEN environment variable shows the literal ${{ secrets.GITHUB_TOKEN }} expression as intended.