### PR TITLE
chore: release v0.6.9 (version bump + changelog roll)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.6.9] - 2026-07-07
+
 ### Added
 
 - **12 more built-in NL→SQL providers + a metadata-driven provider

--- a/packaging/mcpb/manifest.json
+++ b/packaging/mcpb/manifest.json
@@ -1,10 +1,10 @@
 {
   "manifest_version": "0.4",
   "name": "mcpg",
-  "display_name": "MCPg — PostgreSQL",
-  "version": "0.6.8",
-  "description": "Production-grade PostgreSQL MCP server: 252 tools for querying, tuning, and operating Postgres — read-only by default.",
-  "long_description": "MCPg lets AI agents safely inspect, query, operate, and tune a PostgreSQL database. 252 tools spanning catalog introspection, query intelligence, natural-language SQL, structural diffs, hybrid search, graph queries, live ops, and more.\n\n**Safe by default**: read-only access mode, AST-validated SQL, and every tool publishes MCP annotations (`readOnlyHint`/`destructiveHint`) so the client knows exactly which calls are safe. Write, DDL, shell, and LISTEN capabilities stay off until explicitly enabled via environment variables.\n\nNo data yet? Run `mcpg --demo` against a scratch database to seed a curated demo dataset and take the tools for a spin — see the guided tour at https://github.com/devopam/MCPg/blob/main/docs/demo.md.",
+  "display_name": "MCPg \u2014 PostgreSQL",
+  "version": "0.6.9",
+  "description": "Production-grade PostgreSQL MCP server: 252 tools for querying, tuning, and operating Postgres \u2014 read-only by default.",
+  "long_description": "MCPg lets AI agents safely inspect, query, operate, and tune a PostgreSQL database. 252 tools spanning catalog introspection, query intelligence, natural-language SQL, structural diffs, hybrid search, graph queries, live ops, and more.\n\n**Safe by default**: read-only access mode, AST-validated SQL, and every tool publishes MCP annotations (`readOnlyHint`/`destructiveHint`) so the client knows exactly which calls are safe. Write, DDL, shell, and LISTEN capabilities stay off until explicitly enabled via environment variables.\n\nNo data yet? Run `mcpg --demo` against a scratch database to seed a curated demo dataset and take the tools for a spin \u2014 see the guided tour at https://github.com/devopam/MCPg/blob/main/docs/demo.md.",
   "author": {
     "name": "Devopam Mittra",
     "email": "devopam@gmail.com",
@@ -44,7 +44,7 @@
     "database_url": {
       "type": "string",
       "title": "PostgreSQL connection URL",
-      "description": "e.g. postgresql://user:password@localhost:5432/mydb — remote hosts need ?sslmode=require. Stored securely by the OS keychain.",
+      "description": "e.g. postgresql://user:password@localhost:5432/mydb \u2014 remote hosts need ?sslmode=require. Stored securely by the OS keychain.",
       "sensitive": true,
       "required": true
     },

--- a/packaging/mcpb/pyproject.toml
+++ b/packaging/mcpb/pyproject.toml
@@ -5,9 +5,9 @@
 # to the release tag by the publish workflow, exactly like server.json.
 [project]
 name = "mcpg-desktop-extension"
-version = "0.6.8"
+version = "0.6.9"
 description = "MCPB launcher shim for the MCPg PostgreSQL MCP server."
 requires-python = ">=3.12"
 dependencies = [
-    "mcpg==0.6.8",
+    "mcpg==0.6.9",
 ]

--- a/src/mcpg/__init__.py
+++ b/src/mcpg/__init__.py
@@ -2,7 +2,7 @@
 
 import warnings
 
-__version__ = "0.6.8"
+__version__ = "0.6.9"
 
 # ``schema`` is the natural field name for "which Postgres schema" across
 # ~180 tool-return dataclasses. The ``mcp`` SDK dynamically builds a


### PR DESCRIPTION
## Why

The `v0.6.9` tag was cut on `main` **before** the version bump landed, so its publish run ([28814059582](https://github.com/devopam/MCPg/actions/runs/28814059582)) **failed the "tag matches package version" sanity check** (`tag 0.6.9 ≠ __version__ 0.6.8`). That check runs first, before any PyPI/GHCR upload, so **nothing was published and `0.6.9` is not burnt** — fully recoverable.

This PR is the missing version-bump so `main` matches the tag.

## What

- `src/mcpg/__init__.py`: `__version__` → **0.6.9** (single source; `pyproject.toml` derives it).
- `packaging/mcpb/{pyproject.toml,manifest.json}`: bundle pin synced to `mcpg==0.6.9` via `sync_version.py` (the `test_bundle_pyproject_pins_the_current_release` invariant).
- `CHANGELOG.md`: rolled `[Unreleased]` → `[0.6.9] - 2026-07-07` (adjust the date if you cut it a different day).

Verified: `python -m build` → `mcpg-0.6.9`; bundle test green.

## ⚠️ Recovery steps after this merges

The existing `v0.6.9` tag points at the old (unbumped) commit, so it must be replaced:

```bash
git fetch origin
git checkout main && git pull origin main          # picks up this bump
git push origin :refs/tags/v0.6.9                   # delete the bad remote tag
git tag -d v0.6.9                                   # delete local
git tag -s v0.6.9 -m "MCPg v0.6.9"                  # re-tag the bumped HEAD
git push origin v0.6.9                              # re-fires publish.yml — now passes
```

Then approve the `pypi` deployment at the gate (Actions → Review pending deployments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Align project versioning and packaging metadata with the v0.6.9 release tag.

Enhancements:
- Bump core mcpg package version to 0.6.9 and sync dependent bundle/extension metadata to the same version.

Documentation:
- Roll the changelog forward by adding a 0.6.9 release section and update descriptive text in the MCP bundle manifest.