### PR TITLE
fix: friendly error for missing required tool arguments (#287)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Friendly error for a missing required tool argument (#287).** Calling
+  any tool with a required argument omitted used to leak the MCP SDK's raw
+  `pydantic` `ValidationError` dump — including a `For further information
+  visit https://errors.pydantic.dev/...` link — to both the MCP client and
+  the audit log, e.g. `Error executing tool list_indexes: 1 validation
+  error for list_indexesArguments\ntable\n  Field required [type=missing,
+  ...]`. This was generic to every tool (the failure happens in the shared
+  MCP SDK argument-validation path, not per-tool code).
+  `AuditedFastMCP.call_tool` in `src/mcpg/server.py` now detects a
+  `pydantic.ValidationError` (directly, or as the SDK's wrapping
+  `ToolError.__cause__`) and replaces it with a short, actionable message
+  built from `ValidationError.errors()` before it reaches the audit log or
+  the client, e.g. `list_indexes: table: Field required`. Non-validation
+  tool errors (e.g. a plain `ValueError`/`RuntimeError` raised for a
+  business-logic reason) are unaffected — only the pydantic-validation-error
+  case is reformatted.
 - **`translate_nl_to_sql` now reports its internal LLM call's token usage.**
   The tool makes its own HTTP call to whichever NL→SQL provider is
   configured — independent of and invisible to whatever's driving MCPg over

--- a/src/mcpg/server.py
+++ b/src/mcpg/server.py
@@ -15,7 +15,9 @@ from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
 from mcp.types import ContentBlock
+from pydantic import ValidationError
 
 from mcpg import __version__, about, audit
 from mcpg.analytical import AnalyticalRunner
@@ -28,6 +30,22 @@ from mcpg.middleware.rate_limit import RateLimiter
 from mcpg.observability import get_metrics
 from mcpg.otel_tracing import TracerHandle, setup_tracing, tool_span
 from mcpg.tools import register_tools
+
+
+def _friendly_validation_error(tool_name: str, error: ValidationError) -> str:
+    """Build a short, actionable message from a pydantic ``ValidationError``.
+
+    The MCP SDK's tool-argument validation (a required argument missing, or
+    an argument of the wrong type) raises a raw ``pydantic``
+    ``ValidationError`` that the SDK stringifies verbatim into a
+    ``ToolError`` — a multi-line dump including a noisy
+    ``errors.pydantic.dev`` link (see GH #287). This collapses it into one
+    line per error using each error's already-human-readable ``msg`` (e.g.
+    "Field required"), keyed by its field path.
+    """
+    details = "; ".join(f"{'.'.join(str(part) for part in err['loc'])}: {err['msg']}" for err in error.errors())
+    return f"{tool_name}: {details}"
+
 
 SERVER_NAME = "mcpg"
 SERVER_INSTRUCTIONS = (
@@ -99,6 +117,22 @@ class AuditedFastMCP(FastMCP[AppContext]):
             except Exception as exc:
                 duration = time.monotonic() - start
                 self._log_if_slow(name, duration)
+                # The SDK's argument-validation failure surfaces here as a
+                # ToolError whose message is str(ValidationError) (chained
+                # via __cause__); some paths may raise the ValidationError
+                # directly, so check both defensively. Either way, replace
+                # it with a friendly message before it's used below, since
+                # both the audit log (`error=`) and the client-visible
+                # message (further up the call stack) read from this same
+                # exception object. See GH #287.
+                validation_error = exc if isinstance(exc, ValidationError) else exc.__cause__
+                if isinstance(validation_error, ValidationError):
+                    friendly_exc = ToolError(_friendly_validation_error(name, validation_error))
+                    audit.record(
+                        audit.AuditEvent(tool=name, arguments=arguments, status="error", error=str(friendly_exc))
+                    )
+                    metrics.record_call(name, "error", duration, bucket=bucket)
+                    raise friendly_exc from exc
                 audit.record(audit.AuditEvent(tool=name, arguments=arguments, status="error", error=str(exc)))
                 metrics.record_call(name, "error", duration, bucket=bucket)
                 raise

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -132,6 +132,84 @@ async def test_lifespan_waits_for_in_flight_calls_to_drain() -> None:
     assert server.in_flight_calls == 0
 
 
+async def test_call_tool_missing_required_argument_returns_friendly_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Issue #287: a missing required argument must produce a short,
+    actionable message — not the raw multi-line pydantic ``ValidationError``
+    dump (which includes a noisy ``errors.pydantic.dev`` link) — both in
+    what the client sees (the raised/returned exception) and in the audit
+    log, since both read from the same exception object.
+    """
+    import logging
+
+    server = create_server(_SETTINGS)
+
+    def fake_tool(required_arg: str) -> dict[str, bool]:
+        return {"ok": True}
+
+    server.add_tool(fake_tool, name="fake_tool")
+
+    mcpg_logger = logging.getLogger("mcpg")
+    old_propagate = mcpg_logger.propagate
+    mcpg_logger.propagate = True
+    try:
+        with caplog.at_level(logging.WARNING, logger="mcpg.audit"), pytest.raises(Exception) as exc_info:
+            await server.call_tool("fake_tool", {})
+    finally:
+        mcpg_logger.propagate = old_propagate
+
+    message = str(exc_info.value)
+    assert "errors.pydantic.dev" not in message
+    assert "validation error for" not in message
+    assert "fake_tool" in message
+    assert "required_arg" in message
+
+    audit_warnings = [r for r in caplog.records if r.levelname == "WARNING" and r.name == "mcpg.audit"]
+    assert len(audit_warnings) == 1
+    audit_message = audit_warnings[0].message
+    assert "errors.pydantic.dev" not in audit_message
+    assert "validation error for" not in audit_message
+    assert "fake_tool" in audit_message
+    assert "required_arg" in audit_message
+
+
+async def test_call_tool_validation_error_does_not_leak_other_argument_values(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The raw pydantic dump embeds ``input_value={...}`` — the full,
+    *unredacted* arguments dict — into the error text. ``audit.record``
+    masks the ``arguments=`` field via ``redact_arguments``, but only runs
+    ``obfuscate_password`` (DSN passwords only) over the ``error=`` field,
+    so a secret-named argument supplied alongside a missing required one
+    previously reached the audit sink in the clear via the raw dump's
+    ``input_value``. The friendly message is built only from ``loc``/``msg``
+    and never touches the submitted values, so this can no longer leak.
+    """
+    import logging
+
+    server = create_server(_SETTINGS)
+
+    def fake_tool(required_arg: str, password: str) -> dict[str, bool]:
+        return {"ok": True}
+
+    server.add_tool(fake_tool, name="fake_tool_with_secret")
+
+    mcpg_logger = logging.getLogger("mcpg")
+    old_propagate = mcpg_logger.propagate
+    mcpg_logger.propagate = True
+    try:
+        with caplog.at_level(logging.WARNING, logger="mcpg.audit"), pytest.raises(Exception) as exc_info:
+            await server.call_tool("fake_tool_with_secret", {"password": "hunter2"})
+    finally:
+        mcpg_logger.propagate = old_propagate
+
+    assert "hunter2" not in str(exc_info.value)
+    audit_warnings = [r for r in caplog.records if r.levelname == "WARNING" and r.name == "mcpg.audit"]
+    assert len(audit_warnings) == 1
+    assert "hunter2" not in audit_warnings[0].message
+
+
 async def test_lifespan_drain_timeout() -> None:
     import dataclasses
     import time


### PR DESCRIPTION
## Summary

Calling any MCP tool with a required argument omitted returned the MCP SDK's raw `pydantic` `ValidationError` dump — including a `For further information visit https://errors.pydantic.dev/...` link — to both the MCP client and the audit log, instead of a short, actionable message. This was generic to every tool (the failure happens in the shared MCP SDK argument-validation path, not per-tool code), matching the exact reproduction in #287:

```
Error executing tool list_indexes: 1 validation error for list_indexesArguments
table
  Field required [type=missing, input_value={'schema': 'public', 'database': 'bench'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.13/v/missing
```

`AuditedFastMCP.call_tool` in `src/mcpg/server.py` is the single first-party interception point through which both the client-visible message and the audit log's `error=` field flow (both read `str()` of the same re-raised exception). It now detects a `pydantic.ValidationError` — either directly, or as the SDK's wrapping `ToolError.__cause__` — and replaces it with a short message built from `ValidationError.errors()`'s `loc`/`msg` before it reaches either consumer:

```
list_indexes: table: Field required
```

(verified live against the actual `list_indexes` tool with the issue's exact repro arguments). Non-validation tool errors (a plain `ValueError`/`RuntimeError` raised for a business-logic reason) are unaffected — only the pydantic-validation-error case is reformatted; see `tests/unit/test_slow_call.py::test_slow_call_warning_emitted_on_error_path`, which patches a raw `ValueError` through the same code path and asserts it's re-raised untouched.

As a side effect, this also closes a minor audit-redaction gap: the raw dump's `input_value={...}` embedded the *unredacted* submitted arguments into the audit log's `error=` field (which only runs `obfuscate_password`, not the `arguments=` field's `redact_arguments` masking) — so a secret-named argument submitted alongside a missing required one previously reached the audit sink in the clear. The friendly message is built only from `loc`/`msg` and never touches submitted values, so this can no longer leak. Covered by a new test.

Does **not** add a schema-wide "optional table" mode to `list_indexes` — the issue explicitly flags that as a possible separate future follow-up, out of scope here.

## Roadmap linkage

Advances roadmap row: N/A — bugfix (#287)

## Checklist

- [x] Tests added/updated first (TDD); suite passes locally
- [x] `ruff`, `ruff format`, and `mypy src/mcpg` pass
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Roadmap row cited above (or `N/A`); row marked ✅ when this PR completes it
- [x] No hand-edits to `src/mcpg/_vendor/`

## Test plan

- [x] `uv run pytest tests/unit/test_server.py -v` — new tests pass, nothing else in the file broke
- [x] `uv run pytest tests/unit tests/contract -q` — full suite green (2879 passed, 3 skipped)
- [x] `uv run mypy src/mcpg` — clean
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] Confirmed via `tests/unit/test_slow_call.py::test_slow_call_warning_emitted_on_error_path` that a non-validation tool error's message is unchanged

Fixes #287

## Summary by Sourcery

Improve MCP tool error handling by converting raw pydantic validation errors for missing or invalid arguments into concise, user-friendly messages and ensuring they are consistently used for client responses and audit logging.

Bug Fixes:
- Normalize argument-validation failures into short messages that reference the tool and offending fields instead of exposing the raw multi-line pydantic ValidationError dump.
- Prevent leaking unredacted tool argument values into audit logs by avoiding inclusion of pydantic ValidationError input_value data in recorded error messages.

Enhancements:
- Introduce a helper to format pydantic validation errors into concise, per-field messages reused for both client-visible errors and audit logging.

Documentation:
- Document the improved handling of missing required tool arguments in the unreleased changelog section.

Tests:
- Add regression tests to verify friendly error messages for missing required tool arguments and to ensure secret argument values are not leaked through validation error text.