### PR TITLE
fix(tenancy): resolve per-request role per message on HTTP/SSE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Security
 
+- **Per-request tenancy role now works on `streamable-http` / `sse`.** The
+  `X-MCPG-Role` header (and per-request OIDC role claim) was set in a ContextVar
+  in the ASGI request task, but FastMCP dispatches tool calls in a long-lived
+  per-session task whose context is copied once at session start — so the
+  override was silently **pinned to the session's first request**, a
+  multi-tenant isolation break (static `MCPG_DEFAULT_ROLE` and stdio were
+  unaffected). The middleware now stashes the validated role on the request,
+  and the tenancy driver resolves it **per message** from the SDK's request
+  context at query time. Regression tests cover the frozen-ContextVar case.
 - **Audit log: error text is now redacted.** A DSN embedded in a tool's error
   message (e.g. a secondary/replica/data-movement connection) is run through
   `obfuscate_password` before logging, matching the existing argument

--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -37,16 +37,17 @@ only (RS256-RS512 + ES256-ES512); HS-family explicitly excluded.
 Static (`MCPG_DEFAULT_ROLE`) plus per-request override
 (`X-MCPG-Role` HTTP header / `MCPG_OIDC_ROLE_CLAIM` from the JWT).
 Allowlist via `MCPG_ALLOWED_ROLES`. Role names identifier-validated.
+The per-request override is resolved **per message** on `streamable-http`
+/ `sse` — the middleware validates the role and stashes it on the request,
+and the tenancy driver reads it from the SDK's per-message request context
+at query time, so it can't be pinned to a session's first request.
 
-> 🟡 **Known limitation (HTTP/SSE), fix landing in 0.6.11.** The
-> per-request *override* is currently pinned to the **first request of a
-> session** on the `streamable-http` / `sse` transports: `current_role`
-> is set in the ASGI request task, but tools execute in the session's
-> long-lived dispatch task, whose context was copied once at session
-> start. Static `MCPG_DEFAULT_ROLE` and stdio are unaffected. The fix
-> resolves the role from the per-message request context at query time
-> (tracked for 0.6.11). Until then, isolate tenants with a separate
-> connection/role rather than per-request `X-MCPG-Role` over one session.
+> **Fixed in 0.6.11.** Releases up to 0.6.10 set the role only in a
+> ContextVar in the ASGI request task, which FastMCP's long-lived per-
+> session dispatch task never saw — so a per-request `X-MCPG-Role` was
+> effectively pinned to the session's first request. It now reads the
+> authoritative role from the per-message request; static
+> `MCPG_DEFAULT_ROLE` and stdio were never affected.
 
 ### ✅ Read-replica routing
 `MCPG_REPLICA_URLS` round-robins read-only queries to healthy

--- a/docs/security.md
+++ b/docs/security.md
@@ -202,14 +202,11 @@ and every call is validated and audited.
   named JWT claim). Each query is wrapped in
   `BEGIN ... SET LOCAL ROLE "<role>" ... <stmt> ... COMMIT` so
   RLS policies keyed on `current_user` isolate tenants correctly
