### PR TITLE
release: cut v0.6.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.6.11] - 2026-07-10
+
 ### Added
 
 - **`recommend_indexes` now flags unindexed foreign keys.** PostgreSQL indexes

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,6 +55,7 @@ them" — pick the section that matches what you're trying to do.
   retrospectives.
 - [**Progress log**](PROGRESS.md) — chronological build log.
 - Release notes:
+  [v0.6.11](release-notes-0.6.11.md) ·
   [v0.6.10](release-notes-0.6.10.md) ·
   [v0.6.9](release-notes-0.6.9.md) ·
   [v0.6.8](release-notes-0.6.8.md) ·

--- a/docs/release-notes-0.6.11.md
+++ b/docs/release-notes-0.6.11.md
@@ -1,0 +1,72 @@
+# MCPg v0.6.11 — release notes
+
+**Released:** 2026-07-10
+**Tool surface:** **252** tools across 19 capability buckets (read-only
+mode exposes a subset)
+**Tests:** unit + integration suite green (PG 14 / 15 / 16 / 17 / 18 / 19
+/ WarehousePG)
+**Runtime:** Python 3.14
+
+A **patch bump (0.6.10 → 0.6.11)** headlined by a multi-tenancy security
+fix and a pre-review hardening pass. Backward-compatible — no tool
+signatures changed.
+
+## Security: per-request tenancy now works on HTTP/SSE
+
+Per-request PostgreSQL role selection — the `X-MCPG-Role` header and the
+per-request OIDC role claim — was silently **pinned to a session's first
+request** on the `streamable-http` and `sse` transports. The role was set
+in a ContextVar in the ASGI request task, but FastMCP dispatches tool
+calls in a long-lived *per-session* task whose context is copied once at
+session creation, so a later request's role never reached the query path.
+Two tenants sharing one MCP session both ran under the first one's role.
+
+The middleware now stashes the validated role on the request, and the
+tenancy driver resolves it **per message** from the MCP SDK's request
+context at query time — authoritative on every transport. A static
+`MCPG_DEFAULT_ROLE` and the stdio transport were never affected.
+
+## Advisor: `recommend_indexes` catches unindexed foreign keys
+
+PostgreSQL auto-indexes `PRIMARY KEY` / `UNIQUE` columns but **not**
+foreign keys, so an unindexed FK silently forces sequential-scan joins and
+slow cascading `UPDATE`/`DELETE`. For each sequential-scan-heavy table the
+advisor now recommends a **btree** on any single-column FK that has no
+covering index — leading the type-driven GIN/trigram suggestions. (This is
+exactly the planted flaw the `mcpg --demo` walkthrough demonstrates, which
+the advisor now actually finds.)
+
+## First-contact polish
+
+- **`mcpg --help` / `-h`** prints usage instead of dying with a
+  `MCPG_DATABASE_URL is required` config error; an unknown argument is
+  reported clearly rather than falling through to the same message.
+- **The stdio transport announces startup** — one stderr line
+  (`ready on stdio (<mode> mode) — waiting for an MCP client`) so a
+  first-time run doesn't look hung.
+- **HTTP quickstart URL corrected** in the README to `/mcp` (`/sse` for
+  SSE), matching where the handler is actually mounted.
+
+## Hardening
+
+- **Audit log error text is redacted** — a DSN embedded in an exception
+  message is run through `obfuscate_password` before logging, matching the
+  existing argument redaction, so a password can't reach the audit sink.
+- **`EXPLAIN ANALYZE` (`io=True`) runs read-only** — the one agent-SQL
+  path that executed at `force_readonly=False` now wraps execution in
+  `BEGIN TRANSACTION READ ONLY` like every other path.
+
+## Upgrade
+
+```bash
+pip install --upgrade mcpg
+docker pull ghcr.io/devopam/mcpg:0.6.11   # or :latest
+```
+
+Or grab `mcpg-0.6.11.mcpb` from this release and double-click it into
+Claude Desktop. No configuration changes required.
+
+## Full changelog
+
+See [`../CHANGELOG.md`](../CHANGELOG.md) `[0.6.11]` for the complete
+itemised list.

