### PR TITLE
feat(nl2sql): 12 more built-in providers via a metadata-driven registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **12 more built-in NL→SQL providers + a metadata-driven provider
+  registry** — `translate_nl_to_sql` now ships **19** built-in providers.
+  The expanded fleet adds **xAI (Grok), GitHub Models, Hugging Face,
+  Groq, Mistral, Together, Fireworks, DeepInfra, Cerebras, Nebius,
+  SambaNova, and Moonshot (Kimi)** alongside the original seven. Each is
+  plug-and-play: set the vendor's conventional API-key env var and it's
+  auto-discovered — including the ones that deviate from the
+  `<VENDOR>_API_KEY` convention (Hugging Face's `HF_TOKEN`, GitHub's
+  `GITHUB_TOKEN`, DeepInfra's `DEEPINFRA_TOKEN`). Internally, all provider
+  metadata now lives in a single declarative registry
+  (`nl2sql.ProviderSpec` / `_PROVIDERS`) that every lookup table derives
+  from, so adding or refreshing a provider — e.g. bumping a default model
+  when a vendor retires one — is a one-line data edit, no code change.
+  Base URLs and key env vars were verified against each vendor's official
+  docs. Local stacks (Ollama, vLLM, LM Studio) stay on the keyless
+  `MCPG_NL2SQL_CUSTOM_PROVIDERS` path by design.
 - **Four new NL→SQL providers: DeepSeek, Qwen, OpenRouter, and
   Perplexity** — `translate_nl_to_sql` now supports seven providers.
   The new four all speak the OpenAI-compatible chat API, so they reuse

--- a/README.md
+++ b/README.md
@@ -221,8 +221,8 @@ are one-shot commands, not configuration). The only required one is
 | HTTP transport with bearer auth | `MCPG_TRANSPORT=streamable-http` + `MCPG_HTTP_AUTH_TOKEN=…` |
 | Multi-tenant SaaS | `MCPG_DEFAULT_ROLE=tenant_a` + `MCPG_ALLOWED_ROLES=tenant_a,tenant_b,…` |
 | Read-replica fan-out | `MCPG_REPLICA_URLS=postgresql://…?sslmode=require,postgresql://…?sslmode=require` |
-| NL→SQL — single provider | Set any one vendor key (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, `DEEPSEEK_API_KEY`, `DASHSCOPE_API_KEY`, `OPENROUTER_API_KEY`, `PERPLEXITY_API_KEY`). MCPg auto-picks the default. |
-| NL→SQL — multiple providers, caller picks | Set all vendor keys you want active. Each call to `translate_nl_to_sql` can pass `provider="anthropic"\|"openai"\|"gemini"`. |
+| NL→SQL — single provider | Set any one vendor key (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, `XAI_API_KEY`, `GROQ_API_KEY`, `HF_TOKEN`, … — 19 built-in providers). MCPg auto-picks the default. |
+| NL→SQL — multiple providers, caller picks | Set all vendor keys you want active. Each call to `translate_nl_to_sql` can pass `provider="…"` (any configured built-in or custom). |
 
 ### Full reference
 
@@ -355,33 +355,35 @@ falls back to the env var, so partial files work.
 #### Natural-language SQL
 
 MCPg auto-discovers every configured provider from the environment at
-startup. Set as many vendor keys as you have — each becomes callable.
-Seven providers ship built in — **Anthropic, OpenAI, Gemini, DeepSeek,
-Qwen, OpenRouter, and Perplexity** (the last four ride the
-OpenAI-compatible API with vendor-preset endpoints) — and **any other
-OpenAI-compatible vendor or local model server is pluggable through
-configuration alone** via `MCPG_NL2SQL_CUSTOM_PROVIDERS`. When
-`MCPG_NL2SQL_PROVIDER` is unset, MCPg picks the default in preference
-order **anthropic → openai → gemini → deepseek → qwen → openrouter →
-perplexity**. The
-`translate_nl_to_sql` tool accepts an optional `provider="…"` argument
-so a caller can route between providers per call; `get_server_info`
-reports which are available.
+startup — set as many vendor keys as you have and each becomes callable.
+**Nineteen providers ship built in.** Three are first-party (Anthropic,
+OpenAI, Gemini); the other sixteen speak the OpenAI-compatible API with
+vendor-preset endpoints: **DeepSeek, Qwen, OpenRouter, Perplexity, xAI
+(Grok), Groq, Mistral, Together, Fireworks, DeepInfra, Cerebras, Nebius,
+Hugging Face, GitHub Models, SambaNova, and Moonshot (Kimi)**. Every
+built-in is plug-and-play — set the vendor's conventional API-key env
+var and it's auto-discovered — and **any *other* OpenAI-compatible
+vendor or local model server (Ollama, vLLM, LM Studio) is still
+pluggable through configuration alone** via `MCPG_NL2SQL_CUSTOM_PROVIDERS`.
+The whole built-in list is one declarative registry in `nl2sql.py`, so
+adding a vendor or refreshing a retired default model is a one-line data
+change.
+
+When `MCPG_NL2SQL_PROVIDER` is unset, MCPg auto-picks the default in
+registry order — **anthropic → openai → gemini** stay first so existing
+deployments are unaffected. `translate_nl_to_sql` accepts an optional
+`provider="…"` argument to route per call; `get_server_info` reports
+which are configured.
 
 | Variable | Default | Description |
 |---|---|---|
-| `ANTHROPIC_API_KEY` | — | Vendor-conventional key for Anthropic / Claude. |
-| `OPENAI_API_KEY` | — | Vendor-conventional key for OpenAI. |
-| `GEMINI_API_KEY` or `GOOGLE_API_KEY` | — | Vendor-conventional key for Google / Gemini. |
-| `DEEPSEEK_API_KEY` | — | Vendor-conventional key for DeepSeek. |
-| `DASHSCOPE_API_KEY` or `QWEN_API_KEY` | — | Vendor-conventional key for Qwen (Alibaba DashScope). |
-| `OPENROUTER_API_KEY` | — | Vendor-conventional key for OpenRouter (any model it fronts). |
-| `PERPLEXITY_API_KEY` | — | Vendor-conventional key for Perplexity (Sonar models). |
-| `MCPG_NL2SQL_PROVIDER` | auto-picked | `anthropic` \| `openai` \| `gemini` \| `deepseek` \| `qwen` \| `openrouter` \| `perplexity`. Pins the default provider used when the tool is called without `provider=`. When unset and any vendor key is in the env, MCPg auto-picks in the order listed. |
+| `<VENDOR>_API_KEY` | — | Setting a vendor's conventional key enables that provider. Standard slugs: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `DEEPSEEK_API_KEY`, `OPENROUTER_API_KEY`, `PERPLEXITY_API_KEY`, `XAI_API_KEY`, `GROQ_API_KEY`, `MISTRAL_API_KEY`, `TOGETHER_API_KEY`, `FIREWORKS_API_KEY`, `CEREBRAS_API_KEY`, `NEBIUS_API_KEY`, `SAMBANOVA_API_KEY`, `MOONSHOT_API_KEY`. |
+| *(keys that deviate)* | — | A few vendors don't follow `<VENDOR>_API_KEY`: **Gemini** → `GEMINI_API_KEY` or `GOOGLE_API_KEY`; **Qwen** → `DASHSCOPE_API_KEY` or `QWEN_API_KEY`; **Hugging Face** → `HF_TOKEN`; **GitHub Models** → `GITHUB_TOKEN`; **DeepInfra** → `DEEPINFRA_TOKEN`. |
+| `MCPG_NL2SQL_PROVIDER` | auto-picked | Any built-in slug (listed above) or a custom name. Pins the default provider used when the tool is called without `provider=`. Unset + any vendor key present → MCPg auto-picks in registry order. |
 | `MCPG_NL2SQL_API_KEY` | — | Explicit key for the configured `MCPG_NL2SQL_PROVIDER`. Overrides the vendor-conventional env var for that provider only. Requires `MCPG_NL2SQL_PROVIDER` to be set. |
