### PR TITLE
ci: assert lockfile consistency (uv sync --locked, was --frozen)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           python-version: "3.14"
           enable-cache: true
-      - run: uv sync --frozen
+      - run: uv sync --locked
       - name: ruff (lint)
         run: uv run ruff check .
       - name: ruff (format)
@@ -39,7 +39,7 @@ jobs:
         with:
           python-version: "3.14"
           enable-cache: true
-      - run: uv sync --frozen
+      - run: uv sync --locked
       # pip-audit consults the PyPI advisory DB + OSV.dev for known
       # CVEs in resolved dependencies. ``--strict`` upgrades warnings
       # to failures so a vulnerable transitive dep blocks merge. We
@@ -193,7 +193,7 @@ jobs:
         with:
           python-version: "3.14"
           enable-cache: true
-      - run: uv sync --frozen
+      - run: uv sync --locked
       # Runs unit, vendored-kernel, and integration suites with the coverage
       # gate (fail_under = 90, authored code only) against each PG version.
       - name: pytest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           python-version: "3.14"
           enable-cache: true
-      - run: uv sync --frozen
+      - run: uv sync --locked
       - name: Sanity check — tag matches package version
         # Tag is the source of truth for the release; the version is
         # single-sourced in src/mcpg/__init__.py (__version__) and read


### PR DESCRIPTION
## Summary

Root-cause fix for the `pglast` lock drift found while reviewing #284 — the reason dependabot's pin bump was never actually exercised by CI.

**What happened.** Dependabot #281 bumped `pglast==8.2 → 8.4` in `pyproject.toml` but left `uv.lock` at `8.2` (dependabot's uv lockfile regeneration is a known rough edge — it detects `uv.lock` via the `pip` ecosystem but doesn't reliably re-resolve it). CI installs with **`uv sync --frozen`**, which installs from the lock *as-is and never checks it against the manifest*. Two consequences:

1. The drift was **invisible** — `--frozen` doesn't compare lock ↔ manifest, so #281 merged green.
2. CI was silently testing **pglast 8.2** (the lock's version), not the 8.4 the pin advertised. The green checkmark meant "8.2 still works," not "8.4 works."

**The fix.** Switch all four dep-install steps (`ci.yml` ×3, `publish.yml` ×1) from `--frozen` to **`uv sync --locked`**, which *asserts the lock is up-to-date with `pyproject.toml`* and fails the run otherwise. A future manifest bump that forgets to regenerate the lock now fails CI instead of drifting invisibly.

Verified locally that the gate catches exactly this drift:
```
$ uv sync --locked
The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
```

The trade-off: a legitimate dependency PR must now include the regenerated `uv.lock` — which is the intended behaviour, and is what dependabot *should* have produced.

## ⚠️ Merge ordering

This PR's own CI will be **red until #284 merges**, because `main`'s `uv.lock` is still the stale `8.2`. The lock sync (8.2 → 8.4) rides in **#284** (per the request to fold it there). Sequence:

1. Merge **#284** → `main`'s lock becomes consistent with `pyproject.toml`.
2. Rebase this branch onto the new `main` → `uv sync --locked` passes → this goes green.
3. Merge this.

I'll rebase this PR automatically once #284 lands if you'd like.

## Roadmap linkage

Advances roadmap row: N/A — CI infrastructure hardening.

## Checklist

- [x] Tests added/updated first (TDD); suite passes locally — N/A (CI-config only); gate behaviour verified locally
- [x] `ruff`, `ruff format`, and `mypy src/mcpg` pass — unaffected (no source change)
- [x] `CHANGELOG.md` updated under `[Unreleased]` — N/A (internal CI tooling, not user-facing)
- [x] Roadmap row cited above (or `N/A`); row marked ✅ when this PR completes it
- [x] No hand-edits to `src/mcpg/_vendor/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Enforce dependency lockfile consistency in CI and publish workflows by tightening uv sync behavior.

CI:
- Update all CI workflow jobs to use `uv sync --locked` so runs fail when the lockfile is out of date with pyproject.toml.
- Align the publish workflow's dependency installation step with CI by switching to `uv sync --locked` as well.