### PR TITLE
release: 0.6.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.6.12] - 2026-07-28
+
 ### Added
 
 - **`run_analytical_query` — long-running reads on an isolated pool.**

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,6 +61,7 @@ them" — pick the section that matches what you're trying to do.
   retrospectives.
 - [**Progress log**](PROGRESS.md) — chronological build log.
 - Release notes:
+  [v0.6.12](release-notes-0.6.12.md) ·
   [v0.6.11](release-notes-0.6.11.md) ·
   [v0.6.10](release-notes-0.6.10.md) ·
   [v0.6.9](release-notes-0.6.9.md) ·

--- a/docs/release-notes-0.6.12.md
+++ b/docs/release-notes-0.6.12.md
@@ -1,0 +1,94 @@
+# MCPg v0.6.12 — release notes
+
+**Released:** 2026-07-28
+**Tool surface:** **254** tools across 19 capability buckets (read-only
+mode exposes a subset)
+**Tests:** unit + integration suite green (PG 14 / 15 / 16 / 17 / 18 / 19
+/ WarehousePG)
+**Runtime:** Python 3.14
+
+A **0.6.11 → 0.6.12** release that adds two tools — a long-running
+analytical read path and a cache-freshness escape hatch — plus a
+dependency security bump. Backward-compatible: no existing tool
+signature changed, and both new tools default to the previous behaviour
+being available (the analytical tool is on by default; the cache still
+behaves exactly as before unless you ask for `fresh` data).
+
+## New: `run_analytical_query` — long-running reads on an isolated pool
+
+`run_select` is deliberately bounded to a short (~30 s) timeout on the
+shared connection pool so an agent can't pin a connection with a runaway
+query — which made genuine analytical queries (large aggregations,
+multi-table joins, window functions) infeasible, and
+`MCPG_STATEMENT_TIMEOUT_MS` didn't help (it moves Postgres's
+`statement_timeout`, not the client-side asyncio cap).
+
+The new tool runs a read-only SELECT through the **same** allowlist +
+tenancy/RLS + read-only transaction as `run_select`, but on a
+**dedicated connection pool** isolated from the main one, with an
+**elevated, bounded** timeout — so a slow analytical query can never
+starve the fast-path tools. A per-call `timeout_ms` (clamped to the
+configured maximum) and optional `work_mem` are exposed, and a
+`run_select` timeout now points the agent at the tool so it needn't
+predict a query's duration up front.
+
+Boot-time knobs: `MCPG_ENABLE_ANALYTICAL_QUERIES` (default `true` — the
+authoritative off-switch; set `false` to withdraw the tool),
+`MCPG_ANALYTICAL_TIMEOUT_MS` (default 120000, 2 min),
+`MCPG_ANALYTICAL_MAX_TIMEOUT_MS` (600000, 10 min ceiling), and
+`MCPG_ANALYTICAL_MAX_CONCURRENCY` (2 — the isolated pool size, which is
+also the concurrency cap). Read-only and primary-database only for now.
+
+## New: cache-freshness controls for out-of-band schema changes
+
+MCPg's read cache is invalidated automatically by MCPg's own write/DDL
+tools, but it could serve stale introspection/advisor results for up to
+`MCPG_CACHE_TTL_SECONDS` (default 300 s) after a schema change made
+*outside* MCPg — a direct `psql`/migration change, another connection,
+or a second process. Re-running index/constraint validation after
+altering a foreign key could return the pre-change answer. Two escape
+hatches:
+
+- a per-call **`fresh: bool = False`** argument on the
+  introspection/advisor reads (`describe_table`, `list_indexes`,
+  `list_constraints`, `list_foreign_keys`, `get_compact_schema`,
+  `recommend_indexes`, `audit_database`) — bypasses the cache read,
+  re-queries live, and refreshes the entry;
+- a new **`clear_cache`** tool that flushes the whole result cache in one
+  call.
+
+## Security: `mcp` SDK bumped to ≥ 1.28.1
+
+Raised the `mcp` SDK floor from `≥ 1.25.0` to `≥ 1.28.1` to clear three
+advisories in the resolved `mcp` 1.27.1 (CVE-2026-52870,
+CVE-2026-52869, CVE-2026-59950). No MCPg source change was required —
+the per-request tenancy role path is unchanged in 1.28.1, and the full
+unit + contract suite passes. `pip-audit --strict` on the resolved
+runtime deps is clean.
+
+## Also in this release
+
+- **`run_analytical_query` hardening.** Query timeouts raise a typed
+  `QueryTimeoutError` detected structurally across the full
+  `__cause__`/`__context__` exception chain — covering both the
+  client-side asyncio cap and the server-side `statement_timeout`
+  (SQLSTATE 57014) — so the self-correcting hint fires reliably and
+  locale-independently.
+- **`pglast` 7.15 → 8.x** (the SQL-safety kernel's parser), tracking the
+  PostgreSQL 18 grammar. No behaviour change — the full adversarial +
+  fuzz + differential-parity SQL-kernel suites pass unchanged.
+
+## Upgrade
+
+```bash
+pip install --upgrade mcpg
+docker pull ghcr.io/devopam/mcpg:0.6.12   # or :latest
+```
+
+Or grab `mcpg-0.6.12.mcpb` from this release and double-click it into
+Claude Desktop. No configuration changes required.
+
+## Full changelog
+
+See [`../CHANGELOG.md`](../CHANGELOG.md) `[0.6.12]` for the complete
+itemised list.

--- a/packaging/mcpb/manifest.json
+++ b/packaging/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "mcpg",
   "display_name": "MCPg \u2014 PostgreSQL",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "description": "Production-grade PostgreSQL MCP server: 252 tools for querying, tuning, and operating Postgres \u2014 read-only by default.",
   "long_description": "MCPg lets AI agents safely inspect, query, operate, and tune a PostgreSQL database. 252 tools spanning catalog introspection, query intelligence, natural-language SQL, structural diffs, hybrid search, graph queries, live ops, and more.\n\n**Safe by default**: read-only access mode, AST-validated SQL, and every tool publishes MCP annotations (`readOnlyHint`/`destructiveHint`) so the client knows exactly which calls are safe. Write, DDL, shell, and LISTEN capabilities stay off until explicitly enabled via environment variables.\n\nNo data yet? Run `mcpg --demo` against a scratch database to seed a curated demo dataset and take the tools for a spin \u2014 see the guided tour at https://github.com/devopam/MCPg/blob/main/docs/demo.md.",
   "author": {

--- a/packaging/mcpb/pyproject.toml
+++ b/packaging/mcpb/pyproject.toml
@@ -5,9 +5,9 @@
 # to the release tag by the publish workflow, exactly like server.json.
 [project]
 name = "mcpg-desktop-extension"
-version = "0.6.11"
+version = "0.6.12"
 description = "MCPB launcher shim for the MCPg PostgreSQL MCP server."
 requires-python = ">=3.12"
 dependencies = [
-    "mcpg==0.6.11",
+    "mcpg==0.6.12",
 ]

--- a/src/mcpg/__init__.py
+++ b/src/mcpg/__init__.py
@@ -2,7 +2,7 @@
 
 import warnings
 
-__version__ = "0.6.11"
+__version__ = "0.6.12"
 
 # ``schema`` is the natural field name for "which Postgres schema" across
 # ~180 tool-return dataclasses. The ``mcp`` SDK dynamically builds a


### PR DESCRIPTION
## Summary

Cuts the **0.6.12** release. Rolls `[Unreleased]` → `[0.6.12] - 2026-07-28` and bumps `__version__` `0.6.11 → 0.6.12` (the single version source — `pyproject`, `mcpg --version`, and the MCP `serverInfo` handshake all derive from it).

What ships since 0.6.11:
- **New tool `run_analytical_query`** — long-running read-only SELECTs on a dedicated, concurrency-capped, timeout-elevated pool isolated from the fast path.
- **New cache-freshness controls** — a per-call `fresh` arg on 7 introspection/advisor reads + a `clear_cache` tool, for out-of-band schema changes.
- **Security:** `mcp` SDK floor raised to `≥ 1.28.1` (clears CVE-2026-52870 / -52869 / -59950).
- **Hardening:** `run_analytical_query` typed-timeout detection across the full exception chain; `pglast` parser bump.

Tool surface **254** (unchanged from trunk).

## Release mechanics

- Syncs the MCPB bundle pins to `0.6.12` (`packaging/mcpb/*` — `test_mcpb_bundle` enforces the match).
- `server.json` is **not** hand-edited — the `publish-mcp-registry` job derives its version from the tag at release time.
- Adds `docs/release-notes-0.6.12.md`, linked at the top of `docs/index.md`.

## Pre-flight (SOP §5)

- ✅ `ruff check` / `ruff format --check` / `mypy src/mcpg`
- ✅ `bandit` (exit 0) · `pip-audit --strict` (no known vulns)
- ✅ `python -m build` + `twine check` → `mcpg-0.6.12` sdist + wheel PASSED
- ✅ doc-tables contract + tool-count sweep (all 254) + MCPB bundle test
- ✅ Full unit + contract suite — **2869 passed, 1 skipped**

## After merge

Tagging `v0.6.12` on the merged commit triggers `publish.yml`. It runs build → TestPyPI → smoke, then **pauses at the `pypi` environment approval gate**. Nothing reaches real PyPI / GHCR / the MCP registry / GitHub Releases until the maintainer clicks **Approve and deploy** (doable from GitHub mobile/web).

## Roadmap linkage

Advances roadmap row: N/A — release chore.

## Checklist

- [x] Tests added/updated first (TDD); suite passes locally
- [x] `ruff`, `ruff format`, and `mypy src/mcpg` pass
- [x] `CHANGELOG.md` updated under `[Unreleased]` — rolled into `[0.6.12]`, fresh `[Unreleased]` on top
- [x] Roadmap row cited above (or `N/A`)
- [x] No hand-edits to `src/mcpg/_vendor/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Cut the 0.6.12 release and align versioning and documentation for the new build.

Build:
- Bump mcpg and mcpg-desktop-extension package versions and dependency pins from 0.6.11 to 0.6.12 in packaging metadata.

Documentation:
- Add v0.6.12 release notes file and link it from the documentation index.
- Roll CHANGELOG entries from Unreleased into a new [0.6.12] section with the release date.

Chores:
- Update the library __version__ constant to 0.6.12 to keep the single source of truth in sync.