### PR TITLE
bench: benchmark-suite plan + Phase 1 perf harness foundation (19)

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,55 @@
+# MCPg benchmark suite
+
+Reproducible, evidence-driven benchmarks for MCPg. **v1 = performance /
+overhead** (this directory's `perf/`); the token-efficiency study is v2. Full
+design and thesis: [`../docs/plans/benchmark-suite.md`](../docs/plans/benchmark-suite.md).
+
+**The framing that keeps this honest:** MCPg does *not* make queries run faster
+— the same SQL executes on the same PostgreSQL. The performance benchmark
+proves MCPg's overhead is small and predictable (and decomposes exactly where
+it goes), so `t_db` is provably identical to native. That "you lose nothing"
+result is what earns credibility for the real wins (measured in v2: tokens).
+
+## What runs today (Phase 1)
+
+- `perf/paths.py` — the **native** (persistent psycopg, same txn envelope, no
+  MCPg overhead) and **server-side** (in-process `run_select`) measurement paths.
+- `perf/queries.py` — the two-axis query set (compute x result-size), heavy tier
+  from TPC-H.
+- `perf/stats.py` — percentiles + bootstrap median CI + warm-up handling (pure,
+  unit-tested).
+- `perf/runner.py` — orchestrates paths x queries (cold + warm) → structured JSON.
+- `datasets/` — TPC-H schema/index DDL + a DuckDB→`COPY` loader.
+
+The end-to-end transport paths, the overhead-decomposition waterfall (the
+`t_db == native` gate), the concurrency sweep, and the HTML dashboard land in
+subsequent phases.
+
+## Running it
+
+```bash
+# 1. A throwaway PostgreSQL (mirror scripts/benchmark_pg19.sh, or your own).
+export MCPG_TEST_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/bench
+
+# 2. Load TPC-H (SF1 for dev, SF10 for a published run). Needs the bench group:
+uv sync --group bench
+uv run python -m benchmarks.datasets.load_tpch --database-url "$MCPG_TEST_DATABASE_URL" --scale-factor 1
+
+# 3. Run the benchmark → JSON under benchmarks/results/.
+uv run python -m benchmarks.perf.runner \
+    --database-url "$MCPG_TEST_DATABASE_URL" \
+    --scale-factor 1 --iterations 50 \
+    --git-sha "$(git rev-parse HEAD)" --timestamp "$(date -u +%FT%TZ)" \
+    --output benchmarks/results/perf-$(date -u +%Y%m%dT%H%M%SZ).json
+```
+
+Provenance (git SHA, timestamp, versions, host, scale factor) is embedded in
+every result file, so a published number always carries the exact conditions
+that produced it.
+
+## Reproducibility
+
+Pinned versions, fixed query literals, seeded bootstrap, warm-up discarded,
+cold vs warm reported separately, medians + CIs (never single-shot means). The
+committed DDL + loader regenerate the data anywhere; the gigabytes are never
+committed.

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""MCPg benchmark suite (roadmap 19)."""

--- a/benchmarks/datasets/__init__.py
+++ b/benchmarks/datasets/__init__.py
@@ -1,0 +1,1 @@
+"""Benchmark datasets (TPC-H loader)."""

--- a/benchmarks/datasets/load_tpch.py
+++ b/benchmarks/datasets/load_tpch.py
@@ -24,6 +24,10 @@ from pathlib import Path
 import psycopg
 
 _DIR = Path(__file__).resolve().parent
+# The only values interpolated into SQL below are ``scale_factor`` (an int, via
+# argparse ``type=int``) and these table names — a frozen tuple of literals.
+# There is no untrusted input: table identifiers and DDL (COPY/VACUUM) cannot be
+# passed as bound parameters, so f-string composition here is safe by construction.
 _TABLES = ("region", "nation", "part", "supplier", "partsupp", "customer", "orders", "lineitem")
 
 

--- a/benchmarks/datasets/load_tpch.py
+++ b/benchmarks/datasets/load_tpch.py
@@ -1,0 +1,82 @@
+"""Load a TPC-H dataset into PostgreSQL, reproducibly, without committing GBs.
+
+Uses DuckDB's ``tpch`` extension to generate the data at a given scale factor,
+streams each table to a temporary CSV, and ``COPY``s it into PostgreSQL — so no
+multi-gigabyte file is ever committed. The schema/index DDL and this loader
+*are* committed; the data is regenerated locally.
+
+    uv run python -m benchmarks.datasets.load_tpch \
+        --database-url "$MCPG_TEST_DATABASE_URL" --scale-factor 1
+
+``duckdb`` is a dev-only dependency (the ``bench`` group); it is not required to
+run MCPg itself. Fallback for users who already have TPC-H ``dbgen`` output:
+``COPY`` the ``.tbl`` files directly after applying ``tpch_schema.sql``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+import tempfile
+from pathlib import Path
+
+import psycopg
+
+_DIR = Path(__file__).resolve().parent
+_TABLES = ("region", "nation", "part", "supplier", "partsupp", "customer", "orders", "lineitem")
+
+
+async def load(database_url: str, scale_factor: int) -> None:
+    try:
+        import duckdb
+    except ImportError as exc:  # pragma: no cover - dev-only dependency
+        raise SystemExit(
+            "duckdb is required to generate TPC-H data. Install the bench group:\n"
+            "  uv sync --group bench\n"
+            "or COPY existing dbgen .tbl files after applying tpch_schema.sql."
+        ) from exc
+
+    schema_sql = (_DIR / "tpch_schema.sql").read_text()
+    index_sql = (_DIR / "tpch_indexes.sql").read_text()
+
+    async with await psycopg.AsyncConnection.connect(database_url, autocommit=True) as conn:
+        print("applying schema ...")
+        await conn.execute(schema_sql)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            duck = duckdb.connect()
+            duck.execute("INSTALL tpch; LOAD tpch;")
+            print(f"generating TPC-H SF{scale_factor} (this can take a while) ...")
+            duck.execute(f"CALL dbgen(sf={scale_factor})")
+            for table in _TABLES:
+                csv_path = Path(tmp) / f"{table}.csv"
+                duck.execute(f"COPY {table} TO '{csv_path}' (FORMAT csv, HEADER false)")
+                async with conn.cursor() as cur:
+                    async with cur.copy(f"COPY {table} FROM STDIN (FORMAT csv)") as copy:
+                        with csv_path.open("rb") as fh:
+                            while chunk := fh.read(1 << 20):
+                                await copy.write(chunk)
+                csv_path.unlink()
+                print(f"  loaded {table}")
+            duck.close()
+
+        print("applying indexes ...")
+        await conn.execute(index_sql)
+        print("VACUUM ANALYZE ...")
+        for table in _TABLES:
+            await conn.execute(f"VACUUM (ANALYZE) {table}")
+    print(f"TPC-H SF{scale_factor} loaded.")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Load TPC-H into PostgreSQL for the MCPg benchmark.")
+    parser.add_argument("--database-url", required=True, help="Target PostgreSQL DSN.")
+    parser.add_argument("--scale-factor", type=int, default=1, help="TPC-H scale factor (1 dev, 10 published).")
+    args = parser.parse_args(argv)
+    asyncio.run(load(args.database_url, args.scale_factor))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/benchmarks/datasets/tpch_indexes.sql
+++ b/benchmarks/datasets/tpch_indexes.sql
@@ -1,0 +1,15 @@
+-- Secondary indexes applied AFTER bulk load (faster load, then index). The
+-- primary keys above already index the point-lookup columns; these cover the
+-- join/filter columns the TPC-H analytical queries hit, so heavy joins are
+-- index-eligible rather than forced seq-scans on every table.
+
+CREATE INDEX IF NOT EXISTS idx_nation_regionkey   ON nation   (n_regionkey);
+CREATE INDEX IF NOT EXISTS idx_supplier_nationkey ON supplier (s_nationkey);
+CREATE INDEX IF NOT EXISTS idx_customer_nationkey ON customer (c_nationkey);
+CREATE INDEX IF NOT EXISTS idx_orders_custkey     ON orders   (o_custkey);
+CREATE INDEX IF NOT EXISTS idx_orders_orderdate   ON orders   (o_orderdate);
+CREATE INDEX IF NOT EXISTS idx_lineitem_orderkey  ON lineitem (l_orderkey);
+CREATE INDEX IF NOT EXISTS idx_lineitem_suppkey   ON lineitem (l_suppkey);
+CREATE INDEX IF NOT EXISTS idx_lineitem_partkey   ON lineitem (l_partkey);
+CREATE INDEX IF NOT EXISTS idx_lineitem_shipdate  ON lineitem (l_shipdate);
+CREATE INDEX IF NOT EXISTS idx_partsupp_suppkey   ON partsupp (ps_suppkey);

