### PR TITLE
build: single-source the version from src/mcpg/__init__.py

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,21 +22,21 @@ jobs:
           python-version: "3.14"
           enable-cache: true
       - run: uv sync --frozen
-      - name: Sanity check — tag matches pyproject version
-        # Tag is the source of truth for the release; pyproject must
-        # already be bumped to match. Refusing here prevents the very
-        # common "tagged v0.5.1 but forgot to bump" footgun. Read the
-        # field through ``tomllib`` so a stray ``version =`` line in
-        # another table (or quote/spacing reshuffles) can't fool us.
+      - name: Sanity check — tag matches package version
+        # Tag is the source of truth for the release; the version is
+        # single-sourced in src/mcpg/__init__.py (__version__) and read
+        # dynamically by hatchling. Validate the tag against that one
+        # source (the freshly-synced package) to catch the very common
+        # "tagged v0.5.1 but forgot to bump" footgun.
         run: |
           TAG_VERSION="${GITHUB_REF_NAME#v}"
-          PYPROJECT_VERSION="$(python -c 'import tomllib, pathlib; print(tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"])')"
-          if [ -z "$PYPROJECT_VERSION" ]; then
-            echo "::error::Could not read project.version from pyproject.toml"
+          PKG_VERSION="$(uv run python -c 'import mcpg; print(mcpg.__version__)')"
+          if [ -z "$PKG_VERSION" ]; then
+            echo "::error::Could not read mcpg.__version__"
             exit 1
           fi
-          if [ "$TAG_VERSION" != "$PYPROJECT_VERSION" ]; then
-            echo "::error::Tag $GITHUB_REF_NAME (=$TAG_VERSION) does not match pyproject.toml version $PYPROJECT_VERSION"
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME (=$TAG_VERSION) does not match mcpg.__version__ $PKG_VERSION"
             exit 1
           fi
       - name: Build

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -256,8 +256,13 @@ Add `build>=1.2` and `twine>=5.1` to `[dependency-groups].dev` in
 
 ### 4.2 Bump the version
 
-Update `version = "X.Y.Z"` in `pyproject.toml`. Update
-`CHANGELOG.md`: rename the `[Unreleased]` heading to
+The version is **single-sourced** in `src/mcpg/__init__.py`
+(`__version__ = "X.Y.Z"`). `pyproject.toml` declares it `dynamic` and
+hatchling reads it from that file, so **bump `__init__.py` and nothing
+else** — the PyPI metadata, `mcpg --version`, and the MCP `serverInfo`
+handshake all derive from that one line and can't drift apart.
+
+Then update `CHANGELOG.md`: rename the `[Unreleased]` heading to
 `[X.Y.Z] - YYYY-MM-DD`, add a fresh empty `[Unreleased]` above it.
 
 > **SemVer reminder.** Adding a new tool / env var that defaults to
@@ -367,7 +372,8 @@ when running locally.
 - [ ] `uv export --no-dev --no-emit-project --format requirements-txt
       > /tmp/r.txt && uv run pip-audit --strict --disable-pip -r
       /tmp/r.txt` reports no known CVEs.
-- [ ] `version` in `pyproject.toml` is bumped to the release.
+- [ ] `__version__` in `src/mcpg/__init__.py` is bumped to the release
+      (this is the single source; `pyproject.toml` derives it dynamically).
 - [ ] `CHANGELOG.md` rolls `[Unreleased]` into the new dated section,
       and a fresh `[Unreleased]` is added on top.
 - [ ] README hero + badges + screenshots — every relative URL has
@@ -622,6 +628,7 @@ every machine-updatable surface.
 | **PulseMCP** | Ingests the MCP Registry daily | Automatic (transitive) |
 | **mcp.so / mcpservers.org / Glama** | Scrape GitHub + the registry | Automatic (transitive) |
 | **Smithery** (`devopam/mcpg`) | `publish-smithery` job (opt-in) | Automatic *once enabled* — see below |
+| **Hosted demo** (HF Space `devopam/mcpg-demo`) | Runs `ghcr.io/devopam/mcpg:latest` | **Manual** rebuild — see below |
 | **Claude connectors directory** | Review portal, no API | **Manual** — see below |
 
 ### Copy that lives in `server.json` (drives the registry-fed listings)
@@ -654,7 +661,30 @@ the job just keeps the declared version and metadata current.
 > aren't set by bundle-publish — set those once in Smithery's web
 > server-card settings (they persist across re-publishes).
 