-| `MCPG_NL2SQL_MODEL` | provider default | Override the default model (e.g. `claude-sonnet-4-6`, `gpt-4o-mini`, `gemini-2.5-flash`). Applies only to the default provider. |
-| `MCPG_NL2SQL_BASE_URL` | — | Endpoint override for the default provider (private gateways; or point `openai` at any self-hosted OpenAI-compatible stack — Ollama, vLLM, LM Studio). |
-| `MCPG_NL2SQL_CUSTOM_PROVIDERS` | — | **Bring your own provider — no code change.** Comma/newline-separated `name=base_url\|model` entries declaring extra OpenAI-compatible providers (Groq, Mistral, Together, xAI, local Ollama/vLLM, …). Key from `<NAME>_API_KEY` by convention, or append `\|KEY_ENV_VAR` for vendors that deviate (e.g. Hugging Face's `HF_TOKEN`); keyless allowed for loopback endpoints. Each name becomes callable via `provider=`. |
+| `MCPG_NL2SQL_MODEL` | provider default | Override the default model (e.g. `claude-sonnet-4-6`, `gpt-4o-mini`, `grok-3-mini`). Applies only to the default provider. |
+| `MCPG_NL2SQL_BASE_URL` | — | Endpoint override for the default provider (private gateways / regional endpoints). |
+| `MCPG_NL2SQL_CUSTOM_PROVIDERS` | — | **Bring your own provider — no code change.** Comma/newline-separated `name=base_url\|model` entries declaring *extra* OpenAI-compatible providers beyond the built-ins (local Ollama / vLLM / LM Studio, or any niche vendor). Key from `<NAME>_API_KEY` by convention, or append `\|KEY_ENV_VAR` for ones that deviate; keyless allowed for loopback endpoints. Each name becomes callable via `provider=`. |
 | `MCPG_NL2SQL_MAX_TOKENS` | `2048` | Cap on generated tokens (hard limit: 16384). |
 
 ---
@@ -490,9 +492,10 @@ Compact category list. For the full, current tool reference see
 - **Search** — `fuzzy_search` (trigram), `full_text_search`,
   `vector_search`, `hybrid_search` (pgvector + FTS via RRF),
   `geo_search` (PostGIS k-NN).
-- **Natural language → SQL** — `translate_nl_to_sql` (Anthropic,
-  OpenAI, or Gemini; output passes through the same safe-SQL kernel
-  as hand-written queries).
+- **Natural language → SQL** — `translate_nl_to_sql` (19 built-in
+  providers — Anthropic, OpenAI, Gemini, xAI, Groq, Mistral, Hugging
+  Face, … — plus any custom OpenAI-compatible endpoint; output passes
+  through the same safe-SQL kernel as hand-written queries).
 - **Visualisation** — `generate_schema_diagram` (ER),
   `generate_fk_cascade_graph` (blast-radius of `ON DELETE CASCADE`),
   `generate_graph_diagram` (Apache AGE property graphs).

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ graph queries, data movement, live ops, and more.
 
 ### 📍 Listed On
 
-- **[Official MCP Registry](https://registry.modelcontextprotocol.io/v0.1/servers/io.github.devopam%2Fmcpg/versions/0.6.5)**  
-- **[mcp.so](https://mcp.so/server/mcpg---production-grade-postgresql-mcp-server/Devopam%20Mittra)**  
+- **[Official MCP Registry](https://registry.modelcontextprotocol.io/v0.1/servers/io.github.devopam%2Fmcpg)**
+- **[mcp.so](https://mcp.so/server/mcpg---production-grade-postgresql-mcp-server/Devopam%20Mittra)**
 - **[mcpservers.org](https://mcpservers.org/servers/devopam/mcpg)**
 - **[Smithery](https://smithery.ai/servers/devopam/mcpg)**
 - **[Glama](https://glama.ai/mcp/servers/devopam/MCPg)**

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -348,8 +348,9 @@ translate_nl_to_sql(question="how many orders were shipped last week?",
 # → { sql, explanation, executed, rows, columns, row_count }
 ```
 
-Requires `MCPG_NL2SQL_PROVIDER` + API key set at startup
-(anthropic / openai / gemini / deepseek / qwen / openrouter / perplexity). The tool sends a compact schema brief
+Requires `MCPG_NL2SQL_PROVIDER` + API key set at startup (any of the 19
+built-in providers — anthropic / openai / gemini / xai / groq / mistral /
+huggingface / … — or a custom one). The tool sends a compact schema brief
 (tables, columns, FKs) to the configured LLM, parses the JSON
 response, and — when `execute=true` — passes the generated SQL
 through `SafeSqlDriver`'s allowlist before running it. A model that

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -718,6 +718,14 @@ publishing surface healthy:
   — make sure the only owner is the maintainer's account.
 - **Re-run `pip-audit`** on the last shipped requirements set; if a
   CVE has landed since release, cut a patch.
+- **Sweep the NL→SQL provider default models (~quarterly).** Vendors
+  retire models on their own cadence (e.g. Cerebras dropped
+  `llama-3.1-8b`), which would leave a built-in provider pointing at a
+  dead default. Check each entry's `default_model` in
+  `src/mcpg/nl2sql.py`'s `_PROVIDERS` registry against the vendor's live
+  models page and bump any that changed. It's a pure data edit — one
+  string per affected provider, no code — then cut a build. Base URLs
+  and key env vars are stable and rarely need attention.
 - **Rotate the `SMITHERY_API_KEY`** secret if it's ever been exposed
   (e.g. pasted into a chat/issue); regenerate at smithery.ai and update
   the repo secret.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -290,16 +290,34 @@ callable through the tool:
 
 | Provider | Set in env | Default model |
 |---|---|---|
-| `anthropic` | `ANTHROPIC_API_KEY` | provider's recent Claude Sonnet |
+| `anthropic` | `ANTHROPIC_API_KEY` | recent Claude Sonnet |
 | `openai` | `OPENAI_API_KEY` | `gpt-4o-mini` |
-| `gemini` | `GEMINI_API_KEY` (falls back to `GOOGLE_API_KEY`) | provider's recent Gemini Flash |
+| `gemini` | `GEMINI_API_KEY` (falls back to `GOOGLE_API_KEY`) | recent Gemini Flash |
 | `deepseek` | `DEEPSEEK_API_KEY` | `deepseek-chat` |
 | `qwen` | `DASHSCOPE_API_KEY` (falls back to `QWEN_API_KEY`) | `qwen-plus` |
-| `openrouter` | `OPENROUTER_API_KEY` | `openai/gpt-4o-mini` (any OpenRouter model via `MCPG_NL2SQL_MODEL`) |
+| `openrouter` | `OPENROUTER_API_KEY` | `openai/gpt-4o-mini` |
 | `perplexity` | `PERPLEXITY_API_KEY` | `sonar` |
+| `xai` | `XAI_API_KEY` | `grok-3-mini` |
+| `groq` | `GROQ_API_KEY` | `llama-3.1-8b-instant` |
+| `mistral` | `MISTRAL_API_KEY` | `mistral-small-latest` |
+| `together` | `TOGETHER_API_KEY` | `meta-llama/Llama-3.3-70B-Instruct-Turbo` |
+| `fireworks` | `FIREWORKS_API_KEY` | `accounts/fireworks/models/llama-v3p1-8b-instruct` |
+| `deepinfra` | `DEEPINFRA_TOKEN` | `meta-llama/Meta-Llama-3.1-8B-Instruct` |
+| `cerebras` | `CEREBRAS_API_KEY` | `qwen-3-32b` |
+| `nebius` | `NEBIUS_API_KEY` | `meta-llama/Meta-Llama-3.1-8B-Instruct` |
+| `huggingface` | `HF_TOKEN` | `openai/gpt-oss-20b` |
+| `github` | `GITHUB_TOKEN` (GitHub Models) | `openai/gpt-4o-mini` |
+| `sambanova` | `SAMBANOVA_API_KEY` | `Meta-Llama-3.1-8B-Instruct` |
+| `moonshot` | `MOONSHOT_API_KEY` (Kimi) | `kimi-k2.5` |
 
-The last four are OpenAI-compatible vendors: MCPg drives them through
-the same chat-completions client with vendor-preset endpoints.
+All but the first three (`anthropic` / `openai` / `gemini`) are
+OpenAI-compatible vendors: MCPg drives them through one chat-completions
+client with vendor-preset endpoints. The whole list is a single
+declarative registry (`_PROVIDERS` in `nl2sql.py`), so adding a vendor or
+refreshing a default model as vendors retire them is a one-line data
+change. Base URLs and key env vars were verified against each vendor's
+docs; the `default_model` column is the volatile one — override it per
+call with `MCPG_NL2SQL_MODEL`.
 
 ### Bring your own provider (no code change)
 
@@ -308,21 +326,25 @@ declared through configuration alone:
 
 ```bash
 export MCPG_NL2SQL_CUSTOM_PROVIDERS="
-  groq=https://api.groq.com/openai/v1|llama-3.3-70b-versatile,
-  hf=https://router.huggingface.co/v1|meta-llama/Llama-3.3-70B-Instruct|HF_TOKEN,
+  myvendor=https://api.myvendor.example/v1|big-model,
+  privategw=https://llm.internal/v1|my-model|PRIVATEGW_TOKEN,
   ollama=http://localhost:11434/v1|llama3.1
 "
-export GROQ_API_KEY=gsk_...   # <NAME>_API_KEY convention
-export HF_TOKEN=hf_...        # explicit third segment for vendors that deviate
+export MYVENDOR_API_KEY=...    # <NAME>_API_KEY convention
+export PRIVATEGW_TOKEN=...     # explicit third segment for a deviating key var
+# ollama needs no key — it's a loopback endpoint
 ```
+
+> The names above must **not** collide with a built-in provider (the 19
+> in the table); a clash is rejected at startup. Use custom entries for
+> vendors *not* already built in, or for a local model server.
 
 Each entry is `name=base_url|model` with an optional `|KEY_ENV_VAR`
 third segment. Rules, stated plainly:
 
-- The API key is read from `<NAME>_API_KEY` (the convention Groq,
-  Mistral, Together, xAI, and most vendors follow); the third segment
-  names the env var explicitly when a vendor deviates (Hugging Face's
-  `HF_TOKEN`).
+- The API key is read from `<NAME>_API_KEY` (the convention most vendors
+  follow); the third segment names the env var explicitly when a vendor
+  deviates from it.
 - **Keyless is allowed** for loopback endpoints — local Ollama / vLLM
   / LM Studio are first-class, no dummy key needed.
 - `http://` is accepted only for loopback hosts; anything remote must
@@ -337,9 +359,10 @@ third segment. Rules, stated plainly:
 ```bash
 export ANTHROPIC_API_KEY=sk-ant-...      # configures anthropic
 export OPENAI_API_KEY=sk-...             # configures openai too
-# Both available; MCPg auto-picks anthropic as the default
-# (preference order: anthropic → openai → gemini → deepseek
-# → qwen → openrouter → perplexity).
+# Both available; MCPg auto-picks anthropic as the default. Preference
+# is the registry order — anthropic → openai → gemini stay first, then
+# the OpenAI-compatible fleet (deepseek, qwen, …, xai, groq, …) — so
+# existing setups keep their current default.
 ```
 
 To pin a specific default, set `MCPG_NL2SQL_PROVIDER` explicitly:

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -316,8 +316,8 @@ client with vendor-preset endpoints. The whole list is a single
 declarative registry (`_PROVIDERS` in `nl2sql.py`), so adding a vendor or
 refreshing a default model as vendors retire them is a one-line data
 change. Base URLs and key env vars were verified against each vendor's
-docs; the `default_model` column is the volatile one — override it per
-call with `MCPG_NL2SQL_MODEL`.
+docs; the `default_model` column is the volatile one — override it in
+configuration with `MCPG_NL2SQL_MODEL` (applies to the default provider).
 
 ### Bring your own provider (no code change)
 

--- a/src/mcpg/config.py
+++ b/src/mcpg/config.py
@@ -16,7 +16,7 @@ from os.path import isabs
 from urllib.parse import urlparse
 
 from mcpg._vendor.sql import obfuscate_password
-from mcpg.nl2sql import AUTO_PICK_ORDER, VENDOR_ENV_VAR_HINT
+from mcpg.nl2sql import AUTO_PICK_ORDER, VENDOR_ENV_VAR_HINT, VENDOR_KEY_ENV_VARS
 from mcpg.secrets import SecretsError, build_secrets_provider
 
 # PG role names must be safe identifiers — we inline them into
@@ -764,26 +764,19 @@ def load_settings(env: Mapping[str, str] | None = None) -> Settings:
     # not just the configured default. Operator can also point one
     # provider at an explicit key via ``MCPG_NL2SQL_API_KEY`` —
     # which always wins over the vendor-conventional fallback.
+    # Discovery is driven entirely by nl2sql's provider registry
+    # (VENDOR_KEY_ENV_VARS): for each built-in provider, try its candidate
+    # env vars in order and take the first one set. Adding a provider to
+    # the registry makes it discoverable here with no change to this file.
+    # The candidate lists cover the vendors that deviate from the
+    # <VENDOR>_API_KEY convention — Gemini (GOOGLE_API_KEY), Qwen
+    # (QWEN_API_KEY), Hugging Face (HF_TOKEN), DeepInfra (DEEPINFRA_TOKEN).
     api_keys: dict[str, str] = {}
-    if anthropic_key := (secrets.get("ANTHROPIC_API_KEY") or "").strip():
-        api_keys["anthropic"] = anthropic_key
-    if openai_key := (secrets.get("OPENAI_API_KEY") or "").strip():
-        api_keys["openai"] = openai_key
-    gemini_key = (secrets.get("GEMINI_API_KEY") or "").strip() or (secrets.get("GOOGLE_API_KEY") or "").strip()
-    if gemini_key:
-        api_keys["gemini"] = gemini_key
-    # OpenAI-compatible vendors (DeepSeek / Qwen / OpenRouter /
-    # Perplexity) — discovered the same way, driven through the same
-    # chat-completions client with vendor-preset endpoints (nl2sql.py).
-    if deepseek_key := (secrets.get("DEEPSEEK_API_KEY") or "").strip():
-        api_keys["deepseek"] = deepseek_key
-    qwen_key = (secrets.get("DASHSCOPE_API_KEY") or "").strip() or (secrets.get("QWEN_API_KEY") or "").strip()
-    if qwen_key:
-        api_keys["qwen"] = qwen_key
-    if openrouter_key := (secrets.get("OPENROUTER_API_KEY") or "").strip():
-        api_keys["openrouter"] = openrouter_key
-    if perplexity_key := (secrets.get("PERPLEXITY_API_KEY") or "").strip():
-        api_keys["perplexity"] = perplexity_key
+    for provider, env_vars in VENDOR_KEY_ENV_VARS.items():
+        for var in env_vars:
+            if key := (secrets.get(var) or "").strip():
+                api_keys[provider] = key
+                break
 
     # Operator-declared OpenAI-compatible providers (the pluggable
     # path). Same list convention as MCPG_SECONDARY_DATABASE_URLS;

--- a/src/mcpg/nl2sql.py
+++ b/src/mcpg/nl2sql.py
@@ -47,60 +47,158 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Default models per provider — chosen for low cost / high availability
-# at writing time. Override via ``MCPG_NL2SQL_MODEL``.
-DEFAULT_MODELS: dict[str, str] = {
-    "anthropic": "claude-sonnet-4-6",
-    "openai": "gpt-4o-mini",
-    "gemini": "gemini-2.0-flash",
-    "deepseek": "deepseek-chat",
-    "qwen": "qwen-plus",
-    "openrouter": "openai/gpt-4o-mini",
-    "perplexity": "sonar",
-}
 
-# Providers that speak the OpenAI-compatible chat-completions API —
-# they reuse :class:`OpenAIProvider` with a preset ``base_url``. This
-# is why supporting the wider model ecosystem costs one dict entry per
-# vendor instead of one HTTP client per vendor. An explicit
-# ``MCPG_NL2SQL_BASE_URL`` still overrides the preset (private
-# gateways, regional endpoints), and self-hosted OpenAI-compatible
-# stacks (Ollama, vLLM, LM Studio) are reachable by pointing the
-# ``openai`` provider's base_url at them.
-OPENAI_COMPATIBLE_BASE_URLS: dict[str, str] = {
-    "deepseek": "https://api.deepseek.com/v1",
-    "qwen": "https://dashscope.aliyuncs.com/compatible-mode/v1",
-    "openrouter": "https://openrouter.ai/api/v1",
-    "perplexity": "https://api.perplexity.ai",
-}
+@dataclass(frozen=True)
+class ProviderSpec:
+    """Declarative metadata for one built-in NL→SQL provider.
 
-# Human-readable env-var hint per provider, used in error messages
-# when MCPg needs to tell the operator which env var to set to
-# enable a given provider. Single source of truth so the wording
-# stays consistent between startup validation (config.py) and
-# runtime tool errors (tools.py).
-VENDOR_ENV_VAR_HINT: dict[str, str] = {
-    "anthropic": "ANTHROPIC_API_KEY",
-    "openai": "OPENAI_API_KEY",
-    "gemini": "GEMINI_API_KEY (or GOOGLE_API_KEY)",
-    "deepseek": "DEEPSEEK_API_KEY",
-    "qwen": "DASHSCOPE_API_KEY (or QWEN_API_KEY)",
-    "openrouter": "OPENROUTER_API_KEY",
-    "perplexity": "PERPLEXITY_API_KEY",
-}
+    ``_PROVIDERS`` (below) is the **single source of truth** for the
+    built-in provider list. Every lookup table in this module — default
+    models, OpenAI-compatible base URLs, key env vars, the hint strings,
+    the auto-pick order — is *derived* from it, and ``config.py``'s key
+    discovery iterates it directly. Consequences:
 
-# When MCPG_NL2SQL_PROVIDER is unset, the default is auto-picked from
-# whichever vendor keys are present, in this order. The original three
-# stay first so existing deployments keep their current default.
-AUTO_PICK_ORDER: tuple[str, ...] = (
-    "anthropic",
-    "openai",
-    "gemini",
-    "deepseek",
-    "qwen",
-    "openrouter",
-    "perplexity",
+    * **Adding a provider** = one ``ProviderSpec`` entry here. No other
+      code artifact changes.
+    * **The recurring maintenance** — vendors retire models every few
+      months (e.g. Cerebras dropped ``llama-3.1-8b``) — is editing the
+      ``default_model`` string on the affected entries and cutting a new
+      build. Purely data; nothing else moves.
+
+    Fields:
+        key:           lowercase slug used as the provider name.
+        api_style:     which wire client handles it — ``"anthropic"``,
+                       ``"gemini"``, or ``"openai"`` (the OpenAI
+                       chat-completions dialect, which most vendors
+                       implement, reusing one HTTP client).
+        base_url:      OpenAI-compatible endpoint preset. ``None`` means
+                       "use the client class's own default host" — only
+                       the three first-party providers leave it ``None``.
+        default_model: cheap / widely-available default, overridable per
+                       call via ``MCPG_NL2SQL_MODEL``. The volatile field
+                       the quarterly sweep refreshes.
+        key_env_vars:  ordered candidate env vars holding the API key;
+                       the first one set wins. Most vendors follow
+                       ``<VENDOR>_API_KEY``; the deviations (Gemini,
+                       Qwen, Hugging Face's ``HF_TOKEN``, GitHub's
+                       ``GITHUB_TOKEN``, DeepInfra's ``DEEPINFRA_TOKEN``)
+                       are grounded in each vendor's own docs.
+    """
+
+    key: str
+    api_style: str
+    base_url: str | None
+    default_model: str
+    key_env_vars: tuple[str, ...]
+
+
+# ── Built-in provider registry: the ONE place to add or refresh a provider ──
+# Order defines the auto-pick precedence when several vendor keys are present
+# and MCPG_NL2SQL_PROVIDER is unset. The three first-party providers stay
+# first so existing deployments keep their current default; the
+# OpenAI-compatible fleet follows. Base URLs + key env vars for the expanded
+# fleet were verified against each vendor's official docs; ``default_model``
+# is the field expected to age (see ProviderSpec).
+#
+# Not built-in on purpose: local stacks (Ollama, vLLM, LM Studio) are keyless
+# and the served model varies, so they use the keyless
+# MCPG_NL2SQL_CUSTOM_PROVIDERS path instead (documented in the user guide).
+_PROVIDERS: tuple[ProviderSpec, ...] = (
+    # First-party providers — bespoke wire clients, own default host.
+    ProviderSpec("anthropic", "anthropic", None, "claude-sonnet-4-6", ("ANTHROPIC_API_KEY",)),
+    ProviderSpec("openai", "openai", None, "gpt-4o-mini", ("OPENAI_API_KEY",)),
+    ProviderSpec("gemini", "gemini", None, "gemini-2.0-flash", ("GEMINI_API_KEY", "GOOGLE_API_KEY")),
+    # OpenAI-compatible vendors — same client, vendor-preset endpoint.
+    ProviderSpec("deepseek", "openai", "https://api.deepseek.com/v1", "deepseek-chat", ("DEEPSEEK_API_KEY",)),
+    ProviderSpec(
+        "qwen",
+        "openai",
+        "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        "qwen-plus",
+        ("DASHSCOPE_API_KEY", "QWEN_API_KEY"),
+    ),
+    ProviderSpec("openrouter", "openai", "https://openrouter.ai/api/v1", "openai/gpt-4o-mini", ("OPENROUTER_API_KEY",)),
+    ProviderSpec("perplexity", "openai", "https://api.perplexity.ai", "sonar", ("PERPLEXITY_API_KEY",)),
+    # Expanded fleet — doc-verified base URLs + key env vars.
+    ProviderSpec("xai", "openai", "https://api.x.ai/v1", "grok-3-mini", ("XAI_API_KEY",)),
+    ProviderSpec("groq", "openai", "https://api.groq.com/openai/v1", "llama-3.1-8b-instant", ("GROQ_API_KEY",)),
+    ProviderSpec("mistral", "openai", "https://api.mistral.ai/v1", "mistral-small-latest", ("MISTRAL_API_KEY",)),
+    ProviderSpec(
+        "together",
+        "openai",
+        "https://api.together.ai/v1",
+        "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+        ("TOGETHER_API_KEY",),
+    ),
+    ProviderSpec(
+        "fireworks",
+        "openai",
+        "https://api.fireworks.ai/inference/v1",
+        "accounts/fireworks/models/llama-v3p1-8b-instruct",
+        ("FIREWORKS_API_KEY",),
+    ),
+    ProviderSpec(
+        "deepinfra",
+        "openai",
+        "https://api.deepinfra.com/v1/openai",
+        "meta-llama/Meta-Llama-3.1-8B-Instruct",
+        ("DEEPINFRA_TOKEN", "DEEPINFRA_API_KEY"),
+    ),
+    ProviderSpec("cerebras", "openai", "https://api.cerebras.ai/v1", "qwen-3-32b", ("CEREBRAS_API_KEY",)),
+    ProviderSpec(
+        "nebius",
+        "openai",
+        "https://api.studio.nebius.ai/v1",
+        "meta-llama/Meta-Llama-3.1-8B-Instruct",
+        ("NEBIUS_API_KEY",),
+    ),
+    ProviderSpec(
+        "huggingface",
+        "openai",
+        "https://router.huggingface.co/v1",
+        "openai/gpt-oss-20b",
+        ("HF_TOKEN", "HUGGINGFACE_API_KEY"),
+    ),
+    ProviderSpec("github", "openai", "https://models.github.ai/inference", "openai/gpt-4o-mini", ("GITHUB_TOKEN",)),
+    ProviderSpec(
+        "sambanova", "openai", "https://api.sambanova.ai/v1", "Meta-Llama-3.1-8B-Instruct", ("SAMBANOVA_API_KEY",)
+    ),
+    ProviderSpec("moonshot", "openai", "https://api.moonshot.ai/v1", "kimi-k2.5", ("MOONSHOT_API_KEY",)),
 )
+
+_PROVIDERS_BY_KEY: dict[str, ProviderSpec] = {p.key: p for p in _PROVIDERS}
+
+
+def _env_hint(env_vars: tuple[str, ...]) -> str:
+    """Render a human-readable ``VAR (or ALT …)`` hint from candidate vars."""
+    if len(env_vars) == 1:
+        return env_vars[0]
+    return f"{env_vars[0]} (or {' or '.join(env_vars[1:])})"
+
+
+# ── Derived lookups — regenerated from _PROVIDERS; do not hand-edit ──
+# Default model per provider; override per call via MCPG_NL2SQL_MODEL.
+DEFAULT_MODELS: dict[str, str] = {p.key: p.default_model for p in _PROVIDERS}
+
+# OpenAI-compatible vendors → preset base_url. The bespoke first-party
+# clients are excluded (they carry their own default host). An explicit
+# MCPG_NL2SQL_BASE_URL still overrides the preset (private gateways,
+# regional endpoints).
+OPENAI_COMPATIBLE_BASE_URLS: dict[str, str] = {
+    p.key: p.base_url for p in _PROVIDERS if p.api_style == "openai" and p.base_url is not None
+}
+
+# Ordered candidate env vars per provider (first set wins). Single source
+# for key discovery (config.py) and the hint strings below.
+VENDOR_KEY_ENV_VARS: dict[str, tuple[str, ...]] = {p.key: p.key_env_vars for p in _PROVIDERS}
+
+# Human-readable env-var hint per provider, used in error messages so the
+# wording stays consistent between startup validation (config.py) and
+# runtime tool errors (tools.py).
+VENDOR_ENV_VAR_HINT: dict[str, str] = {p.key: _env_hint(p.key_env_vars) for p in _PROVIDERS}
+
+# Auto-pick order when MCPG_NL2SQL_PROVIDER is unset — the registry order.
+AUTO_PICK_ORDER: tuple[str, ...] = tuple(p.key for p in _PROVIDERS)
 
 # Conservative budget — NL→SQL responses are usually a few hundred
 # tokens of JSON. Override via ``MCPG_NL2SQL_MAX_TOKENS``.
@@ -481,17 +579,21 @@ def build_provider(
     Raises:
         NL2SQLError: When ``name`` is not in :data:`_SUPPORTED_PROVIDERS`.
     """
-    if name == "anthropic":
-        return AnthropicProvider(api_key=api_key, **({"base_url": base_url} if base_url else {}))
-    if name == "openai":
-        return OpenAIProvider(api_key=api_key, **({"base_url": base_url} if base_url else {}))
-    if name == "gemini":
-        return GeminiProvider(api_key=api_key, **({"base_url": base_url} if base_url else {}))
-    if name in OPENAI_COMPATIBLE_BASE_URLS:
-        # DeepSeek / Qwen / OpenRouter / Perplexity speak the OpenAI
-        # chat-completions dialect — same client, vendor-preset endpoint
-        # (an explicit base_url override still wins).
-        return OpenAIProvider(api_key=api_key, base_url=base_url or OPENAI_COMPATIBLE_BASE_URLS[name])
+    spec = _PROVIDERS_BY_KEY.get(name)
+    if spec is not None:
+        # A registered built-in. For OpenAI-compatible vendors, an explicit
+        # base_url override wins over the vendor preset; the first-party
+        # clients (base_url None) fall back to their own default host.
+        effective = base_url or spec.base_url
+        kwargs = {"base_url": effective} if effective else {}
+        if spec.api_style == "anthropic":
+            return AnthropicProvider(api_key=api_key, **kwargs)
+        if spec.api_style == "gemini":
+            return GeminiProvider(api_key=api_key, **kwargs)
+        # "openai" — first-party OpenAI *and* every OpenAI-compatible vendor
+        # share one client; the preset (or override) base_url is the only
+        # thing that differs.
+        return OpenAIProvider(api_key=api_key, **kwargs)
     if base_url:
         # Operator-declared custom provider (MCPG_NL2SQL_CUSTOM_PROVIDERS):
         # by definition OpenAI-compatible, endpoint from its declaration.

--- a/src/mcpg/nl2sql.py
+++ b/src/mcpg/nl2sql.py
@@ -34,7 +34,7 @@ import re
 import time
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
 
 import httpx
 
@@ -86,7 +86,7 @@ class ProviderSpec:
     """
 
     key: str
-    api_style: str
+    api_style: Literal["anthropic", "gemini", "openai"]
     base_url: str | None
     default_model: str
     key_env_vars: tuple[str, ...]
@@ -167,6 +167,12 @@ _PROVIDERS: tuple[ProviderSpec, ...] = (
 )
 
 _PROVIDERS_BY_KEY: dict[str, ProviderSpec] = {p.key: p for p in _PROVIDERS}
+
+# Fail fast on a malformed registry rather than silently dropping a
+# duplicate key (the dict comprehension above would overwrite it) or
+# registering a provider with no way to supply its API key.
+assert len(_PROVIDERS_BY_KEY) == len(_PROVIDERS), "duplicate provider key in nl2sql._PROVIDERS"
+assert all(p.key_env_vars for p in _PROVIDERS), "every nl2sql provider needs at least one key env var"
 
 
 def _env_hint(env_vars: tuple[str, ...]) -> str:
@@ -590,10 +596,15 @@ def build_provider(
             return AnthropicProvider(api_key=api_key, **kwargs)
         if spec.api_style == "gemini":
             return GeminiProvider(api_key=api_key, **kwargs)
-        # "openai" — first-party OpenAI *and* every OpenAI-compatible vendor
-        # share one client; the preset (or override) base_url is the only
-        # thing that differs.
-        return OpenAIProvider(api_key=api_key, **kwargs)
+        if spec.api_style == "openai":
+            # First-party OpenAI *and* every OpenAI-compatible vendor share
+            # one client; the preset (or override) base_url is the only thing
+            # that differs.
+            return OpenAIProvider(api_key=api_key, **kwargs)
+        # Unrecognised api_style — the Literal type makes this unreachable for
+        # the checked-in registry, but fail loudly rather than silently route a
+        # future misconfigured entry through the OpenAI client.
+        raise NL2SQLError(f"provider {name!r} has an unknown api_style {spec.api_style!r}")
     if base_url:
         # Operator-declared custom provider (MCPG_NL2SQL_CUSTOM_PROVIDERS):
         # by definition OpenAI-compatible, endpoint from its declaration.

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -343,44 +343,44 @@ def test_custom_providers_parse_with_keys_keyless_and_key_env_override() -> None
         {
             "MCPG_DATABASE_URL": _DB_URL,
             "MCPG_NL2SQL_CUSTOM_PROVIDERS": (
-                "groq=https://api.groq.com/openai/v1|llama-3.3-70b-versatile,\n"
-                "hf=https://router.huggingface.co/v1|meta-llama/Llama-3.3-70B-Instruct|HF_TOKEN,\n"
+                "acme=https://api.acme.example/v1|acme-large,\n"
+                "myvendor=https://api.myvendor.example/v1|big-model|MYVENDOR_TOKEN,\n"
                 "ollama=http://localhost:11434/v1|llama3.1"
             ),
-            "GROQ_API_KEY": "gsk-key",
-            "HF_TOKEN": "hf-key",
+            "ACME_API_KEY": "gsk-key",
+            "MYVENDOR_TOKEN": "mv-key",
         }
     )
     assert settings.nl2sql_custom_providers == (
-        ("groq", "https://api.groq.com/openai/v1", "llama-3.3-70b-versatile"),
-        ("hf", "https://router.huggingface.co/v1", "meta-llama/Llama-3.3-70B-Instruct"),
+        ("acme", "https://api.acme.example/v1", "acme-large"),
+        ("myvendor", "https://api.myvendor.example/v1", "big-model"),
         ("ollama", "http://localhost:11434/v1", "llama3.1"),
     )
     keys = dict(settings.nl2sql_api_keys)
-    assert keys["groq"] == "gsk-key"  # <NAME>_API_KEY convention
-    assert keys["hf"] == "hf-key"  # explicit KEY_ENV_VAR segment (vendors that deviate)
+    assert keys["acme"] == "gsk-key"  # <NAME>_API_KEY convention
+    assert keys["myvendor"] == "mv-key"  # explicit KEY_ENV_VAR segment (vendors that deviate)
     assert keys["ollama"] == "unused"  # keyless local endpoint
     # Built-ins absent -> auto-pick falls through to first declared custom.
-    assert settings.nl2sql_provider == "groq"
+    assert settings.nl2sql_provider == "acme"
 
 
 def test_custom_provider_can_be_pinned_as_default() -> None:
     settings = load_settings(
         {
             "MCPG_DATABASE_URL": _DB_URL,
-            "MCPG_NL2SQL_CUSTOM_PROVIDERS": "groq=https://api.groq.com/openai/v1|llama-3.3-70b-versatile",
-            "MCPG_NL2SQL_PROVIDER": "groq",
+            "MCPG_NL2SQL_CUSTOM_PROVIDERS": "acme=https://api.acme.example/v1|acme-large",
+            "MCPG_NL2SQL_PROVIDER": "acme",
             "ANTHROPIC_API_KEY": "would-otherwise-win",
         }
     )
-    assert settings.nl2sql_provider == "groq"
+    assert settings.nl2sql_provider == "acme"
 
 
 def test_built_in_vendors_still_beat_customs_in_auto_pick() -> None:
     settings = load_settings(
         {
             "MCPG_DATABASE_URL": _DB_URL,
-            "MCPG_NL2SQL_CUSTOM_PROVIDERS": "groq=https://api.groq.com/openai/v1|m",
+            "MCPG_NL2SQL_CUSTOM_PROVIDERS": "acme=https://api.acme.example/v1|m",
             "PERPLEXITY_API_KEY": "p",
         }
     )
@@ -390,18 +390,41 @@ def test_built_in_vendors_still_beat_customs_in_auto_pick() -> None:
 @pytest.mark.parametrize(
     ("entry", "match"),
     [
-        ("groq=https://a/v1|m, groq=https://b/v1|m", "duplicate"),
+        ("acme=https://a/v1|m, acme=https://b/v1|m", "duplicate"),
+        # A name that collides with any built-in is rejected — the original
+        # first-party trio and every provider in the expanded fleet.
         ("openai=https://a/v1|m", "clashes with a built-in"),
-        ("groq=http://api.groq.com/v1|m", "plain HTTP is only allowed for loopback"),
-        ("groq=https://api.groq.com/openai/v1", "no default model"),
-        ("groq=ftp://api.groq.com/v1|m", "must be http"),
-        ("Groq Name=https://a/v1|m", "must match"),
-        ("groq=https://a/v1|m|lower_case", "UPPER_SNAKE_CASE"),
+        ("groq=https://a/v1|m", "clashes with a built-in"),
+        ("huggingface=https://a/v1|m", "clashes with a built-in"),
+        ("acme=http://api.acme.example/v1|m", "plain HTTP is only allowed for loopback"),
+        ("acme=https://api.acme.example/v1", "no default model"),
+        ("acme=ftp://api.acme.example/v1|m", "must be http"),
+        ("Acme Name=https://a/v1|m", "must match"),
+        ("acme=https://a/v1|m|lower_case", "UPPER_SNAKE_CASE"),
     ],
 )
 def test_custom_provider_declarations_fail_fast_on_malformed_entries(entry: str, match: str) -> None:
     with pytest.raises(ConfigError, match=match):
         load_settings({"MCPG_DATABASE_URL": _DB_URL, "MCPG_NL2SQL_CUSTOM_PROVIDERS": entry})
+
+
+@pytest.mark.parametrize(
+    ("env_var", "provider"),
+    [
+        ("XAI_API_KEY", "xai"),
+        ("MISTRAL_API_KEY", "mistral"),
+        ("HF_TOKEN", "huggingface"),  # deviates from <VENDOR>_API_KEY
+        ("GITHUB_TOKEN", "github"),  # deviates
+        ("DEEPINFRA_TOKEN", "deepinfra"),  # deviates
+        ("SAMBANOVA_API_KEY", "sambanova"),
+    ],
+)
+def test_expanded_fleet_provider_discovered_from_its_vendor_env_var(env_var: str, provider: str) -> None:
+    # A built-in becomes configured (and, as the sole key, auto-picked) purely
+    # from its vendor env var — including the ones whose var isn't <NAME>_API_KEY.
+    settings = load_settings({"MCPG_DATABASE_URL": _DB_URL, env_var: "k"})
+    assert dict(settings.nl2sql_api_keys).get(provider) == "k"
+    assert settings.nl2sql_provider == provider
 
 
 def test_nl2sql_provider_requires_an_api_key_somewhere() -> None:

--- a/tests/unit/test_nl2sql.py
+++ b/tests/unit/test_nl2sql.py
@@ -17,6 +17,7 @@ from mcpg.nl2sql import (
     HARD_MAX_TOKENS,
     OPENAI_COMPATIBLE_BASE_URLS,
     VENDOR_ENV_VAR_HINT,
+    VENDOR_KEY_ENV_VARS,
     AnthropicProvider,
     GeminiProvider,
     LLMProvider,
@@ -139,16 +140,16 @@ def test_resolve_routes_declared_custom_providers() -> None:
         {
             "MCPG_DATABASE_URL": "postgresql://u:p@localhost/db",
             "MCPG_NL2SQL_CUSTOM_PROVIDERS": (
-                "groq=https://api.groq.com/openai/v1|llama-3.3-70b-versatile,ollama=http://localhost:11434/v1|llama3.1"
+                "acme=https://api.acme.example/v1|acme-large,ollama=http://localhost:11434/v1|llama3.1"
             ),
-            "GROQ_API_KEY": "gsk",
-            "MCPG_NL2SQL_MODEL": "llama-3.1-8b-instant",
+            "ACME_API_KEY": "gsk",
+            "MCPG_NL2SQL_MODEL": "acme-small",
         }
     )
     default = resolve_provider_call_params(settings, None)
-    assert default.provider_name == "groq"
-    assert default.model == "llama-3.1-8b-instant"  # override applies to the default
-    assert default.base_url == "https://api.groq.com/openai/v1"
+    assert default.provider_name == "acme"
+    assert default.model == "acme-small"  # override applies to the default
+    assert default.base_url == "https://api.acme.example/v1"
 
     explicit = resolve_provider_call_params(settings, "ollama")
     assert explicit.model == "llama3.1"  # non-default keeps its declared model
@@ -166,28 +167,60 @@ def test_resolve_unknown_provider_error_lists_declared_customs() -> None:
     settings = load_settings(
         {
             "MCPG_DATABASE_URL": "postgresql://u:p@localhost/db",
-            "MCPG_NL2SQL_CUSTOM_PROVIDERS": "groq=https://api.groq.com/openai/v1|m",
+            "MCPG_NL2SQL_CUSTOM_PROVIDERS": "acme=https://api.acme.example/v1|m",
         }
     )
-    with pytest.raises(NL2SQLError, match="groq"):
+    with pytest.raises(NL2SQLError, match="acme"):
         resolve_provider_call_params(settings, "bogus")
 
 
+@pytest.mark.parametrize(
+    ("name", "expected_base"),
+    [
+        ("xai", "https://api.x.ai/v1"),
+        ("groq", "https://api.groq.com/openai/v1"),
+        ("mistral", "https://api.mistral.ai/v1"),
+        ("huggingface", "https://router.huggingface.co/v1"),
+        ("github", "https://models.github.ai/inference"),
+        ("deepinfra", "https://api.deepinfra.com/v1/openai"),
+    ],
+)
+def test_build_provider_routes_new_built_ins_to_openai_client_with_preset_base_url(
+    name: str, expected_base: str
+) -> None:
+    # Every expanded-fleet vendor is OpenAI-compatible, so build_provider
+    # returns an OpenAIProvider pointed at the registry's preset base_url.
+    provider = build_provider(name, "key")
+    assert isinstance(provider, OpenAIProvider)
+    assert provider._base_url == expected_base
+
+
+def test_build_provider_honours_explicit_base_url_override_for_built_in() -> None:
+    # An explicit base_url (e.g. a private gateway) still wins over the preset.
+    provider = build_provider("groq", "key", base_url="https://gw.internal/v1")
+    assert isinstance(provider, OpenAIProvider)
+    assert provider._base_url == "https://gw.internal/v1"
+
+
 def test_default_models_table_covers_every_supported_provider() -> None:
-    assert set(DEFAULT_MODELS) == {
-        "anthropic",
-        "openai",
-        "gemini",
-        "deepseek",
-        "qwen",
-        "openrouter",
-        "perplexity",
-    }
-    # Every OpenAI-compatible preset must also have a default model and
-    # an env-var hint — the three tables move together.
-    assert set(OPENAI_COMPATIBLE_BASE_URLS) <= set(DEFAULT_MODELS)
+    # Every table is derived from the same provider registry, so they move
+    # together by construction. Assert that invariant, plus a sample of the
+    # expected members so a botched registry entry is still caught.
     assert set(VENDOR_ENV_VAR_HINT) == set(DEFAULT_MODELS)
     assert set(AUTO_PICK_ORDER) == set(DEFAULT_MODELS)
+    assert set(VENDOR_KEY_ENV_VARS) == set(DEFAULT_MODELS)
+    # OpenAI-compatible presets are a subset — the first-party clients
+    # (anthropic / openai / gemini) carry their own default host, no preset.
+    assert set(OPENAI_COMPATIBLE_BASE_URLS) <= set(DEFAULT_MODELS)
+    assert {"anthropic", "openai", "gemini"}.isdisjoint(OPENAI_COMPATIBLE_BASE_URLS)
+    # First-party trio kept first (auto-pick precedence) + a sample of the
+    # expanded fleet, including the ones whose key env var deviates.
+    assert AUTO_PICK_ORDER[:3] == ("anthropic", "openai", "gemini")
+    for provider in ("deepseek", "xai", "groq", "mistral", "huggingface", "github"):
+        assert provider in DEFAULT_MODELS
+    # Providers with non-standard key env vars are grounded correctly.
+    assert VENDOR_KEY_ENV_VARS["huggingface"][0] == "HF_TOKEN"
+    assert VENDOR_KEY_ENV_VARS["github"] == ("GITHUB_TOKEN",)
 
 
 def test_parse_response_extracts_sql_and_explanation_from_clean_json() -> None:

--- a/tests/unit/test_nl2sql.py
+++ b/tests/unit/test_nl2sql.py
@@ -202,6 +202,18 @@ def test_build_provider_honours_explicit_base_url_override_for_built_in() -> Non
     assert provider._base_url == "https://gw.internal/v1"
 
 
+def test_build_provider_fails_fast_on_unknown_api_style(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The Literal type makes this unreachable for the real registry, but a
+    # future entry with a bogus api_style must error, not silently route
+    # through the OpenAI client.
+    from mcpg import nl2sql
+
+    bogus = nl2sql.ProviderSpec("weird", "grpc", None, "m", ("WEIRD_API_KEY",))  # type: ignore[arg-type]
+    monkeypatch.setitem(nl2sql._PROVIDERS_BY_KEY, "weird", bogus)
+    with pytest.raises(NL2SQLError, match="unknown api_style"):
+        build_provider("weird", "key")
+
+
 def test_default_models_table_covers_every_supported_provider() -> None:
     # Every table is derived from the same provider registry, so they move
     # together by construction. Assert that invariant, plus a sample of the


### PR DESCRIPTION
## What

`translate_nl_to_sql` now ships **19 built-in providers**. The expanded fleet adds **xAI (Grok), GitHub Models, Hugging Face, Groq, Mistral, Together, Fireworks, DeepInfra, Cerebras, Nebius, SambaNova, and Moonshot (Kimi)** alongside the original seven (Anthropic, OpenAI, Gemini, DeepSeek, Qwen, OpenRouter, Perplexity).

Each is **plug-and-play** — set the vendor's conventional API-key env var and MCPg auto-discovers it, including the ones that deviate from `<VENDOR>_API_KEY`: **Hugging Face → `HF_TOKEN`**, **GitHub Models → `GITHUB_TOKEN`**, **DeepInfra → `DEEPINFRA_TOKEN`** (plus the existing `GOOGLE_API_KEY` / `QWEN_API_KEY` fallbacks). Every base URL + key env var was **verified against each vendor's official docs**.

## Design: one metadata registry, zero code edits to maintain

The four scattered lookup tables (default models, base URLs, env-var hints, auto-pick order) are replaced by a **single declarative registry** — `nl2sql.ProviderSpec` / `_PROVIDERS` — that every table derives from, and `config.py`'s key discovery iterates directly. Consequences:

- **Adding a provider** = one `ProviderSpec` line.
- **The recurring maintenance** — vendors retire models every few months (Cerebras already dropped `llama-3.1-8b`) — is editing a `default_model` string and cutting a build. Pure data, no code. A new `docs/release-process.md` chore documents the ~quarterly sweep.

Local stacks (Ollama / vLLM / LM Studio) stay on the keyless `MCPG_NL2SQL_CUSTOM_PROVIDERS` path by design — they're keyless and the served model varies.

## Tests

- Registry-consistency (all derived tables move together), new-provider `build_provider` routing (correct preset base URL), and env-var discovery for the deviating vars (`HF_TOKEN`/`GITHUB_TOKEN`/`DEEPINFRA_TOKEN`).
- Renamed the custom-provider test fixtures off now-built-in slugs (`groq`→`acme` etc.) and added clash-rejection checks for the new built-ins.
- Full unit suite green (2579 passed); ruff + mypy clean.

## Version

Staged under `[Unreleased]` in the CHANGELOG — ships as **0.6.9** at the next release cut (per repo convention, `__version__` + the MCPB bundle pin are bumped together at tag time, not in feature PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Introduce a metadata-driven registry for NL→SQL providers and expand the built-in provider set.

New Features:
- Add 12 new built-in NL→SQL providers, bringing the total to 19, including major hosted LLM vendors like xAI, Groq, Mistral, Hugging Face, GitHub Models, and others.

Enhancements:
- Centralize all NL→SQL provider metadata in a single declarative ProviderSpec registry that drives defaults, base URLs, env-var discovery, and auto-pick order.
- Update configuration and provider construction logic to use the registry for auto-discovery of vendor API keys and routing to the appropriate client.
- Clarify and expand user-facing documentation for NL→SQL configuration, built-in providers, and custom provider setup, including env-var conventions and auto-pick behavior.
- Document the periodic sweep process for refreshing default NL→SQL models as vendors retire or change offerings.

Tests:
- Add and update unit tests to validate registry consistency, routing of new built-in providers, env-var discovery (including non-standard keys), and rejection of custom providers that clash with built-ins.