### PR TITLE
fix: pin selector event loop for the HTTP transport on Windows

### DIFF
--- a/src/mcpg/http_runtime.py
+++ b/src/mcpg/http_runtime.py
@@ -25,6 +25,7 @@ import asyncio
 import hmac
 import json
 import logging
+import sys
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, cast
 
@@ -631,6 +632,17 @@ def run_http(server: object, settings: Settings, *, kind: str) -> None:
 
     app = build_http_app(server, settings, kind=kind)
     tls_kwargs = _uvicorn_tls_kwargs(settings, ssl_module=ssl)
+    # Windows: async psycopg refuses to run on the ProactorEventLoop and
+    # needs a SelectorEventLoop. ``__main__`` sets the selector policy at
+    # startup, but uvicorn's own loop setup reinstalls the *proactor*
+    # policy on Windows before serving — which would silently break every
+    # database connection under the HTTP transport (stdio is unaffected,
+    # nothing overrides the policy there). Re-pin the selector policy here
+    # and tell uvicorn to leave the loop alone (``loop="none"``) so it
+    # runs on the loop our policy creates. No-op off Windows.
+    if sys.platform == "win32":
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+        tls_kwargs["loop"] = "none"
     # mypy can't reason about ``**dict[str, object]`` against the
     # large, overloaded ``uvicorn.run`` signature; the dict's contents
     # are already constrained by ``_uvicorn_tls_kwargs``.

--- a/tests/unit/test_http_runtime.py
+++ b/tests/unit/test_http_runtime.py
@@ -835,6 +835,76 @@ def test_run_http_builds_app_and_serves_via_uvicorn(monkeypatch: pytest.MonkeyPa
     assert captured["app"] is not None
 
 
+def test_run_http_pins_selector_loop_on_windows(monkeypatch: pytest.MonkeyPatch) -> None:
+    # async psycopg dies on the ProactorEventLoop; uvicorn reinstalls the
+    # proactor policy on Windows, so run_http must re-pin the selector
+    # policy and tell uvicorn to leave the loop alone (loop="none").
+    import asyncio
+
+    from mcpg import http_runtime
+
+    settings = load_settings({"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db"})
+
+    captured_kwargs: dict[str, object] = {}
+
+    def _fake_run(app: object, *, host: str, port: int, **kwargs: object) -> None:
+        captured_kwargs.update(kwargs)
+
+    class _FakeSelectorPolicy:
+        pass
+
+    policy_calls: list[object] = []
+
+    import uvicorn
+
+    monkeypatch.setattr(uvicorn, "run", _fake_run)
+    monkeypatch.setattr(http_runtime.sys, "platform", "win32")
+    # WindowsSelectorEventLoopPolicy doesn't exist off Windows — provide it
+    # so the win32 branch can be exercised on a Linux CI runner.
+    monkeypatch.setattr(asyncio, "WindowsSelectorEventLoopPolicy", _FakeSelectorPolicy, raising=False)
+    monkeypatch.setattr(asyncio, "set_event_loop_policy", lambda policy: policy_calls.append(policy))
+
+    class _Stub:
+        def streamable_http_app(self) -> Starlette:
+            return _bare_app()
+
+    http_runtime.run_http(_Stub(), settings, kind="streamable-http")
+
+    assert captured_kwargs.get("loop") == "none"
+    assert len(policy_calls) == 1
+    assert isinstance(policy_calls[0], _FakeSelectorPolicy)
+
+
+def test_run_http_leaves_the_event_loop_alone_off_windows(monkeypatch: pytest.MonkeyPatch) -> None:
+    import asyncio
+
+    from mcpg import http_runtime
+
+    settings = load_settings({"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db"})
+
+    captured_kwargs: dict[str, object] = {}
+
+    def _fake_run(app: object, *, host: str, port: int, **kwargs: object) -> None:
+        captured_kwargs.update(kwargs)
+
+    policy_calls: list[object] = []
+
+    import uvicorn
+
+    monkeypatch.setattr(uvicorn, "run", _fake_run)
+    monkeypatch.setattr(http_runtime.sys, "platform", "linux")
+    monkeypatch.setattr(asyncio, "set_event_loop_policy", lambda policy: policy_calls.append(policy))
+
+    class _Stub:
+        def streamable_http_app(self) -> Starlette:
+            return _bare_app()
+
+    http_runtime.run_http(_Stub(), settings, kind="streamable-http")
+
+    assert "loop" not in captured_kwargs
+    assert policy_calls == []
+
+
 # --- request timeout middleware -------------------------------------------
 
 


### PR DESCRIPTION
Closing — we're dropping the hosted-demo direction entirely, so the Windows HTTP-transport path is no longer on the critical path (MCPg is used as a local stdio server, which already works on Windows).

Note for the record: the underlying bug is real — running MCPg with `MCPG_TRANSPORT=streamable-http` on Windows fails because uvicorn reinstalls the ProactorEventLoop, which async psycopg rejects. If HTTP-on-Windows is ever needed, the fix is a one-liner in `run_http` (re-pin `WindowsSelectorEventLoopPolicy` + uvicorn `loop="none"`). Shelved intentionally, not forgotten.