### PR TITLE
fix: connect to Postgres from the HTTP transport on Windows (selector event loop)

### DIFF
--- a/src/mcpg/http_runtime.py
+++ b/src/mcpg/http_runtime.py
@@ -25,6 +25,7 @@ import asyncio
 import hmac
 import json
 import logging
+import sys
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, cast
 
@@ -631,6 +632,18 @@ def run_http(server: object, settings: Settings, *, kind: str) -> None:
 
     app = build_http_app(server, settings, kind=kind)
     tls_kwargs = _uvicorn_tls_kwargs(settings, ssl_module=ssl)
+    # Windows: async psycopg refuses to run on the ProactorEventLoop and
+    # needs a SelectorEventLoop. ``__main__`` sets the selector policy at
+    # startup, but uvicorn's own loop setup reinstalls the *proactor*
+    # policy on Windows before serving — which silently breaks every
+    # database connection under the HTTP transport (the connection pool
+    # times out after 30s and the session crashes). stdio is unaffected;
+    # nothing overrides the policy there. Re-pin the selector policy and
+    # tell uvicorn to leave the loop alone (``loop="none"``) so it runs on
+    # the loop our policy creates. No-op off Windows.
+    if sys.platform == "win32":
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+        tls_kwargs["loop"] = "none"
     # mypy can't reason about ``**dict[str, object]`` against the
     # large, overloaded ``uvicorn.run`` signature; the dict's contents
     # are already constrained by ``_uvicorn_tls_kwargs``.

--- a/tests/unit/test_http_runtime.py
+++ b/tests/unit/test_http_runtime.py
@@ -835,6 +835,80 @@ def test_run_http_builds_app_and_serves_via_uvicorn(monkeypatch: pytest.MonkeyPa
     assert captured["app"] is not None
 
 
+def test_run_http_pins_selector_loop_on_windows(monkeypatch: pytest.MonkeyPatch) -> None:
+    # async psycopg dies on the ProactorEventLoop; uvicorn reinstalls the
+    # proactor policy on Windows, so run_http must re-pin the selector
+    # policy and tell uvicorn to leave the loop alone (loop="none").
+    import asyncio
+
+    from mcpg import http_runtime
+
+    settings = load_settings({"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db"})
+
+    captured_kwargs: dict[str, object] = {}
+
+    def _fake_run(app: object, *, host: str, port: int, **kwargs: object) -> None:
+        captured_kwargs.update(kwargs)
+
+    class _FakeSelectorPolicy:
+        pass
+
+    policy_calls: list[object] = []
+
+    import uvicorn
+
+    monkeypatch.setattr(uvicorn, "run", _fake_run)
+    monkeypatch.setattr(http_runtime.sys, "platform", "win32")
+    # WindowsSelectorEventLoopPolicy doesn't exist off Windows. Inject it
+    # via __dict__ (dict subscript) rather than setattr — on Python 3.14
+    # even *reading* asyncio.WindowsSelectorEventLoopPolicy on Linux trips
+    # the module's __getattr__ with a NameError, which setattr's original-
+    # value save would hit. Direct __dict__ insertion avoids that path and
+    # is what attribute lookup resolves against anyway.
+    monkeypatch.setitem(asyncio.__dict__, "WindowsSelectorEventLoopPolicy", _FakeSelectorPolicy)
+    monkeypatch.setattr(asyncio, "set_event_loop_policy", lambda policy: policy_calls.append(policy))
+
+    class _Stub:
+        def streamable_http_app(self) -> Starlette:
+            return _bare_app()
+
+    http_runtime.run_http(_Stub(), settings, kind="streamable-http")
+
+    assert captured_kwargs.get("loop") == "none"
+    assert len(policy_calls) == 1
+    assert isinstance(policy_calls[0], _FakeSelectorPolicy)
+
+
+def test_run_http_leaves_the_event_loop_alone_off_windows(monkeypatch: pytest.MonkeyPatch) -> None:
+    import asyncio
+
+    from mcpg import http_runtime
+
+    settings = load_settings({"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db"})
+
+    captured_kwargs: dict[str, object] = {}
+
+    def _fake_run(app: object, *, host: str, port: int, **kwargs: object) -> None:
+        captured_kwargs.update(kwargs)
+
+    policy_calls: list[object] = []
+
+    import uvicorn
+
+    monkeypatch.setattr(uvicorn, "run", _fake_run)
+    monkeypatch.setattr(http_runtime.sys, "platform", "linux")
+    monkeypatch.setattr(asyncio, "set_event_loop_policy", lambda policy: policy_calls.append(policy))
+
+    class _Stub:
+        def streamable_http_app(self) -> Starlette:
+            return _bare_app()
+
+    http_runtime.run_http(_Stub(), settings, kind="streamable-http")
+
+    assert "loop" not in captured_kwargs
+    assert policy_calls == []
+
+
 # --- request timeout middleware -------------------------------------------
 
 


### PR DESCRIPTION
## Symptom

On Windows, running MCPg with `MCPG_TRANSPORT=streamable-http` (or `sse`) starts the server, but **the database never connects** — the first request logs, repeatedly:

```
Psycopg cannot use the 'ProactorEventLoop' to run in async mode.
Please use a compatible event loop … SelectorEventLoop …
```

…then the pool times out after 30s and the session crashes with `PoolTimeout: couldn't get a connection`. Reproduced live against a hosted Neon DB (with seed data) from a Windows host.

## Root cause

async psycopg only works on a `SelectorEventLoop`; Windows defaults asyncio to `ProactorEventLoop`. `__main__.py` already installs `WindowsSelectorEventLoopPolicy` at startup — which is why **stdio works on Windows**. But the HTTP transport serves via `uvicorn.run(...)`, and uvicorn's own loop setup **reinstalls the proactor policy on Windows** before serving, silently undoing ours. So only the HTTP path was broken.

## Fix

In `run_http`, on Windows only: re-pin `WindowsSelectorEventLoopPolicy` and pass uvicorn `loop="none"` so it serves on the loop our policy creates instead of installing its own. No-op off Windows (Linux/macOS default loops are already selector-based).

## Tests

- `test_run_http_pins_selector_loop_on_windows` — monkeypatches `sys.platform` to `win32` and asserts the selector policy is set and `loop="none"` reaches uvicorn.
- `test_run_http_leaves_the_event_loop_alone_off_windows` — asserts no policy change and no `loop` kwarg elsewhere.

The Windows test injects the Windows-only `WindowsSelectorEventLoopPolicy` via `asyncio.__dict__` rather than `setattr`: on **Python 3.14** even *reading* that attribute on Linux trips asyncio's module `__getattr__` with `NameError: name 'windows_events' is not defined`, which `setattr`'s original-value save would hit. A dict subscript sidesteps that path entirely — verified by simulating the 3.14 `__getattr__` behavior locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Ensure the HTTP transport uses a selector-based event loop on Windows so async Postgres connections succeed without pool timeouts.

Bug Fixes:
- Prevent HTTP transport database connection failures on Windows by avoiding the ProactorEventLoop and running psycopg on a SelectorEventLoop.

Tests:
- Add tests verifying run_http pins the selector event loop and passes loop="none" to uvicorn on Windows, and leaves the event loop policy unchanged on non-Windows platforms.