### PR TITLE
Add deploy/ — one-command demo-endpoint hosting for Smithery scoring

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,73 @@
+# Hosting a public MCPg demo endpoint
+
+A small, **read-only** MCPg instance hosted at a public HTTPS URL,
+backed by a throwaway demo database. It exists so directories like
+**Smithery** can connect to score/route it, and it doubles as a
+"try MCPg live" endpoint. No real data is ever exposed — it points at
+a demo database and runs in `read-only` access mode.
+
+This uses the already-published GHCR image (`ghcr.io/devopam/mcpg`) —
+no bespoke build, no repo code changes.
+
+## 1. Provision + seed a demo database
+
+Any managed Postgres works; a free-tier [Neon](https://neon.tech)
+project is zero-maintenance and scales to zero. Once you have its
+connection string, seed the curated demo dataset **from your own
+machine** (the seeder needs direct Postgres access):
+
+```bash
+MCPG_DATABASE_URL="postgresql://…@…neon.tech/neondb?sslmode=require" \
+  uvx mcpg --demo
+```
+
+Optional hardening: create a dedicated read-only Postgres role for the
+hosted instance instead of the owner role. MCPg already enforces
+read-only at the app layer, so this is defence-in-depth, not required
+for a throwaway demo DB.
+
+## 2. Deploy the endpoint (Fly.io)
+
+[`fly.toml`](fly.toml) in this directory is ready to go. From a machine
+with [flyctl](https://fly.io/docs/flyctl/install/) installed:
+
+```bash
+cd deploy
+flyctl launch --no-deploy --copy-config --name mcpg-demo
+# Set the connection string as a SECRET (never committed):
+flyctl secrets set MCPG_DATABASE_URL="postgresql://…@…neon.tech/neondb?sslmode=require"
+flyctl deploy
+```
+
+Your endpoint is then `https://mcpg-demo.fly.dev/mcp`. (Railway,
+Render, or any container host works the same way — the only
+requirements are a public HTTPS URL and the two env vars.)
+
+Verify it's live:
+
+```bash
+curl -sS https://mcpg-demo.fly.dev/mcp -H "Accept: text/event-stream" | head
+```
+
+## 3. Register the URL with Smithery
+
+Add the hosted endpoint to the existing `devopam/mcpg` listing so
+Smithery scores it:
+
+```bash
+export SMITHERY_API_KEY="…"
+npx --yes @smithery/cli@latest mcp publish https://mcpg-demo.fly.dev/mcp -n devopam/mcpg
+```
+
+Smithery connects, runs its tool scan against the read-only demo data,
+and the listing gains its routing score.
+
+## Notes
+
+- **Read-only, public**: the instance serves only read tools against
+  demo data. Even so, treat the demo DB as disposable.
+- **Cost**: with `auto_stop_machines`, the instance idles to zero and
+  wakes on demand — a demo fits comfortably in free allowances.
+- **Local use is unaffected**: real users still install MCPg locally
+  (`uvx mcpg`) pointed at their own database, running next to it. This
+  hosted instance is purely for discovery/scoring + a live demo.

--- a/deploy/fly.toml
+++ b/deploy/fly.toml
@@ -1,0 +1,47 @@
+# Fly.io config for the public, read-only MCPg *demo* instance.
+#
+# Purpose: a hosted streamable-HTTP endpoint that Smithery (and anyone)
+# can connect to — it powers Smithery's routing score and doubles as a
+# "try MCPg live" demo. It runs the already-published GHCR image
+# pointed at a throwaway demo database, in read-only mode, so no real
+# data is ever exposed.
+#
+# Deploy:
+#   flyctl launch --no-deploy --copy-config --name mcpg-demo   # first time
+#   flyctl secrets set MCPG_DATABASE_URL="postgresql://.../neondb?sslmode=require"
+#   flyctl deploy
+#
+# The connection URL is a SECRET (never committed) — set it with
+# `flyctl secrets set`, not here.
+
+app = "mcpg-demo"
+primary_region = "iad"   # us-east; match your Neon region for low latency
+
+[build]
+  # The production image, unchanged — no bespoke build.
+  image = "ghcr.io/devopam/mcpg:latest"
+
+[env]
+  MCPG_TRANSPORT = "streamable-http"
+  MCPG_HTTP_HOST = "0.0.0.0"
+  MCPG_HTTP_PORT = "8000"
+  # Safe by default, and this is a public endpoint: read-only, hard.
+  MCPG_ACCESS_MODE = "read-only"
+
+[http_service]
+  internal_port = 8000
+  force_https = true
+  # Scale to zero when idle — the free allowance covers a demo that
+  # only wakes when Smithery scores it or someone tries it.
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+[[http_service.checks]]
+  # MCPg serves the MCP endpoint at /mcp; a GET there returns a
+  # protocol response once the server is up (and the DB is reachable).
+  method = "GET"
+  path = "/mcp"
+  interval = "30s"
+  timeout = "5s"
+  grace_period = "20s"


### PR DESCRIPTION
## Summary

Smithery's routing score needs a reachable HTTP endpoint (its scanner connects and enumerates tools). MCPg requires a live Postgres to start, so a hosted demo needs a database — this sets up a **read-only demo endpoint** that Smithery can score, which doubles as a live "try MCPg" URL.

**Why this approach over Smithery-hosted-container:** hosting the already-published **GHCR image** (`ghcr.io/devopam/mcpg`, serving streamable-http since v0.6.5) sidesteps two things I can't verify or test from CI: Smithery's container-build contract (docs behind auth) and any Dockerfile change (no Docker daemon to test with). The GHCR image is battle-tested and needs zero changes — a PaaS just maps HTTPS → its port 8000.

- **`deploy/fly.toml`**: runs `ghcr.io/devopam/mcpg:latest`, `MCPG_ACCESS_MODE=read-only` (it's a public endpoint), `internal_port = 8000`, `force_https`, and scale-to-zero so it idles within free allowances. The connection string is a **Fly secret**, never committed.
- **`deploy/README.md`**: the three steps — seed a free Neon demo DB (from the maintainer's machine; the seeder needs direct Postgres access, which CI/sandboxes can't do), `flyctl deploy`, then register the URL with Smithery (`mcp publish <url> -n devopam/mcpg`).

Entirely additive: no code changes, and local use is unaffected (users still run `mcpg` next to their own database).

## Test plan

- [x] `deploy/fly.toml` validated as TOML (app / image / port / read-only access mode parse correctly).
- [ ] Real deploy is the maintainer's step (needs a Fly account + the Neon demo DB); the endpoint + Smithery registration validate on first deploy.
- [x] `ruff format --check` clean; docs/config-only otherwise.


---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Add deployment configuration and documentation for hosting a public, read-only MCPg demo endpoint for Smithery scoring and live trials.

Deployment:
- Introduce Fly.io configuration for running the public, read-only MCPg demo container against a demo database, including HTTPS exposure and scale-to-zero settings.

Documentation:
- Document end-to-end steps for provisioning a demo Postgres database, deploying a hosted MCPg demo endpoint, and registering it with Smithery.