### PR TITLE
review-readiness: CLI/UX/security polish + unindexed-FK index advisor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`recommend_indexes` now flags unindexed foreign keys.** PostgreSQL indexes
+  PRIMARY KEY / UNIQUE columns automatically but *not* foreign keys, so an
+  unindexed FK silently forces sequential-scan joins and slow cascading
+  UPDATE/DELETE. For each seq-scan-heavy table the advisor now recommends a
+  **btree** on any single-column FK that has no covering index (leading the
+  type-driven GIN/trigram suggestions). Closes the gap the demo walkthrough
+  demonstrates.
+
+### Fixed
+
+- **`mcpg --help` / `-h`** now prints usage instead of dying with a
+  `MCPG_DATABASE_URL is required` config error; an unknown argument is
+  reported clearly (exit 2) rather than falling through to the same misleading
+  message.
+- **README HTTP quickstart** pointed clients at `http://localhost:8000`; the
+  handler is mounted at `/mcp` (`/sse` for SSE) — corrected so a copy-pasted
+  first connection doesn't 404.
+- **Stdio startup is no longer silent** — `mcpg` logs one line to stderr
+  (`ready on stdio (<mode> mode) — waiting for an MCP client`) so a first-time
+  user doesn't think it hung.
+
+### Security
+
+- **Audit log: error text is now redacted.** A DSN embedded in a tool's error
+  message (e.g. a secondary/replica/data-movement connection) is run through
+  `obfuscate_password` before logging, matching the existing argument
+  redaction, so a password can't leak into the audit sink.
+- **`EXPLAIN ANALYZE` (`io=True`) now runs read-only.** The only agent-SQL path
+  that executed at `force_readonly=False`, reachable in read-only mode, now
+  wraps execution in `BEGIN TRANSACTION READ ONLY` like every other path.
+
 ## [0.6.10] - 2026-07-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -203,7 +203,8 @@ MCPG_HTTP_PORT=8000 \
 mcpg
 ```
 
-Then point any MCP-aware client at `http://localhost:8000`. Set
+Then point any MCP-aware client at `http://localhost:8000/mcp` (or
+`/sse` for the SSE transport). Set
 `MCPG_HTTP_AUTH_TOKEN=...` for a static bearer, or
 `MCPG_AUTH_MODE=oidc` for full JWT validation against an OIDC issuer.
 

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -254,6 +254,11 @@ The plan shows a **sequential scan over every order** to find one customer's row
     "reason": "large table read mostly by sequential scan",
     "suggestions": [
       {
+        "column": "customer_id",
+        "index_type": "btree",
+        "rationale": "foreign-key column with no covering index — unindexed FKs force sequential scans on joins and slow cascading UPDATE/DELETE on the referenced table"
+      },
+      {
         "column": "status",
         "index_type": "gin_trgm",
         "rationale": "trigram GIN (pg_trgm) accelerates LIKE/ILIKE pattern search"
@@ -263,6 +268,11 @@ The plan shows a **sequential scan over every order** to find one customer's row
   }
 ]
 ```
+
+The advisor leads with a **btree on `orders.customer_id`** — the planted flaw
+and the exact fix for the slow query above (PostgreSQL doesn't index foreign
+keys automatically, so it took a seq scan). It also spots the free-text
+`status` column as a trigram-GIN candidate for `LIKE`/`ILIKE` search.
 
 ---
 

--- a/src/mcpg/__main__.py
+++ b/src/mcpg/__main__.py
@@ -12,6 +12,32 @@ from mcpg import __version__
 from mcpg.config import ConfigError, load_settings
 from mcpg.server import run
 
+_USAGE = """\
+mcpg {version} — a PostgreSQL Model Context Protocol (MCP) server
+
+Usage:
+  mcpg                Start the MCP server (stdio transport by default)
+  mcpg --version, -V  Print the version and exit
+  mcpg --help, -h     Show this help and exit
+  mcpg --demo         Seed a small demo dataset into the configured database
+  mcpg --demo-drop    Drop the demo dataset
+
+MCPg is configured entirely through environment variables. The only required
+one is MCPG_DATABASE_URL; all others have safe defaults. Most common:
+
+  MCPG_DATABASE_URL   PostgreSQL connection URL, e.g.
+                      postgresql://user:pass@host:5432/db   (required)
+  MCPG_ACCESS_MODE    read-only (default) | restricted | unrestricted
+  MCPG_TRANSPORT      stdio (default) | streamable-http | sse
+
+Full configuration reference and docs:
+  https://github.com/devopam/MCPg#configuration
+"""
+
+
+def _print_help() -> None:
+    print(_USAGE.format(version=__version__))
+
 
 def _run_demo_command(command: str, database_url: str) -> int:
     """Seed or drop the demo dataset. Returns a process exit code."""
@@ -54,6 +80,16 @@ def main() -> int:
     if len(sys.argv) > 1 and sys.argv[1] in {"--version", "-V"}:
         print(f"mcpg {__version__}")
         return 0
+    # ``--help`` / ``-h`` must work WITHOUT a configured database — it's the
+    # first thing a new user types, so it can't depend on load_settings().
+    if len(sys.argv) > 1 and sys.argv[1] in {"--help", "-h"}:
+        _print_help()
+        return 0
+    # Reject an unknown argument with a clear message instead of falling
+    # through to a confusing "MCPG_DATABASE_URL is required" config error.
+    if len(sys.argv) > 1 and sys.argv[1] not in {"--demo", "--demo-drop"}:
+        print(f"mcpg: unknown argument: {sys.argv[1]!r}\nTry 'mcpg --help'.", file=sys.stderr)
+        return 2
     try:
         settings = load_settings()
     except ConfigError as exc:

--- a/src/mcpg/advisors.py
+++ b/src/mcpg/advisors.py
@@ -714,6 +714,7 @@ async def optimize_query(driver: SqlDriver, sql: str) -> OptimizationResult:
     """Analyze a SQL query for anti-patterns and performance issues, returning an optimized version."""
     findings = []
     ex_summary = ""
+    plan = None
 
     # 1. Plan analysis
     try:
@@ -789,7 +790,7 @@ async def optimize_query(driver: SqlDriver, sql: str) -> OptimizationResult:
         )
 
     try:
-        if "plan" in locals() and plan.sequential_scans:
+        if plan is not None and plan.sequential_scans:
             rationale_parts.append(
                 "- Consider adding indexes on columns used in WHERE or JOIN clauses for tables with Seq Scan."
             )

--- a/src/mcpg/audit.py
+++ b/src/mcpg/audit.py
@@ -140,21 +140,26 @@ def redact_arguments(arguments: dict[str, Any]) -> dict[str, Any]:
 def record(event: AuditEvent) -> None:
     """Emit an audit event to the ``mcpg.audit`` logger."""
     safe_arguments = redact_arguments(event.arguments)
+    # The error is free-form ``str(exc)`` and can embed a connection string
+    # (e.g. a secondary/replica/data-movement DSN whose driver didn't
+    # pre-obfuscate); redact it exactly like the arguments so a password can't
+    # reach the audit sink.
+    safe_error = obfuscate_password(event.error) if event.error is not None else None
     if _log_format == "json":
         payload = {
             "tool": event.tool,
             "status": event.status,
             "arguments": safe_arguments,
         }
-        if event.error is not None:
-            payload["error"] = event.error
+        if safe_error is not None:
+            payload["error"] = safe_error
         msg = json.dumps(payload)
-        if event.error is None:
+        if safe_error is None:
             audit_logger.info(msg)
         else:
             audit_logger.warning(msg)
     else:
-        if event.error is None:
+        if safe_error is None:
             audit_logger.info("tool=%s status=%s arguments=%s", event.tool, event.status, safe_arguments)
         else:
             audit_logger.warning(
@@ -162,7 +167,7 @@ def record(event: AuditEvent) -> None:
                 event.tool,
                 event.status,
                 safe_arguments,
-                event.error,
+                safe_error,
             )
 
 
@@ -1025,6 +1030,7 @@ async def audit_slow_queries(driver: SqlDriver) -> CategoryResult:
             "LIMIT 1",
             force_readonly=True,
         )
+        calls = 0
         if rows:
             cells = rows[0].cells
             calls = int(cells["calls"] or 0)

--- a/src/mcpg/indexing.py
+++ b/src/mcpg/indexing.py
@@ -1,9 +1,11 @@
 """Index recommendations from table scan statistics and column types.
 
 A table-level heuristic flags large tables read mostly by sequential scan;
-for each, column types drive per-column index-type suggestions (GIN for
-``jsonb``/arrays, trigram GIN for text). Choosing exactly which columns a
-workload filters on still needs query analysis (see ``analyze_workload``).
+for each, it recommends a btree on any unindexed single-column foreign key
+(PostgreSQL doesn't auto-index FKs) and column types drive per-column
+index-type suggestions (GIN for ``jsonb``/arrays, trigram GIN for text).
+Choosing exactly which columns a workload filters on still needs query
+analysis (see ``analyze_workload``).
 
 The companion :func:`recommend_index_drops` looks at the same scan
 statistics from the opposite angle — flagging *existing* indexes that
@@ -78,18 +80,33 @@ class _TableAgg:
         self.live_tuples += live_tup
         self.partitioned = self.partitioned or is_partition
 
-    def add_suggestion(self, column: str, data_type: str) -> None:
+    def add_suggestion(self, column: str, data_type: str, is_unindexed_fk: bool = False) -> None:
         if column in self._seen_columns:
             return
-        suggestion = _suggest(column, data_type)
+        suggestion = _suggest(column, data_type, is_unindexed_fk)
         if suggestion is None:
             return
         self._seen_columns.add(column)
         self.suggestions.append(suggestion)
 
 
-def _suggest(column: str, data_type: str) -> IndexSuggestion | None:
-    """Suggest an index type for a column based on its data type, if any."""
+# Rationale for a foreign-key column that has no covering index. PostgreSQL
+# indexes PRIMARY KEY / UNIQUE columns automatically but NOT foreign keys, so
+# an unindexed FK is a common, high-impact gap: joins from the referenced side
+# fall back to sequential scans, and every UPDATE/DELETE on the parent has to
+# seq-scan the child to enforce the constraint.
+_FK_RATIONALE = (
+    "foreign-key column with no covering index — unindexed FKs force sequential "
+    "scans on joins and slow cascading UPDATE/DELETE on the referenced table"
+)
+
+
+def _suggest(column: str, data_type: str, is_unindexed_fk: bool = False) -> IndexSuggestion | None:
+    """Suggest an index for a column based on FK status, then data type."""
+    # An unindexed foreign key wins: a plain btree on the FK column is the
+    # highest-value fix, independent of the column's data type.
+    if is_unindexed_fk:
+        return IndexSuggestion(column, "btree", _FK_RATIONALE)
     if data_type == "jsonb":
         return IndexSuggestion(column, "gin", "GIN supports jsonb containment and key lookups")
     if data_type == "ARRAY":
@@ -105,8 +122,12 @@ async def recommend_indexes(
     """Recommend tables that may benefit from indexing, with column hints.
 
     Heuristic: large tables (at least ``min_live_tuples`` rows) read more
-    often by sequential scan than by index scan. For each, columns with
-    GIN-friendly types yield an :class:`IndexSuggestion`. A flagged partition
+    often by sequential scan than by index scan. For each, two kinds of
+    per-column suggestion are emitted: a **btree** on any single-column
+    foreign key that has no covering index (PostgreSQL doesn't auto-index FKs,
+    so these silently force seq-scan joins), and a type-driven suggestion for
+    GIN-friendly columns (``jsonb`` / arrays → GIN, text → trigram GIN). A
+    flagged partition
     is rolled up to its partitioned parent, since an index belongs on the
     parent; scan and row counts are summed across the partitions. The
     partitioned parent's own (empty) stats row is excluded from the
@@ -119,7 +140,19 @@ async def recommend_indexes(
     rows = await driver.execute_query(
         "SELECT s.schemaname, s.relname, s.seq_scan, s.n_live_tup, "
         "c.column_name, c.data_type, "
-        "pn.nspname AS parent_schema, parent.relname AS parent_table "
+        "pn.nspname AS parent_schema, parent.relname AS parent_table, "
+        # A single-column foreign key on this column with no index whose
+        # leading column is that FK column — PostgreSQL doesn't auto-index FKs.
+        "EXISTS ("
+        "  SELECT 1 FROM pg_constraint con "
+        "  JOIN pg_attribute a ON a.attrelid = con.conrelid AND a.attnum = con.conkey[1] "
+        "  WHERE con.contype = 'f' AND array_length(con.conkey, 1) = 1 "
+        "    AND con.conrelid = self.oid AND a.attname = c.column_name "
+        "    AND NOT EXISTS ("
+        "      SELECT 1 FROM pg_index ix "
+        "      WHERE ix.indrelid = con.conrelid AND ix.indkey[0] = con.conkey[1]"
+        "    )"
+        ") AS is_unindexed_fk "
         "FROM pg_stat_user_tables s "
         "JOIN pg_class self ON self.oid = s.relid AND self.relkind <> 'p' "
         "JOIN information_schema.columns c "
@@ -152,7 +185,7 @@ async def recommend_indexes(
         if physical not in counted:
             counted.add(physical)
             agg.add_stats(row.cells["seq_scan"], row.cells["n_live_tup"], is_partition)
-        agg.add_suggestion(row.cells["column_name"], row.cells["data_type"])
+        agg.add_suggestion(row.cells["column_name"], row.cells["data_type"], bool(row.cells.get("is_unindexed_fk")))
 
     return [
         IndexRecommendation(

--- a/src/mcpg/listen.py
+++ b/src/mcpg/listen.py
@@ -248,7 +248,7 @@ class ListenManager:
             # __aexit__ still runs.
             try:
                 await asyncio.wait_for(conn.close(), timeout=2.0)
-            except (TimeoutError, Exception):
+            except Exception:
                 pass
         if task is not None:
             task.cancel()

--- a/src/mcpg/migration_history.py
+++ b/src/mcpg/migration_history.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import Any
 
 from mcpg.sql import SqlDriver
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -180,8 +183,12 @@ async def read_migration_history(
                 alembic.extend(
                     [AlembicMigration(version_num=str(row.cells["version_num"])) for row in alembic_rows or []]
                 )
-            except Exception:
-                pass
+            except Exception as exc:
+                # The table exists but couldn't be read (permissions, or a
+                # column shape that doesn't match this framework's expected
+                # layout) — skip this framework rather than fail the whole
+                # report, and leave a breadcrumb for debugging.
+                logger.debug("migration_history: skipping %s (%s)", t, exc)
 
         elif t == "flyway_schema_history":
             try:
@@ -211,8 +218,12 @@ async def read_migration_history(
                         for row in flyway_rows or []
                     ]
                 )
-            except Exception:
-                pass
+            except Exception as exc:
+                # The table exists but couldn't be read (permissions, or a
+                # column shape that doesn't match this framework's expected
+                # layout) — skip this framework rather than fail the whole
+                # report, and leave a breadcrumb for debugging.
+                logger.debug("migration_history: skipping %s (%s)", t, exc)
 
         elif t == "__diesel_schema_migrations":
             try:
@@ -231,8 +242,12 @@ async def read_migration_history(
                         for row in diesel_rows or []
                     ]
                 )
-            except Exception:
-                pass
+            except Exception as exc:
+                # The table exists but couldn't be read (permissions, or a
+                # column shape that doesn't match this framework's expected
+                # layout) — skip this framework rather than fail the whole
+                # report, and leave a breadcrumb for debugging.
+                logger.debug("migration_history: skipping %s (%s)", t, exc)
 
         elif t == "django_migrations":
             try:
@@ -253,8 +268,12 @@ async def read_migration_history(
                         for row in django_rows or []
                     ]
                 )
-            except Exception:
-                pass
+            except Exception as exc:
+                # The table exists but couldn't be read (permissions, or a
+                # column shape that doesn't match this framework's expected
+                # layout) — skip this framework rather than fail the whole
+                # report, and leave a breadcrumb for debugging.
+                logger.debug("migration_history: skipping %s (%s)", t, exc)
 
         elif t == "_prisma_migrations":
             try:
@@ -282,8 +301,12 @@ async def read_migration_history(
                         for row in prisma_rows or []
                     ]
                 )
-            except Exception:
-                pass
+            except Exception as exc:
+                # The table exists but couldn't be read (permissions, or a
+                # column shape that doesn't match this framework's expected
+                # layout) — skip this framework rather than fail the whole
+                # report, and leave a breadcrumb for debugging.
+                logger.debug("migration_history: skipping %s (%s)", t, exc)
 
         elif t == "schema_migrations":
             try:
@@ -303,8 +326,12 @@ async def read_migration_history(
                         for row in gm_rows or []
                     ]
                 )
-            except Exception:
-                pass
+            except Exception as exc:
+                # The table exists but couldn't be read (permissions, or a
+                # column shape that doesn't match this framework's expected
+                # layout) — skip this framework rather than fail the whole
+                # report, and leave a breadcrumb for debugging.
+                logger.debug("migration_history: skipping %s (%s)", t, exc)
 
         elif t == "goose_db_version":
             try:
@@ -325,8 +352,12 @@ async def read_migration_history(
                         for row in goose_rows or []
                     ]
                 )
-            except Exception:
-                pass
+            except Exception as exc:
+                # The table exists but couldn't be read (permissions, or a
+                # column shape that doesn't match this framework's expected
+                # layout) — skip this framework rather than fail the whole
+                # report, and leave a breadcrumb for debugging.
+                logger.debug("migration_history: skipping %s (%s)", t, exc)
 
         elif t == "SequelizeMeta":
             try:
@@ -337,8 +368,12 @@ async def read_migration_history(
                 if sequelize is None:
                     sequelize = []
                 sequelize.extend([SequelizeMigration(name=str(row.cells["name"])) for row in seq_rows or []])
-            except Exception:
-                pass
+            except Exception as exc:
+                # The table exists but couldn't be read (permissions, or a
+                # column shape that doesn't match this framework's expected
+                # layout) — skip this framework rather than fail the whole
+                # report, and leave a breadcrumb for debugging.
+                logger.debug("migration_history: skipping %s (%s)", t, exc)
 
     return MigrationHistoryReport(
         alembic=alembic,

--- a/src/mcpg/query.py
+++ b/src/mcpg/query.py
@@ -252,8 +252,13 @@ async def explain_query(
             # the raw driver doesn't, so reinstate the bound here. Without
             # this an EXPLAIN ANALYZE on a runaway query (long sort, missing
             # index, deadlock) would block the server worker indefinitely.
+            # force_readonly wraps the execution in BEGIN TRANSACTION READ ONLY
+            # so EXPLAIN ANALYZE (which really runs the query) can't have a
+            # write side effect even if a future allowlist gap let one through
+            # — matching every other agent-SQL path. EXPLAIN ANALYZE of a
+            # validated SELECT runs fine inside a read-only transaction.
             rows = await asyncio.wait_for(
-                driver.execute_query(f"EXPLAIN (ANALYZE, BUFFERS, TIMING, FORMAT JSON) {sql}"),
+                driver.execute_query(f"EXPLAIN (ANALYZE, BUFFERS, TIMING, FORMAT JSON) {sql}", force_readonly=True),
                 timeout=timeout,
             )
         else:

--- a/src/mcpg/server.py
+++ b/src/mcpg/server.py
@@ -8,6 +8,7 @@ mutable global state.
 
 from __future__ import annotations
 
+import logging
 import time
 from collections.abc import AsyncIterator, Callable, Sequence
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
@@ -239,6 +240,15 @@ def run(settings: Settings) -> None:
     server = create_server(settings)
     match settings.transport:
         case Transport.STDIO:
+            # stdout carries the JSON-RPC stream, so this reassuring banner
+            # goes to the logger (stderr) — otherwise a first-time user who
+            # runs `mcpg` just to see it work stares at a silent, blocked
+            # process and assumes it hung.
+            logging.getLogger("mcpg.server").info(
+                "mcpg %s ready on stdio (%s mode) — waiting for an MCP client to connect",
+                __version__,
+                settings.access_mode.value,
+            )
             server.run(transport="stdio")
         case Transport.STREAMABLE_HTTP:
             from mcpg.http_runtime import run_http

--- a/src/mcpg/timescaledb.py
+++ b/src/mcpg/timescaledb.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import Any
 
 from mcpg.extensions import extension_installed
 from mcpg.sql import SqlDriver
@@ -43,10 +42,6 @@ def _check_identifier(name: str, kind: str) -> None:
 def _check_interval(value: str) -> None:
     if not _INTERVAL.match(value.strip()):
         raise TimescaleError(f"invalid interval {value!r}; expected e.g. '7 days', '1 hour', '30 minutes'")
-
-
-def _quoted(name: str) -> str:
-    return f'"{name}"'
 
 
 @dataclass(frozen=True)
@@ -260,10 +255,3 @@ async def add_retention_policy(
     )
     detail = f"job_id={rows[0].cells['job_id']}" if rows else "policy added"
     return TimescaleWriteResult(available=True, function="add_retention_policy", details=detail)
-
-
-def _quoted_unused(_: Any) -> None:
-    # Placeholder so an editor's "unused import" warning on _quoted
-    # doesn't fire in modules that only validate identifiers but never
-    # build qualified relations directly.
-    pass

--- a/tests/integration/test_demo_integration.py
+++ b/tests/integration/test_demo_integration.py
@@ -82,14 +82,24 @@ async def test_demo_lifecycle_and_planted_findings(database_url: str, is_warehou
                 await driver.execute_query(f"ANALYZE {DEMO_SCHEMA}.{table}")  # type: ignore[arg-type]
             for _ in range(8):
                 await driver.execute_query(_SLOW_QUERY)  # type: ignore[arg-type]
-            flagged = False
+            orders_rec = None
             for _ in range(30):
                 recommendations = await recommend_indexes(driver, min_live_tuples=1000)
-                flagged = any(r.schema == DEMO_SCHEMA and r.table == "orders" for r in recommendations)
-                if flagged:
+                orders_rec = next(
+                    (r for r in recommendations if r.schema == DEMO_SCHEMA and r.table == "orders"), None
+                )
+                if orders_rec is not None:
                     break
                 await asyncio.sleep(0.5)
-            assert flagged, "recommend_indexes never flagged mcpg_demo.orders"
+            assert orders_rec is not None, "recommend_indexes never flagged mcpg_demo.orders"
+            # The planted flaw is the unindexed FK orders.customer_id; the
+            # advisor must actually catch it with a btree recommendation (this
+            # is exactly what docs/demo.md promises).
+            fk_suggestion = next(
+                (s for s in orders_rec.suggestions if s.column == "customer_id"), None
+            )
+            assert fk_suggestion is not None, "recommend_indexes did not flag the unindexed FK customer_id"
+            assert fk_suggestion.index_type == "btree"
 
             # Planted prose: review text is full-text searchable.
             matches = await full_text_search(driver, DEMO_SCHEMA, "reviews", "review_text", '"battery life"', limit=5)

--- a/tests/integration/test_demo_integration.py
+++ b/tests/integration/test_demo_integration.py
@@ -85,9 +85,7 @@ async def test_demo_lifecycle_and_planted_findings(database_url: str, is_warehou
             orders_rec = None
             for _ in range(30):
                 recommendations = await recommend_indexes(driver, min_live_tuples=1000)
-                orders_rec = next(
-                    (r for r in recommendations if r.schema == DEMO_SCHEMA and r.table == "orders"), None
-                )
+                orders_rec = next((r for r in recommendations if r.schema == DEMO_SCHEMA and r.table == "orders"), None)
                 if orders_rec is not None:
                     break
                 await asyncio.sleep(0.5)
@@ -95,9 +93,7 @@ async def test_demo_lifecycle_and_planted_findings(database_url: str, is_warehou
             # The planted flaw is the unindexed FK orders.customer_id; the
             # advisor must actually catch it with a btree recommendation (this
             # is exactly what docs/demo.md promises).
-            fk_suggestion = next(
-                (s for s in orders_rec.suggestions if s.column == "customer_id"), None
-            )
+            fk_suggestion = next((s for s in orders_rec.suggestions if s.column == "customer_id"), None)
             assert fk_suggestion is not None, "recommend_indexes did not flag the unindexed FK customer_id"
             assert fk_suggestion.index_type == "btree"
 

--- a/tests/unit/test_audit.py
+++ b/tests/unit/test_audit.py
@@ -377,3 +377,29 @@ def test_audit_record_json_format(caplog) -> None:
             logger.propagate = old_propagate
     finally:
         configure_log_format("text")
+
+
+def test_audit_record_redacts_password_in_error_text(caplog) -> None:
+    """A DSN embedded in a tool's error message must not leak into the audit log."""
+    import logging
+
+    from mcpg.audit import AuditEvent, record
+
+    event = AuditEvent(
+        tool="copy_table_between_databases",
+        arguments={},
+        status="error",
+        error="connection to postgresql://admin:hunter2@db.internal:5432/app failed",
+    )
+    logger = logging.getLogger("mcpg")
+    old_propagate = logger.propagate
+    logger.propagate = True
+    try:
+        caplog.set_level(logging.WARNING)
+        record(event)
+        messages = " ".join(r.message for r in caplog.records if r.name == "mcpg.audit")
+        assert "hunter2" not in messages  # the password is masked
+        assert "****" in messages
+        assert "db.internal" in messages  # non-secret host is preserved
+    finally:
+        logger.propagate = old_propagate

--- a/tests/unit/test_indexing.py
+++ b/tests/unit/test_indexing.py
@@ -11,7 +11,7 @@ from mcpg.server import create_server
 _SETTINGS = load_settings({"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db"})
 
 
-def _row(column: str, data_type: str) -> dict[str, object]:
+def _row(column: str, data_type: str, *, is_unindexed_fk: bool = False) -> dict[str, object]:
     """One (candidate table x column) row for the orders table."""
     return {
         "schemaname": "app",
@@ -22,6 +22,7 @@ def _row(column: str, data_type: str) -> dict[str, object]:
         "data_type": data_type,
         "parent_schema": None,
         "parent_table": None,
+        "is_unindexed_fk": is_unindexed_fk,
     }
 
 
@@ -38,6 +39,7 @@ def _partition_row(
         "data_type": data_type,
         "parent_schema": "app",
         "parent_table": parent,
+        "is_unindexed_fk": False,
     }
 
 
@@ -120,6 +122,32 @@ async def test_recommend_indexes_makes_no_suggestions_for_plain_scalar_columns()
     result = await recommend_indexes(FakeDriver([_row("id", "integer")]))
 
     assert result[0].suggestions == []
+
+
+async def test_recommend_indexes_flags_unindexed_foreign_key_with_btree() -> None:
+    # A plain integer column gets no suggestion on its own; the same column as
+    # an UNINDEXED foreign key must get a btree — the demo's planted flaw.
+    result = await recommend_indexes(FakeDriver([_row("customer_id", "integer", is_unindexed_fk=True)]))
+
+    assert len(result[0].suggestions) == 1
+    fk = result[0].suggestions[0]
+    assert fk.column == "customer_id"
+    assert fk.index_type == "btree"
+    assert "foreign-key" in fk.rationale
+
+
+async def test_recommend_indexes_fk_btree_leads_type_based_suggestions() -> None:
+    # The demo's orders table: an unindexed FK (customer_id) plus a text
+    # column (status). Both are suggested; the FK btree — the actual cause of
+    # the slow query — comes first (by ordinal position).
+    driver = FakeDriver([_row("customer_id", "integer", is_unindexed_fk=True), _row("status", "text")])
+
+    result = await recommend_indexes(driver, min_live_tuples=1000)
+
+    assert [(s.column, s.index_type) for s in result[0].suggestions] == [
+        ("customer_id", "btree"),
+        ("status", "gin_trgm"),
+    ]
 
 
 async def test_recommend_indexes_returns_empty_when_nothing_qualifies() -> None:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -9,6 +9,7 @@ from mcpg.config import Settings
 def test_main_returns_1_and_reports_when_config_is_missing(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
+    monkeypatch.setattr("sys.argv", ["mcpg"])
     monkeypatch.delenv("MCPG_DATABASE_URL", raising=False)
 
     exit_code = __main__.main()
@@ -18,6 +19,7 @@ def test_main_returns_1_and_reports_when_config_is_missing(
 
 
 def test_main_runs_the_server_with_loaded_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("sys.argv", ["mcpg"])
     monkeypatch.setenv("MCPG_DATABASE_URL", "postgresql://u:p@localhost/db")
     received: list[Settings] = []
     monkeypatch.setattr(__main__, "run", received.append)
@@ -27,6 +29,56 @@ def test_main_runs_the_server_with_loaded_settings(monkeypatch: pytest.MonkeyPat
     assert exit_code == 0
     assert len(received) == 1
     assert received[0].database_url == "postgresql://u:p@localhost/db"
+
+
+@pytest.mark.parametrize("flag", ["--help", "-h"])
+def test_help_flag_prints_usage_without_a_database(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], flag: str
+) -> None:
+    # --help must work with NO configuration set — it's the first thing a new
+    # user types, so it can't depend on load_settings().
+    monkeypatch.delenv("MCPG_DATABASE_URL", raising=False)
+    monkeypatch.setattr("sys.argv", ["mcpg", flag])
+
+    exit_code = __main__.main()
+
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Usage:" in out
+    assert "MCPG_DATABASE_URL" in out
+    assert "configuration error" not in out
+
+
+@pytest.mark.parametrize("flag", ["--version", "-V"])
+def test_version_flag_works_without_a_database(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], flag: str
+) -> None:
+    from mcpg import __version__
+
+    monkeypatch.delenv("MCPG_DATABASE_URL", raising=False)
+    monkeypatch.setattr("sys.argv", ["mcpg", flag])
+
+    exit_code = __main__.main()
+
+    assert exit_code == 0
+    assert capsys.readouterr().out.strip() == f"mcpg {__version__}"
+
+
+def test_unknown_argument_reports_clearly_not_a_config_error(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # An unknown flag must not fall through to a confusing "MCPG_DATABASE_URL
+    # is required" config error.
+    monkeypatch.delenv("MCPG_DATABASE_URL", raising=False)
+    monkeypatch.setattr("sys.argv", ["mcpg", "--bogus"])
+
+    exit_code = __main__.main()
+
+    err = capsys.readouterr().err
+    assert exit_code == 2
+    assert "unknown argument" in err
+    assert "--bogus" in err
+    assert "configuration error" not in err
 
 
 def test_demo_flag_seeds_and_prints_the_summary(

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -291,11 +291,14 @@ async def test_explain_query_io_true_runs_analyze_buffers_timing() -> None:
     options on the EXPLAIN — otherwise PG won't emit the I/O fields."""
     driver = FakeDriver([{"QUERY PLAN": [{"Plan": {"Node Type": "Result"}}]}])
     await explain_query(driver, "SELECT 1", io=True)
-    sent_query, _, _ = driver.calls[-1]
+    sent_query, _, force_readonly = driver.calls[-1]
     assert "ANALYZE" in sent_query
     assert "BUFFERS" in sent_query
     assert "TIMING" in sent_query
     assert "FORMAT JSON" in sent_query
+    # EXPLAIN ANALYZE executes the query — it must run inside a read-only
+    # transaction so a validated SELECT can't have a write side effect.
+    assert force_readonly is True
 
 
 async def test_explain_query_default_keeps_the_plan_only_path() -> None:

--- a/tools/generate_demo_walkthrough.py
+++ b/tools/generate_demo_walkthrough.py
@@ -158,6 +158,12 @@ async def _build_sections() -> list[str]:
                 "Recommend indexes for this database and explain the reasoning.",
                 "recommend_indexes(min_live_tuples=1000)",
                 _render(demo_recs or recommendations),
+                postscript=(
+                    "The advisor leads with a **btree on `orders.customer_id`** — the planted "
+                    "flaw and the exact fix for the slow query above (PostgreSQL doesn't index "
+                    "foreign keys automatically, so it took a seq scan). It also spots the "
+                    "free-text `status` column as a trigram-GIN candidate for `LIKE`/`ILIKE` search."
+                ),
             )
         )
 


### PR DESCRIPTION
## Summary

A pre-review readiness pass ahead of an external review — four independent audits (first-contact UX/CLI, docs accuracy, code rough-edges, security) plus the fixes they surfaced. All under `[Unreleased]`; folds into 0.6.11.

**First-contact fixes (what a reviewer hits in the first five minutes):**
- **`mcpg --help` / `-h` now works** — it was falling through to config loading and dying with `MCPG_DATABASE_URL is required`. An unknown argument is now reported clearly (exit 2) instead of the same misleading error.
- **README HTTP quickstart** pointed clients at `http://localhost:8000`; the handler is mounted at `/mcp` (`/sse` for SSE) — corrected so a copy-pasted first connection doesn't 404.
- **Stdio startup is no longer silent** — one stderr line (`ready on stdio (<mode> mode) — waiting for an MCP client`) so a first run doesn't look hung.

