### PR TITLE
dependabot: drop labels that don't exist in the repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,12 @@
 #   - weekly schedule, Monday morning UTC (lines up with the start of
 #     the working week)
 #   - open-pull-requests-limit: 5 so a backlog can't flood
-#   - labels: "dependencies" + the ecosystem name for easy filtering
+#   - labels: "dependencies" (the only label auto-provisioned by
+#     GitHub). Per-ecosystem labels were dropped because Dependabot
+#     warns when a referenced label doesn't exist in the repo, and
+#     the commit-message prefix already tags the ecosystem
+#     (chore(deps) / ci(deps) / build(deps)). To re-add ecosystem
+#     labels, first create them under Issues -> Labels, then list them here.
 #   - commit-message prefix matches Conventional Commits so the
 #     changelog rollup picks them up cleanly
 #   - groups for related updates (e.g. all Python minor/patch into one PR,
@@ -43,7 +48,6 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
-      - "python"
     commit-message:
       # `chore(deps): bump …` matches Conventional Commits so the
       # release rollup script picks them up under the right section.
@@ -70,7 +74,6 @@ updates:
     open-pull-requests-limit: 3
     labels:
       - "dependencies"
-      - "github-actions"
     commit-message:
       prefix: "ci(deps)"
       include: "scope"
@@ -95,7 +98,6 @@ updates:
     open-pull-requests-limit: 3
     labels:
       - "dependencies"
-      - "docker"
     commit-message:
       prefix: "build(deps)"
       include: "scope"
@@ -110,8 +112,6 @@ updates:
     open-pull-requests-limit: 3
     labels:
       - "dependencies"
-      - "docker"
-      - "ci"
     commit-message:
       prefix: "ci(deps)"
       include: "scope"


### PR DESCRIPTION
## Summary

Fixes the Dependabot warning *"The following labels could not be found: `python`. Please create it before Dependabot can add it to a pull request."*

Root cause: `.github/dependabot.yml` asked Dependabot to apply per-ecosystem labels (`python`, `github-actions`, `docker`, `ci`), but only **`dependencies`** exists in the repo (GitHub auto-provisions that one). Verified via the API — the other four are all missing, so the warning fires on *every* ecosystem, not just pip.

Reduced each ecosystem's `labels:` to just `dependencies` (which exists), killing the warning with **no manual step**. Dependabot still opened/merged the PRs fine — this only removes the noise. The ecosystem stays distinguishable via the commit-message prefix already configured (`chore(deps)` / `ci(deps)` / `build(deps)`).

**Alternative (not taken):** create the four labels under *Issues → Labels* to keep per-ecosystem filtering. The config comment now documents how to re-add them if you want that later — I couldn't create labels from here (no label-creation API access), so the self-healing config fix is the default.

## Test plan

- [x] `.github/dependabot.yml` re-parses as valid YAML; all 4 ecosystems now carry `labels: ["dependencies"]` only.
- [x] Confirmed via API that `dependencies` exists and `python`/`github-actions`/`docker`/`ci` do not.


---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Simplify Dependabot configuration to only use the auto-provisioned `dependencies` label and avoid warnings about missing labels.

Build:
- Update `.github/dependabot.yml` to remove non-existent per-ecosystem labels and rely on `dependencies` plus commit-message prefixes for differentiation.

Documentation:
- Clarify inline documentation in `dependabot.yml` about label usage, warning behavior when labels are missing, and how to reintroduce per-ecosystem labels if desired.