### PR TITLE
deploy: add Hugging Face Spaces recipe for the hosted demo endpoint

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -26,48 +26,75 @@ hosted instance instead of the owner role. MCPg already enforces
 read-only at the app layer, so this is defence-in-depth, not required
 for a throwaway demo DB.
 
-## 2. Deploy the endpoint (Fly.io)
+## 2. Deploy the endpoint
 
-[`fly.toml`](fly.toml) in this directory is ready to go. From a machine
-with [flyctl](https://fly.io/docs/flyctl/install/) installed:
+Any container host with a public HTTPS URL works — the only
+requirements are the image `ghcr.io/devopam/mcpg:latest`, a reachable
+Postgres via `MCPG_DATABASE_URL`, and the transport env vars. Two
+ready-to-go recipes:
+
+### Option A — Hugging Face Spaces (recommended)
+
+Hugging Face Spaces runs a Docker container at a public HTTPS URL for
+free with no payment card. [`hfspace/`](hfspace/) contains the whole
+recipe: a one-line `Dockerfile` wrapping the GHCR image on port 7860, a
+`README.md` with the Space metadata, and [`deploy.py`](hfspace/deploy.py)
+which creates/updates the Space and sets the DB secret via the HF API:
+
+```bash
+pip install huggingface_hub
+export HF_TOKEN="hf_…"        # a write / manage-spaces token
+export MCPG_DATABASE_URL="postgresql://…@…neon.tech/neondb?sslmode=require"
+python deploy/hfspace/deploy.py           # → <you>/mcpg-demo
+```
+
+Endpoint: `https://<owner>-mcpg-demo.hf.space/mcp`. The free tier sleeps
+after ~48h idle and cold-starts in ~30–60s — fine for periodic scoring.
+
+### Option B — Fly.io
+
+[`fly.toml`](fly.toml) is ready to go, but Fly requires a payment card on
+file. From a machine with [flyctl](https://fly.io/docs/flyctl/install/):
 
 ```bash
 cd deploy
 flyctl launch --no-deploy --copy-config --name mcpg-demo
-# Set the connection string as a SECRET (never committed):
 flyctl secrets set MCPG_DATABASE_URL="postgresql://…@…neon.tech/neondb?sslmode=require"
 flyctl deploy
 ```
 
-Your endpoint is then `https://mcpg-demo.fly.dev/mcp`. (Railway,
-Render, or any container host works the same way — the only
-requirements are a public HTTPS URL and the two env vars.)
+Endpoint: `https://mcpg-demo.fly.dev/mcp`. (Render, a small VPS, or any
+container host works the same way.)
 
-Verify it's live:
+Verify whichever you deployed (substitute your URL) with a real MCP
+`initialize` — a clean `serverInfo` reply means it connected to the DB:
 
 ```bash
-curl -sS https://mcpg-demo.fly.dev/mcp -H "Accept: text/event-stream" | head
+curl -sS https://<your-endpoint>/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  --data-raw '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"probe","version":"1"}}}'
 ```
 
-## 3. Register the URL with Smithery
+## 3. Register the URL with directories
 
-Add the hosted endpoint to the existing `devopam/mcpg` listing so
-Smithery scores it:
+Add the hosted endpoint to directories that score by connecting, e.g.
+Smithery:
 
 ```bash
 export SMITHERY_API_KEY="…"
-npx --yes @smithery/cli@latest mcp publish https://mcpg-demo.fly.dev/mcp -n devopam/mcpg
+npx --yes @smithery/cli@latest mcp publish https://<your-endpoint>/mcp -n devopam/mcpg
 ```
 
-Smithery connects, runs its tool scan against the read-only demo data,
-and the listing gains its routing score.
+They connect, scan the tools against the read-only demo data, and the
+listing gains its routing score.
 
 ## Notes
 
 - **Read-only, public**: the instance serves only read tools against
   demo data. Even so, treat the demo DB as disposable.
-- **Cost**: with `auto_stop_machines`, the instance idles to zero and
-  wakes on demand — a demo fits comfortably in free allowances.
+- **Cost**: both recipes idle to zero and wake on demand — a demo fits
+  comfortably in free allowances (HF Spaces needs no payment card).
 - **Local use is unaffected**: real users still install MCPg locally
   (`uvx mcpg`) pointed at their own database, running next to it. This
   hosted instance is purely for discovery/scoring + a live demo.

--- a/deploy/hfspace/Dockerfile
+++ b/deploy/hfspace/Dockerfile
@@ -1,0 +1,12 @@
+# Read-only MCPg demo for Hugging Face Spaces.
+# Wraps the published image unchanged; only overrides env so it serves
+# streamable-HTTP on the port HF Spaces routes to (7860), read-only.
+FROM ghcr.io/devopam/mcpg:latest
+
+ENV MCPG_TRANSPORT=streamable-http \
+    MCPG_HTTP_HOST=0.0.0.0 \
+    MCPG_HTTP_PORT=7860 \
+    MCPG_ACCESS_MODE=read-only
+
+EXPOSE 7860
+# ENTRYPOINT ["python","-m","mcpg"] and USER mcpg come from the base image.

--- a/deploy/hfspace/README.md
+++ b/deploy/hfspace/README.md
@@ -1,0 +1,23 @@
+---
+title: MCPg Demo
+emoji: 🐘
+colorFrom: blue
+colorTo: indigo
+sdk: docker
+app_port: 7860
+pinned: false
+short_description: Read-only PostgreSQL MCP server (MCPg) live demo endpoint
+---
+
+# MCPg — live read-only demo
+
+A public, **read-only** [MCPg](https://github.com/devopam/MCPg) instance — a
+production-grade PostgreSQL MCP server (252 tools). It exists so MCP
+directories (e.g. Smithery) can connect to score/route it, and as a
+"try MCPg live" endpoint.
+
+- **MCP endpoint:** `/mcp` (streamable-HTTP)
+- **Access mode:** read-only, pointed at a throwaway demo database — no real
+  data is exposed.
+
+Run MCPg yourself against your own database: `uvx mcpg`.

--- a/deploy/hfspace/deploy.py
+++ b/deploy/hfspace/deploy.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Create (or update) the public read-only MCPg demo on Hugging Face Spaces.
+
+Hugging Face Spaces hosts a Docker container at a public HTTPS URL for
+free with no payment card, which is exactly what MCP directories
+(Smithery, Glama, …) need to connect to and score. This script wraps the
+already-published GHCR image in a Docker Space, points it at a throwaway
+demo database, and runs it read-only — no real data is ever exposed.
+
+The two files uploaded to the Space live next to this script:
+  - ``Dockerfile``  – ``FROM ghcr.io/devopam/mcpg:latest`` + port 7860 env
+  - ``README.md``   – Space metadata (``sdk: docker``, ``app_port: 7860``)
+
+The database connection string is stored as a Space *secret*, never
+committed. It is read from the environment, not hard-coded.
+
+Prereqs:
+  pip install huggingface_hub
+  export HF_TOKEN="hf_..."            # a write / manage-spaces token
+  export MCPG_DATABASE_URL="postgresql://…@…neon.tech/neondb?sslmode=require"
+
+Usage:
+  python deploy.py [repo_id]          # default repo_id: <you>/mcpg-demo
+
+Re-running is idempotent: it updates the existing Space in place.
+The endpoint is then  https://<owner>-<name>.hf.space/mcp
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from huggingface_hub import HfApi
+
+
+def main() -> int:
+    token = os.environ.get("HF_TOKEN")
+    dsn = os.environ.get("MCPG_DATABASE_URL")
+    if not token or not dsn:
+        print("Set HF_TOKEN and MCPG_DATABASE_URL in the environment first.", file=sys.stderr)
+        return 1
+
+    api = HfApi(token=token)
+    default_owner = api.whoami()["name"]
+    repo_id = sys.argv[1] if len(sys.argv) > 1 else f"{default_owner}/mcpg-demo"
+    here = Path(__file__).resolve().parent
+
+    # 1) The Docker Space itself (idempotent).
+    api.create_repo(repo_id, repo_type="space", space_sdk="docker", exist_ok=True)
+    # 2) The connection string as a Space secret — injected as an env var
+    #    at runtime, never baked into the image or the repo.
+    api.add_space_secret(repo_id, "MCPG_DATABASE_URL", dsn, description="Demo DB (read-only)")
+    # 3) Dockerfile + README.md in one commit. HF rebuilds on push.
+    api.upload_folder(
+        folder_path=str(here),
+        repo_id=repo_id,
+        repo_type="space",
+        allow_patterns=["Dockerfile", "README.md"],
+        commit_message="Deploy MCPg read-only demo",
+    )
+
+    endpoint = f"https://{repo_id.replace('/', '-')}.hf.space/mcp"
+    print(f"Space:    https://huggingface.co/spaces/{repo_id}")
+    print(f"Endpoint: {endpoint}")
+    print("\nRegister it with directories that score by connecting, e.g. Smithery:")
+    print(f"  npx --yes @smithery/cli@latest mcp publish {endpoint} -n {repo_id}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closing — superseded by the decision to **not** document the demo as host-for-scoring (it would mislead consumers into connecting to a shared read-only demo instead of running MCPg against their own database). The live HF Space stays up as a "Try it live" link only; its recipe lives in the Space's own repo. See the README "Try it live" line added in its place.