**Flagship demo now delivers its promise:**
- `recommend_indexes` **now flags unindexed foreign keys** with a btree recommendation. PostgreSQL auto-indexes PK/UNIQUE but not FKs, so an unindexed FK silently forces seq-scan joins — a classic DBA gap. The demo's planted flaw is the unindexed `orders.customer_id`; the advisor previously recommended only a trigram on `status`, contradicting the walkthrough narrative. Now it catches the FK. `docs/demo.md` + the generator postscript updated; `test_demo_integration` strengthened to pin the finding against a live DB.

**Security defense-in-depth** (the audit found no exploitable issue; posture is strong):
- Audit **error text** is now run through `obfuscate_password` (a DSN in an exception message can't leak a password into the audit log — arguments were already redacted).
- `EXPLAIN ANALYZE` (`io=True`) now runs inside `BEGIN TRANSACTION READ ONLY` — it was the only agent-SQL path at `force_readonly=False`, and it's reachable in read-only mode.

**Code hygiene:** removed a dead `_quoted`/`_quoted_unused` pair; converted 8 silent `except: pass` swallows in `migration_history` to logged skips; replaced two `"x" in locals()` control-flow anti-patterns; dropped a redundant `except (TimeoutError, Exception)`.

**Not in this PR (tracked):** the confirmed per-request HTTP/SSE tenancy limitation (`X-MCPG-Role` pinned to a session's first request) — documented honestly in-repo, fix targeted for 0.6.11 as its own security-focused change.

Verification: `2802` unit + contract tests pass; `ruff` + `mypy src/mcpg` clean; the new `recommend_indexes` SQL parse-checked via pglast; tool-surface + return-shape snapshots unchanged (btree is just a new `index_type` value).

## Roadmap linkage

N/A — pre-review readiness (bug/UX/security polish) plus a small enhancement to the existing `recommend_indexes` advisor (no new roadmap row).

## Checklist

- [x] Tests added/updated first (TDD); suite passes locally
- [x] `ruff`, `ruff format`, and `mypy src/mcpg` pass
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Roadmap row cited above (`N/A`)
- [x] No hand-edits to `src/mcpg/_vendor/` (the vendor tree no longer exists — 18.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_