### PR TITLE
docs(security-hardening): correct stale "Queued" note

### DIFF
--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -122,9 +122,12 @@ left in place.
 
 ## Queued (next focused PRs)
 
-> Most of this section has now shipped. Only **Pluggable secrets
-> backend** remains queued; the rest are marked ✅ with the landing
-> note inline.
+> Most of this section has now shipped (each marked ✅ with the
+> landing note inline). Two items remain, both small and both scoped
+> to `translate_nl_to_sql` / `mcpg.nl2sql`: **NL→SQL prompt-injection
+> hardening** and **NL→SQL EXPLAIN dry-run pre-flight** (the two ⬜
+> entries below). They're the current top security priority and a
+> natural single focused PR.
 
 ### ✅ HTTP hardening (request limits + security headers + CORS + timeout)
 **Shipped.** Security headers + request-size limit + CORS allowlist


### PR DESCRIPTION
## Summary

The "Queued (next focused PRs)" section intro claimed only **Pluggable secrets backend** remained queued, but that shipped (✅). Corrected the note to name the two genuinely-remaining items — **NL→SQL prompt-injection hardening** and **NL→SQL EXPLAIN dry-run pre-flight** (both ⬜, both scoped to `translate_nl_to_sql`) — and flag them as the current top security priority and a natural single focused PR.

## Roadmap linkage

Advances roadmap row: N/A — documentation veracity fix.

## Checklist

- [x] Verified against the section's own ✅/⬜ markers
- [ ] `CHANGELOG.md` — N/A (docs-only)
- [x] Roadmap row cited (`N/A`)
- [x] No hand-edits to `src/mcpg/_vendor/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Documentation:
- Clarify the "Queued" section to list the two remaining NL→SQL security tasks and note their priority and scope.