### PR TITLE
docs: close the never-reviewed-docs coverage gap

### DIFF
--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -6,33 +6,36 @@
 
 ## Current state
 
-- **Phase:** post-v0.5.0 — every Batch (A–G) from the original
-  shortlist closed, plus the following post-release waves:
-  - **Security (C1–C3):** IP allowlist, TLS / mTLS for the HTTP
-    transport, cloud secrets backends (Vault / AWS / GCP).
-  - **Observability (B2–B3):** slow-call logging + OpenTelemetry
-    tracing (one span per `call_tool`, argument-values omitted).
-  - **Migrations (E1–E4):** migration-history table integration,
-    pre-deployment validation, `list_unapplied_migration_scripts`.
-  - **pgvector analytics (A3–A8):** `cross_table_similarity`,
-    `cluster_vectors`, `detect_vector_outliers`,
-    `monitor_embedding_drift`, `migrate_vector_to_halfvec`,
-    `analyze_distance_metric`, `import_vectors`.
-  - **Advisors (6.1):** `recommend_index_drops`.
-  - **UX (F2 first wave):** inline usage examples in tool
-    descriptions.
-- **Last updated:** 2026-06-05
+- **Phase:** post-v0.6.9. Every Batch (A–G) from the original
+  shortlist plus the 0.6.x waves have shipped — security (IP
+  allowlist, TLS/mTLS, cloud secrets backends), observability
+  (slow-call logging + OpenTelemetry), staged migrations + history,
+  pgvector analytics, BM25/`pg_search`, `pg_turboquant`, the RAG
+  efficiency suite, PG 19 readiness (SQL/PGQ, `REPACK`, skip-scan,
+  `WAIT FOR LSN`, data-checksum/logical-rep toggles, partition
+  merge/split), WarehousePG (MPP) coverage, Redis FDW, `pg_prewarm`,
+  the 19-provider NL→SQL fleet, and the generated-doc-table drift
+  guard.
+- **Last updated:** 2026-07-07
 - **Branch:** `main`
-- **Tool count:** 141
-- **Released:** v0.5.0 (2026-05-27)
+- **Tool count:** 252 (source of truth:
+  `tests/contract/tool_surface.snapshot.json`)
+- **Released:** v0.6.9 (2026-07-07)
+
+> **Note on this log.** The dated session log below is a historical
+> record that trails off at **2026-05-26** (~90 tools). The nine
+> 0.6.x releases and ~160 tools shipped since are *not* re-logged
+> here — `CHANGELOG.md` and the `docs/release-notes-0.6.*.md` files
+> are the authoritative history for that period, and
+> `docs/feature-shortlist.md` is the live roadmap.
 
 ## Next action
 
-> All Tier-A/B/C shortlist + the post-v0.5.0 waves above are
-> shipped on trunk. Next direction is open — un-ticked rows in
-> `docs/feature-shortlist.md` are the queue, or a v0.6.0 cut
-> bundling the security / observability / analytics work since
-> v0.5.0.
+> Trunk is at 0.6.9. The live queue is the un-ticked rows in
+> `docs/feature-shortlist.md` — currently the two NL→SQL
+> security-hardening items (§ "Queued" in
+> `docs/security-hardening.md`) and roadmap 18.1 (de-vendor the
+> SQL-safety kernel).
 
 ## Phase 0 — Spike & foundation  ✅ COMPLETE
 
@@ -202,9 +205,16 @@
 
 ## Open questions
 
-- Remote HTTP transport auth model (Phase 1/3).
-- Whether tuning tools need opt-in beyond `unrestricted` (Phase 5).
-- Observability scope (Phase 6).
+_All resolved as of 0.6.9:_
+
+- ~~Remote HTTP transport auth model (Phase 1/3).~~ Shipped: static
+  bearer token + OIDC/JWT validation (`mcpg.http_runtime`,
+  `mcpg.oidc`).
+- ~~Whether tuning tools need opt-in beyond `unrestricted` (Phase 5).~~
+  Resolved: reads need no opt-in; only DDL/shell/listen/migrate carry
+  the per-feature `MCPG_ALLOW_*` gates (see `policy.py`).
+- ~~Observability scope (Phase 6).~~ Shipped: Prometheus metrics +
+  OpenTelemetry tracing (`mcpg.observability`, `mcpg.otel_tracing`).
 
 ## Session log
 