-  from a single pooled connection.
-  > **Known limitation on `streamable-http` / `sse` (fix in 0.6.11).**
-  > The per-request *override* is pinned to the first request of a
-  > session on these transports (the role is set in the request task but
-  > the tool runs in the session's long-lived dispatch task). Static
-  > `MCPG_DEFAULT_ROLE` and stdio are unaffected. Until 0.6.11, don't
-  > rely on per-request `X-MCPG-Role` for isolation over a shared HTTP
-  > session — use a separate connection/role per tenant.
+  from a single pooled connection. On `streamable-http` / `sse` the role
+  is resolved **per message** from the request's own context, so two
+  tenants sharing one MCP session each run under their own role. (Fixed
+  in 0.6.11 — up to 0.6.10 the override was pinned to a session's first
+  request; static `MCPG_DEFAULT_ROLE` and stdio were never affected.)
 - `MCPG_ALLOWED_ROLES` provides an allowlist — header / claim
   values not in the list are rejected with 403.
 - Role names are identifier-validated before being inlined into

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -246,16 +246,12 @@ HTTP requests override the default by sending
 `MCPG_OIDC_ROLE_CLAIM` — the named JWT claim's value becomes the
 per-request role automatically.
 
-> **Known limitation on `streamable-http` / `sse` (fixed in 0.6.11).**
-> The per-request *override* (`X-MCPG-Role` header / per-request OIDC
-> role claim) is currently pinned to the **first request of a session**
-> on the HTTP/SSE transports — a role set later in the session is not
-> applied, because the value is set in the ASGI request task but the
-> tool runs in the session's long-lived dispatch task. A **static**
-> `MCPG_DEFAULT_ROLE` is unaffected, and **stdio** is unaffected. Until
-> 0.6.11, don't rely on per-request `X-MCPG-Role` for tenant isolation
-> over a shared HTTP session — use a separate connection (or a distinct
-> static `MCPG_DEFAULT_ROLE`) per tenant.
+Per-request role selection is honoured **per message** on the
+`streamable-http` / `sse` transports — every tool call resolves the role
+from its own request, so two tenants sharing one MCP session each run
+under their own role. (This is threaded through the SDK's per-message
+request context; earlier releases up to 0.6.10 pinned the role to a
+session's first request — fixed in 0.6.11.)
 
 Role names are identifier-validated
 (`[A-Za-z_][A-Za-z0-9_]*`) so they're safe to inline into

--- a/src/mcpg/http_runtime.py
+++ b/src/mcpg/http_runtime.py
@@ -32,7 +32,7 @@ from typing import TYPE_CHECKING, Any, cast
 from mcpg.config import Settings
 from mcpg.observability import render_prometheus
 from mcpg.oidc import OIDCError, OIDCVerifier
-from mcpg.tenancy import TenancyError, current_role, validate_role
+from mcpg.tenancy import _ROLE_SCOPE_KEY, TenancyError, current_role, validate_role
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -183,6 +183,10 @@ class _OIDCAuthMiddleware:
             await _send_401(send, "role claim contains an invalid identifier")
             return
 
+        # Stash on the scope so the tool-dispatch task (a separate, session-
+        # scoped task on HTTP/SSE) reads the correct per-request role via the
+        # SDK request context; the ContextVar alone doesn't reach it.
+        scope[_ROLE_SCOPE_KEY] = verified.role
         reset_token = current_role.set(verified.role)
         try:
             await self._app(scope, receive, send)  # type: ignore[operator]
@@ -250,6 +254,10 @@ class _TenantRoleMiddleware:
             await _send_403(send, "X-MCPG-Role is not in the allowed-roles list")
             return
 
+        # Stash on the scope so the tool-dispatch task (a separate, session-
+        # scoped task on HTTP/SSE) reads the correct per-request role via the
+        # SDK request context; the ContextVar alone doesn't reach it.
+        scope[_ROLE_SCOPE_KEY] = role
         token = current_role.set(role)
         try:
             await self._app(scope, receive, send)  # type: ignore[operator]

--- a/src/mcpg/tenancy.py
+++ b/src/mcpg/tenancy.py
@@ -13,10 +13,15 @@ Two ways to set the role for a request:
   no per-request override is present. The HTTP bearer-token /
   stdio paths use this.
 * **Per-request**: the streamable-http / sse transports parse
-  ``X-MCPG-Role: <role>`` and store it in
-  :data:`current_role` for the duration of the request. The
-  :class:`TenantSqlDriver` then reads the contextvar and falls back
-  to the static default when no header was sent.
+  ``X-MCPG-Role: <role>`` (or the OIDC role claim), validate it, and
+  stash it on the request's ASGI ``scope``. FastMCP dispatches tool
+  calls in a long-lived *per-session* task, so a plain ContextVar set
+  in the request's ASGI task never reaches it — but the MCP SDK threads
+  the *per-message* request into that task via its ``request_ctx``, so
+  :func:`resolve_role` reads the authoritative role from the request's
+  scope at query time. The :class:`TenantSqlDriver` then issues
+  ``SET LOCAL ROLE`` and falls back to the static default when the
+  request carried no role.
 
 When neither is configured, the driver is identical to the vendored
 :class:`SqlDriver` and zero overhead is added.
@@ -40,10 +45,20 @@ logger = logging.getLogger(__name__)
 # module has no import-cycle on Settings.
 _ROLE_IDENTIFIER = re.compile(r"\A[A-Za-z_][A-Za-z0-9_]*\Z")
 
-# Per-request override. ``None`` means "no override, use the static
-# default". ContextVars propagate naturally across ``await``-points
-# because asyncio.Task copies its parent's context at creation.
+# Per-request override for the stdio path (and a legacy fallback). ``None``
+# means "no override, use the static default". IMPORTANT: on the HTTP/SSE
+# transports this ContextVar is NOT authoritative — FastMCP dispatches tool
+# calls in a long-lived per-session task whose context is copied once at
+# session creation, so a role set in a *later* request's ASGI task never
+# reaches it. The per-message request path (see :func:`_role_from_request`)
+# is authoritative there.
 current_role: ContextVar[str | None] = ContextVar("mcpg_current_role", default=None)
+
+# Key under which the HTTP/SSE middlewares stash the validated per-request
+# role on the ASGI ``scope``. The MCP SDK threads that same request (and its
+# scope) into the tool-dispatch task via its ``request_ctx``, so the driver
+# reads the authoritative per-message role at query time.
+_ROLE_SCOPE_KEY = "mcpg.tenant_role"
 
 
 class TenancyError(ValueError):
@@ -57,13 +72,48 @@ def validate_role(role: str) -> str:
     return role
 
 
+def _role_from_request() -> tuple[bool, str | None]:
+    """Read the per-message request's role from the MCP SDK's request context.
+
+    Returns ``(has_http_request, role)``:
+
+    * ``has_http_request`` is ``True`` when the current tool call is being
+      dispatched for an HTTP/SSE message (the SDK set ``request_ctx`` with a
+      Starlette request). In that case the request's scope is authoritative:
+      ``role`` is the value the tenant middleware stashed (or ``None`` when the
+      request carried no ``X-MCPG-Role`` / role claim) — and the caller must
+      NOT consult :data:`current_role`, which on these transports is frozen to
+      the session's first request.
+    * ``(False, None)`` when there is no HTTP request (stdio, or any path
+      without an SDK request context) — the caller uses the ContextVar path.
+    """
+    try:
+        from mcp.server.lowlevel.server import request_ctx
+    except Exception:  # SDK internals moved — fail safe to the ContextVar path
+        return (False, None)
+    try:
+        ctx = request_ctx.get()
+    except LookupError:
+        return (False, None)
+    scope = getattr(getattr(ctx, "request", None), "scope", None)
+    if not isinstance(scope, dict):
+        return (False, None)
+    role = scope.get(_ROLE_SCOPE_KEY)
+    return (True, role if isinstance(role, str) else None)
+
+
 def resolve_role(default: str | None) -> str | None:
     """Return the role for the current request.
 
-    Per-request ContextVar wins; falls back to the static default
-    when the var is unset. ``None`` means "do nothing — use the role
-    the pool was opened with".
+    On HTTP/SSE the per-message request is authoritative: its stashed role, or
+    the static ``default`` when the request carried no role — never the
+    session-frozen :data:`current_role`. On stdio (no request context) the
+    :data:`current_role` ContextVar wins, falling back to ``default``. ``None``
+    means "do nothing — use the role the pool was opened with".
     """
+    has_request, request_role = _role_from_request()
+    if has_request:
+        return request_role if request_role is not None else default
     override = current_role.get()
     if override is not None:
         return override

--- a/tests/unit/test_http_runtime.py
+++ b/tests/unit/test_http_runtime.py
@@ -262,6 +262,13 @@ def test_tenant_role_middleware_sets_contextvar_for_the_inner_app() -> None:
     assert observed_roles == ["tenant_a"]
     # ContextVar is reset on exit so the next request starts clean.
     assert current_role.get() is None
+    # The role is also stashed on the ASGI scope — this is what reaches the
+    # tool-dispatch task (a separate, session-scoped task) via the SDK request
+    # context, since the ContextVar alone does not. Unlike the ContextVar, the
+    # scope stash is NOT reset: the scope is per-request and discarded after.
+    from mcpg.tenancy import _ROLE_SCOPE_KEY
+
+    assert scope[_ROLE_SCOPE_KEY] == "tenant_a"
 
 
 def test_tenant_role_middleware_returns_403_when_role_is_not_in_allowlist() -> None:

--- a/tests/unit/test_tenancy.py
+++ b/tests/unit/test_tenancy.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
+from mcp.server.lowlevel.server import request_ctx
 
 from mcpg.tenancy import (
+    _ROLE_SCOPE_KEY,
     TenancyError,
     TenantSqlDriver,
     current_role,
@@ -44,11 +48,52 @@ def test_resolve_role_returns_default_when_contextvar_is_unset() -> None:
 
 
 def test_resolve_role_prefers_contextvar_over_default() -> None:
+    # No HTTP request context (the stdio path) → the ContextVar wins.
     token = current_role.set("tenant_42")
     try:
         assert resolve_role(default="static_default") == "tenant_42"
     finally:
         current_role.reset(token)
+
+
+# --- HTTP/SSE per-message request path (roadmap: 0.6.11 tenancy fix) --------
+
+
+def _http_request_ctx(scope: dict[str, object]) -> object:
+    """A stand-in for the SDK's per-message RequestContext carrying a request."""
+    return SimpleNamespace(request=SimpleNamespace(scope=scope))
+
+
+def test_resolve_role_uses_per_message_request_role_on_http() -> None:
+    token = request_ctx.set(_http_request_ctx({_ROLE_SCOPE_KEY: "tenant_b"}))
+    try:
+        assert resolve_role(default="static_default") == "tenant_b"
+    finally:
+        request_ctx.reset(token)
+
+
+def test_http_request_role_is_authoritative_over_frozen_contextvar() -> None:
+    """The bug this fix closes: on HTTP/SSE the dispatch task's ``current_role``
+    is frozen to the session's FIRST request. A later request that carries no
+    role header must resolve to the static default — NOT the frozen value."""
+    frozen = current_role.set("tenant_FIRST")  # the session-frozen role
+    req = request_ctx.set(_http_request_ctx({}))  # this request: no role header
+    try:
+        assert resolve_role(default="static_default") == "static_default"
+    finally:
+        request_ctx.reset(req)
+        current_role.reset(frozen)
+
+
+def test_http_request_role_wins_over_contextvar() -> None:
+    # A per-message role overrides whatever the frozen ContextVar holds.
+    frozen = current_role.set("tenant_FIRST")
+    req = request_ctx.set(_http_request_ctx({_ROLE_SCOPE_KEY: "tenant_CURRENT"}))
+    try:
+        assert resolve_role(default="static_default") == "tenant_CURRENT"
+    finally:
+        request_ctx.reset(req)
+        current_role.reset(frozen)
 
 
 def test_tenant_sql_driver_default_role_is_stored_on_instance() -> None:


### PR DESCRIPTION
## Summary

Closes the confirmed multi-tenancy isolation break on the `streamable-http` / `sse` transports — the last item for 0.6.11.

**The bug:** per-request role selection (`X-MCPG-Role` header / per-request OIDC role claim) was silently **pinned to a session's first request**. The role was set in the `current_role` ContextVar in the ASGI request task, but FastMCP dispatches tool calls in a long-lived *per-session* task whose context is copied once at session creation — so a role set in a later request's task never reached the query path. Two tenants sharing one MCP session both ran under the first one's role. (stdio and a static `MCPG_DEFAULT_ROLE` were never affected.)

**The fix:** the tenant / OIDC middlewares now stash the validated role on the ASGI `scope`, and `resolve_role` reads it from the MCP SDK's **per-message request context** (`request_ctx.get().request.scope`) at query time — authoritative on HTTP/SSE, never the session-frozen ContextVar. A request that carries no role falls back to the static default (not the frozen value). stdio keeps the ContextVar path unchanged.

Why this is the correct seam: the SDK threads each message's Starlette request into the dispatch task via `ServerMessageMetadata(request_context=request)` → `request_ctx` (verified in `mcp/server/streamable_http.py` + `sse.py` + `lowlevel/server.py`), and that request's `.scope` is the same dict the middleware mutated — so the per-message role is available exactly where the tool runs.

**Tests:** regression tests pin the frozen-ContextVar case (a header-less later request must resolve to the static default, *not* the first request's role — this fails without the fix), the per-message role winning over a set ContextVar, and the middleware scope-stash. `2805` unit + contract tests pass.

**Docs:** flipped from "known limitation" to fixed across `security.md`, `security-hardening.md`, and `user-guide.md`.

Verification: `ruff format --check .`, `ruff check .`, `mypy src/mcpg` all clean; full unit + contract suite green.

## Roadmap linkage

N/A — security fix (completes the 0.6.11 batch; no new roadmap row).

## Checklist

- [x] Tests added/updated first (TDD); suite passes locally
- [x] `ruff`, `ruff format`, and `mypy src/mcpg` pass
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Roadmap row cited above (`N/A`)
- [x] No hand-edits to `src/mcpg/_vendor/` (the vendor tree no longer exists — 18.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_