--- a/packaging/mcpb/manifest.json
+++ b/packaging/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "mcpg",
   "display_name": "MCPg \u2014 PostgreSQL",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "description": "Production-grade PostgreSQL MCP server: 252 tools for querying, tuning, and operating Postgres \u2014 read-only by default.",
   "long_description": "MCPg lets AI agents safely inspect, query, operate, and tune a PostgreSQL database. 252 tools spanning catalog introspection, query intelligence, natural-language SQL, structural diffs, hybrid search, graph queries, live ops, and more.\n\n**Safe by default**: read-only access mode, AST-validated SQL, and every tool publishes MCP annotations (`readOnlyHint`/`destructiveHint`) so the client knows exactly which calls are safe. Write, DDL, shell, and LISTEN capabilities stay off until explicitly enabled via environment variables.\n\nNo data yet? Run `mcpg --demo` against a scratch database to seed a curated demo dataset and take the tools for a spin \u2014 see the guided tour at https://github.com/devopam/MCPg/blob/main/docs/demo.md.",
   "author": {

--- a/packaging/mcpb/pyproject.toml
+++ b/packaging/mcpb/pyproject.toml
@@ -5,9 +5,9 @@
 # to the release tag by the publish workflow, exactly like server.json.
 [project]
 name = "mcpg-desktop-extension"
-version = "0.6.10"
+version = "0.6.11"
 description = "MCPB launcher shim for the MCPg PostgreSQL MCP server."
 requires-python = ">=3.12"
 dependencies = [
-    "mcpg==0.6.10",
+    "mcpg==0.6.11",
 ]

--- a/src/mcpg/__init__.py
+++ b/src/mcpg/__init__.py
@@ -2,7 +2,7 @@
 
 import warnings
 
-__version__ = "0.6.10"
+__version__ = "0.6.11"
 
 # ``schema`` is the natural field name for "which Postgres schema" across
 # ~180 tool-return dataclasses. The ``mcp`` SDK dynamically builds a


### PR DESCRIPTION
## Summary

Cuts **v0.6.11** — the release cut for the changes already merged to `main` since 0.6.10 (they were sitting under `[Unreleased]`; an earlier tag mistakenly landed on the v0.6.9 commit and its publish failed harmlessly, so this does the proper cut).

- `__version__` → **0.6.11**
- MCPB bundle pins synced to 0.6.11 (`test_mcpb_bundle` enforces the match)
- `CHANGELOG.md` `[Unreleased]` rolled into `[0.6.11] - 2026-07-10`
- `docs/release-notes-0.6.11.md` added + linked from `docs/index.md`

**What 0.6.11 contains** (all already on `main`):
- **Security — per-request tenancy works on HTTP/SSE.** The `X-MCPG-Role` / OIDC role override was pinned to a session's first request; now resolved per message from the SDK request context.
- **`recommend_indexes` flags unindexed foreign keys** (btree) — the demo's planted flaw is now actually caught.
- **Hardening:** audit error-text redaction; `EXPLAIN ANALYZE` (`io=True`) runs read-only.
- **First-contact polish:** `mcpg --help` works without a DB; stdio startup banner; README HTTP `/mcp` URL fix.

Verification: `ruff format --check .`, `ruff check .`, `mypy src/mcpg`, and the doc-drift guard all clean; `python -m build` + `twine check` produce a clean `mcpg-0.6.11` sdist + wheel.

After merge, the `v0.6.11` tag is created at the merge commit (maintainer-managed) to trigger the PyPI publish.

## Roadmap linkage

N/A — release cut.

## Checklist

- [x] Tests added/updated first (TDD); suite passes locally
- [x] `ruff`, `ruff format`, and `mypy src/mcpg` pass
- [x] `CHANGELOG.md` updated (rolled `[Unreleased]` → `[0.6.11]`)
- [x] Roadmap row cited above (`N/A`)
- [x] No hand-edits to `src/mcpg/_vendor/` (the vendor tree no longer exists — 18.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_