### PR TITLE
fix(deps): cap mcp[cli] below 2.0 to unbreak fresh installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,14 @@ adheres to [Semantic Versioning](https://semver.org/).
   selector policy for psycopg (`__main__.py`, `http_runtime.run_http`) now
   fall back to the private name when the public one is gone, instead of
   raising `AttributeError` at startup on 3.14. Surfaced by `mypy --strict`
-  run on Windows (the repo's `python_version = "3.14"` target).
+  run on Windows (the repo's `python_version = "3.14"` target). Hardened
+  per review feedback (#290): the public-name lookup now uses
+  `try`/`except (AttributeError, NameError)` rather than
+  `getattr(..., default)`, since CPython 3.14's own deprecation shim can
+  raise `NameError` reading the removed name — a bare `getattr` with a
+  default only swallows `AttributeError` and would have re-raised
+  uncaught. Covered by
+  `test_run_http_falls_back_to_private_policy_name_when_public_name_raises`.
 - **Two Windows-only test bugs**, surfaced while verifying the above on a
   Windows dev box: `test_subprocess_hardening_parses_allowlist_and_limits`
   (and the adjacent relative-path-rejection test) hardcoded POSIX

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Capped `mcp[cli]` below 2.0** (`>=1.28.1,<2`). The upstream `mcp` SDK
+  published a `2.0.0` release that renames `mcp.server.fastmcp.FastMCP` to
+  `mcp.server.mcpserver.MCPServer` (and restructures the module tree around
+  it) with no back-compat shim — since MCPg's dependency spec had no upper
+  bound, a fresh `pip install mcpg` started resolving `mcp==2.0.0` and
+  crashing at import (`ModuleNotFoundError: No module named
+  'mcp.server.fastmcp'`) before `src/mcpg/server.py` could even start. Pins
+  the resolved SDK to the last compatible 1.x line until MCPg migrates to
+  the new `MCPServer` API (tracked separately). `uv.lock` regenerated
+  (resolves `mcp==1.28.1`); full unit + contract suite green.
+- **`asyncio.WindowsSelectorEventLoopPolicy` forward-compat for CPython
+  3.14.** CPython 3.14 privatized the class to
+  `_WindowsSelectorEventLoopPolicy` (confirmed against typeshed's
+  `windows_events.pyi`); the two Windows-only call sites that pin the
+  selector policy for psycopg (`__main__.py`, `http_runtime.run_http`) now
+  fall back to the private name when the public one is gone, instead of
+  raising `AttributeError` at startup on 3.14. Surfaced by `mypy --strict`
+  run on Windows (the repo's `python_version = "3.14"` target).
+- **Two Windows-only test bugs**, surfaced while verifying the above on a
+  Windows dev box: `test_subprocess_hardening_parses_allowlist_and_limits`
+  (and the adjacent relative-path-rejection test) hardcoded POSIX
+  `/usr/bin`-style paths that `os.path.isabs` doesn't accept on Windows —
+  now anchored via `abspath()` so the assertion holds on either platform.
+  `test_run_http_builds_app_and_serves_via_uvicorn`'s fake `uvicorn.run`
+  didn't accept the `loop` kwarg that `run_http` has always passed on
+  `win32` — now accepts `**kwargs`.
+
 ## [0.6.12] - 2026-07-28
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "mcp[cli]>=1.28.1",
+    "mcp[cli]>=1.28.1,<2",
     "psycopg[binary]>=3.3.2",
     "psycopg-pool>=3.3.0",
     "pglast==8.4",

--- a/src/mcpg/__main__.py
+++ b/src/mcpg/__main__.py
@@ -8,10 +8,26 @@ import sys
 if sys.platform == "win32":
     # CPython 3.14 privatized WindowsSelectorEventLoopPolicy to
     # _WindowsSelectorEventLoopPolicy; fall back to it when the public
-    # name is gone so this keeps working on 3.12-3.14.
-    _selector_policy_cls = (
-        getattr(asyncio, "WindowsSelectorEventLoopPolicy", None) or asyncio._WindowsSelectorEventLoopPolicy
-    )
+    # name is gone so this keeps working on 3.12-3.14. Reading the removed
+    # public name can raise NameError (not AttributeError) via asyncio's
+    # own deprecation shim, which a bare getattr(..., default) would NOT
+    # catch — a plain try/except is used instead, and a missing private
+    # name too fails with the clear RuntimeError below rather than an
+    # obscure AttributeError/NameError.
+    try:
+        # mypy's python_version=3.14 target sheds the public name from
+        # typeshed entirely (see pyproject.toml's [tool.mypy]) — this is
+        # exactly the removed-on-3.14 case the except branch below handles
+        # at runtime; ignore is scoped to this one attribute reference.
+        _selector_policy_cls = asyncio.WindowsSelectorEventLoopPolicy  # type: ignore[attr-defined]
+    except (AttributeError, NameError):
+        _selector_policy_cls = getattr(asyncio, "_WindowsSelectorEventLoopPolicy", None)
+    if _selector_policy_cls is None:
+        raise RuntimeError(
+            "mcpg: this Python's asyncio module exposes neither WindowsSelectorEventLoopPolicy "
+            "nor _WindowsSelectorEventLoopPolicy; the Windows selector-loop policy mcpg needs for "
+            "psycopg can't be set. Please file a bug with your Python version."
+        )
     asyncio.set_event_loop_policy(_selector_policy_cls())
 
 from mcpg import __version__

--- a/src/mcpg/__main__.py
+++ b/src/mcpg/__main__.py
@@ -6,7 +6,13 @@ import asyncio
 import sys
 
 if sys.platform == "win32":
-    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+    # CPython 3.14 privatized WindowsSelectorEventLoopPolicy to
+    # _WindowsSelectorEventLoopPolicy; fall back to it when the public
+    # name is gone so this keeps working on 3.12-3.14.
+    _selector_policy_cls = (
+        getattr(asyncio, "WindowsSelectorEventLoopPolicy", None) or asyncio._WindowsSelectorEventLoopPolicy
+    )
+    asyncio.set_event_loop_policy(_selector_policy_cls())
 
 from mcpg import __version__
 from mcpg.config import ConfigError, load_settings

--- a/src/mcpg/http_runtime.py
+++ b/src/mcpg/http_runtime.py
@@ -650,7 +650,13 @@ def run_http(server: object, settings: Settings, *, kind: str) -> None:
     # tell uvicorn to leave the loop alone (``loop="none"``) so it runs on
     # the loop our policy creates. No-op off Windows.
     if sys.platform == "win32":
-        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+        # CPython 3.14 privatized WindowsSelectorEventLoopPolicy to
+        # _WindowsSelectorEventLoopPolicy; fall back to it when the public
+        # name is gone so this keeps working on 3.12-3.14.
+        selector_policy_cls = (
+            getattr(asyncio, "WindowsSelectorEventLoopPolicy", None) or asyncio._WindowsSelectorEventLoopPolicy
+        )
+        asyncio.set_event_loop_policy(selector_policy_cls())
         tls_kwargs["loop"] = "none"
     # mypy can't reason about ``**dict[str, object]`` against the
     # large, overloaded ``uvicorn.run`` signature; the dict's contents

--- a/src/mcpg/http_runtime.py
+++ b/src/mcpg/http_runtime.py
@@ -652,10 +652,26 @@ def run_http(server: object, settings: Settings, *, kind: str) -> None:
     if sys.platform == "win32":
         # CPython 3.14 privatized WindowsSelectorEventLoopPolicy to
         # _WindowsSelectorEventLoopPolicy; fall back to it when the public
-        # name is gone so this keeps working on 3.12-3.14.
-        selector_policy_cls = (
-            getattr(asyncio, "WindowsSelectorEventLoopPolicy", None) or asyncio._WindowsSelectorEventLoopPolicy
-        )
+        # name is gone so this keeps working on 3.12-3.14. Reading the
+        # removed public name can raise NameError (not AttributeError) via
+        # asyncio's own deprecation shim, which a bare getattr(..., default)
+        # would NOT catch — a plain try/except is used instead, and a
+        # missing private name too fails with the clear RuntimeError below
+        # rather than an obscure AttributeError/NameError.
+        try:
+            # mypy's python_version=3.14 target sheds the public name from
+            # typeshed entirely (see pyproject.toml's [tool.mypy]) — this is
+            # exactly the removed-on-3.14 case the except branch below handles
+            # at runtime; ignore is scoped to this one attribute reference.
+            selector_policy_cls = asyncio.WindowsSelectorEventLoopPolicy  # type: ignore[attr-defined]
+        except (AttributeError, NameError):
+            selector_policy_cls = getattr(asyncio, "_WindowsSelectorEventLoopPolicy", None)
+        if selector_policy_cls is None:
+            raise RuntimeError(
+                "mcpg: this Python's asyncio module exposes neither WindowsSelectorEventLoopPolicy "
+                "nor _WindowsSelectorEventLoopPolicy; the Windows selector-loop policy mcpg needs for "
+                "psycopg can't be set. Please file a bug with your Python version."
+            )
         asyncio.set_event_loop_policy(selector_policy_cls())
         tls_kwargs["loop"] = "none"
     # mypy can't reason about ``**dict[str, object]`` against the

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,5 +1,7 @@
 """Tests for the env-driven configuration loader."""
 
+from os.path import abspath
+
 import pytest
 
 from mcpg.config import AccessMode, ConfigError, Transport, load_settings
@@ -986,15 +988,19 @@ def test_subprocess_hardening_defaults_to_open() -> None:
 
 
 def test_subprocess_hardening_parses_allowlist_and_limits() -> None:
+    # "/usr/bin"-style paths are absolute on POSIX but not per Windows'
+    # isabs (no drive letter) — abspath() anchors them to something
+    # isabs() accepts on either platform without changing what's asserted.
+    bin_dir, local_bin_dir = abspath("/usr/bin"), abspath("/usr/local/bin")
     settings = load_settings(
         {
             "MCPG_DATABASE_URL": _DB_URL,
-            "MCPG_SUBPROCESS_BIN_ALLOWLIST": "/usr/bin, /usr/local/bin",
+            "MCPG_SUBPROCESS_BIN_ALLOWLIST": f"{bin_dir}, {local_bin_dir}",
             "MCPG_SUBPROCESS_CPU_SECONDS": "30",
             "MCPG_SUBPROCESS_MEMORY_MB": "512",
         }
     )
-    assert settings.subprocess_bin_allowlist == ("/usr/bin", "/usr/local/bin")
+    assert settings.subprocess_bin_allowlist == (bin_dir, local_bin_dir)
     assert settings.subprocess_cpu_seconds == 30
     assert settings.subprocess_memory_mb == 512
 
@@ -1004,7 +1010,7 @@ def test_subprocess_bin_allowlist_rejects_relative_paths() -> None:
         load_settings(
             {
                 "MCPG_DATABASE_URL": _DB_URL,
-                "MCPG_SUBPROCESS_BIN_ALLOWLIST": "/usr/bin, relative/dir",
+                "MCPG_SUBPROCESS_BIN_ALLOWLIST": f"{abspath('/usr/bin')}, relative/dir",
             }
         )
 

--- a/tests/unit/test_http_runtime.py
+++ b/tests/unit/test_http_runtime.py
@@ -822,7 +822,10 @@ def test_run_http_builds_app_and_serves_via_uvicorn(monkeypatch: pytest.MonkeyPa
 
     captured: dict[str, object] = {}
 
-    def _fake_run(app: object, *, host: str, port: int) -> None:
+    def _fake_run(app: object, *, host: str, port: int, **kwargs: object) -> None:
+        # **kwargs swallows the win32-only ``loop="none"`` kwarg
+        # (see http_runtime.run_http) without coupling this test to
+        # the host platform.
         captured["app"] = app
         captured["host"] = host
         captured["port"] = port

--- a/tests/unit/test_http_runtime.py
+++ b/tests/unit/test_http_runtime.py
@@ -845,6 +845,57 @@ def test_run_http_builds_app_and_serves_via_uvicorn(monkeypatch: pytest.MonkeyPa
     assert captured["app"] is not None
 
 
+def test_run_http_falls_back_to_private_policy_name_when_public_name_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CPython 3.14 privatized WindowsSelectorEventLoopPolicy; reading the
+    old public name can raise NameError (not AttributeError) via the
+    module's own deprecation shim — see the comment on
+    test_run_http_pins_selector_loop_on_windows. A bare
+    ``getattr(asyncio, name, default)`` does NOT catch NameError, only
+    AttributeError, so this simulates that exact shim to prove the
+    fallback to the private name still works."""
+    import asyncio
+
+    from mcpg import http_runtime
+
+    settings = load_settings({"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db"})
+
+    captured_kwargs: dict[str, object] = {}
+
+    def _fake_run(app: object, *, host: str, port: int, **kwargs: object) -> None:
+        captured_kwargs.update(kwargs)
+
+    class _FakePrivateSelectorPolicy:
+        pass
+
+    def _raising_getattr(name: str) -> object:
+        if name == "WindowsSelectorEventLoopPolicy":
+            raise NameError(f"module 'asyncio' has no attribute {name!r} (renamed in 3.14)")
+        raise AttributeError(name)
+
+    policy_calls: list[object] = []
+
+    import uvicorn
+
+    monkeypatch.setattr(uvicorn, "run", _fake_run)
+    monkeypatch.setattr(http_runtime.sys, "platform", "win32")
+    monkeypatch.delitem(asyncio.__dict__, "WindowsSelectorEventLoopPolicy", raising=False)
+    monkeypatch.setattr(asyncio, "__getattr__", _raising_getattr, raising=False)
+    monkeypatch.setitem(asyncio.__dict__, "_WindowsSelectorEventLoopPolicy", _FakePrivateSelectorPolicy)
+    monkeypatch.setattr(asyncio, "set_event_loop_policy", lambda policy: policy_calls.append(policy))
+
+    class _Stub:
+        def streamable_http_app(self) -> Starlette:
+            return _bare_app()
+
+    http_runtime.run_http(_Stub(), settings, kind="streamable-http")
+
+    assert captured_kwargs.get("loop") == "none"
+    assert len(policy_calls) == 1
+    assert isinstance(policy_calls[0], _FakePrivateSelectorPolicy)
+
+
 def test_run_http_pins_selector_loop_on_windows(monkeypatch: pytest.MonkeyPatch) -> None:
     # async psycopg dies on the ProactorEventLoop; uvicorn reinstalls the
     # proactor policy on Windows, so run_http must re-pin the selector

--- a/uv.lock
+++ b/uv.lock
@@ -1178,7 +1178,7 @@ requires-dist = [
     { name = "google-cloud-secret-manager", marker = "extra == 'gcp'", specifier = ">=2.16" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "hvac", marker = "extra == 'vault'", specifier = ">=1.0" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.28.1" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.28.1,<2" },
     { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.27" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'otel'", specifier = ">=1.27" },
     { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.27" },


### PR DESCRIPTION
## Summary

- Upstream `mcp` SDK just published `2.0.0`, which renames `mcp.server.fastmcp.FastMCP` to `mcp.server.mcpserver.MCPServer` with no back-compat shim. MCPg's dependency spec (`mcp[cli]>=1.28.1`) had no upper bound, so a fresh `pip install mcpg` today resolves `mcp==2.0.0` and crashes at import (`ModuleNotFoundError: No module named 'mcp.server.fastmcp'`) before the server can even start.
- Caps the spec to `>=1.28.1,<2` and regenerates `uv.lock` (resolves `mcp==1.28.1`). Migrating MCPg itself onto the new `MCPServer` API is tracked as separate follow-up work — this PR is the hotfix that unbreaks installs in the meantime.
- While verifying this on a Windows dev box, surfaced and fixed two unrelated, pre-existing bugs blocking a clean local `mypy`/test run (both reproduce identically on unmodified `main`, confirmed via `git stash`):
  - CPython 3.14 privatized `asyncio.WindowsSelectorEventLoopPolicy` to `_WindowsSelectorEventLoopPolicy` (confirmed against typeshed's `windows_events.pyi`). The two Windows-only call sites that pin the selector policy for psycopg (`__main__.py`, `http_runtime.run_http`) now fall back to the private name when the public one is gone.
  - Two tests hardcoded POSIX-only assumptions that only fail when actually run on Windows: a subprocess-allowlist test asserted `/usr/bin`-style paths are absolute (`os.path.isabs` disagrees on Windows), and the `http_runtime` uvicorn test's fake `run()` didn't accept the `loop` kwarg the win32 code path has always passed.

## Roadmap linkage

Advances roadmap row: N/A — dependency hotfix + pre-existing Windows compatibility fixes, no feature-shortlist row.

## Test plan

- [x] `uv run mypy src/mcpg` — clean (0 errors, down from 2 pre-existing)
- [x] `uv run pytest tests/unit tests/contract -q` — 2867 passed, 3 skipped, 0 failed
- [x] `uv run ruff check` / `uv run ruff format --check` — clean
- [x] `mcpg --version` / `mcpg --help` manually verified against the regenerated lockfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Cap the MCP CLI dependency below 2.0 and add Windows compatibility fixes to keep installs and runtime working across supported Python versions.

Bug Fixes:
- Cap mcp[cli] dependency to the 1.x line to avoid breaking imports with the upstream 2.0 SDK.
- Restore Windows event loop policy configuration on Python 3.14 so the server starts correctly on win32.
- Fix Windows-specific subprocess allowlist tests so path assertions behave consistently across platforms.
- Update the HTTP runtime uvicorn test stub to accept the loop kwarg used on Windows.

Tests:
- Adjust subprocess configuration tests to use platform-agnostic absolute paths and maintain coverage on Windows.
- Relax the fake uvicorn.run signature in HTTP runtime tests to accommodate Windows-specific kwargs without coupling to the host platform.