### PR TITLE
Add StackHawk CI workflow for dynamic security testing

### DIFF
--- a/.github/workflows/stackhawk.yml
+++ b/.github/workflows/stackhawk.yml
@@ -1,0 +1,63 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+#           🦅 STACKHAWK        https://stackhawk.com
+
+# The StackHawk HawkScan action makes it easy to integrate dynamic application security testing (DAST) into your
+# CI pipeline. See the Getting Started guide (https://docs.stackhawk.com/hawkscan/) to get up and running with
+# StackHawk quickly.
+
+# To use this workflow, you must:
+#
+# 1.  Create an API Key and Application: Sign up for a free StackHawk account to obtain an API Key and
+#     create your first app and configuration file at https://app.stackhawk.com.
+#
+# 2.  Save your API Key as a Secret: Save your API key as a GitHub Secret named HAWK_API_KEY.
+#
+# 3.  Add your Config File: Add your stackhawk.yml configuration file to the base of your repository directory.
+#
+# 4.  Set the Scan Failure Threshold: Add the hawk.failureThreshold configuration option
+#     (https://docs.stackhawk.com/hawkscan/configuration/#hawk) to your stackhawk.yml configuration file. If your scan
+#     produces alerts that meet or exceed the hawk.failureThreshold alert level, the scan will return exit code 42
+#     and trigger a Code Scanning alert with a link to your scan results.
+#
+# 5.  Update the "Start your service" Step: Update the "Start your service" step in the StackHawk workflow below to
+#     start your service so that it can be scanned with the "Run HawkScan" step.
+
+
+name: "StackHawk"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '29 20 * * 2'
+
+permissions:
+  contents: read
+
+jobs:
+  stackhawk:
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for stackhawk/hawkscan-action to upload code scanning alert info
+    name: StackHawk
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Start your service
+        run: ./your-service.sh &                  # ✏️ Update this to run your own service to be scanned
+
+      - name: Run HawkScan
+        uses: stackhawk/hawkscan-action@4c3258cd62248dac6d9fe91dd8d45928c697dee0
+        continue-on-error: true                   # ✏️ Set to false to break your build on scan errors
+        with:
+          apiKey: ${{ secrets.HAWK_API_KEY }}
+          codeScanningAlerts: true
+          githubToken: ${{ github.token }}


### PR DESCRIPTION
## Summary

<!-- What does this PR change, and why? -->

## Roadmap linkage

<!--
Cite the roadmap row this PR advances, one per line, in the form:

  Advances roadmap row: 8.6

The id is the leading cell of the row in docs/feature-shortlist.md
(e.g. 8.6, 15.2). Reviewers validate + clear the row at merge with:

  python tools/roadmap_linkage.py check 8.6

Use "N/A — <reason>" for chores / infra PRs with no roadmap row.
-->

Advances roadmap row:

## Checklist

- [ ] Tests added/updated first (TDD); suite passes locally
- [ ] `ruff`, `ruff format`, and `mypy src/mcpg` pass
- [ ] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] Roadmap row cited above (or `N/A`); row marked ✅ when this PR completes it
- [ ] No hand-edits to `src/mcpg/_vendor/`

## Summary by Sourcery

CI:
- Introduce a StackHawk GitHub Actions workflow that checks out the repository, starts the target service, and runs HawkScan with code scanning alerts enabled.