--- a/docs/contributing/adding-tools.md
+++ b/docs/contributing/adding-tools.md
@@ -208,7 +208,7 @@ When sweeping a legacy tool onto the typed-return shape:
 3. Replace `return asdict(result)` with `return result`.
 4. Add the tool's name + expected field set to the manifest in `tests/contract/test_tool_output_schemas.py`.
 5. Regenerate the surface + return-shape snapshots (`MCPG_REGENERATE_TOOL_SNAPSHOT=1` / `MCPG_REGENERATE_TOOL_RETURN_SHAPES=1`).
-6. Bump the `_FLOOR` constant in `test_tool_output_schemas.py::test_converted_tool_count_grows_monotonically`.
+6. Bump the `floor` literal in `test_tool_output_schemas.py::test_converted_tool_count_grows_monotonically`.
 
 Write/DDL tools clear the cache after running:
 

--- a/docs/parallel-roadmap.md
+++ b/docs/parallel-roadmap.md
@@ -1,6 +1,16 @@
 # MCPg parallel-work roadmap
 
-A planning view of the **remaining** feature work, organised so several
+> ⚠️ **Largely historical (as of 0.6.9).** Most workstreams below have
+> since shipped — the A-series vector analytics, D-series logical
+> replication + blocking-chain tools, F-series test-data/schema-doc
+> generators, G-series WAL/PITR helpers, and multi-database support are
+> all live. Treat the tables below as a **method illustration** (how to
+> slice parallel PRs with the conflict map in §2), not a live to-do
+> list. For current open items use
+> [`feature-shortlist.md`](feature-shortlist.md) and
+> [`security-hardening.md`](security-hardening.md).
+
+A planning view of parallelisable feature work, organised so several
 contributors can pick items up **simultaneously in separate PRs** with
 minimal merge friction.
 
@@ -140,9 +150,10 @@ All four are independent.
 
 ### Deferred
 
-- Multi-database support (10.1, **L**) — one server, many DSNs. Big
-  architectural change (pool-per-DB, per-tool selector, gate rework).
-  No concrete demand; leave parked.
+- ~~Multi-database support (10.1, **L**)~~ — **shipped** (roadmap
+  13.1): `MCPG_SECONDARY_DATABASE_URLS` adds named read-only
+  secondaries with a per-tool `database` selector and `list_databases`.
+  Writable secondaries remain deferred.
 
 ---
 

--- a/docs/reviews/tool-surface-fact-pack.md
+++ b/docs/reviews/tool-surface-fact-pack.md
@@ -262,7 +262,7 @@ Interpretations the raw stats above point at — not verdicts, just leads worth 
 
 Phase A surfaces leads; Phase B (LLM behaviour observation) confirms or refutes them. The Phase-B prompt corpus should include at least:
 
-1. **Picker-confusion probes** for the top-scoring overlap pairs from `tool-overlap-report.md` (Phase A.0). Ask the LLM to disambiguate them; if it can't, the static flag is real.
+1. **Picker-confusion probes** for the top-scoring overlap pairs from `tool-overlap-report.md` (Phase A.0 — a working artifact no longer committed; regenerate with `python tools/analyse_tool_overlap.py`). Ask the LLM to disambiguate them; if it can't, the static flag is real.
 2. **Permission-denial probes** for the `missing security caveat` list. Simulate a denial; see whether the LLM can suggest the right `MCPG_*` flag.
 3. **Return-shape probes** for the `no return hint` list. Ask the LLM what it expects the tool to return; compare to reality.
 4. **Self-introspection probes** — 'What can this MCP server do?' / 'List mcpg's capabilities' / 'Can mcpg do X?' Measure whether the response is accurate, complete, and useful.

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -73,7 +73,7 @@ Capacity guidance:
   becomes the bottleneck on write throughput or replication
   bandwidth.
 - Routing decisions land in Prometheus
-  (`mcpg_tool_calls_total{tool="__replica_route",status="…"}`)
+  (`mcpg_tool_calls_total{tool="__replica_route",bucket="unknown",status="…"}`)
   with statuses `primary` / `primary_no_healthy` / `fallback` /
   `replica_<n>`.
 
@@ -123,9 +123,9 @@ limiter:
   `MCPG_RATE_LIMIT_WINDOW_SECONDS` across all tools (defaults
   60 / 60 s).
 - **Heavy quota.** `MCPG_RATE_LIMIT_HEAVY_MAX` per
-  `MCPG_RATE_LIMIT_HEAVY_WINDOW` for `run_write`, `run_ddl`,
-  `dump_database`, `restore_database`, and similar (defaults
-  5 / 60 s).
+  `MCPG_RATE_LIMIT_HEAVY_WINDOW` for the computationally heavy tools
+  (`analyze_workload`, `audit_database`, `generate_test_data`,
+  `export_table`, `export_query`) (defaults 5 / 60 s).
 
 Rate-limited calls return an error immediately rather than
 queueing.