-### The one genuinely manual listing: Claude connectors directory
+### Refreshing the hosted demo (HF Space)
+
+The public read-only demo at `https://devopam-mcpg-demo.hf.space/mcp`
+runs the `ghcr.io/devopam/mcpg:latest` image. Two things mean it does
+**not** pick up a new release on its own:
+
+1. `:latest` is only rebuilt by the `publish-ghcr` job — i.e. on the
+   release tag — so between releases it stays on the last shipped image.
+2. Hugging Face Docker Spaces resolve `FROM …:latest` at **build** time
+   and cache the layer; a new GHCR push does not auto-repull.
+
+So after the release finishes (the `publish-ghcr` job is green), trigger
+a **Factory rebuild** of the Space so it pulls the new image — either in
+the Space's **Settings → Factory rebuild**, or via the HF API:
+
+```python
+from huggingface_hub import HfApi
+HfApi(token="hf_…").restart_space("devopam/mcpg-demo", factory_reboot=True)
+```
+
+Only then does the live demo (and its `serverInfo` version) match the
+release. Nothing else about the demo changes between releases.
+
+### The reviewed submission: Claude connectors directory
 
 The Claude directory is a **reviewed** submission portal with no
 publish API, so releases can't push to it automatically. After a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,10 @@
 [project]
 name = "mcpg"
-version = "0.6.8"
+# Version is single-sourced from src/mcpg/__init__.py (__version__) and read
+# here dynamically by hatchling — see [tool.hatch.version]. A release bumps
+# exactly one line, so pip, `mcpg --version`, and the MCP serverInfo
+# handshake can never disagree.
+dynamic = ["version"]
 description = "A production-grade PostgreSQL Model Context Protocol (MCP) server."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -98,6 +102,13 @@ mcpg = "mcpg.__main__:main"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+# Single source of truth for the version: hatchling reads ``__version__``
+# from this file at build time (its built-in regex version source), so the
+# project version, ``mcpg --version``, and the MCP serverInfo handshake all
+# derive from one line. Bump src/mcpg/__init__.py and nothing else.
+[tool.hatch.version]
+path = "src/mcpg/__init__.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/mcpg"]


### PR DESCRIPTION
## Why

The version lived in **two** hand-edited places — `pyproject.toml` and `src/mcpg/__init__.py` — with nothing enforcing they match. Since the `serverInfo` fix (#243), `mcpg.__version__` drives both `mcpg --version` and the MCP handshake. So a release that bumped `pyproject.toml` but forgot `__init__.py` would ship a package whose advertised version disagreed with its pip version — the same class of quiet drift that left the hosted demo reporting the SDK's `1.27.1`.

## What

Make `src/mcpg/__init__.py` the **single source of truth**. `pyproject.toml` declares the version `dynamic`, and hatchling reads `__version__` from that file at build time. A release now bumps **exactly one line**.

- **`pyproject.toml`** — drop the static `version`, add `dynamic = ["version"]` + `[tool.hatch.version] path = "src/mcpg/__init__.py"`.
- **`.github/workflows/publish.yml`** — the tag-match sanity check read `[project].version` (now gone); it now validates the tag against `mcpg.__version__`, the single source.
- **`docs/release-process.md`** — §4.2 and the §5 checklist now say "bump `__init__.py`" (pyproject derives it); §8b documents that the hosted **HF demo Space needs a factory rebuild after a release** to pull the new `:latest` image, else the live demo lags a release behind.

## Verified

- `python -m build` produces `mcpg-0.6.8` resolved from `__init__.py`; wheel metadata version = `0.6.8`.
- `packaging/mcpb` bundle version pin is unaffected — `sync_version.py` targets the bundle's own `pyproject.toml` (`bundle_dir`), not the root.
- Packaging tests (`test_mcpb_bundle`, `test_smithery_build`) green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Single-source the mcpg version from src/mcpg/__init__.py, updating build and CI configuration and release documentation to align with the new versioning flow and hosted demo behavior.

Bug Fixes:
- Prevent version drift between the published package, CLI output, and MCP serverInfo by single-sourcing the package version.

Enhancements:
- Centralize version management by making src/mcpg/__init__.py the single source of truth for the project version and wiring hatchling to read it dynamically.

Build:
- Configure pyproject.toml to use a dynamic version sourced from src/mcpg/__init__.py via hatchling.

CI:
- Update the publish workflow tag sanity check to compare the release tag against mcpg.__version__ instead of pyproject.toml.

Documentation:
- Revise the release process documentation to describe the single-sourced version bump and to document the manual rebuild requirement for the hosted HF demo Space.