--- a/benchmarks/datasets/tpch_schema.sql
+++ b/benchmarks/datasets/tpch_schema.sql
@@ -1,0 +1,91 @@
+-- TPC-H schema (8 tables). Standard column set; primary keys declared so
+-- point-lookups in the benchmark are genuinely index-served. Loaded by
+-- benchmarks/datasets/load_tpch.py; the data itself is generated locally
+-- (DuckDB's tpch extension), never committed.
+
+CREATE TABLE IF NOT EXISTS region (
+    r_regionkey  integer PRIMARY KEY,
+    r_name       char(25)   NOT NULL,
+    r_comment    varchar(152)
+);
+
+CREATE TABLE IF NOT EXISTS nation (
+    n_nationkey  integer PRIMARY KEY,
+    n_name       char(25)   NOT NULL,
+    n_regionkey  integer    NOT NULL,
+    n_comment    varchar(152)
+);
+
+CREATE TABLE IF NOT EXISTS part (
+    p_partkey     integer PRIMARY KEY,
+    p_name        varchar(55)  NOT NULL,
+    p_mfgr        char(25)     NOT NULL,
+    p_brand       char(10)     NOT NULL,
+    p_type        varchar(25)  NOT NULL,
+    p_size        integer      NOT NULL,
+    p_container   char(10)     NOT NULL,
+    p_retailprice numeric(15,2) NOT NULL,
+    p_comment     varchar(23)  NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS supplier (
+    s_suppkey    integer PRIMARY KEY,
+    s_name       char(25)     NOT NULL,
+    s_address    varchar(40)  NOT NULL,
+    s_nationkey  integer      NOT NULL,
+    s_phone      char(15)     NOT NULL,
+    s_acctbal    numeric(15,2) NOT NULL,
+    s_comment    varchar(101) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS partsupp (
+    ps_partkey    integer NOT NULL,
+    ps_suppkey    integer NOT NULL,
+    ps_availqty   integer NOT NULL,
+    ps_supplycost numeric(15,2) NOT NULL,
+    ps_comment    varchar(199) NOT NULL,
+    PRIMARY KEY (ps_partkey, ps_suppkey)
+);
+
+CREATE TABLE IF NOT EXISTS customer (
+    c_custkey     integer PRIMARY KEY,
+    c_name        varchar(25)  NOT NULL,
+    c_address     varchar(40)  NOT NULL,
+    c_nationkey   integer      NOT NULL,
+    c_phone       char(15)     NOT NULL,
+    c_acctbal     numeric(15,2) NOT NULL,
+    c_mktsegment  char(10)     NOT NULL,
+    c_comment     varchar(117) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS orders (
+    o_orderkey      integer PRIMARY KEY,
+    o_custkey       integer      NOT NULL,
+    o_orderstatus   char(1)      NOT NULL,
+    o_totalprice    numeric(15,2) NOT NULL,
+    o_orderdate     date         NOT NULL,
+    o_orderpriority char(15)     NOT NULL,
+    o_clerk         char(15)     NOT NULL,
+    o_shippriority  integer      NOT NULL,
+    o_comment       varchar(79)  NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS lineitem (
+    l_orderkey      integer NOT NULL,
+    l_partkey       integer NOT NULL,
+    l_suppkey       integer NOT NULL,
+    l_linenumber    integer NOT NULL,
+    l_quantity      numeric(15,2) NOT NULL,
+    l_extendedprice numeric(15,2) NOT NULL,
+    l_discount      numeric(15,2) NOT NULL,
+    l_tax           numeric(15,2) NOT NULL,
+    l_returnflag    char(1) NOT NULL,
+    l_linestatus    char(1) NOT NULL,
+    l_shipdate      date NOT NULL,
+    l_commitdate    date NOT NULL,
+    l_receiptdate   date NOT NULL,
+    l_shipinstruct  char(25) NOT NULL,
+    l_shipmode      char(10) NOT NULL,
+    l_comment       varchar(44) NOT NULL,
+    PRIMARY KEY (l_orderkey, l_linenumber)
+);

--- a/benchmarks/perf/__init__.py
+++ b/benchmarks/perf/__init__.py
@@ -1,0 +1,1 @@
+"""Performance / overhead benchmark harness (v1)."""

--- a/benchmarks/perf/paths.py
+++ b/benchmarks/perf/paths.py
@@ -1,0 +1,81 @@
+"""The measurement paths.
+
+Each runner times **one execution** of a query with ``time.perf_counter_ns()``
+and returns the elapsed nanoseconds; the runner (``runner.py``) calls it N
+times. All paths share one asyncio event loop; the DB-touching paths point at
+the same warmed pool / same DSN so event-loop and DB-work cost is common-mode
+and cancels out of the *differences* we report.
+
+* :class:`NativeRunner` — the fair floor. A single persistent ``psycopg``
+  connection replicating the **exact** transaction envelope MCPg issues
+  (``BEGIN TRANSACTION READ ONLY`` → execute → fetchall → ``[dict(row)]`` →
+  ``ROLLBACK``) but with **no** pglast validation, no ``SafeSqlDriver``
+  allocation, no pool checkout. Same DB work, none of MCPg's overhead — which
+  is what makes ``t_db == native`` a meaningful assertion. (Not ``psql -c``,
+  which would pay per-call process + connection startup.)
+* :class:`ServerSideRunner` — MCPg in-process: the real ``run_select`` over the
+  real ``SafeSqlDriver`` + real pool, bypassing the MCP transport. Includes the
+  genuine per-call ``SafeSqlDriver`` allocation and result serialization — those
+  are real MCPg cost and are never optimized away.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Protocol
+
+import psycopg
+from psycopg.rows import dict_row
+
+from mcpg.database import Database
+from mcpg.query import run_select
+
+
+class PathRunner(Protocol):
+    """One measurement path. ``run_once`` returns elapsed nanoseconds."""
+
+    async def run_once(self, sql: str, *, max_rows: int) -> int: ...
+
+
+class NativeRunner:
+    """Raw ``psycopg`` baseline replicating MCPg's transaction envelope."""
+
+    def __init__(self, connection: psycopg.AsyncConnection[Any]) -> None:
+        self._conn = connection
+
+    @classmethod
+    async def connect(cls, dsn: str) -> NativeRunner:
+        # autocommit=True so the explicit BEGIN/ROLLBACK envelope (matching
+        # MCPg's SqlDriver) is what drives the transaction, with no implicit
+        # transaction wrapping to double-count.
+        conn = await psycopg.AsyncConnection.connect(dsn, autocommit=True)
+        return cls(conn)
+
+    async def close(self) -> None:
+        await self._conn.close()
+
+    async def run_once(self, sql: str, *, max_rows: int) -> int:
+        conn = self._conn
+        start = time.perf_counter_ns()
+        async with conn.cursor(row_factory=dict_row) as cur:
+            await cur.execute("BEGIN TRANSACTION READ ONLY")
+            await cur.execute(sql)
+            rows = await cur.fetchall()
+            # Match run_select's max_rows truncation + dict materialization so
+            # the serialization work compared is like-for-like.
+            _ = [dict(r) for r in rows[:max_rows]]
+            await cur.execute("ROLLBACK")
+        return time.perf_counter_ns() - start
+
+
+class ServerSideRunner:
+    """MCPg in-process: real ``run_select`` over the real driver + pool."""
+
+    def __init__(self, database: Database) -> None:
+        self._database = database
+
+    async def run_once(self, sql: str, *, max_rows: int) -> int:
+        driver = self._database.driver()
+        start = time.perf_counter_ns()
+        await run_select(driver, sql, max_rows=max_rows)
+        return time.perf_counter_ns() - start

--- a/benchmarks/perf/paths.py
+++ b/benchmarks/perf/paths.py
@@ -59,12 +59,18 @@ class NativeRunner:
         start = time.perf_counter_ns()
         async with conn.cursor(row_factory=dict_row) as cur:
             await cur.execute("BEGIN TRANSACTION READ ONLY")
-            await cur.execute(sql)
-            rows = await cur.fetchall()
-            # Match run_select's max_rows truncation + dict materialization so
-            # the serialization work compared is like-for-like.
-            _ = [dict(r) for r in rows[:max_rows]]
-            await cur.execute("ROLLBACK")
+            try:
+                await cur.execute(sql)
+                rows = await cur.fetchall()
+                # Match run_select's max_rows truncation + dict materialization
+                # so the serialization work compared is like-for-like.
+                _ = [dict(r) for r in rows[:max_rows]]
+            finally:
+                # Always close the transaction. A failing query on this
+                # persistent connection would otherwise leave it in an aborted
+                # state and poison every subsequent measurement. ROLLBACK is
+                # valid (and the correct recovery) even after an error.
+                await cur.execute("ROLLBACK")
         return time.perf_counter_ns() - start
 
 

--- a/benchmarks/perf/queries.py
+++ b/benchmarks/perf/queries.py
@@ -1,0 +1,164 @@
+"""The benchmark query set — two independent axes.
+
+* **compute_class** — ultralight / light / heavy (how much work the DB does).
+* **result_size** — 1 / ~100 / large (how many rows come back, which drives
+  MCPg's serialization cost independently of compute).
+
+Heavy queries are drawn from the standard **TPC-H** analytical set (fixed
+parameter literals so every run is identical). Ultralight/light run against the
+same TPC-H schema so a single loaded dataset serves the whole suite.
+
+All SQL here is read-only SELECT — it flows through ``run_select`` /
+``SafeSqlDriver`` unchanged, exactly as an agent's query would.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+ComputeClass = Literal["ultralight", "light", "heavy"]
+ResultSize = Literal["1", "~100", "large"]
+
+
+@dataclass(frozen=True)
+class BenchQuery:
+    """One benchmark query with its taxonomy labels."""
+
+    id: str
+    sql: str
+    compute_class: ComputeClass
+    result_size: ResultSize
+    # run_select truncates at max_rows (default 1000); the large-result cases
+    # raise it so the serialization cost is actually exercised end to end.
+    max_rows: int = 1000
+
+
+# --- ultralight: sub-millisecond, index/point access ----------------------
+
+_ULTRALIGHT = [
+    BenchQuery("select_1", "SELECT 1 AS one", "ultralight", "1"),
+    BenchQuery(
+        "pk_lookup_orders",
+        "SELECT * FROM orders WHERE o_orderkey = 1",
+        "ultralight",
+        "1",
+    ),
+    BenchQuery(
+        "pk_lookup_customer",
+        "SELECT * FROM customer WHERE c_custkey = 1",
+        "ultralight",
+        "1",
+    ),
+]
+
+# --- light: single-digit ms, indexed range + small aggregate --------------
+
+_LIGHT = [
+    BenchQuery(
+        "orders_status_counts",
+        "SELECT o_orderstatus, count(*) AS n FROM orders "
+        "WHERE o_orderdate BETWEEN DATE '1995-01-01' AND DATE '1995-03-31' "
+        "GROUP BY o_orderstatus",
+        "light",
+        "~100",
+    ),
+]
+
+# --- heavy: 100 ms-seconds, standard TPC-H analytical queries -------------
+# Fixed parameter substitutions (TPC-H validation-style constants) so the run
+# is deterministic. A representative cross-section for the first cut — the full
+# Q1-Q22 set is added incrementally.
+
+_TPCH_Q1 = """
+SELECT l_returnflag, l_linestatus,
+       sum(l_quantity) AS sum_qty,
+       sum(l_extendedprice) AS sum_base_price,
+       sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
+       sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
+       avg(l_quantity) AS avg_qty, avg(l_extendedprice) AS avg_price,
+       avg(l_discount) AS avg_disc, count(*) AS count_order
+FROM lineitem
+WHERE l_shipdate <= DATE '1998-12-01' - INTERVAL '90 day'
+GROUP BY l_returnflag, l_linestatus
+ORDER BY l_returnflag, l_linestatus
+""".strip()
+
+_TPCH_Q6 = """
+SELECT sum(l_extendedprice * l_discount) AS revenue
+FROM lineitem
+WHERE l_shipdate >= DATE '1994-01-01'
+  AND l_shipdate < DATE '1994-01-01' + INTERVAL '1 year'
+  AND l_discount BETWEEN 0.06 - 0.01 AND 0.06 + 0.01
+  AND l_quantity < 24
+""".strip()
+
+_TPCH_Q3 = """
+SELECT l_orderkey,
+       sum(l_extendedprice * (1 - l_discount)) AS revenue,
+       o_orderdate, o_shippriority
+FROM customer, orders, lineitem
+WHERE c_mktsegment = 'BUILDING'
+  AND c_custkey = o_custkey
+  AND l_orderkey = o_orderkey
+  AND o_orderdate < DATE '1995-03-15'
+  AND l_shipdate > DATE '1995-03-15'
+GROUP BY l_orderkey, o_orderdate, o_shippriority
+ORDER BY revenue DESC, o_orderdate
+LIMIT 10
+""".strip()
+
+_TPCH_Q5 = """
+SELECT n_name, sum(l_extendedprice * (1 - l_discount)) AS revenue
+FROM customer, orders, lineitem, supplier, nation, region
+WHERE c_custkey = o_custkey
+  AND l_orderkey = o_orderkey
+  AND l_suppkey = s_suppkey
+  AND c_nationkey = s_nationkey
+  AND s_nationkey = n_nationkey
+  AND n_regionkey = r_regionkey
+  AND r_name = 'ASIA'
+  AND o_orderdate >= DATE '1994-01-01'
+  AND o_orderdate < DATE '1994-01-01' + INTERVAL '1 year'
+GROUP BY n_name
+ORDER BY revenue DESC
+""".strip()
+
+_HEAVY = [
+    BenchQuery("tpch_q1", _TPCH_Q1, "heavy", "~100"),
+    BenchQuery("tpch_q6", _TPCH_Q6, "heavy", "1"),
+    BenchQuery("tpch_q3", _TPCH_Q3, "heavy", "~100"),
+    BenchQuery("tpch_q5", _TPCH_Q5, "heavy", "~100"),
+]
+
+# --- result-size axis: decouple serialization cost from compute weight ----
+# Same cheap-ish scan, three return sizes, so t_serialize is isolated.
+
+_RESULT_SIZE = [
+    BenchQuery(
+        "rows_1",
+        "SELECT count(*) AS n FROM lineitem WHERE l_shipdate < DATE '1994-01-01'",
+        "light",
+        "1",
+    ),
+    BenchQuery(
+        "rows_100",
+        "SELECT l_orderkey, l_quantity, l_extendedprice FROM lineitem WHERE l_shipdate < DATE '1994-01-01' LIMIT 100",
+        "light",
+        "~100",
+        max_rows=100,
+    ),
+    BenchQuery(
+        "rows_100k",
+        "SELECT l_orderkey, l_quantity, l_extendedprice FROM lineitem "
+        "WHERE l_shipdate < DATE '1994-01-01' LIMIT 100000",
+        "light",
+        "large",
+        max_rows=100_000,
+    ),
+]
+
+
+def all_queries() -> list[BenchQuery]:
+    """Every benchmark query, across both axes."""
+    return [*_ULTRALIGHT, *_LIGHT, *_HEAVY, *_RESULT_SIZE]

--- a/benchmarks/perf/runner.py
+++ b/benchmarks/perf/runner.py
@@ -1,0 +1,168 @@
+"""Performance-run orchestrator (CLI).
+
+Times the **native** and **server-side** paths across the query set (cold +
+warm), aggregates to percentiles + a bootstrap median CI, and writes one
+structured JSON document under ``benchmarks/results/``.
+
+    uv run python -m benchmarks.perf.runner \
+        --database-url "$MCPG_TEST_DATABASE_URL" \
+        --scale-factor 1 --iterations 50 --output benchmarks/results/perf.json
+
+Provenance (git SHA, timestamp) is passed in so a result always carries the
+exact conditions that produced it. This first cut covers native + server-side;
+the end-to-end transport paths, the overhead decomposition, and the
+concurrency sweep land in follow-up phases (see docs/plans/benchmark-suite.md).
+
+Operator tool — not unit-tested (needs a live PostgreSQL); the pure helpers it
+calls (stats, queries, schema) are.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import gc
+import json
+import platform
+import sys
+from pathlib import Path
+from typing import Any
+
+from benchmarks.perf import stats
+from benchmarks.perf.paths import NativeRunner, PathRunner, ServerSideRunner
+from benchmarks.perf.queries import BenchQuery, all_queries
+from benchmarks.perf.schema import Assertion, LatencyBlock, PerfRun, ResultRow
+from mcpg import __version__
+from mcpg.config import load_settings
+from mcpg.database import Database
+
+_WARMUP = 5
+
+
+async def _sample_path(runner: PathRunner, query: BenchQuery, iterations: int) -> tuple[list[int], int]:
+    """Return (warm samples, cold sample) for one path x query.
+
+    GC is disabled around each timed call so a collection pause never lands
+    inside a measurement; collected in the gaps instead.
+    """
+    gc.collect()
+    cold = await runner.run_once(query.sql, max_rows=query.max_rows)  # first call = cold bucket
+    samples: list[int] = []
+    for i in range(iterations + _WARMUP):
+        gc.disable()
+        try:
+            elapsed = await runner.run_once(query.sql, max_rows=query.max_rows)
+        finally:
+            gc.enable()
+        samples.append(elapsed)
+        if i % 8 == 7:
+            gc.collect()
+    warm = stats.drop_warmup(samples, _WARMUP)
+    return warm, cold
+
+
+def _row(path: str, query: BenchQuery, temperature: str, samples_ns: list[int]) -> ResultRow:
+    s = stats.summarize(samples_ns)
+    return ResultRow(
+        path=path,
+        query_id=query.id,
+        compute_class=query.compute_class,
+        result_size=query.result_size,
+        temperature=temperature,
+        concurrency=1,
+        n=s.n,
+        latency_ms=LatencyBlock(
+            p50=s.p50, p95=s.p95, p99=s.p99, mean=s.mean, stdev=s.stdev, min=s.min, max=s.max, median_ci95=s.median_ci95
+        ),
+        samples_ns=samples_ns,
+    )
+
+
+async def _run(args: argparse.Namespace) -> PerfRun:
+    settings = load_settings(
+        {"MCPG_DATABASE_URL": args.database_url, "MCPG_POOL_MIN_SIZE": "1", "MCPG_POOL_MAX_SIZE": "4"}
+    )
+    database = Database(settings)
+    await database.connect()
+    native = await NativeRunner.connect(args.database_url)
+    results: list[ResultRow] = []
+    try:
+        pg = await database.driver().execute_query(
+            "SELECT current_setting('server_version') AS v, current_setting('server_version_num')::int AS num",
+            force_readonly=True,
+        )
+        pg_meta = {"version_string": pg[0].cells["v"], "server_version_num": pg[0].cells["num"]} if pg else {}
+
+        for query in all_queries():
+            for label, runner in (("native", native), ("server_side", ServerSideRunner(database))):
+                warm, cold = await _sample_path(runner, query, args.iterations)
+                results.append(_row(label, query, "warm", warm))
+                results.append(_row(label, query, "cold", [cold]))
+    finally:
+        await native.close()
+        await database.close()
+
+    metadata: dict[str, Any] = {
+        "timestamp": args.timestamp,
+        "git_sha": args.git_sha,
+        "mcpg_version": __version__,
+        "postgres": pg_meta,
+        "scale_factor": args.scale_factor,
+        "host": {
+            "python": platform.python_version(),
+            "os": platform.platform(),
+            "machine": platform.machine(),
+        },
+        "iterations": args.iterations,
+        "warmup_discarded": _WARMUP,
+    }
+    return PerfRun(metadata=metadata, results=results, assertions=_assertions(results))
+
+
+def _assertions(results: list[ResultRow]) -> list[Assertion]:
+    """Overhead sanity checks. The fine-grained t_db == native assertion lands
+    with the decomposition phase; here we record the warm total-latency delta
+    per query so the report can show MCPg's overhead is bounded."""
+    out: list[Assertion] = []
+    by_key = {(r.path, r.query_id): r for r in results if r.temperature == "warm"}
+    query_ids = {r.query_id for r in results}
+    for qid in sorted(query_ids):
+        native = by_key.get(("native", qid))
+        server = by_key.get(("server_side", qid))
+        if native is None or server is None:
+            continue
+        overhead_ms = server.latency_ms.p50 - native.latency_ms.p50
+        out.append(
+            Assertion(
+                name="server_side_overhead_p50_ms",
+                query_id=qid,
+                passed=True,  # informational; the t_db==native gate lands with decomposition
+                detail={
+                    "native_p50_ms": native.latency_ms.p50,
+                    "server_side_p50_ms": server.latency_ms.p50,
+                    "overhead_p50_ms": overhead_ms,
+                },
+            )
+        )
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="MCPg performance benchmark (native vs server-side).")
+    parser.add_argument("--database-url", required=True, help="PostgreSQL DSN (a TPC-H-loaded database).")
+    parser.add_argument("--iterations", type=int, default=50, help="Warm iterations per pathxquery (>= 20).")
+    parser.add_argument("--scale-factor", type=int, default=1, help="TPC-H scale factor the DB was loaded at.")
+    parser.add_argument("--output", type=Path, required=True, help="Path to write the result JSON.")
+    parser.add_argument("--git-sha", default="unknown", help="Provenance: the commit under test.")
+    parser.add_argument("--timestamp", default="unknown", help="Provenance: ISO-8601 run timestamp.")
+    args = parser.parse_args(argv)
+
+    run = asyncio.run(_run(args))
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(run.to_dict(), indent=2) + "\n")
+    print(f"wrote {args.output} ({len(run.results)} result rows)")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/benchmarks/perf/runner.py
+++ b/benchmarks/perf/runner.py
@@ -86,12 +86,16 @@ async def _run(args: argparse.Namespace) -> PerfRun:
     await database.connect()
     native = await NativeRunner.connect(args.database_url)
     results: list[ResultRow] = []
+    # Pre-initialised so a failure in the metadata query below can't mask the
+    # original exception with an UnboundLocalError when `metadata` is built.
+    pg_meta: dict[str, Any] = {}
     try:
         pg = await database.driver().execute_query(
             "SELECT current_setting('server_version') AS v, current_setting('server_version_num')::int AS num",
             force_readonly=True,
         )
-        pg_meta = {"version_string": pg[0].cells["v"], "server_version_num": pg[0].cells["num"]} if pg else {}
+        if pg:
+            pg_meta = {"version_string": pg[0].cells["v"], "server_version_num": pg[0].cells["num"]}
 
         for query in all_queries():
             for label, runner in (("native", native), ("server_side", ServerSideRunner(database))):
@@ -150,12 +154,18 @@ def _assertions(results: list[ResultRow]) -> list[Assertion]:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="MCPg performance benchmark (native vs server-side).")
     parser.add_argument("--database-url", required=True, help="PostgreSQL DSN (a TPC-H-loaded database).")
-    parser.add_argument("--iterations", type=int, default=50, help="Warm iterations per pathxquery (>= 20).")
+    parser.add_argument(
+        "--iterations", type=int, default=50, help=f"Warm iterations per pathxquery (>= {_WARMUP + 1})."
+    )
     parser.add_argument("--scale-factor", type=int, default=1, help="TPC-H scale factor the DB was loaded at.")
     parser.add_argument("--output", type=Path, required=True, help="Path to write the result JSON.")
     parser.add_argument("--git-sha", default="unknown", help="Provenance: the commit under test.")
     parser.add_argument("--timestamp", default="unknown", help="Provenance: ISO-8601 run timestamp.")
     args = parser.parse_args(argv)
+    if args.iterations < _WARMUP + 1:
+        # Below this the warm bucket is empty after dropping warmup, and
+        # summarize() would report misleading all-zero stats that look valid.
+        parser.error(f"--iterations must be >= {_WARMUP + 1} (warm measurements would be empty)")
 
     run = asyncio.run(_run(args))
     args.output.parent.mkdir(parents=True, exist_ok=True)

--- a/benchmarks/perf/schema.py
+++ b/benchmarks/perf/schema.py
@@ -1,0 +1,85 @@
+"""Structured result schema for a performance run.
+
+Frozen dataclasses serialized with ``dataclasses.asdict`` (repo convention).
+One JSON file per run under ``benchmarks/results/``. Provenance
+(``timestamp`` / ``git_sha`` / host / versions) is **passed in** by the caller
+so a published number always carries the exact conditions that produced it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+SCHEMA_VERSION = 1
+
+# The measurement paths (see perf/paths.py).
+Path = str  # "native" | "server_side" | "e2e_inmemory" | "e2e_stdio" | "e2e_http"
+
+
+@dataclass(frozen=True)
+class Decomposition:
+    """The overhead waterfall, in nanoseconds (medians). ``None`` where N/A."""
+
+    t_parse: float | None = None
+    t_pool: float | None = None
+    t_txn: float | None = None
+    t_db: float | None = None
+    t_serialize: float | None = None
+    t_protocol: float | None = None
+    t_cache: float | None = None
+
+
+@dataclass(frozen=True)
+class LatencyBlock:
+    """Reported latency in milliseconds (from perf/stats.LatencySummary)."""
+
+    p50: float
+    p95: float
+    p99: float
+    mean: float
+    stdev: float
+    min: float
+    max: float
+    median_ci95: tuple[float, float]
+
+
+@dataclass(frozen=True)
+class ResultRow:
+    """One (path, query, temperature, concurrency) measurement."""
+
+    path: Path
+    query_id: str
+    compute_class: str
+    result_size: str
+    temperature: str  # "cold" | "warm"
+    concurrency: int
+    n: int
+    latency_ms: LatencyBlock
+    throughput_rps: float | None = None
+    samples_ns: list[int] = field(default_factory=list)
+    decomposition_ns: Decomposition | None = None
+
+
+@dataclass(frozen=True)
+class Assertion:
+    """A machine-checkable claim (the load-bearing one: t_db == native)."""
+
+    name: str
+    query_id: str
+    passed: bool
+    detail: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class PerfRun:
+    """A full performance run — the top-level JSON document."""
+
+    metadata: dict[str, Any]
+    results: list[ResultRow]
+    assertions: list[Assertion] = field(default_factory=list)
+    schema_version: int = SCHEMA_VERSION
+    kind: str = "performance"
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)

--- a/benchmarks/perf/stats.py
+++ b/benchmarks/perf/stats.py
@@ -1,0 +1,95 @@
+"""Statistical aggregation for the performance harness.
+
+Pure functions over sample arrays (nanosecond integers from
+``time.perf_counter_ns()``). No I/O, no database — unit-tested. The harness
+records raw samples in the result JSON; these turn them into the reported
+percentiles + a bootstrap confidence interval on the median (robust, no
+normality assumption).
+"""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class LatencySummary:
+    """Summary of one sample array, in **milliseconds** (converted from ns)."""
+
+    n: int
+    p50: float
+    p95: float
+    p99: float
+    mean: float
+    stdev: float
+    min: float
+    max: float
+    median_ci95: tuple[float, float]
+
+
+def percentile(sorted_ns: list[int], pct: float) -> float:
+    """Nearest-rank percentile of an already-sorted ns array (0 < pct <= 100)."""
+    if not sorted_ns:
+        return 0.0
+    import math
+
+    rank = max(0, min(len(sorted_ns) - 1, math.ceil(pct / 100.0 * len(sorted_ns)) - 1))
+    return float(sorted_ns[rank])
+
+
+def _median(sorted_ns: list[int]) -> float:
+    n = len(sorted_ns)
+    if n == 0:
+        return 0.0
+    mid = n // 2
+    if n % 2:
+        return float(sorted_ns[mid])
+    return (sorted_ns[mid - 1] + sorted_ns[mid]) / 2.0
+
+
+def bootstrap_median_ci(samples_ns: list[int], *, resamples: int = 10_000, seed: int = 0) -> tuple[float, float]:
+    """95% CI on the median via seeded bootstrap resampling (returns ns).
+
+    Seeded so a published number is reproducible. Returns ``(median, median)``
+    for a degenerate (<2) sample.
+    """
+    if len(samples_ns) < 2:
+        m = _median(sorted(samples_ns))
+        return (m, m)
+    rng = random.Random(seed)
+    n = len(samples_ns)
+    medians: list[float] = []
+    for _ in range(resamples):
+        resample = sorted(samples_ns[rng.randrange(n)] for _ in range(n))
+        medians.append(_median(resample))
+    medians.sort()
+    lo = percentile([int(m) for m in medians], 2.5)
+    hi = percentile([int(m) for m in medians], 97.5)
+    return (lo, hi)
+
+
+def summarize(samples_ns: list[int], *, bootstrap_seed: int = 0) -> LatencySummary:
+    """Summarize a sample array into reported milliseconds."""
+    import statistics as _stats
+
+    n = len(samples_ns)
+    ordered = sorted(samples_ns)
+    ns_to_ms = 1e-6
+    ci_lo_ns, ci_hi_ns = bootstrap_median_ci(samples_ns, seed=bootstrap_seed)
+    return LatencySummary(
+        n=n,
+        p50=percentile(ordered, 50) * ns_to_ms,
+        p95=percentile(ordered, 95) * ns_to_ms,
+        p99=percentile(ordered, 99) * ns_to_ms,
+        mean=(_stats.fmean(samples_ns) * ns_to_ms) if n else 0.0,
+        stdev=(_stats.stdev(samples_ns) * ns_to_ms) if n > 1 else 0.0,
+        min=(float(ordered[0]) * ns_to_ms) if n else 0.0,
+        max=(float(ordered[-1]) * ns_to_ms) if n else 0.0,
+        median_ci95=(ci_lo_ns * ns_to_ms, ci_hi_ns * ns_to_ms),
+    )
+
+
+def drop_warmup(samples_ns: list[int], warmup: int) -> list[int]:
+    """Discard the first ``warmup`` samples (pool priming, plan cache, first-call)."""
+    return samples_ns[warmup:] if warmup < len(samples_ns) else []

--- a/docs/feature-shortlist.md
+++ b/docs/feature-shortlist.md
@@ -280,6 +280,25 @@ gate.
 |---|---|---|---|---|
 | 18.1 | ✅ **Shipped.** Replaced the vendored `crystaldba/postgres-mcp` kernel with a first-party `src/mcpg/sql/` package — `allowlist.py` (policy as data), `safety.py` (`SafeSqlDriver` walker), `driver.py` (`SqlDriver`/`DbConnPool`/`obfuscate_password`). The dead `bind_params.py` / `extension_utils.py` / `index.py` were deleted, not rebuilt. All ~74 consumers swung to `mcpg.sql`; `_vendor/` + `tests/vendor/` deleted; the 5 quality-gate carve-outs removed (the kernel is now inside coverage + `mypy --strict` + `ruff` + `bandit`). Faithful re-author, proven identical by a differential parity harness (0 divergence) + the ported 760-LOC adversarial suite + a fuzz pass + `/security-review` (no findings). Supersedes ADR-0001 with [ADR-0007](adr/0007-first-party-sql-kernel.md); plan in [`plans/devendor-sql-kernel.md`](plans/devendor-sql-kernel.md), sign-off in [`reviews/devendor-sql-kernel-security-review.md`](reviews/devendor-sql-kernel-security-review.md). | L | Medium | Removes the last third-party runtime core; full control over the safety semantics. |
 
+## 19. Benchmark suite — public, evidence-driven
+
+A reproducible benchmark making a conclusive, publishable case for MCPg on
+the axes where the evidence is unassailable: **token efficiency** and **agent
+reliability**, at **negligible performance overhead**, with safety guarantees.
+Full spec (thesis, methodology, TPC-H scale, token break-even model, reusable
+HTML dashboard, honest-caveats section) in
+[`plans/benchmark-suite.md`](plans/benchmark-suite.md). Explicitly does **not**
+claim MCPg out-executes PostgreSQL — the perf tier disarms that objection by
+quantifying the sub-ms overhead; the win is measured elsewhere.
+
+| # | Item | Effort | Value | Notes |
+|---|---|---|---|---|
+| 19.1 | **Perf harness + overhead decomposition.** Native (persistent psycopg) vs MCPg server-side vs MCPg end-to-end (stdio + http), with a timed waterfall (`t_parse`/`t_pool`/`t_txn`/`t_db`/`t_serialize`/`t_protocol`). TPC-H heavy tier + ultralight/light + throughput-under-concurrency; p50/p95/p99, cold/warm, cache-hit path separate. Deterministic (no LLM). | M-L | High | Phase 1. Proves `t_db == native` and the overhead is sub-ms. |
+| 19.2 | **Token accounting — Tier A (deterministic).** Tokenize MCPg's compact/structured tool I/O vs the raw-SQL equivalent (compact schema vs `information_schema` dump; structured advisor reports vs raw rows). CI-able. | M | High | Phase 2. Backbone of the token claim. |
+| 19.3 | **Reusable dashboard.** JSON results → self-contained, theme-aware HTML (latency percentiles, overhead waterfall, throughput, token savings, **break-even curve** net of the 252-tool context cost). | M | High | Phase 3. The break-even chart is the credibility centerpiece. |
+| 19.4 | **Token study — Tier B (agent-loop).** Fixed model at temp 0, N trials per task, published transcripts; total tokens + tool-calls + turns + correctness to completion. Captures the round-trip savings. | L | High | Phase 4. The costed phase; task set has known-correct answers via the demo dataset. |
+| 19.5 | **Public writeup** drawing 19.1–19.4 together, with the honest-caveats section and "run it yourself" harness. | S-M | High | Phase 5. |
+
 ---
 
 ## Currently deferred (no commitments)

--- a/docs/feature-shortlist.md
+++ b/docs/feature-shortlist.md
@@ -289,15 +289,19 @@ Full spec (thesis, methodology, TPC-H scale, token break-even model, reusable
 HTML dashboard, honest-caveats section) in
 [`plans/benchmark-suite.md`](plans/benchmark-suite.md). Explicitly does **not**
 claim MCPg out-executes PostgreSQL — the perf tier disarms that objection by
-quantifying the sub-ms overhead; the win is measured elsewhere.
+quantifying the sub-ms overhead; the win is measured elsewhere. **v1 = the
+performance rows (19.1–19.3); the token study (19.4–19.6) is v2**, inheriting
+the same dashboard. Published heavy scale is TPC-H SF10; dashboard is
+self-contained static HTML.
 
 | # | Item | Effort | Value | Notes |
 |---|---|---|---|---|
-| 19.1 | **Perf harness + overhead decomposition.** Native (persistent psycopg) vs MCPg server-side vs MCPg end-to-end (stdio + http), with a timed waterfall (`t_parse`/`t_pool`/`t_txn`/`t_db`/`t_serialize`/`t_protocol`). TPC-H heavy tier + ultralight/light + throughput-under-concurrency; p50/p95/p99, cold/warm, cache-hit path separate. Deterministic (no LLM). | M-L | High | Phase 1. Proves `t_db == native` and the overhead is sub-ms. |
-| 19.2 | **Token accounting — Tier A (deterministic).** Tokenize MCPg's compact/structured tool I/O vs the raw-SQL equivalent (compact schema vs `information_schema` dump; structured advisor reports vs raw rows). CI-able. | M | High | Phase 2. Backbone of the token claim. |
-| 19.3 | **Reusable dashboard.** JSON results → self-contained, theme-aware HTML (latency percentiles, overhead waterfall, throughput, token savings, **break-even curve** net of the 252-tool context cost). | M | High | Phase 3. The break-even chart is the credibility centerpiece. |
-| 19.4 | **Token study — Tier B (agent-loop).** Fixed model at temp 0, N trials per task, published transcripts; total tokens + tool-calls + turns + correctness to completion. Captures the round-trip savings. | L | High | Phase 4. The costed phase; task set has known-correct answers via the demo dataset. |
-| 19.5 | **Public writeup** drawing 19.1–19.4 together, with the honest-caveats section and "run it yourself" harness. | S-M | High | Phase 5. |
+| 19.1 | **(v1) Perf harness + overhead decomposition.** Native (persistent psycopg) vs MCPg server-side vs MCPg end-to-end (stdio + http), with a timed waterfall (`t_parse`/`t_pool`/`t_txn`/`t_db`/`t_serialize`/`t_protocol`). TPC-H heavy tier (SF1 dev / SF10 published) + ultralight/light + throughput-under-concurrency; p50/p95/p99, cold/warm, cache-hit path separate. Deterministic (no LLM). | M-L | High | Phase 1. Proves `t_db == native` and the overhead is sub-ms. |
+| 19.2 | **(v1) Static HTML dashboard.** JSON results → self-contained, theme-aware HTML (latency percentiles, overhead waterfall, throughput). Evolves to add the token charts in v2. | M | High | Phase 2. Portable, publishable, re-generated per run. |
+| 19.3 | **(v1) Performance writeup** — the "negligible overhead" result, publishable on its own, with the "run it yourself" harness. | S | High | Phase 3. |
+| 19.4 | **(v2) Token accounting — Tier A (deterministic).** Tokenize MCPg's compact/structured tool I/O vs the raw-SQL equivalent (compact schema vs `information_schema` dump; structured advisor reports vs raw rows). CI-able. Adds the token + **break-even** charts (net of the 252-tool context cost) to the dashboard. | M | High | Phase 4. Backbone of the token claim. |
+| 19.5 | **(v2) Token study — Tier B (agent-loop).** Fixed model at temp 0, N trials per task, published transcripts; total tokens + tool-calls + turns + correctness to completion. Captures the round-trip savings. | L | High | Phase 5. The costed phase; task set has known-correct answers via the demo dataset. |
+| 19.6 | **(v2) Combined writeup** drawing performance + tokens together, with the honest-caveats section. | S-M | High | Phase 6. |
 
 ---
 

--- a/docs/plans/benchmark-suite.md
+++ b/docs/plans/benchmark-suite.md
@@ -40,6 +40,15 @@ scrupulous about the overhead is a feature of the argument, not a weakness.
    purpose-built surface vs a bare SQL-execution tool, **net of** the
    tool-definition context cost.
 
+### Scope: v1 vs later
+
+**v1 is the performance objective + the dashboard.** It's fully deterministic
+(no model, no cost, no non-determinism), proves the "negligible overhead" half
+of the thesis, and stands on its own as a publishable result. The **token
+objective (2) is v2** — it inherits the same dashboard, which evolves to add
+the token charts as those results land. This keeps v1 shippable fast and defers
+the costed/non-deterministic agent work until the free result is in hand.
+
 ## Non-goals / honesty guardrails
 
 - Not a claim that MCPg out-executes Postgres.
@@ -185,12 +194,17 @@ queries, tasks, transcripts, raw JSON — committed alongside the results.
 
 The harness writes **structured JSON** result files; a generator renders a
 **self-contained, theme-aware HTML dashboard** (no external hosts — same rules
-as an Artifact): latency percentiles by query class, the overhead
-**waterfall**, throughput-vs-concurrency, token-savings by task, and the
-**break-even curve**. Re-run the harness → regenerate the dashboard. Portable,
-reviewable, publishable. (MCPg already exposes Prometheus metrics, so a Grafana
-variant is a cheap follow-on if we want a live dashboard, but the committed
-HTML is the primary, self-contained artifact.)
+as an Artifact). It ships in **v1** rendering the performance results (latency
+percentiles by query class, the overhead **waterfall**, throughput-vs-
+concurrency) and **evolves** to add the token charts (savings by task, the
+break-even curve) in v2. Re-run the harness → regenerate. Portable, reviewable,
+publishable.
+
+*(A Grafana/Prometheus live variant was considered — MCPg already exposes
+Prometheus metrics — but rejected for v1: a benchmark result is a snapshot, not
+a live feed, so the runnable-infra overhead buys little. The self-contained
+committed HTML is the artifact; a live variant can come later if a genuine need
+appears.)*
 
 ## Repo layout
 
@@ -208,12 +222,17 @@ benchmarks/
 
 ## Phasing
 
+**v1 (performance):**
 1. **Perf harness + overhead decomposition** on TPC-H (deterministic, no LLM).
-2. **Tier-A token accounting** (deterministic).
-3. **Dashboard generator** (JSON → HTML).
-4. **Tier-B agent study** (fixed model, N trials, published transcripts — the
+2. **Dashboard generator** (JSON → self-contained HTML) rendering the perf
+   results.
+3. **v1 writeup** — the "negligible overhead" result, publishable on its own.
+
+**v2 (tokens), inheriting the same dashboard:**
+4. **Tier-A token accounting** (deterministic).
+5. **Tier-B agent study** (fixed model, N trials, published transcripts — the
    costed phase).
-5. **Public writeup** drawing the four together.
+6. **Combined writeup** drawing performance + tokens together.
 
 Each phase is independently valuable and lands as its own PR.
 
@@ -227,18 +246,23 @@ Each phase is independently valuable and lands as its own PR.
 | "Cherry-picked queries/tasks." | Full sets committed; TPC-H is a standard; demo tasks have known answers. |
 | "Non-deterministic agent runs." | Tier A is deterministic; Tier B pins model+temp, N trials, reports distribution. |
 
-## Defaults (override in review)
+## Resolved decisions (locked for v1)
 
-- **Tier-B model:** pin one fixed model at temperature 0 for reproducible token
-  counts (candidate: a fixed Claude model; final choice recorded in the run
-  metadata).
-- **TPC-H scale:** SF1 dev / SF10 published.
+- **v1 scope:** performance objective + the HTML dashboard. Token objective is v2.
+- **TPC-H scale:** **SF1** for development, **SF10** for the published run —
+  SF10 is the ceiling (no SF30).
+- **Dashboard:** self-contained **static HTML** (no Grafana/Prometheus in v1 —
+  a result is a snapshot, not a live feed). Evolves to add token charts in v2.
 - **Concurrency points:** 1 / 4 / 16 / 64 clients.
-- **Trials:** ≥ 20 per perf point; ≥ 10 Tier-B trials per task.
+- **Trials:** ≥ 20 per perf data-point (medians + variance reported).
+- **Token baseline (v2):** a bare `run_select` tool, same model — isolates
+  MCPg's tool *design*, not merely DB access.
+- **Writeup home:** the reproducible harness + JSON + generated HTML under
+  `benchmarks/`, plus a narrative writeup on the docs site (surfaced as a
+  shareable Artifact).
 
-## Open questions
+## Deferred to v2 (decide then)
 
-- Which exact model(s) to pin for Tier B (and whether to run a second model to
-  show the effect generalizes).
-- SF10 vs SF30 for the published heavy run (infra cost vs impressiveness).
-- Whether to ship the Grafana/Prometheus live variant in v1 or defer it.
+- The exact Tier-B model(s) to pin at temperature 0 (and whether to run a
+  second model to show the token savings generalize across models).
+- Tier-B trial count (default ≥ 10 per task) and the final task set.

--- a/docs/plans/benchmark-suite.md
+++ b/docs/plans/benchmark-suite.md
@@ -16,7 +16,7 @@ Every clause of that sentence maps to a measured number:
 
 | Clause | Evidence |
 |---|---|
-| *dramatically more token-efficient* | 40–70 %+ fewer tokens per database task vs a bare `run_select` tool (the headline) |
+| *dramatically more token-efficient* | 40–70%+ fewer tokens per database task vs a bare `run_select` tool (the headline) |
 | *more reliable* | fewer error→retry loops, higher task-completion rate |
 | *negligible performance cost* | sub-millisecond, decomposed overhead; ~0 % on heavy queries; cache **beats** native on repeat reads |
 | *safety guarantees* | dangerous statements provably rejected |

--- a/docs/plans/benchmark-suite.md
+++ b/docs/plans/benchmark-suite.md
@@ -1,0 +1,244 @@
+# MCPg benchmark suite — plan
+
+**Status:** planning (this doc). **Approach:** plan-first, then phased PRs
+(harness → token accounting → dashboard → agent study → writeup).
+**Audience of the *output*:** public — a conclusive, evidence-driven case,
+built to survive a skeptical technical reader (the kind who knows Postgres).
+
+## The thesis (what we set out to prove)
+
+> **An LLM agent doing database work is dramatically more token-efficient and
+> more reliable through MCPg than through a bare SQL-execution tool — at a
+> negligible performance cost, with safety guarantees raw SQL access can't
+> offer.**
+
+Every clause of that sentence maps to a measured number:
+
+| Clause | Evidence |
+|---|---|
+| *dramatically more token-efficient* | 40–70 %+ fewer tokens per database task vs a bare `run_select` tool (the headline) |
+| *more reliable* | fewer error→retry loops, higher task-completion rate |
+| *negligible performance cost* | sub-millisecond, decomposed overhead; ~0 % on heavy queries; cache **beats** native on repeat reads |
+| *safety guarantees* | dangerous statements provably rejected |
+
+### The framing rule (non-negotiable)
+
+**We do not claim MCPg makes queries run faster.** It can't — the same SQL
+executes on the same PostgreSQL, so the database does identical work. Any
+deck headlined "MCPg is faster" is dead on arrival with the target audience.
+The performance objective exists to **disarm the obvious objection** ("this
+must add latency") by proving the overhead is tiny and predictable — which is
+precisely what *earns credibility* for the large token-efficiency claim. Being
+scrupulous about the overhead is a feature of the argument, not a weakness.
+
+## Objectives
+
+1. **Performance / overhead.** Quantify MCPg's added latency vs native SQL on
+   the same database, across ultralight / light / heavy queries — and
+   **decompose** where the overhead goes.
+2. **Token efficiency.** Quantify the tokens an LLM agent saves using MCPg's
+   purpose-built surface vs a bare SQL-execution tool, **net of** the
+   tool-definition context cost.
+
+## Non-goals / honesty guardrails
+
+- Not a claim that MCPg out-executes Postgres.
+- Not a comparison against "no database access" (a rigged win). The token
+  baseline is a *bare `run_select` tool*, so we isolate the value of MCPg's
+  **tool design**, not merely "having a database."
+- No cherry-picking: the full query set, task set, harness, and (for the agent
+  study) transcripts are published. "Run it yourself."
+- The 252-tool context cost is measured and shown, never hidden.
+
+---
+
+## Objective 1 — Performance / overhead
+
+### Three measurement paths (the middle one is the insight)
+
+| Path | Isolates |
+|---|---|
+| **Native** — a persistent `psycopg` connection running the SQL directly | DB execution + minimal client. The fair baseline — **not** `psql -c`, which pays process startup per call. |
+| **MCPg server-side** — call the tool function in-process | MCPg's own overhead: pglast parse + AST-walk validation, pool checkout, `BEGIN TRANSACTION READ ONLY` / `ROLLBACK`, row→JSON serialization, middleware. |
+| **MCPg end-to-end** — through the MCP client + transport (stdio **and** streamable-http) | What an agent actually experiences: adds JSON-RPC encode/decode + transport. |
+
+### Overhead decomposition (diagnostic, not just comparative)
+
+Instrument the server path into timed segments and report a **waterfall**:
+
+```
+t_protocol → t_parse → t_pool → t_txn → t_db → t_serialize → t_cache(hit)
+```
+
+The killer result: **`t_db` is identical to native**, and we point at exactly
+where the added milliseconds live (parse + serialize dominate; all are
+fixed-cost, so they vanish as a fraction of heavy queries).
+
+### Query taxonomy — two independent axes
+
+Compute-weight and result-size stress MCPg differently, so vary both:
+
+- **Compute weight:** *ultralight* (`SELECT 1`, PK point-lookup; sub-ms) ·
+  *light* (indexed lookup / small GROUP BY; 1–10 ms) · *heavy* (TPC-H
+  analytical joins/sorts/aggregates; 100 ms–seconds).
+- **Result size:** 1 row · ~100 rows · 10 k–100 k rows. Serialization scales
+  with rows, so a *fast* query returning 100 k rows is a different stress than
+  a *slow* query returning 1 row.
+
+The heavy tier is the **22 TPC-H queries**; ultralight/light draw from
+point-lookups and small aggregates over the TPC-H schema (+ a TPC-C-style
+small-transaction set for throughput).
+
+### Metrics & statistical treatment
+
+- Latency **p50 / p95 / p99** (tail matters more than mean), reported cold and
+  warm, with the **cache-hit path measured separately** (where MCPg
+  legitimately beats native).
+- **Throughput under concurrency** (queries/sec at 1/4/16/64 clients) — pool
+  and serialization overhead only show up under load.
+- N iterations with warm-up discarded; report **medians + variance / CIs**,
+  never single-shot means.
+
+### Expected (honest) shape of the result
+
+Overhead ≈ 0 % on heavy queries; possibly 3–10× *relative* on `SELECT 1` but
+still **sub-ms absolute** (so: immaterial); cache hits < native on repeats.
+We lead with **absolute** numbers to keep the relative ones honest.
+
+---
+
+## Objective 2 — Token efficiency
+
+### Baseline
+
+**MCPg's purpose-built surface** (compact schema, advisors, structured
+`outputSchema`, NL→SQL, resources) **vs. a bare `run_select` tool** — same
+model, same tasks, same dataset. This isolates tool *design*, not DB access.
+
+### Two tiers (do both)
+
+- **Tier A — deterministic I/O accounting** (cheap, reproducible, CI-able, no
+  LLM). Tokenize the *content* MCPg returns vs the raw-SQL equivalent:
+  `get_compact_schema` vs a full `information_schema` dump; an `audit_database`
+  structured report vs the raw rows an agent would pull and interpret;
+  `analyze_query_plan` typed output vs raw `EXPLAIN` text. Measures **per-call
+  compactness** deterministically. This is the backbone.
+- **Tier B — agent-loop task runs** (realistic; costs money; non-deterministic).
+  Run a fixed agent to task completion, counting total in+out tokens, tool
+  calls, turns, and **correctness**, over N trials per task. Captures the big
+  saving Tier A can't: **fewer round-trips** (one `analyze_workload` call vs
+  many exploratory queries + interpretation loops).
+
+### Task archetypes (mix of big-win and honest-small-win)
+
+1. Schema comprehension — "describe this database."
+2. Slow-query diagnosis **and fix** — "why is this slow, and how do I fix it?"
+3. Database health audit — "audit this database."
+4. PII discovery — "find columns with sensitive data."
+5. Plain NL→SQL — "top 5 customers by revenue last quarter." *(Include this
+   deliberately: MCPg saves little here. A one-sided result reads as marketing.)*
+
+Tasks run over TPC-H (rich schema) plus the **`mcpg --demo` dataset** for the
+planted-finding tasks (the unindexed FK, PII columns, camelCase naming) that
+have **known-correct answers** — so "correctness" is objective.
+
+### The break-even accounting (the credibility centerpiece)
+
+MCPg exposes **252 tool definitions**, and every definition costs context
+tokens each turn. A "tokens saved" figure that ignores that is dishonest and a
+reviewer *will* pounce. So we:
+
+- Measure the upfront tool-schema token cost: full 252 vs a `MCPG_SESSION_INTENT`-
+  filtered subset vs the bare `run_select` baseline.
+- Report **net** tokens (upfront + per-task) and plot a **break-even curve**:
+  after *K* database tasks in a session, the per-task savings overtake the
+  upfront cost — and show how session-intent filtering moves *K* left.
+
+Publishing our own strongest counter-argument *as a chart we then defeat* is
+what convinces engineers.
+
+### Metrics
+
+Tokens in / out per task; tool-call count; turns-to-completion; correctness
+rate; upfront tool-schema cost; **net** savings; break-even *K*.
+
+---
+
+## Datasets
+
+- **TPC-H** (heavy/analytical): scale factor **SF1** (~1 GB) for development,
+  **SF10** for the published run. Loader script + a documented generator path
+  (`dbgen`, or a DuckDB/`pgbench`-based generator) committed so anyone can
+  reproduce.
+- **TPC-C-style** small-transaction set for ultralight/throughput.
+- **`mcpg --demo`** dataset (deterministic, planted findings) for the
+  correctness-checkable token tasks.
+
+## Reproducibility
+
+Pinned MCPg + PostgreSQL + model versions; fixed seeds; fixed model at
+temperature 0 for Tier B; dedicated DB instance (or explicitly-controlled
+concurrency); warm-up discarded; N runs with variance reported. Everything —
+queries, tasks, transcripts, raw JSON — committed alongside the results.
+
+## Dashboards (reusable)
+
+The harness writes **structured JSON** result files; a generator renders a
+**self-contained, theme-aware HTML dashboard** (no external hosts — same rules
+as an Artifact): latency percentiles by query class, the overhead
+**waterfall**, throughput-vs-concurrency, token-savings by task, and the
+**break-even curve**. Re-run the harness → regenerate the dashboard. Portable,
+reviewable, publishable. (MCPg already exposes Prometheus metrics, so a Grafana
+variant is a cheap follow-on if we want a live dashboard, but the committed
+HTML is the primary, self-contained artifact.)
+
+## Repo layout
+
+```
+benchmarks/
+  README.md                 # how to run everything, reproducibly
+  datasets/                 # TPC-H / TPC-C loaders, demo hook, generators
+  perf/                     # native vs server-side vs end-to-end + decomposition
+  tokens/
+    tier_a/                 # deterministic I/O token accounting
+    tier_b/                 # agent-loop task runner (fixed model, N trials)
+  dashboard/                # JSON → self-contained HTML generator
+  results/                  # committed JSON + generated dashboards for published runs
+```
+
+## Phasing
+
+1. **Perf harness + overhead decomposition** on TPC-H (deterministic, no LLM).
+2. **Tier-A token accounting** (deterministic).
+3. **Dashboard generator** (JSON → HTML).
+4. **Tier-B agent study** (fixed model, N trials, published transcripts — the
+   costed phase).
+5. **Public writeup** drawing the four together.
+
+Each phase is independently valuable and lands as its own PR.
+
+## What a skeptic attacks — and our answer
+
+| Attack | Answer baked into the design |
+|---|---|
+| "MCPg can't be faster than Postgres." | Correct — we never claim it. Perf objective proves *negligible overhead*, and cache wins on repeats. |
+| "Your token baseline is rigged." | Baseline is a bare `run_select` tool (real DB access), same model; tasks + transcripts published. |
+| "You ignored the 252-tool context cost." | Measured explicitly; net-of-overhead break-even is a headline chart. |
+| "Cherry-picked queries/tasks." | Full sets committed; TPC-H is a standard; demo tasks have known answers. |
+| "Non-deterministic agent runs." | Tier A is deterministic; Tier B pins model+temp, N trials, reports distribution. |
+
+## Defaults (override in review)
+
+- **Tier-B model:** pin one fixed model at temperature 0 for reproducible token
+  counts (candidate: a fixed Claude model; final choice recorded in the run
+  metadata).
+- **TPC-H scale:** SF1 dev / SF10 published.
+- **Concurrency points:** 1 / 4 / 16 / 64 clients.
+- **Trials:** ≥ 20 per perf point; ≥ 10 Tier-B trials per task.
+
+## Open questions
+
+- Which exact model(s) to pin for Tier B (and whether to run a second model to
+  show the effect generalizes).
+- SF10 vs SF30 for the published heavy run (infra cost vs impressiveness).
+- Whether to ship the Grafana/Prometheus live variant in v1 or defer it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,9 +150,16 @@ dev = [
     "opentelemetry-sdk>=1.27",
     "opentelemetry-exporter-otlp-proto-http>=1.27",
 ]
+# Benchmark suite (roadmap 19) — dev-only. Keeps the shipped package lean;
+# `duckdb` generates the TPC-H dataset for benchmarks/datasets/load_tpch.py.
+bench = [
+    "duckdb>=1.1",
+]
 
 [tool.pytest.ini_options]
-pythonpath = ["src", "tests"]
+# "." so the root-level ``benchmarks`` package (roadmap 19) is importable in
+# its unit tests; "src" for mcpg, "tests" for the _fakes helpers.
+pythonpath = ["src", "tests", "."]
 testpaths = ["tests"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"

--- a/tests/unit/test_bench_perf.py
+++ b/tests/unit/test_bench_perf.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 
 import json
 
-from benchmarks.perf import queries, stats
+import pytest
+
+from benchmarks.perf import queries, runner, stats
 from benchmarks.perf.schema import Assertion, Decomposition, LatencyBlock, PerfRun, ResultRow
 
 # --- stats ----------------------------------------------------------------
@@ -107,3 +109,14 @@ def test_perf_run_serializes_to_json() -> None:
     assert payload["results"][0]["path"] == "server_side"
     assert payload["results"][0]["decomposition_ns"]["t_db"] == 800_000.0
     assert payload["assertions"][0]["name"] == "server_side_overhead_p50_ms"
+
+
+# --- runner CLI validation (DB-free; fails before any connection) ---------
+
+
+def test_runner_rejects_too_few_iterations() -> None:
+    # Below _WARMUP + 1 the warm bucket is empty after dropping warmup, so the
+    # guard must fail fast (SystemExit from argparse) before touching the DB.
+    with pytest.raises(SystemExit) as exc:
+        runner.main(["--database-url", "postgresql://unused", "--output", "/tmp/unused.json", "--iterations", "0"])
+    assert exc.value.code == 2

--- a/tests/unit/test_bench_perf.py
+++ b/tests/unit/test_bench_perf.py
@@ -1,0 +1,109 @@
+"""Unit tests for the benchmark suite's pure core (roadmap 19, Phase 1).
+
+Covers the deterministic, DB-free parts — the statistics, the query taxonomy,
+and the result schema serialization. The DB-touching paths (paths.py, runner.py)
+are operator tools run against a live PostgreSQL, not unit-tested (matching
+benchmarks/bench.py).
+"""
+
+from __future__ import annotations
+
+import json
+
+from benchmarks.perf import queries, stats
+from benchmarks.perf.schema import Assertion, Decomposition, LatencyBlock, PerfRun, ResultRow
+
+# --- stats ----------------------------------------------------------------
+
+
+def test_percentile_nearest_rank() -> None:
+    data = sorted([10, 20, 30, 40, 50])
+    assert stats.percentile(data, 50) == 30
+    assert stats.percentile(data, 100) == 50
+    assert stats.percentile([], 50) == 0.0
+
+
+def test_summarize_converts_ns_to_ms_and_reports_percentiles() -> None:
+    # 1_000_000 ns == 1 ms.
+    samples = [1_000_000, 2_000_000, 3_000_000, 4_000_000, 5_000_000]
+    s = stats.summarize(samples)
+    assert s.n == 5
+    assert s.p50 == 3.0
+    assert s.min == 1.0
+    assert s.max == 5.0
+    lo, hi = s.median_ci95
+    assert lo <= s.p50 <= hi
+
+
+def test_bootstrap_median_ci_is_seeded_reproducible() -> None:
+    samples = [5, 7, 7, 8, 9, 10, 12, 15, 20, 100]
+    a = stats.bootstrap_median_ci(samples, seed=42)
+    b = stats.bootstrap_median_ci(samples, seed=42)
+    assert a == b  # same seed → identical CI
+    assert a[0] <= a[1]
+
+
+def test_bootstrap_median_ci_degenerate_sample() -> None:
+    assert stats.bootstrap_median_ci([42]) == (42.0, 42.0)
+    assert stats.bootstrap_median_ci([]) == (0.0, 0.0)
+
+
+def test_drop_warmup() -> None:
+    assert stats.drop_warmup([1, 2, 3, 4, 5], 2) == [3, 4, 5]
+    assert stats.drop_warmup([1, 2], 5) == []
+
+
+# --- query taxonomy -------------------------------------------------------
+
+
+def test_query_set_spans_both_axes() -> None:
+    qs = queries.all_queries()
+    assert len(qs) >= 8
+    ids = {q.id for q in qs}
+    assert len(ids) == len(qs)  # ids are unique
+    classes = {q.compute_class for q in qs}
+    assert {"ultralight", "light", "heavy"} <= classes
+    sizes = {q.result_size for q in qs}
+    assert {"1", "~100", "large"} <= sizes
+    # The large-result case raises max_rows so serialization is exercised.
+    large = next(q for q in qs if q.result_size == "large")
+    assert large.max_rows >= 100_000
+    # Every query is a read-only SELECT (no writes sneak into the harness).
+    for q in qs:
+        assert q.sql.lstrip().upper().startswith("SELECT")
+
+
+def test_heavy_tier_includes_tpch() -> None:
+    heavy = [q for q in queries.all_queries() if q.compute_class == "heavy"]
+    assert any(q.id.startswith("tpch_") for q in heavy)
+
+
+# --- schema serialization -------------------------------------------------
+
+
+def test_perf_run_serializes_to_json() -> None:
+    row = ResultRow(
+        path="server_side",
+        query_id="tpch_q1",
+        compute_class="heavy",
+        result_size="~100",
+        temperature="warm",
+        concurrency=1,
+        n=50,
+        latency_ms=LatencyBlock(
+            p50=1.2, p95=1.9, p99=2.1, mean=1.3, stdev=0.2, min=1.0, max=2.5, median_ci95=(1.1, 1.3)
+        ),
+        samples_ns=[1_200_000, 1_300_000],
+        decomposition_ns=Decomposition(t_parse=1000.0, t_db=800_000.0),
+    )
+    run = PerfRun(
+        metadata={"timestamp": "2026-07-18T00:00:00Z", "scale_factor": 1},
+        results=[row],
+        assertions=[Assertion(name="server_side_overhead_p50_ms", query_id="tpch_q1", passed=True, detail={})],
+    )
+    payload = json.loads(json.dumps(run.to_dict()))  # round-trips cleanly
+    assert payload["schema_version"] == 1
+    assert payload["kind"] == "performance"
+    assert payload["results"][0]["path"] == "server_side"
+    assert payload["results"][0]["decomposition_ns"]["t_db"] == 800_000.0
+    assert payload["assertions"][0]["name"] == "server_side_overhead_p50_ms"

--- a/uv.lock
+++ b/uv.lock
@@ -533,6 +533,35 @@ wheels = [
 ]
 
 [[package]]
+name = "duckdb"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/29/9bad86ed7aa812d8c822a27c15c355b6d5423b991feeec86ed18027b6daa/duckdb-1.5.4.tar.gz", hash = "sha256:f9e32f1cdd106793d79d190186bed9e75289d51e68bd9174e47c04bffedeab6f", size = 18046634, upload-time = "2026-06-17T10:48:52.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/f2/e2f4b477ae3a3b40e8b5f429832e48edb62ed9da99807cc4902e157e5646/duckdb-1.5.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:291a9e7502551170af989ff63139a7a49e99d68edbc5ef5017ac27541fe54c65", size = 32708876, upload-time = "2026-06-17T10:48:01.527Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/2b/b698d82a5e1e30b6a05748d72045f672994c6b22f4f0f8423523608b991f/duckdb-1.5.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:83e8c089bbb756ca4471d8b05943b80a106058697cf00615e70423106bb783bc", size = 17346125, upload-time = "2026-06-17T10:48:04.035Z" },
+    { url = "https://files.pythonhosted.org/packages/71/75/37e13f39268eaf34864453b3a039c4a1ff0b088d3eae45a4289b41c98c1b/duckdb-1.5.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ff96d2a342b200e1ec6f1f19986c77f4ac16a49b6112f71c5b763989203a9d60", size = 15488133, upload-time = "2026-06-17T10:48:06.312Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/59/2d082af578f689231798245b54562c61416e49049b0bda81a06c56a4b53e/duckdb-1.5.4-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f935ef210ab00bc94bb1e3052697adaa36bb0ce7bdfeda8b0f34e2ff1643870", size = 19367895, upload-time = "2026-06-17T10:48:08.59Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2b/55c34d2863a76ca824ef8274691e84240b4ff1acde3d231709e82557c240/duckdb-1.5.4-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0cda263d8c20addb8d4f95464787cbe0af1144f7ab7e21db3709fb826ee01725", size = 21486499, upload-time = "2026-06-17T10:48:10.963Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/30/ade5952b8182fac86fab43b95ebe3836e66381d0ad64eb1e54bd8207c988/duckdb-1.5.4-cp312-cp312-win_amd64.whl", hash = "sha256:266c7c909558ce7377f57d082cee408aadebdd9111be017558ca54e44a031037", size = 13147934, upload-time = "2026-06-17T10:48:13.061Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/00/278f0f70e25b9911afe2fd227b9460f2e6d76177f0dcc03f7f1454afefa5/duckdb-1.5.4-cp312-cp312-win_arm64.whl", hash = "sha256:f14e79a006341f29ee5a2692a24dac5114e77533d579c57ec39124adf0135033", size = 13965235, upload-time = "2026-06-17T10:48:15.782Z" },
+    { url = "https://files.pythonhosted.org/packages/da/69/3fcb34e523a9bad1f0557a6c7691a71ba66c43a05e5be9ee96a9a841ed65/duckdb-1.5.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:42a612e67d64450b446eb69695290d460713eef46e0f64467ab9dfe96264ee05", size = 32708366, upload-time = "2026-06-17T10:48:18.084Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/bff5054c2c1d65decab36aa6296621e51a2a575a9f250db7ab9b83a325d6/duckdb-1.5.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:3fb6f07d54ecf4d0d3c5179a2361fdddfafa14de4fc42696de4632479b703421", size = 17345735, upload-time = "2026-06-17T10:48:20.67Z" },
+    { url = "https://files.pythonhosted.org/packages/93/12/d1b2b344e9699246aada6f9de5156e708fb476e2780e5bff9b5d95fe11d9/duckdb-1.5.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0f32ad7e0286c1c29ab6c73b29118c86101f8eee46aae54f54d0b50916f542f6", size = 15488568, upload-time = "2026-06-17T10:48:23.038Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/d1/ac56c6096e3e95da60b2c5dd5a0f0eb5540a80622e2e4f8faab893ec4e96/duckdb-1.5.4-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:698ec90bd5d5538bd5f6d212a4b61af443d240703cf45f134738535026556ea5", size = 19368184, upload-time = "2026-06-17T10:48:25.601Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/0b/2ae4c3e157a19d9b4ac1f09a5dea6f93012334cc2db09f1e0c71eb99693d/duckdb-1.5.4-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136cea7f886b78caf4035485b4b1e766e8b309e999f9e83a966f81ebb8122844", size = 21486523, upload-time = "2026-06-17T10:48:27.817Z" },
+    { url = "https://files.pythonhosted.org/packages/64/7b/c3d8d21e0d0db8faa81eeeb3a55b9932f5a0a16466cb968dc713a653d701/duckdb-1.5.4-cp313-cp313-win_amd64.whl", hash = "sha256:bd6777e8ddd74fb603a6d09766bfcff28638189f8aaa61fc0dffd9e9a4baa8e5", size = 13147807, upload-time = "2026-06-17T10:48:30.017Z" },
+    { url = "https://files.pythonhosted.org/packages/44/48/ddf8d3740e3d28582944f70d84e720b5dc28c10ec22b668a0e0bd965f2f2/duckdb-1.5.4-cp313-cp313-win_arm64.whl", hash = "sha256:73f4878a3012283024a64a1909e440aac12091ef336f671fc142f7e87449ce0c", size = 13965189, upload-time = "2026-06-17T10:48:32.251Z" },
+    { url = "https://files.pythonhosted.org/packages/62/01/67ac4cbc8e552a1e14c029b5c443d828e68f94d5d913c574f577e1db277e/duckdb-1.5.4-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:4647968629d0677bbcc2416c7aeda8685eb84e4ca15a6dbd4f82a66cfc91a532", size = 32714364, upload-time = "2026-06-17T10:48:34.724Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/0e/eb44d983fa56b175f971eea251bde284a36d26cbb93fcb68035061f54078/duckdb-1.5.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e8fcef301cf68d3951ea1eb8ac4d76cea0a6f6a08f4c78fe4026fc96d217bebc", size = 17349820, upload-time = "2026-06-17T10:48:37.126Z" },
+    { url = "https://files.pythonhosted.org/packages/10/b2/b9dc7624b105d414585b8530451c1162c0b4750c0be9be2e497bb47a8a9b/duckdb-1.5.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f6f39cd0dc6948dee17fd130aec55114f97a8ef6e1db519b9774087962bc5c8c", size = 15498160, upload-time = "2026-06-17T10:48:40.032Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/57/61356444f6a8c62dec3c3d129abfc53f428de1d484093d1bb381db441231/duckdb-1.5.4-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:262f068158beb5943f2c618f4e54b46db8306b959f90dce956f90a89f613673d", size = 19374183, upload-time = "2026-06-17T10:48:42.698Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/f4/d5d633dd7c5138d8f7c434e6ac2553c831b7fb658494efa8d0bc73df8623/duckdb-1.5.4-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d2307a76d199077b0055b354e90e857479461a0d875437535dd4833172c8b6d", size = 21487202, upload-time = "2026-06-17T10:48:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/26/5be13bbd5c3421dccfc1ad4ca9da4b97c5a3ddd73f66542092f3167ec52c/duckdb-1.5.4-cp314-cp314-win_amd64.whl", hash = "sha256:6dcbb81a1276bc48deb4d562bce4f8895e4fc6348750a096e30052345c6d6552", size = 13666989, upload-time = "2026-06-17T10:48:47.764Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/82/4d52f3f9f9703a226b26b80bdae3f6905aeefe5221bf1815fc93ff02ca25/duckdb-1.5.4-cp314-cp314-win_arm64.whl", hash = "sha256:0f8722346024e5d9f02b58bf7b0491a629f97fdc8a04a10e432940f471ee387a", size = 14449863, upload-time = "2026-06-17T10:48:50.18Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.29.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1016,6 +1045,9 @@ vault = [
 ]
 
 [package.dev-dependencies]
+bench = [
+    { name = "duckdb" },
+]
 dev = [
     { name = "bandit" },
     { name = "build" },
@@ -1052,6 +1084,7 @@ requires-dist = [
 provides-extras = ["aws", "gcp", "otel", "vault"]
 
 [package.metadata.requires-dev]
+bench = [{ name = "duckdb", specifier = ">=1.1" }]
 dev = [
     { name = "bandit", specifier = ">=1.7.8" },
     { name = "build", specifier = ">=1.2" },


### PR DESCRIPTION
## Summary

Kicks off the public, evidence-driven **benchmark suite** (roadmap 19). Two parts:

**1. The plan** — `docs/plans/benchmark-suite.md` (+ roadmap §19). The thesis, the non-negotiable framing rule (**we never claim MCPg out-executes Postgres** — the perf tier exists to *disarm* that objection and prove the overhead is sub-ms, which earns credibility for the real token win in v2), the methodology, TPC-H scale, the break-even model, the honest-caveats table, and the locked v1 decisions (v1 = performance + static HTML dashboard; SF10 ceiling).

**2. Phase 1 foundation** — the performance harness, designed by the Opus architect grounded in MCPg's real APIs:
- `benchmarks/perf/paths.py` — **NativeRunner** (a persistent `psycopg` connection replicating MCPg's *exact* `BEGIN READ ONLY … ROLLBACK` envelope, minus all MCPg overhead — the fair floor, not `psql -c`) and **ServerSideRunner** (the real in-process `run_select` over the real `SafeSqlDriver` + pool, keeping the genuine per-call allocation + serialization).
- `benchmarks/perf/queries.py` — the two-axis query set (compute × result-size), heavy tier from TPC-H (Q1/Q3/Q5/Q6).
- `benchmarks/perf/stats.py` — percentiles + seeded bootstrap median CI + warm-up drop (pure, **unit-tested**).
- `benchmarks/perf/schema.py` — structured JSON result schema (provenance passed in).
- `benchmarks/perf/runner.py` — orchestrates paths × queries (cold + warm) → JSON, gc-disabled around timed regions.
- `benchmarks/datasets/` — TPC-H schema/index DDL + a DuckDB→`COPY` loader (SF1/SF10; data regenerated locally, never committed).
- `pyproject.toml` — dev-only `bench` group (`duckdb`); pytest `pythonpath += "."` so the benchmark package is importable in its tests.

**Next phases** (own PRs): the end-to-end transport paths, the overhead-decomposition waterfall (the `t_db == native` gate), the concurrency sweep, and the self-contained HTML dashboard — then the v1 writeup.

Verification: `8` new unit tests pass; full suite `2813 passed`; `ruff check .`, `ruff format --check .`, `mypy src/mcpg` all clean. The DB-touching harness is an operator tool (runs against a live PostgreSQL), not unit-tested — matching the existing `benchmarks/bench.py`.

## Roadmap linkage

Advances roadmap row: 19.1 (and lands the §19 plan).

## Checklist

- [x] Tests added/updated first (TDD); suite passes locally
- [x] `ruff`, `ruff format`, and `mypy src/mcpg` pass
- [x] `CHANGELOG.md` — n/a (no shipped-surface change; benchmarks are an operator tool)
- [x] Roadmap row cited above (19.1)
- [x] No hand-edits to `src/mcpg/_vendor/` (the vendor tree no longer exists — 18.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Introduce a reproducible performance benchmarking harness and documented plan for the MCPg benchmark suite, including initial native vs server-side latency measurements on TPC-H workloads.

Enhancements:
- Add a structured performance benchmarking harness with native and server-side runners, query taxonomy, statistics aggregation, and JSON result schema under a new benchmarks package.
- Provide scripts and SQL to generate and load a TPC-H dataset into PostgreSQL for local benchmark runs, without committing data files.

Build:
- Define a dev-only bench dependency group (DuckDB) and adjust pytest pythonpath so the benchmarks package is importable in its tests.

Documentation:
- Document the benchmark-suite roadmap and methodology, including performance and token-efficiency objectives, datasets, and phasing in a new benchmark plan and feature-shortlist entry.

Tests:
- Add unit tests covering benchmark statistics, query coverage across compute and result-size axes, and serialization of performance run results.