### PR TITLE
fix: report mcpg's own version in the MCP serverInfo handshake

### DIFF
--- a/src/mcpg/server.py
+++ b/src/mcpg/server.py
@@ -16,7 +16,7 @@ from typing import Any
 from mcp.server.fastmcp import FastMCP
 from mcp.types import ContentBlock
 
-from mcpg import about, audit
+from mcpg import __version__, about, audit
 from mcpg.config import Settings, Transport
 from mcpg.context import AppContext
 from mcpg.cursors import CursorManager
@@ -203,6 +203,11 @@ def create_server(
         host=settings.http_host,
         port=settings.http_port,
     )
+    # FastMCP doesn't forward a ``version`` to the low-level server, so the
+    # MCP ``initialize`` handshake reports ``serverInfo.version`` as the MCP
+    # SDK's own version (e.g. "1.28.1") rather than mcpg's. Pin it to mcpg's
+    # version so clients, inspectors, and registries see the right number.
+    server._mcp_server.version = __version__
     server.mcpg_settings = settings
     server.otel_tracer = setup_tracing(settings)
     # Instantiate and register the RateLimiter

--- a/src/mcpg/server.py
+++ b/src/mcpg/server.py
@@ -46,6 +46,16 @@ class AuditedFastMCP(FastMCP[AppContext]):
     # treats both cases as no-ops so ``call_tool`` doesn't branch.
     otel_tracer: TracerHandle | None = None
 
+    def __init__(self, *args: Any, version: str | None = None, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        # FastMCP's constructor doesn't forward a version to the low-level
+        # MCP server, so the ``initialize`` handshake reports the MCP SDK's
+        # version in ``serverInfo`` rather than ours. This subclass exists
+        # to extend FastMCP, so it's the right place to hold that one bit of
+        # SDK-internal knowledge: pin the advertised version to mcpg's own.
+        if version is not None:
+            self._mcp_server.version = version
+
     def _log_if_slow(self, name: str, duration: float) -> None:
         if not hasattr(self, "mcpg_settings"):
             return
@@ -199,15 +209,11 @@ def create_server(
     server: AuditedFastMCP = AuditedFastMCP(
         SERVER_NAME,
         instructions=SERVER_INSTRUCTIONS,
+        version=__version__,
         lifespan=make_lifespan(settings, db, lm, cm),
         host=settings.http_host,
         port=settings.http_port,
     )
-    # FastMCP doesn't forward a ``version`` to the low-level server, so the
-    # MCP ``initialize`` handshake reports ``serverInfo.version`` as the MCP
-    # SDK's own version (e.g. "1.28.1") rather than mcpg's. Pin it to mcpg's
-    # version so clients, inspectors, and registries see the right number.
-    server._mcp_server.version = __version__
     server.mcpg_settings = settings
     server.otel_tracer = setup_tracing(settings)
     # Instantiate and register the RateLimiter

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -25,6 +25,17 @@ def test_create_server_returns_named_fastmcp() -> None:
     assert server.name == SERVER_NAME
 
 
+def test_create_server_reports_mcpg_version_in_serverinfo() -> None:
+    # FastMCP doesn't forward a version, so without the pin the initialize
+    # handshake would advertise the MCP SDK's version instead of mcpg's.
+    from mcpg import __version__
+
+    server = create_server(_SETTINGS)
+
+    init_options = server._mcp_server.create_initialization_options()
+    assert init_options.server_version == __version__
+
+
 async def test_lifespan_connects_database_and_yields_app_context() -> None:
     pool = FakePool()
     db = Database(_SETTINGS, pool=pool)  # type: ignore[arg-type]


### PR DESCRIPTION
## Symptom

An MCP `initialize` against MCPg returns:
```json
"serverInfo": { "name": "mcpg", "version": "1.28.1" }
```
`1.28.1` is the **MCP SDK's** version, not MCPg's (`0.6.8`). Every client, inspector, and registry that reads the handshake sees the wrong version. Surfaced while testing the streamable-http endpoint on Windows.

## Root cause

FastMCP's constructor accepts no `version` argument and builds the low-level `MCPServer(...)` without passing one. The low-level server then does:
```python
server_version=self.version if self.version else pkg_version("mcp")
```
With `self.version` unset, it falls back to the `mcp` package version.

## Fix

Pin the low-level server's `version` to `mcpg.__version__` right after constructing the server in `create_server`. (FastMCP exposes no public setter, so this sets `_mcp_server.version` directly — the same attribute the handshake reads.)

## Test

`test_create_server_reports_mcpg_version_in_serverinfo` builds the server and asserts `create_initialization_options().server_version == mcpg.__version__`.

Affects all transports (not Windows-specific). Independent of the Windows event-loop fix (#242).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Ensure MCP initialization handshake reports mcpg’s own version instead of the MCP SDK version.

Bug Fixes:
- Correct the MCP serverInfo.version in the initialize handshake to use mcpg.__version__.

Tests:
- Add a unit test verifying the created server reports mcpg.__version__ in serverInfo during initialization.