@@ -159,13 +159,14 @@ uv run python benchmarks/bench.py --requests 2000 --concurrency 16 \
 
 The HTTP transport exposes Prometheus metrics at `GET /metrics`:
 
-- `mcpg_tool_calls_total{tool,status}` — counter; one of the
+- `mcpg_tool_calls_total{tool,bucket,status}` — counter; one of the
   best signals for "is X being called too often / failing too
   often". `status` ∈ `ok` / `error` plus the replica-routing
-  statuses noted above.
+  statuses noted above; `bucket` is the capability bucket the tool
+  routes into (aggregate with `sum by (bucket) (…)`).
 - `mcpg_tool_duration_seconds_*` — histogram per tool; bucket
   defaults are SDK-shaped (0.005, 0.01, 0.025, 0.05, 0.1, 0.25,
-  0.5, 1, 2.5, 5, 10 s).
+  0.5, 1, 2.5, 5, 10, 30, 60 s).
 
 For stdio deployments, `get_metrics_exposition()` returns the same
 Prometheus payload as a string the agent can hand to a scrape
@@ -200,9 +201,9 @@ cover the three axes you need:
   bumping `max_rows`. They give the agent backpressure and don't
   buffer the whole result in MCPg memory.
 - **Heavy DBA tools** (`audit_database`, `analyze_workload`,
-  `dump_database`) are I/O-heavy on the database. Rate-limit them
-  via `MCPG_RATE_LIMIT_HEAVY_*` if an agent calls them on a tight
-  loop.
+  `generate_test_data`, `export_table`, `export_query`) are
+  I/O-heavy on the database. Rate-limit them via
+  `MCPG_RATE_LIMIT_HEAVY_*` if an agent calls them on a tight loop.
 
 ---
 


### PR DESCRIPTION
## Summary

The earlier "audit every doc" effort in fact missed 13 files. This sweeps all 13 against the actual code and fixes what had drifted. Verified-clean (no change): the 6 ADRs, `demo.md`, `postgres-fdw-pushdown.md`. Fixes:

- **`PROGRESS.md`** — "Current state" was frozen at v0.5.0 / 141 tools with a "cut v0.6.0" next-action. Updated to v0.6.9 / 252; marked the session log as a historical record that trails off at 2026-05-26 (CHANGELOG + release-notes are authoritative for the 0.6.x period); closed the three resolved "Open questions".
- **`parallel-roadmap.md`** — added a "largely historical" banner (most workstreams shipped); corrected the false "multi-database… leave parked" line (it shipped as roadmap 13.1).
- **`scaling.md`** — the heavy-rate-limit tool list was wrong (named `run_write`/`run_ddl`/`dump_database`); replaced with the actual `HEAVY_TOOLS` set (`analyze_workload`/`audit_database`/`generate_test_data`/`export_table`/`export_query`); added the missing `30`/`60`s histogram buckets and the `bucket` metric label — all verified against `rate_limit.py` + `observability.py`.
- **`contributing/adding-tools.md`** — `_FLOOR` constant → the actual `floor` literal.
- **`reviews/tool-surface-fact-pack.md`** — noted the referenced `tool-overlap-report.md` is uncommitted but regenerable via `tools/analyse_tool_overlap.py`.

## Roadmap linkage

Advances roadmap row: N/A — documentation veracity fix.

## Checklist

- [x] Every claim verified against the code before editing
- [x] `ruff` / `mypy` unaffected (docs-only)
- [ ] `CHANGELOG.md` — N/A (docs veracity fix, no behaviour change)
- [x] Roadmap row cited (`N/A`)
- [x] No hand-edits to `src/mcpg/_vendor/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Update and clarify several documentation files to reflect the current v0.6.9 state, shipped features, and accurate operational details.

Documentation:
- Refresh PROGRESS overview to describe the v0.6.9 release, current tool count, and clarify the historical scope of the session log and roadmap linkage.
- Mark the parallel-work roadmap as largely historical, pointing readers to the current shortlist and security-hardening docs, and note that multi-database support has shipped.
- Correct scaling guidance to match the actual heavy-tool set and metrics schema, including histogram buckets and metric labels.
- Clarify contributor guidance on updating the typed-return conversion test by referring to the literal value instead of an internal constant name.
- Note that the tool-overlap report referenced in the tool-surface fact pack is a regenerable working artifact rather than a committed file.