### PR TITLE
bench: complete 19.1 core — decomposition + e2e transports + concurrency

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -10,10 +10,16 @@ proves MCPg's overhead is small and predictable (and decomposes exactly where
 it goes), so `t_db` is provably identical to native. That "you lose nothing"
 result is what earns credibility for the real wins (measured in v2: tokens).
 
-## What runs today (Phase 1)
+## What runs today
 
 - `perf/paths.py` — the **native** (persistent psycopg, same txn envelope, no
   MCPg overhead) and **server-side** (in-process `run_select`) measurement paths.
+- `perf/decompose.py` — the **overhead-decomposition waterfall**: times the
+  server path segment-by-segment (`t_parse → t_pool → t_txn → t_db →
+  t_serialize`) and records the load-bearing **`t_db == native`** assertion.
+- `perf/e2e.py` — the **end-to-end paths** through the real MCP protocol
+  (in-memory, stdio subprocess, streamable HTTP) — the `t_protocol` band. Opt-in
+  via `--e2e` / `--e2e-http-url`.
 - `perf/queries.py` — the two-axis query set (compute x result-size), heavy tier
   from TPC-H.
 - `perf/stats.py` — percentiles + bootstrap median CI + warm-up handling (pure,
@@ -21,9 +27,7 @@ result is what earns credibility for the real wins (measured in v2: tokens).
 - `perf/runner.py` — orchestrates paths x queries (cold + warm) → structured JSON.
 - `datasets/` — TPC-H schema/index DDL + a DuckDB→`COPY` loader.
 
-The end-to-end transport paths, the overhead-decomposition waterfall (the
-`t_db == native` gate), the concurrency sweep, and the HTML dashboard land in
-subsequent phases.
+The concurrency sweep and the HTML dashboard land in subsequent phases.
 
 ## Running it
 
@@ -41,6 +45,23 @@ uv run python -m benchmarks.perf.runner \
     --scale-factor 1 --iterations 50 \
     --git-sha "$(git rev-parse HEAD)" --timestamp "$(date -u +%FT%TZ)" \
     --output benchmarks/results/perf-$(date -u +%Y%m%dT%H%M%SZ).json
+```
+
+### Also measuring the end-to-end MCP paths (`--e2e`)
+
+`--e2e` adds the in-memory and stdio-subprocess paths (they self-configure from
+`--database-url`). For the HTTP path, start a server first and point the runner
+at it:
+
+```bash
+# In one shell: an operator-started streamable-HTTP server on the same DB.
+MCPG_DATABASE_URL="$MCPG_TEST_DATABASE_URL" mcpg --transport streamable-http
+
+# In another: run with the e2e paths, including HTTP.
+uv run python -m benchmarks.perf.runner \
+    --database-url "$MCPG_TEST_DATABASE_URL" --scale-factor 1 --iterations 50 \
+    --e2e --e2e-http-url http://127.0.0.1:8000/mcp \
+    --output benchmarks/results/perf-e2e.json
 ```
 
 Provenance (git SHA, timestamp, versions, host, scale factor) is embedded in

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -20,6 +20,9 @@ result is what earns credibility for the real wins (measured in v2: tokens).
 - `perf/e2e.py` — the **end-to-end paths** through the real MCP protocol
   (in-memory, stdio subprocess, streamable HTTP) — the `t_protocol` band. Opt-in
   via `--e2e` / `--e2e-http-url`.
+- `perf/concurrency.py` — the **throughput sweep** at 1/4/16/64 concurrent
+  clients (native + server-side), where pool + serialization overhead surface.
+  Opt-in via `--concurrency`.
 - `perf/queries.py` — the two-axis query set (compute x result-size), heavy tier
   from TPC-H.
 - `perf/stats.py` — percentiles + bootstrap median CI + warm-up handling (pure,
@@ -27,7 +30,7 @@ result is what earns credibility for the real wins (measured in v2: tokens).
 - `perf/runner.py` — orchestrates paths x queries (cold + warm) → structured JSON.
 - `datasets/` — TPC-H schema/index DDL + a DuckDB→`COPY` loader.
 
-The concurrency sweep and the HTML dashboard land in subsequent phases.
+The HTML dashboard (rendering these JSON results) lands in the next phase.
 
 ## Running it
 

--- a/benchmarks/perf/concurrency.py
+++ b/benchmarks/perf/concurrency.py
@@ -1,0 +1,97 @@
+"""Throughput-under-concurrency sweep.
+
+Single-client latency hides the costs that only appear under load: the
+connection **pool** (bounded checkout) and per-call **serialization** competing
+for CPU. This sweep drives a path with 1 / 4 / 16 / 64 concurrent clients and
+reports aggregate **throughput (queries/sec)** plus the latency distribution
+*under load*.
+
+Fairness: at concurrency ``C`` each path gets ``C`` real connections — the
+native baseline opens ``C`` persistent connections, and the server-side pool is
+sized to the sweep's ceiling — so we measure genuine throughput + serialization
+overhead, not artificial pool starvation. (Starvation under a deliberately small
+pool is a separate question; here we isolate the overhead.)
+
+Each worker runs a warm-up round first; then a single timed region brackets all
+workers' steady-state work, so wall-clock reflects concurrent throughput rather
+than warm-up. Operator tool (live DB) — not unit-tested; the pure aggregation
+(:func:`throughput_rps`, :func:`aggregate`) is.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+
+from benchmarks.perf.paths import PathRunner
+from benchmarks.perf.queries import BenchQuery
+
+# The concurrency points (locked in docs/plans/benchmark-suite.md).
+CONCURRENCY_LEVELS = (1, 4, 16, 64)
+
+
+@dataclass(frozen=True)
+class ConcurrencyResult:
+    """Aggregate outcome of one path x query x concurrency level."""
+
+    concurrency: int
+    total_queries: int
+    wall_seconds: float
+    throughput_rps: float
+    latencies_ns: list[int]
+
+
+def throughput_rps(total_queries: int, wall_seconds: float) -> float:
+    """Queries per second, guarding a zero/negative wall time (returns 0.0)."""
+    if wall_seconds <= 0:
+        return 0.0
+    return total_queries / wall_seconds
+
+
+def aggregate(concurrency: int, per_worker_latencies: list[list[int]], wall_ns: int) -> ConcurrencyResult:
+    """Fold per-worker latency lists + the shared wall time into a result.
+
+    Pure so the throughput/latency bookkeeping is unit-tested without a DB.
+    """
+    latencies = [lat for worker in per_worker_latencies for lat in worker]
+    wall_seconds = wall_ns / 1e9
+    return ConcurrencyResult(
+        concurrency=concurrency,
+        total_queries=len(latencies),
+        wall_seconds=wall_seconds,
+        throughput_rps=throughput_rps(len(latencies), wall_seconds),
+        latencies_ns=latencies,
+    )
+
+
+async def sweep_level(
+    runners: list[PathRunner],
+    query: BenchQuery,
+    *,
+    iterations_per_worker: int,
+    warmup_per_worker: int,
+) -> ConcurrencyResult:
+    """Run ``len(runners)`` workers concurrently for one query.
+
+    Each worker owns one runner (so ``native`` gets a dedicated connection;
+    ``server_side`` runners share the pool, which is concurrent-safe). A warm-up
+    gather primes caches/pool, then a single timed gather measures steady-state
+    concurrent throughput.
+    """
+
+    async def _warmup(runner: PathRunner) -> None:
+        for _ in range(warmup_per_worker):
+            await runner.run_once(query.sql, max_rows=query.max_rows)
+
+    async def _timed(runner: PathRunner) -> list[int]:
+        out: list[int] = []
+        for _ in range(iterations_per_worker):
+            out.append(await runner.run_once(query.sql, max_rows=query.max_rows))
+        return out
+
+    await asyncio.gather(*(_warmup(r) for r in runners))
+    start = time.perf_counter_ns()
+    per_worker = await asyncio.gather(*(_timed(r) for r in runners))
+    wall_ns = time.perf_counter_ns() - start
+    return aggregate(len(runners), list(per_worker), wall_ns)

--- a/benchmarks/perf/decompose.py
+++ b/benchmarks/perf/decompose.py
@@ -83,25 +83,35 @@ class DecompositionRunner:
                 await cur.execute("BEGIN TRANSACTION READ ONLY")
                 t_txn_begin = time.perf_counter_ns() - t0
 
-                # t_db — the query + fetch. This is the segment that must match
-                # native; it runs the exact statement the server sends.
-                t0 = time.perf_counter_ns()
-                await cur.execute(f"{_MARKER}{sql}")
-                rows = await cur.fetchall()
-                t_db = time.perf_counter_ns() - t0
+                try:
+                    # t_db — the query + fetch. This is the segment that must
+                    # match native; it runs the exact statement the server sends.
+                    t0 = time.perf_counter_ns()
+                    await cur.execute(f"{_MARKER}{sql}")
+                    rows = await cur.fetchall()
+                    t_db = time.perf_counter_ns() - t0
 
-                # t_serialize — RowResult wrap (driver) + dict + max_rows
-                # truncation (run_select), mirrored exactly.
-                t0 = time.perf_counter_ns()
-                row_results = [SqlDriver.RowResult(cells=dict(row)) for row in rows]
-                all_rows = [dict(rr.cells) for rr in row_results]
-                _ = all_rows[:max_rows]
-                t_serialize = time.perf_counter_ns() - t0
+                    # t_serialize — RowResult wrap (driver) + dict + max_rows
+                    # truncation (run_select), mirrored exactly.
+                    t0 = time.perf_counter_ns()
+                    row_results = [SqlDriver.RowResult(cells=dict(row)) for row in rows]
+                    all_rows = [dict(rr.cells) for rr in row_results]
+                    _ = all_rows[:max_rows]
+                    t_serialize = time.perf_counter_ns() - t0
 
-                # Close the read-only transaction (second half of t_txn).
-                t0 = time.perf_counter_ns()
-                await cur.execute("ROLLBACK")
-                t_txn = t_txn_begin + (time.perf_counter_ns() - t0)
+                    # Close the read-only transaction (second half of t_txn).
+                    t0 = time.perf_counter_ns()
+                    await cur.execute("ROLLBACK")
+                    t_txn = t_txn_begin + (time.perf_counter_ns() - t0)
+                except BaseException:
+                    # A failing sample must not return the pooled connection mid
+                    # transaction and poison later checkouts. Best-effort close,
+                    # then re-raise the original error.
+                    try:
+                        await cur.execute("ROLLBACK")
+                    except Exception:
+                        pass
+                    raise
 
         return SegmentSample(
             t_parse=t_parse,

--- a/benchmarks/perf/decompose.py
+++ b/benchmarks/perf/decompose.py
@@ -1,0 +1,157 @@
+"""Overhead decomposition — the server-side latency waterfall.
+
+Times the MCPg server path **segment by segment** so we can attribute the
+added latency and land the load-bearing result: **``t_db`` is identical to the
+native path**, with the (fixed-cost) overhead living in parse + serialize.
+
+    t_parse -> t_pool -> t_txn -> t_db -> t_serialize
+
+:class:`DecompositionRunner` faithfully mirrors the real production path with
+``time.perf_counter_ns()`` checkpoints between segments. It MUST stay in
+lockstep with:
+
+* ``src/mcpg/sql/safety.py`` ``SafeSqlDriver._validate``       -> ``t_parse``
+* ``src/mcpg/sql/driver.py`` ``_execute_with_connection``      -> ``t_pool`` /
+  ``t_txn`` / ``t_db`` / ``t_serialize``
+* ``src/mcpg/query.py`` ``run_select``                         -> ``t_serialize``
+  (the ``max_rows`` truncation + dict materialization)
+
+If any of those change, update the checkpoints here or the waterfall silently
+lies. The ``t_db`` segment executes the **same** ``/* crystaldba */``-prefixed
+statement the server issues, so it is directly comparable to the native path's
+``t_db`` (the marker comment is lexed and discarded — nil execution cost).
+
+Operator tool — needs a live PostgreSQL, so (like ``paths.py`` / ``runner.py``)
+it is not unit-tested; the pure summariser + tolerance check below are.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+from psycopg.rows import dict_row
+
+from benchmarks.perf import stats
+from mcpg.database import Database
+from mcpg.sql import SafeSqlDriver, SqlDriver
+
+from .schema import Decomposition
+
+# Same marker the server prefixes onto every validated query (safety.py). We
+# replicate it verbatim so the timed t_db statement is byte-identical to what
+# MCPg actually sends.
+_MARKER = "/* crystaldba */ "
+
+
+@dataclass(frozen=True)
+class SegmentSample:
+    """One decomposition measurement, per-segment elapsed nanoseconds."""
+
+    t_parse: int
+    t_pool: int
+    t_txn: int
+    t_db: int
+    t_serialize: int
+
+
+class DecompositionRunner:
+    """Times the server path segment-by-segment (see module docstring)."""
+
+    def __init__(self, database: Database) -> None:
+        self._database = database
+
+    async def run_once(self, sql: str, *, max_rows: int) -> SegmentSample:
+        driver = self._database.driver()
+        safe = SafeSqlDriver(sql_driver=driver)
+        # Ensure the pool is open before timing — the one-time open is not part
+        # of a per-query cost and must not land in t_pool.
+        pool = await driver.connect().pool_connect()
+
+        # t_parse — pglast parse + allowlist AST walk (the real validator).
+        t0 = time.perf_counter_ns()
+        safe._validate(sql)
+        t_parse = time.perf_counter_ns() - t0
+
+        # t_pool — check a connection out of the warmed pool.
+        t0 = time.perf_counter_ns()
+        async with pool.connection() as conn:
+            t_pool = time.perf_counter_ns() - t0
+            async with conn.cursor(row_factory=dict_row) as cur:
+                # t_txn — BEGIN READ ONLY + ROLLBACK (both ends of the envelope).
+                t0 = time.perf_counter_ns()
+                await cur.execute("BEGIN TRANSACTION READ ONLY")
+                t_txn_begin = time.perf_counter_ns() - t0
+
+                # t_db — the query + fetch. This is the segment that must match
+                # native; it runs the exact statement the server sends.
+                t0 = time.perf_counter_ns()
+                await cur.execute(f"{_MARKER}{sql}")
+                rows = await cur.fetchall()
+                t_db = time.perf_counter_ns() - t0
+
+                # t_serialize — RowResult wrap (driver) + dict + max_rows
+                # truncation (run_select), mirrored exactly.
+                t0 = time.perf_counter_ns()
+                row_results = [SqlDriver.RowResult(cells=dict(row)) for row in rows]
+                all_rows = [dict(rr.cells) for rr in row_results]
+                _ = all_rows[:max_rows]
+                t_serialize = time.perf_counter_ns() - t0
+
+                # Close the read-only transaction (second half of t_txn).
+                t0 = time.perf_counter_ns()
+                await cur.execute("ROLLBACK")
+                t_txn = t_txn_begin + (time.perf_counter_ns() - t0)
+
+        return SegmentSample(
+            t_parse=t_parse,
+            t_pool=t_pool,
+            t_txn=t_txn,
+            t_db=t_db,
+            t_serialize=t_serialize,
+        )
+
+
+def _median(values: list[int]) -> float:
+    return stats.percentile(sorted(values), 50)
+
+
+def summarize_segments(samples: list[SegmentSample], warmup: int = 0) -> Decomposition:
+    """Aggregate per-segment samples to a :class:`Decomposition` of medians (ns).
+
+    The first ``warmup`` samples are dropped (cold effects). Returns an
+    all-``None`` :class:`Decomposition` when nothing survives, so a degenerate
+    run serializes cleanly rather than raising.
+    """
+    kept = samples[warmup:] if warmup else samples
+    if not kept:
+        return Decomposition()
+    return Decomposition(
+        t_parse=_median([s.t_parse for s in kept]),
+        t_pool=_median([s.t_pool for s in kept]),
+        t_txn=_median([s.t_txn for s in kept]),
+        t_db=_median([s.t_db for s in kept]),
+        t_serialize=_median([s.t_serialize for s in kept]),
+    )
+
+
+def t_db_within_native(
+    server_t_db_ns: float,
+    native_t_db_ns: float,
+    *,
+    rel_tol: float = 0.30,
+    abs_floor_ns: float = 200_000.0,
+) -> bool:
+    """Whether the server path's ``t_db`` matches native's — the killer claim.
+
+    Same SQL on the same PostgreSQL does the same work, so the server-path DB
+    segment should equal the native baseline. "Equal" is checked with a
+    relative tolerance plus an absolute floor: sub-millisecond timings are
+    jitter-dominated, so a tiny query's ``t_db`` is allowed to wander by the
+    floor (default 0.2 ms) even when that exceeds ``rel_tol``; large queries
+    are held to the tight relative bound.
+    """
+    if native_t_db_ns <= 0:
+        return server_t_db_ns <= abs_floor_ns
+    allowed = max(rel_tol * native_t_db_ns, abs_floor_ns)
+    return abs(server_t_db_ns - native_t_db_ns) <= allowed

--- a/benchmarks/perf/e2e.py
+++ b/benchmarks/perf/e2e.py
@@ -1,0 +1,168 @@
+"""End-to-end measurement paths — through the real MCP protocol.
+
+Where ``ServerSideRunner`` (paths.py) calls the tool *function* in-process,
+these runners drive the ``run_select`` tool through a real
+:class:`mcp.ClientSession`, so the timing includes what an agent actually pays
+on top of the server-side cost: **JSON-RPC encode/decode + transport** — the
+``t_protocol`` band of the waterfall.
+
+Three transports, cheapest first:
+
+* :class:`E2EInMemoryRunner` — client and server share in-memory streams
+  (``create_connected_server_and_client_session``). Isolates the protocol
+  (serialize/deserialize + FastMCP dispatch) with **no** OS transport, so it is
+  the cleanest attribution of MCPg's own protocol overhead. The server runs its
+  real lifespan, so the tool executes against the real database.
+* :class:`E2EStdioRunner` — spawns ``python -m mcpg`` as a subprocess and talks
+  to it over stdio (``stdio_client``). Adds pipe + subprocess transport — what a
+  locally-launched MCP client experiences.
+* :class:`E2EHttpRunner` — connects to an **operator-started** streamable-HTTP
+  server (``--e2e-http-url``). Adds the HTTP/JSON-RPC transport. We connect to a
+  separately-run server rather than managing uvicorn's blocking lifecycle
+  in-process, which keeps the harness honest and robust.
+
+All three are opt-in (``runner.py --e2e`` / ``--e2e-http-url``) and, like the
+rest of the DB-touching harness, are operator tools — not unit-tested. The pure
+helper (:func:`row_count_of`) is.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from contextlib import AsyncExitStack
+from datetime import timedelta
+from typing import Any, Protocol
+
+from mcp import ClientSession
+from mcp.client.stdio import StdioServerParameters, stdio_client
+from mcp.client.streamable_http import streamablehttp_client
+from mcp.shared.memory import create_connected_server_and_client_session
+from mcp.types import CallToolResult
+
+from mcpg.config import Settings
+from mcpg.server import create_server
+
+# Generous per-call ceiling so a heavy TPC-H query over the protocol doesn't
+# trip the client's default read timeout mid-measurement.
+_READ_TIMEOUT = timedelta(seconds=120)
+
+
+def _check(result: CallToolResult) -> CallToolResult:
+    """Raise if the tool call errored, so a broken setup fails loudly.
+
+    A silent error path would otherwise report suspiciously fast timings (an
+    immediate error round-trip) as if they were real query latencies.
+    """
+    if result.isError:
+        text = result.content[0].text if result.content and hasattr(result.content[0], "text") else str(result.content)
+        raise RuntimeError(f"run_select failed over the MCP protocol: {text}")
+    return result
+
+
+class E2ERunner(Protocol):
+    """An end-to-end path with an explicit async lifecycle.
+
+    ``start`` / ``close`` bracket a long-lived client session that ``run_once``
+    (the :class:`~benchmarks.perf.paths.PathRunner` timing method) reuses across
+    every query.
+    """
+
+    async def start(self) -> None: ...
+    async def close(self) -> None: ...
+    async def run_once(self, sql: str, *, max_rows: int) -> int: ...
+
+
+def row_count_of(result: CallToolResult) -> int | None:
+    """Best-effort row count from a ``run_select`` CallToolResult.
+
+    Reads ``structuredContent['row_count']`` when present (typed-output tools
+    carry it); returns ``None`` when the shape doesn't expose it. Pure — unit
+    tested — so the sanity check doesn't depend on a live server.
+    """
+    sc: Any = result.structuredContent
+    if isinstance(sc, dict):
+        count = sc.get("row_count")
+        if isinstance(count, int):
+            return count
+    return None
+
+
+class _SessionRunner:
+    """Shared timing body: call ``run_select`` over an initialized session."""
+
+    _session: ClientSession | None = None
+
+    async def run_once(self, sql: str, *, max_rows: int) -> int:
+        assert self._session is not None, "runner not started"
+        start = time.perf_counter_ns()
+        result = await self._session.call_tool("run_select", {"sql": sql, "max_rows": max_rows})
+        elapsed = time.perf_counter_ns() - start
+        _check(result)
+        return elapsed
+
+
+class E2EInMemoryRunner(_SessionRunner):
+    """Client + server over in-memory streams — isolates ``t_protocol``."""
+
+    def __init__(self, settings: Settings) -> None:
+        self._settings = settings
+        self._stack = AsyncExitStack()
+
+    async def start(self) -> None:
+        # The server runs its real lifespan here (connecting the DB), so the
+        # tool executes for real; only the transport is in-memory.
+        server = create_server(self._settings)
+        self._session = await self._stack.enter_async_context(
+            create_connected_server_and_client_session(server, read_timeout_seconds=_READ_TIMEOUT)
+        )
+
+    async def close(self) -> None:
+        self._session = None
+        await self._stack.aclose()
+
+
+class E2EStdioRunner(_SessionRunner):
+    """Talks to a ``python -m mcpg`` subprocess over stdio."""
+
+    def __init__(self, database_url: str) -> None:
+        self._database_url = database_url
+        self._stack = AsyncExitStack()
+
+    async def start(self) -> None:
+        params = StdioServerParameters(
+            command=sys.executable,
+            args=["-m", "mcpg"],
+            # Inherit the environment so the child finds its interpreter/packages,
+            # then point it at the benchmark database.
+            env={**os.environ, "MCPG_DATABASE_URL": self._database_url},
+        )
+        read, write = await self._stack.enter_async_context(stdio_client(params))
+        session = await self._stack.enter_async_context(ClientSession(read, write, read_timeout_seconds=_READ_TIMEOUT))
+        await session.initialize()
+        self._session = session
+
+    async def close(self) -> None:
+        self._session = None
+        await self._stack.aclose()
+
+
+class E2EHttpRunner(_SessionRunner):
+    """Connects to an operator-started streamable-HTTP MCPg server."""
+
+    def __init__(self, url: str) -> None:
+        self._url = url
+        self._stack = AsyncExitStack()
+
+    async def start(self) -> None:
+        # streamablehttp_client yields (read, write, get_session_id); we only
+        # need the two streams for a ClientSession.
+        read, write, _ = await self._stack.enter_async_context(streamablehttp_client(self._url))
+        session = await self._stack.enter_async_context(ClientSession(read, write, read_timeout_seconds=_READ_TIMEOUT))
+        await session.initialize()
+        self._session = session
+
+    async def close(self) -> None:
+        self._session = None
+        await self._stack.aclose()

--- a/benchmarks/perf/paths.py
+++ b/benchmarks/perf/paths.py
@@ -73,6 +73,27 @@ class NativeRunner:
                 await cur.execute("ROLLBACK")
         return time.perf_counter_ns() - start
 
+    async def db_segment_once(self, sql: str) -> int:
+        """Time **only** ``execute`` + ``fetchall`` — the pure DB segment.
+
+        The comparison anchor for the ``t_db == native`` claim: it isolates the
+        exact work the server path's ``t_db`` measures (query + fetch), inside
+        the same ``BEGIN READ ONLY`` … ``ROLLBACK`` envelope so connection state
+        matches, but excludes the txn statements and serialization from the
+        timed region.
+        """
+        conn = self._conn
+        async with conn.cursor(row_factory=dict_row) as cur:
+            await cur.execute("BEGIN TRANSACTION READ ONLY")
+            try:
+                start = time.perf_counter_ns()
+                await cur.execute(sql)
+                await cur.fetchall()
+                elapsed = time.perf_counter_ns() - start
+            finally:
+                await cur.execute("ROLLBACK")
+        return elapsed
+
 
 class ServerSideRunner:
     """MCPg in-process: real ``run_select`` over the real driver + pool."""

--- a/benchmarks/perf/runner.py
+++ b/benchmarks/perf/runner.py
@@ -210,19 +210,22 @@ async def _run(args: argparse.Namespace) -> PerfRun:
         # Opt-in end-to-end paths (through the real MCP protocol). Started once
         # and reused across every query; torn down in the finally.
         e2e_paths: list[tuple[str, PathRunner]] = []
+        # Register each runner for teardown *before* starting it, so a failure
+        # partway through start() still gets closed by the finally (close() is a
+        # no-op on an un-entered stack).
         if args.e2e:
             inmem = E2EInMemoryRunner(settings)
-            await inmem.start()
             e2e_runners.append(inmem)
+            await inmem.start()
             e2e_paths.append(("e2e_inmemory", inmem))
             stdio = E2EStdioRunner(args.database_url)
-            await stdio.start()
             e2e_runners.append(stdio)
+            await stdio.start()
             e2e_paths.append(("e2e_stdio", stdio))
         if args.e2e_http_url:
             http = E2EHttpRunner(args.e2e_http_url)
-            await http.start()
             e2e_runners.append(http)
+            await http.start()
             e2e_paths.append(("e2e_http", http))
 
         paths: list[tuple[str, PathRunner]] = [
@@ -287,7 +290,10 @@ def _assertions(results: list[ResultRow], native_db_ns_by_query: dict[str, float
     on.
     """
     out: list[Assertion] = []
-    by_key = {(r.path, r.query_id): r for r in results if r.temperature == "warm"}
+    # Only the single-client baseline rows (concurrency == 1) feed the overhead
+    # and t_db assertions — the concurrency-sweep rows share (path, query_id) but
+    # carry under-load latencies, and must not overwrite the baseline here.
+    by_key = {(r.path, r.query_id): r for r in results if r.temperature == "warm" and r.concurrency == 1}
     query_ids = {r.query_id for r in results}
     for qid in sorted(query_ids):
         native = by_key.get(("native", qid))

--- a/benchmarks/perf/runner.py
+++ b/benchmarks/perf/runner.py
@@ -12,10 +12,10 @@ It also runs the **overhead decomposition** (perf/decompose.py) on the
 server-side path and records the load-bearing ``t_db == native`` assertion.
 With ``--e2e`` it additionally measures the **end-to-end paths** through the
 real MCP protocol (perf/e2e.py): in-memory + stdio subprocess, plus streamable
-HTTP against an operator-started server via ``--e2e-http-url``. Provenance (git
-SHA, timestamp) is passed in so a result always carries the exact conditions
-that produced it. The concurrency sweep lands in a follow-up phase (see
-docs/plans/benchmark-suite.md).
+HTTP against an operator-started server via ``--e2e-http-url``. With
+``--concurrency`` it runs the **throughput sweep** (perf/concurrency.py) at
+1/4/16/64 clients. Provenance (git SHA, timestamp) is passed in so a result
+always carries the exact conditions that produced it.
 
 Operator tool — not unit-tested (needs a live PostgreSQL); the pure helpers it
 calls (stats, queries, schema, decompose) are.
@@ -33,6 +33,7 @@ from pathlib import Path
 from typing import Any
 
 from benchmarks.perf import stats
+from benchmarks.perf.concurrency import CONCURRENCY_LEVELS, ConcurrencyResult, sweep_level
 from benchmarks.perf.decompose import DecompositionRunner, SegmentSample, summarize_segments, t_db_within_native
 from benchmarks.perf.e2e import E2EHttpRunner, E2EInMemoryRunner, E2ERunner, E2EStdioRunner
 from benchmarks.perf.paths import NativeRunner, PathRunner, ServerSideRunner
@@ -101,6 +102,65 @@ async def _sample_native_db(native: NativeRunner, query: BenchQuery, iterations:
             gc.collect()
     warm = stats.drop_warmup(samples, _WARMUP)
     return stats.percentile(sorted(warm), 50)
+
+
+def _conc_row(path: str, query: BenchQuery, cr: ConcurrencyResult) -> ResultRow:
+    """Build a ResultRow for one concurrency data-point.
+
+    Raw per-call samples are omitted (``samples_ns=[]``) — at 64 clients x N
+    iterations they'd bloat the JSON with little added value over the
+    percentiles + throughput already summarised here.
+    """
+    s = stats.summarize(cr.latencies_ns)
+    return ResultRow(
+        path=path,
+        query_id=query.id,
+        compute_class=query.compute_class,
+        result_size=query.result_size,
+        temperature="warm",
+        concurrency=cr.concurrency,
+        n=s.n,
+        latency_ms=LatencyBlock(
+            p50=s.p50, p95=s.p95, p99=s.p99, mean=s.mean, stdev=s.stdev, min=s.min, max=s.max, median_ci95=s.median_ci95
+        ),
+        throughput_rps=cr.throughput_rps,
+        samples_ns=[],
+    )
+
+
+async def _run_concurrency(database_url: str, iterations: int) -> list[ResultRow]:
+    """Sweep every query across the concurrency levels for native + server-side.
+
+    Owns its own resources: a dedicated pool sized to the sweep ceiling (so the
+    server-side path isn't starved) and one persistent native connection per
+    concurrent client (opened once, sliced per level). Everything is torn down
+    before returning.
+    """
+    max_c = max(CONCURRENCY_LEVELS)
+    conc_settings = load_settings(
+        {"MCPG_DATABASE_URL": database_url, "MCPG_POOL_MIN_SIZE": "1", "MCPG_POOL_MAX_SIZE": str(max_c)}
+    )
+    conc_db = Database(conc_settings)
+    await conc_db.connect()
+    native_conns = [await NativeRunner.connect(database_url) for _ in range(max_c)]
+    rows: list[ResultRow] = []
+    try:
+        for query in all_queries():
+            for level in CONCURRENCY_LEVELS:
+                native_result = await sweep_level(
+                    list(native_conns[:level]), query, iterations_per_worker=iterations, warmup_per_worker=_WARMUP
+                )
+                rows.append(_conc_row("native", query, native_result))
+                server_runners: list[PathRunner] = [ServerSideRunner(conc_db) for _ in range(level)]
+                server_result = await sweep_level(
+                    server_runners, query, iterations_per_worker=iterations, warmup_per_worker=_WARMUP
+                )
+                rows.append(_conc_row("server_side", query, server_result))
+    finally:
+        for conn in native_conns:
+            await conn.close()
+        await conc_db.close()
+    return rows
 
 
 def _row(
@@ -184,6 +244,11 @@ async def _run(args: argparse.Namespace) -> PerfRun:
                 results.append(_row(label, query, "cold", [cold]))
             # The native DB segment (execute + fetch only) anchors t_db == native.
             native_db_ns_by_query[query.id] = await _sample_native_db(native, query, args.iterations)
+
+        # Throughput-under-concurrency sweep (opt-in; owns its own pool sized to
+        # the sweep ceiling so the server-side path isn't starved).
+        if args.concurrency:
+            results.extend(await _run_concurrency(args.database_url, args.iterations))
     finally:
         for e2e in e2e_runners:
             await e2e.close()
@@ -203,6 +268,7 @@ async def _run(args: argparse.Namespace) -> PerfRun:
         },
         "iterations": args.iterations,
         "warmup_discarded": _WARMUP,
+        "concurrency_levels": list(CONCURRENCY_LEVELS) if args.concurrency else [],
     }
     return PerfRun(
         metadata=metadata,
@@ -277,6 +343,12 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="Add the streamable-HTTP e2e path against an operator-started mcpg server at this URL (e.g. "
         "http://127.0.0.1:8000/mcp). Implies the HTTP transport is already running.",
+    )
+    parser.add_argument(
+        "--concurrency",
+        action="store_true",
+        help=f"Also run the throughput sweep at {'/'.join(map(str, CONCURRENCY_LEVELS))} concurrent clients "
+        "(native + server-side). Multiplies DB load — each level runs --iterations per client.",
     )
     parser.add_argument("--git-sha", default="unknown", help="Provenance: the commit under test.")
     parser.add_argument("--timestamp", default="unknown", help="Provenance: ISO-8601 run timestamp.")

--- a/benchmarks/perf/runner.py
+++ b/benchmarks/perf/runner.py
@@ -8,13 +8,14 @@ structured JSON document under ``benchmarks/results/``.
         --database-url "$MCPG_TEST_DATABASE_URL" \
         --scale-factor 1 --iterations 50 --output benchmarks/results/perf.json
 
+It also runs the **overhead decomposition** (perf/decompose.py) on the
+server-side path and records the load-bearing ``t_db == native`` assertion.
 Provenance (git SHA, timestamp) is passed in so a result always carries the
-exact conditions that produced it. This first cut covers native + server-side;
-the end-to-end transport paths, the overhead decomposition, and the
+exact conditions that produced it. The end-to-end transport paths and the
 concurrency sweep land in follow-up phases (see docs/plans/benchmark-suite.md).
 
 Operator tool — not unit-tested (needs a live PostgreSQL); the pure helpers it
-calls (stats, queries, schema) are.
+calls (stats, queries, schema, decompose) are.
 """
 
 from __future__ import annotations
@@ -29,9 +30,10 @@ from pathlib import Path
 from typing import Any
 
 from benchmarks.perf import stats
+from benchmarks.perf.decompose import DecompositionRunner, SegmentSample, summarize_segments, t_db_within_native
 from benchmarks.perf.paths import NativeRunner, PathRunner, ServerSideRunner
 from benchmarks.perf.queries import BenchQuery, all_queries
-from benchmarks.perf.schema import Assertion, LatencyBlock, PerfRun, ResultRow
+from benchmarks.perf.schema import Assertion, Decomposition, LatencyBlock, PerfRun, ResultRow
 from mcpg import __version__
 from mcpg.config import load_settings
 from mcpg.database import Database
@@ -61,7 +63,49 @@ async def _sample_path(runner: PathRunner, query: BenchQuery, iterations: int) -
     return warm, cold
 
 
-def _row(path: str, query: BenchQuery, temperature: str, samples_ns: list[int]) -> ResultRow:
+async def _sample_decomposition(runner: DecompositionRunner, query: BenchQuery, iterations: int) -> Decomposition:
+    """Sample the server-path waterfall, returning per-segment medians (ns).
+
+    Warm-up is discarded exactly like :func:`_sample_path`; GC is disabled
+    around each timed call so no collection pause lands inside a segment.
+    """
+    gc.collect()
+    samples: list[SegmentSample] = []
+    for i in range(iterations + _WARMUP):
+        gc.disable()
+        try:
+            sample = await runner.run_once(query.sql, max_rows=query.max_rows)
+        finally:
+            gc.enable()
+        samples.append(sample)
+        if i % 8 == 7:
+            gc.collect()
+    return summarize_segments(samples, warmup=_WARMUP)
+
+
+async def _sample_native_db(native: NativeRunner, query: BenchQuery, iterations: int) -> float:
+    """Median (ns) of native's pure DB segment — the ``t_db == native`` anchor."""
+    gc.collect()
+    samples: list[int] = []
+    for i in range(iterations + _WARMUP):
+        gc.disable()
+        try:
+            samples.append(await native.db_segment_once(query.sql))
+        finally:
+            gc.enable()
+        if i % 8 == 7:
+            gc.collect()
+    warm = stats.drop_warmup(samples, _WARMUP)
+    return stats.percentile(sorted(warm), 50)
+
+
+def _row(
+    path: str,
+    query: BenchQuery,
+    temperature: str,
+    samples_ns: list[int],
+    decomposition: Decomposition | None = None,
+) -> ResultRow:
     s = stats.summarize(samples_ns)
     return ResultRow(
         path=path,
@@ -75,6 +119,7 @@ def _row(path: str, query: BenchQuery, temperature: str, samples_ns: list[int]) 
             p50=s.p50, p95=s.p95, p99=s.p99, mean=s.mean, stdev=s.stdev, min=s.min, max=s.max, median_ci95=s.median_ci95
         ),
         samples_ns=samples_ns,
+        decomposition_ns=decomposition,
     )
 
 
@@ -97,11 +142,20 @@ async def _run(args: argparse.Namespace) -> PerfRun:
         if pg:
             pg_meta = {"version_string": pg[0].cells["v"], "server_version_num": pg[0].cells["num"]}
 
+        decomposer = DecompositionRunner(database)
+        native_db_ns_by_query: dict[str, float] = {}
         for query in all_queries():
             for label, runner in (("native", native), ("server_side", ServerSideRunner(database))):
                 warm, cold = await _sample_path(runner, query, args.iterations)
-                results.append(_row(label, query, "warm", warm))
+                # Attach the overhead waterfall to the server-side warm row —
+                # the one the report reads t_db from for the native comparison.
+                decomposition = (
+                    await _sample_decomposition(decomposer, query, args.iterations) if label == "server_side" else None
+                )
+                results.append(_row(label, query, "warm", warm, decomposition))
                 results.append(_row(label, query, "cold", [cold]))
+            # The native DB segment (execute + fetch only) anchors t_db == native.
+            native_db_ns_by_query[query.id] = await _sample_native_db(native, query, args.iterations)
     finally:
         await native.close()
         await database.close()
@@ -120,13 +174,22 @@ async def _run(args: argparse.Namespace) -> PerfRun:
         "iterations": args.iterations,
         "warmup_discarded": _WARMUP,
     }
-    return PerfRun(metadata=metadata, results=results, assertions=_assertions(results))
+    return PerfRun(
+        metadata=metadata,
+        results=results,
+        assertions=_assertions(results, native_db_ns_by_query),
+    )
 
 
-def _assertions(results: list[ResultRow]) -> list[Assertion]:
-    """Overhead sanity checks. The fine-grained t_db == native assertion lands
-    with the decomposition phase; here we record the warm total-latency delta
-    per query so the report can show MCPg's overhead is bounded."""
+def _assertions(results: list[ResultRow], native_db_ns_by_query: dict[str, float]) -> list[Assertion]:
+    """Overhead + the load-bearing ``t_db == native`` gate.
+
+    Two assertions per query: an informational warm total-latency delta
+    (``server_side_overhead_p50_ms``), and the machine-checkable claim that the
+    server path's DB segment matches the native baseline
+    (``t_db_matches_native``) — the result the whole performance objective turns
+    on.
+    """
     out: list[Assertion] = []
     by_key = {(r.path, r.query_id): r for r in results if r.temperature == "warm"}
     query_ids = {r.query_id for r in results}
@@ -140,7 +203,7 @@ def _assertions(results: list[ResultRow]) -> list[Assertion]:
             Assertion(
                 name="server_side_overhead_p50_ms",
                 query_id=qid,
-                passed=True,  # informational; the t_db==native gate lands with decomposition
+                passed=True,  # informational
                 detail={
                     "native_p50_ms": native.latency_ms.p50,
                     "server_side_p50_ms": server.latency_ms.p50,
@@ -148,6 +211,21 @@ def _assertions(results: list[ResultRow]) -> list[Assertion]:
                 },
             )
         )
+        server_t_db = server.decomposition_ns.t_db if server.decomposition_ns else None
+        native_t_db = native_db_ns_by_query.get(qid)
+        if server_t_db is not None and native_t_db is not None:
+            out.append(
+                Assertion(
+                    name="t_db_matches_native",
+                    query_id=qid,
+                    passed=t_db_within_native(server_t_db, native_t_db),
+                    detail={
+                        "native_t_db_ms": native_t_db / 1e6,
+                        "server_t_db_ms": server_t_db / 1e6,
+                        "delta_ms": (server_t_db - native_t_db) / 1e6,
+                    },
+                )
+            )
     return out
 
 

--- a/benchmarks/perf/runner.py
+++ b/benchmarks/perf/runner.py
@@ -10,9 +10,12 @@ structured JSON document under ``benchmarks/results/``.
 
 It also runs the **overhead decomposition** (perf/decompose.py) on the
 server-side path and records the load-bearing ``t_db == native`` assertion.
-Provenance (git SHA, timestamp) is passed in so a result always carries the
-exact conditions that produced it. The end-to-end transport paths and the
-concurrency sweep land in follow-up phases (see docs/plans/benchmark-suite.md).
+With ``--e2e`` it additionally measures the **end-to-end paths** through the
+real MCP protocol (perf/e2e.py): in-memory + stdio subprocess, plus streamable
+HTTP against an operator-started server via ``--e2e-http-url``. Provenance (git
+SHA, timestamp) is passed in so a result always carries the exact conditions
+that produced it. The concurrency sweep lands in a follow-up phase (see
+docs/plans/benchmark-suite.md).
 
 Operator tool — not unit-tested (needs a live PostgreSQL); the pure helpers it
 calls (stats, queries, schema, decompose) are.
@@ -31,6 +34,7 @@ from typing import Any
 
 from benchmarks.perf import stats
 from benchmarks.perf.decompose import DecompositionRunner, SegmentSample, summarize_segments, t_db_within_native
+from benchmarks.perf.e2e import E2EHttpRunner, E2EInMemoryRunner, E2ERunner, E2EStdioRunner
 from benchmarks.perf.paths import NativeRunner, PathRunner, ServerSideRunner
 from benchmarks.perf.queries import BenchQuery, all_queries
 from benchmarks.perf.schema import Assertion, Decomposition, LatencyBlock, PerfRun, ResultRow
@@ -134,6 +138,7 @@ async def _run(args: argparse.Namespace) -> PerfRun:
     # Pre-initialised so a failure in the metadata query below can't mask the
     # original exception with an UnboundLocalError when `metadata` is built.
     pg_meta: dict[str, Any] = {}
+    e2e_runners: list[E2ERunner] = []
     try:
         pg = await database.driver().execute_query(
             "SELECT current_setting('server_version') AS v, current_setting('server_version_num')::int AS num",
@@ -142,10 +147,33 @@ async def _run(args: argparse.Namespace) -> PerfRun:
         if pg:
             pg_meta = {"version_string": pg[0].cells["v"], "server_version_num": pg[0].cells["num"]}
 
+        # Opt-in end-to-end paths (through the real MCP protocol). Started once
+        # and reused across every query; torn down in the finally.
+        e2e_paths: list[tuple[str, PathRunner]] = []
+        if args.e2e:
+            inmem = E2EInMemoryRunner(settings)
+            await inmem.start()
+            e2e_runners.append(inmem)
+            e2e_paths.append(("e2e_inmemory", inmem))
+            stdio = E2EStdioRunner(args.database_url)
+            await stdio.start()
+            e2e_runners.append(stdio)
+            e2e_paths.append(("e2e_stdio", stdio))
+        if args.e2e_http_url:
+            http = E2EHttpRunner(args.e2e_http_url)
+            await http.start()
+            e2e_runners.append(http)
+            e2e_paths.append(("e2e_http", http))
+
+        paths: list[tuple[str, PathRunner]] = [
+            ("native", native),
+            ("server_side", ServerSideRunner(database)),
+            *e2e_paths,
+        ]
         decomposer = DecompositionRunner(database)
         native_db_ns_by_query: dict[str, float] = {}
         for query in all_queries():
-            for label, runner in (("native", native), ("server_side", ServerSideRunner(database))):
+            for label, runner in paths:
                 warm, cold = await _sample_path(runner, query, args.iterations)
                 # Attach the overhead waterfall to the server-side warm row —
                 # the one the report reads t_db from for the native comparison.
@@ -157,6 +185,8 @@ async def _run(args: argparse.Namespace) -> PerfRun:
             # The native DB segment (execute + fetch only) anchors t_db == native.
             native_db_ns_by_query[query.id] = await _sample_native_db(native, query, args.iterations)
     finally:
+        for e2e in e2e_runners:
+            await e2e.close()
         await native.close()
         await database.close()
 
@@ -237,6 +267,17 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--scale-factor", type=int, default=1, help="TPC-H scale factor the DB was loaded at.")
     parser.add_argument("--output", type=Path, required=True, help="Path to write the result JSON.")
+    parser.add_argument(
+        "--e2e",
+        action="store_true",
+        help="Also measure the end-to-end paths through the MCP protocol (in-memory + stdio subprocess).",
+    )
+    parser.add_argument(
+        "--e2e-http-url",
+        default=None,
+        help="Add the streamable-HTTP e2e path against an operator-started mcpg server at this URL (e.g. "
+        "http://127.0.0.1:8000/mcp). Implies the HTTP transport is already running.",
+    )
     parser.add_argument("--git-sha", default="unknown", help="Provenance: the commit under test.")
     parser.add_argument("--timestamp", default="unknown", help="Provenance: ISO-8601 run timestamp.")
     args = parser.parse_args(argv)

--- a/tests/unit/test_bench_perf.py
+++ b/tests/unit/test_bench_perf.py
@@ -13,6 +13,7 @@ import json
 import pytest
 
 from benchmarks.perf import queries, runner, stats
+from benchmarks.perf.decompose import SegmentSample, summarize_segments, t_db_within_native
 from benchmarks.perf.schema import Assertion, Decomposition, LatencyBlock, PerfRun, ResultRow
 
 # --- stats ----------------------------------------------------------------
@@ -120,3 +121,77 @@ def test_runner_rejects_too_few_iterations() -> None:
     with pytest.raises(SystemExit) as exc:
         runner.main(["--database-url", "postgresql://unused", "--output", "/tmp/unused.json", "--iterations", "0"])
     assert exc.value.code == 2
+
+
+# --- overhead decomposition (pure helpers) --------------------------------
+
+
+def _seg(t_db: int) -> SegmentSample:
+    # Fixed non-db segments; vary only t_db for the median assertions.
+    return SegmentSample(t_parse=100, t_pool=200, t_txn=300, t_db=t_db, t_serialize=400)
+
+
+def test_summarize_segments_medians_per_field() -> None:
+    samples = [_seg(1000), _seg(2000), _seg(3000)]
+    d = summarize_segments(samples)
+    assert d.t_parse == 100
+    assert d.t_pool == 200
+    assert d.t_txn == 300
+    assert d.t_db == 2000  # median of 1000/2000/3000
+    assert d.t_serialize == 400
+
+
+def test_summarize_segments_drops_warmup() -> None:
+    # First two are warmup outliers; only the last three count.
+    samples = [_seg(9_000_000), _seg(9_000_000), _seg(1000), _seg(2000), _seg(3000)]
+    d = summarize_segments(samples, warmup=2)
+    assert d.t_db == 2000
+
+
+def test_summarize_segments_empty_is_all_none() -> None:
+    d = summarize_segments([], warmup=0)
+    assert d.t_db is None and d.t_parse is None
+
+
+def test_t_db_within_native_matches_when_close() -> None:
+    # 1 ms native, server 1.1 ms -> within 30% relative tolerance.
+    assert t_db_within_native(1_100_000, 1_000_000) is True
+
+
+def test_t_db_within_native_absolute_floor_covers_jitter() -> None:
+    # Sub-ms native: a large *relative* wobble under the 0.2 ms floor passes.
+    assert t_db_within_native(150_000, 50_000) is True  # delta 0.1 ms < floor
+    # ...but a delta beyond the floor on a tiny value fails.
+    assert t_db_within_native(500_000, 50_000) is False
+
+
+def test_t_db_within_native_fails_when_far() -> None:
+    # 10 ms native, server 15 ms -> 50% over, well beyond tolerance.
+    assert t_db_within_native(15_000_000, 10_000_000) is False
+
+
+def test_assertions_include_t_db_gate() -> None:
+    # A server-side warm row carrying a decomposition + a native anchor should
+    # yield the machine-checkable t_db_matches_native assertion.
+    def _row(path: str, t_db: float | None) -> ResultRow:
+        return ResultRow(
+            path=path,
+            query_id="tpch_q1",
+            compute_class="heavy",
+            result_size="~100",
+            temperature="warm",
+            concurrency=1,
+            n=20,
+            latency_ms=LatencyBlock(
+                p50=5.0, p95=6.0, p99=6.5, mean=5.1, stdev=0.3, min=4.5, max=7.0, median_ci95=(4.9, 5.2)
+            ),
+            samples_ns=[5_000_000],
+            decomposition_ns=Decomposition(t_db=t_db) if t_db is not None else None,
+        )
+
+    results = [_row("native", None), _row("server_side", 4_000_000.0)]
+    out = runner._assertions(results, {"tpch_q1": 4_100_000.0})
+    gate = [a for a in out if a.name == "t_db_matches_native"]
+    assert len(gate) == 1
+    assert gate[0].passed is True
+    assert gate[0].detail["native_t_db_ms"] == 4.1

--- a/tests/unit/test_bench_perf.py
+++ b/tests/unit/test_bench_perf.py
@@ -14,6 +14,7 @@ import pytest
 from mcp.types import CallToolResult, TextContent
 
 from benchmarks.perf import queries, runner, stats
+from benchmarks.perf.concurrency import aggregate, throughput_rps
 from benchmarks.perf.decompose import SegmentSample, summarize_segments, t_db_within_native
 from benchmarks.perf.e2e import row_count_of
 from benchmarks.perf.schema import Assertion, Decomposition, LatencyBlock, PerfRun, ResultRow
@@ -211,3 +212,33 @@ def test_row_count_of_none_when_absent() -> None:
     # A text-only result (no structuredContent) yields None rather than raising.
     result = CallToolResult(content=[TextContent(type="text", text="[]")])
     assert row_count_of(result) is None
+
+
+# --- concurrency sweep (pure helpers) -------------------------------------
+
+
+def test_throughput_rps_basic_and_guard() -> None:
+    assert throughput_rps(100, 2.0) == 50.0
+    assert throughput_rps(100, 0.0) == 0.0  # zero wall time -> 0, not a crash
+    assert throughput_rps(0, 1.0) == 0.0
+
+
+def test_aggregate_folds_workers_and_computes_rps() -> None:
+    # 2 workers x 2 calls each = 4 queries in 1e9 ns (1.0 s) -> 4 rps.
+    per_worker = [[1_000_000, 2_000_000], [3_000_000, 4_000_000]]
+    cr = aggregate(concurrency=2, per_worker_latencies=per_worker, wall_ns=1_000_000_000)
+    assert cr.concurrency == 2
+    assert cr.total_queries == 4
+    assert cr.wall_seconds == 1.0
+    assert cr.throughput_rps == 4.0
+    assert sorted(cr.latencies_ns) == [1_000_000, 2_000_000, 3_000_000, 4_000_000]
+
+
+def test_conc_row_omits_raw_samples_but_keeps_throughput() -> None:
+    cr = aggregate(concurrency=4, per_worker_latencies=[[1_000_000] * 4], wall_ns=2_000_000_000)
+    q = next(iter(queries.all_queries()))
+    row = runner._conc_row("server_side", q, cr)
+    assert row.concurrency == 4
+    assert row.throughput_rps == cr.throughput_rps
+    assert row.samples_ns == []  # not persisted for concurrency rows
+    assert row.latency_ms.p50 == 1.0

--- a/tests/unit/test_bench_perf.py
+++ b/tests/unit/test_bench_perf.py
@@ -11,9 +11,11 @@ from __future__ import annotations
 import json
 
 import pytest
+from mcp.types import CallToolResult, TextContent
 
 from benchmarks.perf import queries, runner, stats
 from benchmarks.perf.decompose import SegmentSample, summarize_segments, t_db_within_native
+from benchmarks.perf.e2e import row_count_of
 from benchmarks.perf.schema import Assertion, Decomposition, LatencyBlock, PerfRun, ResultRow
 
 # --- stats ----------------------------------------------------------------
@@ -195,3 +197,17 @@ def test_assertions_include_t_db_gate() -> None:
     assert len(gate) == 1
     assert gate[0].passed is True
     assert gate[0].detail["native_t_db_ms"] == 4.1
+
+
+# --- e2e helper (pure) ----------------------------------------------------
+
+
+def test_row_count_of_reads_structured_content() -> None:
+    result = CallToolResult(content=[], structuredContent={"row_count": 42})
+    assert row_count_of(result) == 42
+
+
+def test_row_count_of_none_when_absent() -> None:
+    # A text-only result (no structuredContent) yields None rather than raising.
+    result = CallToolResult(content=[TextContent(type="text", text="[]")])
+    assert row_count_of(result) is None

--- a/tests/unit/test_bench_perf.py
+++ b/tests/unit/test_bench_perf.py
@@ -200,6 +200,39 @@ def test_assertions_include_t_db_gate() -> None:
     assert gate[0].detail["native_t_db_ms"] == 4.1
 
 
+def test_assertions_ignore_concurrency_rows() -> None:
+    # Concurrency-sweep rows share (path, query_id) with the single-client
+    # baseline but carry under-load latencies; they must NOT feed the overhead
+    # assertion (which keys off the concurrency==1 baseline).
+    def _row(path: str, concurrency: int, p50: float) -> ResultRow:
+        return ResultRow(
+            path=path,
+            query_id="q",
+            compute_class="light",
+            result_size="~100",
+            temperature="warm",
+            concurrency=concurrency,
+            n=20,
+            latency_ms=LatencyBlock(
+                p50=p50, p95=p50, p99=p50, mean=p50, stdev=0.0, min=p50, max=p50, median_ci95=(p50, p50)
+            ),
+            samples_ns=[],
+        )
+
+    # Baseline: native 1.0 ms, server 1.2 ms -> overhead 0.2 ms. The 64-client
+    # rows (10x slower) must be ignored.
+    results = [
+        _row("native", 1, 1.0),
+        _row("server_side", 1, 1.2),
+        _row("native", 64, 10.0),
+        _row("server_side", 64, 12.0),
+    ]
+    out = runner._assertions(results, {})
+    overhead = [a for a in out if a.name == "server_side_overhead_p50_ms"]
+    assert len(overhead) == 1
+    assert overhead[0].detail["overhead_p50_ms"] == pytest.approx(0.2)
+
+
 # --- e2e helper (pure) ----------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

Completes the core of the performance objective (roadmap **19.1**) on top of the Phase 1 harness foundation (#270). Three slices, each its own commit:

**1. Overhead decomposition + the `t_db == native` gate** (`perf/decompose.py`)
- `DecompositionRunner` times the server path **segment by segment** — `t_parse → t_pool → t_txn → t_db → t_serialize` — faithfully mirroring `run_select → SafeSqlDriver.execute_query → SqlDriver._execute_with_connection` with `perf_counter_ns` checkpoints. The `t_db` segment runs the exact `/* crystaldba */`-prefixed statement the server sends, so it's directly comparable to native.
- `NativeRunner.db_segment_once` times **only** `execute + fetch` inside the same READ ONLY envelope — the apples-to-apples anchor.
- The runner records the **machine-checkable `t_db_matches_native` assertion** per query (relative tolerance + absolute floor for sub-ms jitter). This is the result the whole objective turns on: *MCPg adds nothing to DB execution; the fixed-cost overhead lives in parse + serialize.*

**2. End-to-end paths through the real MCP protocol** (`perf/e2e.py`, opt-in `--e2e`)
- `E2EInMemoryRunner` (in-memory streams — isolates `t_protocol`), `E2EStdioRunner` (`python -m mcpg` subprocess), `E2EHttpRunner` (operator-started streamable-HTTP via `--e2e-http-url`). Driven through a real `mcp.ClientSession`, so timing includes JSON-RPC encode/decode + transport. An error-raising check ensures a broken setup fails loudly rather than reporting an error round-trip as a fast latency.

**3. Throughput-under-concurrency sweep** (`perf/concurrency.py`, opt-in `--concurrency`)
- Sweeps native + server-side at **1/4/16/64** clients (warm-up gather, then one timed gather bracketing steady-state work) → aggregate queries/sec + latency under load. Fairness: a dedicated pool sized to the sweep ceiling and one persistent native connection per client, so we measure genuine pool/serialization overhead, not artificial starvation.

The single-client deterministic path is unchanged and always-on; e2e and concurrency are opt-in (they multiply load / need extra setup). `benchmarks/README.md` documents both, including the two-shell HTTP recipe.

## Verification

- **24 unit tests** in `test_bench_perf.py` cover every pure helper added (segment medians, the `t_db` tolerance check + the assertion wiring, `row_count_of`, `throughput_rps`/`aggregate`, the concurrency row builder).
- Full unit suite: **2779 passed**.
- `ruff check .`, `ruff format --check .`, `mypy src/mcpg` all clean; the new benchmark modules are mypy-clean too.
- The DB-touching runners stay operator tools (live PostgreSQL), matching `paths.py`/`runner.py`.

## Roadmap linkage

Advances roadmap row: 19.1

## Checklist

- [x] Tests added/updated first (TDD); suite passes locally (2779 passed)
- [x] `ruff`, `ruff format`, and `mypy src/mcpg` pass
- [x] `CHANGELOG.md` — n/a (no shipped-surface change; benchmarks are an operator tool, not in the wheel)
- [x] Roadmap row cited above (19.1)
- [x] No hand-edits to `src/mcpg/_vendor/` (the vendor tree no longer exists — 18.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Extend the benchmarking harness to decompose server-side latency, measure end-to-end MCP protocol paths, and assess throughput under concurrency, recording these results and assertions in the structured perf output.

New Features:
- Add overhead decomposition of the server-side path into per-segment timings and persist them in perf results.
- Introduce end-to-end benchmark runners over MCP protocol transports (in-memory, stdio subprocess, and streamable HTTP) as opt-in measurement paths.
- Add a concurrency sweep to benchmark throughput and latency at multiple client levels for native and server-side paths.

Enhancements:
- Record a machine-checkable assertion that the server-side database segment latency matches the native baseline for each query.
- Extend the perf runner CLI and metadata to configure e2e and concurrency runs and capture their configuration in the output.
- Document the new decomposition, end-to-end, and concurrency benchmarks and how to run them in the benchmarks README.

Tests:
- Add unit tests covering decomposition helpers and t_db tolerance checks, e2e result row-count extraction, and concurrency aggregation/throughput helpers.