### PR TITLE
security(deps): bump mcp SDK ≥1.28.1 to clear 3 high CVEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Security
+
+- **Bumped `mcp` SDK ≥ 1.28.1** (from `≥ 1.25.0`) to clear three advisories in
+  the resolved `mcp` 1.27.1: CVE-2026-52870 and CVE-2026-52869 (fixed in
+  1.27.2) and CVE-2026-59950 (fixed in 1.28.1). No MCPg source change required:
+  the tenancy per-request role path (`tenancy._role_from_request` →
+  `mcp.server.lowlevel.server.request_ctx` +
+  `ServerMessageMetadata.request_context`) is unchanged in 1.28.1, and the full
+  unit + contract suite (incl. `test_tenancy.py`, `test_http_runtime.py`)
+  passes. `pip-audit --strict` on the resolved runtime deps is clean.
+
 ### Changed
 
 - **Bumped `pglast` 7.15 → 8.2** (the SQL-safety kernel's parser). pglast 8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "mcp[cli]>=1.25.0",
+    "mcp[cli]>=1.28.1",
     "psycopg[binary]>=3.3.2",
     "psycopg-pool>=3.3.0",
     "pglast==8.2",

--- a/uv.lock
+++ b/uv.lock
@@ -957,7 +957,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.1"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -975,9 +975,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/83/d1efe7c2980d8a3afa476f4e3d42d53dd54c0ab94c27bee5d755b45c8b73/mcp-1.27.1.tar.gz", hash = "sha256:0f47e1820f8f8f941466b39749eb1d1839a04caddca2bc60e9d46e8a99914924", size = 608458, upload-time = "2026-05-08T16:50:12.601Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/73/42d9596facebdb533b7f0b86c1b0364ef350d1f8ba78b1052e8a58b48b65/mcp-1.27.1-py3-none-any.whl", hash = "sha256:1af3c4203b329430fde7a87b4fcb6392a041f5cb851fd68fc674016ab4e7c06f", size = 216260, upload-time = "2026-05-08T16:50:10.547Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [package.optional-dependencies]
@@ -1039,7 +1039,7 @@ requires-dist = [
     { name = "google-cloud-secret-manager", marker = "extra == 'gcp'", specifier = ">=2.16" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "hvac", marker = "extra == 'vault'", specifier = ">=1.0" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.25.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.28.1" },
     { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.27" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'otel'", specifier = ">=1.27" },
     { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.27" },


### PR DESCRIPTION
## Summary

Raises the `mcp[cli]` floor `>=1.25.0` → `>=1.28.1` (uv resolves **1.28.1**, up from 1.27.1) to clear three advisories GitHub/pip-audit flag on the resolved SDK:

| CVE | Fixed in |
| --- | --- |
| CVE-2026-52870 (high) | 1.27.2 |
| CVE-2026-52869 (high) | 1.27.2 |
| CVE-2026-59950 (high) | 1.28.1 |

This is currently red on `main` and blocks the Security lane on every open PR (incl. the benchmark PR #270). Landing it as its own focused security bump unblocks them.

**No MCPg source change is required.** The one place we reach into SDK internals is the tenancy per-request role path shipped in 0.6.11 — `tenancy._role_from_request` reads `mcp.server.lowlevel.server.request_ctx` and relies on `ServerMessageMetadata.request_context`. Both are unchanged in 1.28.1 (the only `ServerMessageMetadata` delta is two *additive* SSE kwargs).

### Verification

- `test_tenancy.py` + `test_http_runtime.py`: **72 passed** (the request_ctx path the fix depends on).
- Full unit + contract suite: **2805 passed**.
- `ruff check .`, `ruff format --check .`, `mypy src/mcpg`: clean.
- `uv export --no-dev --no-emit-project | pip-audit --strict --disable-pip`: **No known vulnerabilities found.**

## Roadmap linkage

Advances roadmap row: N/A — security dependency bump, no roadmap row.

## Checklist

- [x] Suite passes locally (2805 passed)
- [x] `ruff`, `ruff format`, and `mypy src/mcpg` pass
- [x] `CHANGELOG.md` updated under `[Unreleased]` (Security)
- [x] Roadmap row cited above (`N/A`)
- [x] No hand-edits to `src/mcpg/_vendor/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Raise the minimum mcp[cli] SDK version to address security advisories and document the change in the changelog.

Build:
- Update pyproject dependency constraint to require mcp[cli] >= 1.28.1.

Documentation:
- Add an Unreleased security changelog entry describing the mcp SDK bump and associated CVE fixes.