### PR TITLE
ci: migrate GitHub Pages to Actions workflow with concurrency control

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,65 @@
+name: Deploy Pages
+
+# Publishes the Jekyll site (README + docs/, per _config.yml) to GitHub
+# Pages. Replaces the legacy "Deploy from a branch" mechanism, which has
+# no concurrency control: rapid merges to main fire overlapping Pages
+# deployments and the superseded ones fail with "Deployment failed, try
+# again later" — red X's even though the newest deploy always wins and
+# the site stays current. The `concurrency` group below serialises
+# deploys so an in-flight one finishes before the next starts, ending
+# that lock-contention noise.
+#
+# Requires Settings → Pages → "Build and deployment" → Source set to
+# "GitHub Actions" (this workflow is the source; the branch-deploy
+# mechanism is retired).
+
+on:
+  push:
+    branches: [main]
+  # Lets you re-publish from the Actions tab without a content change.
+  workflow_dispatch:
+
+# The token scopes actions/deploy-pages needs.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Serialise Pages deployments. `cancel-in-progress: false` is the
+# GitHub-recommended setting for Pages — an in-flight deploy is allowed
+# to finish (cancelling a deploy mid-publish can leave Pages wedged);
+# the next run waits its turn instead of racing and failing.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build Jekyll site
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+      - name: Build with Jekyll
+        # Uses the same github-pages gem set the legacy build used, so
+        # the output is byte-for-byte what was publishing before —
+        # only the deploy path changes.
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./
+          destination: ./_site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## What

Replaces the legacy "Deploy from a branch" Pages mechanism with a proper GitHub Actions workflow (`.github/workflows/pages.yml`).

## Why

Our "pages build and deployment" has been failing red on the last few PRs. The diagnosis: the legacy branch-deploy has **no concurrency control**. Rapid merges to `main` fire overlapping Pages deployments, and the superseded ones fail with `Deployment failed, try again later` — even though the newest deploy always wins and the live site stays fully current (verified: `252 tools` present, `deploy/README` reachable, `packaging/` correctly 404).

So the red X's are lock-contention noise, not a broken site.

## Fix

The new workflow serialises deploys via a `pages` concurrency group with `cancel-in-progress: false` — the GitHub-recommended setting for Pages (an in-flight deploy is allowed to finish rather than being cancelled mid-publish). Queued runs wait their turn instead of racing and failing.

Build output is unchanged — same `jekyll-build-pages` gem set the branch mechanism used; only the deploy path moves.

## ⚠️ Required coordinating setting

For this workflow to become the deploy source, **Settings → Pages → "Build and deployment" → Source must be switched from "Deploy from a branch" to "GitHub Actions."** Only a repo admin can flip this. Until it's flipped, this workflow will build but not publish, and the legacy mechanism stays live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

CI:
- Add a GitHub Actions workflow to build and deploy the Jekyll-based site to GitHub Pages on pushes to main and manual dispatch, with appropriate permissions and concurrency settings.