### PR TITLE
security: hash-pin publish.yml TestPyPI installs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,55 @@
+name: CodeQL
+
+# Explicit workflow (replaces GitHub's "default setup") for two reasons:
+# 1. Scorecard's SAST check only recognizes a workflow file running
+#    github/codeql-action — "default setup" scans just as thoroughly but
+#    is invisible to that static check (scorecard alert #54).
+# 2. Running on `pull_request` (not just a schedule) gates every PR, not
+#    just periodic scans of main.
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "23 8 * * 3"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      # Required to upload SARIF results.
+      security-events: write
+      # Required to fetch the source.
+      contents: read
+      # Required for the "actions" language (workflow analysis).
+      actions: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # Matches this repo's actual content — pure Python plus the
+        # workflow files themselves. (Default setup had also flagged
+        # c-cpp from autodetection; there's no C/C++ source in the repo,
+        # only vendored build artifacts under the gitignored .venv/.)
+        language: ["python", "actions"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@e60ea984bd3baa95954f2856bcf24f9eaba46637 # v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@e60ea984bd3baa95954f2856bcf24f9eaba46637 # v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -127,8 +127,17 @@ jobs:
         # just dependency confusion.
         run: |
           VER="${GITHUB_REF_NAME#v}"
-          WHEEL="$(ls dist/mcpg-"${VER}"-*.whl)"
+          mapfile -t WHEELS < <(ls dist/mcpg-"${VER}"-*.whl)
+          if [ "${#WHEELS[@]}" -ne 1 ]; then
+            echo "::error::Expected exactly one wheel for mcpg==${VER} in dist/, found ${#WHEELS[@]}: ${WHEELS[*]}"
+            exit 1
+          fi
+          WHEEL="${WHEELS[0]}"
           HASH="$(python -m pip hash "$WHEEL" | sed -n 's/^--hash=sha256://p')"
+          if ! [[ "$HASH" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "::error::pip hash output for $WHEEL did not look like a sha256 hex digest: '${HASH}'"
+            exit 1
+          fi
           echo "mcpg==${VER} --hash=sha256:${HASH}" > /tmp/mcpg-pin.txt
           for i in 1 2 3; do
             if python -m pip install --no-deps \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,14 +79,21 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.14"
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: dist
+          path: dist/
       - name: Install runtime deps from real PyPI (anti-confusion)
         # TestPyPI is a public sandbox; combining its index with
         # ``--extra-index-url=pypi`` lets an attacker shadow our
         # deps with a higher-numbered fake (dependency confusion).
         # Step 1 pins real PyPI only, dep list canonically derived
-        # from pyproject.toml.
+        # from pyproject.toml. Hashes come from uv's own lockfile
+        # resolution, so pip refuses to install anything whose
+        # artifact doesn't match what we resolved (belt-and-braces
+        # on top of the index pinning above).
         run: |
-          uv export --no-dev --no-emit-project --no-hashes \
+          uv export --no-dev --no-emit-project \
             --format requirements-txt > /tmp/mcpg-deps.txt
           python -m pip install -r /tmp/mcpg-deps.txt
       - name: Wait for TestPyPI to index the upload
@@ -110,16 +117,23 @@ jobs:
           done
           echo "::error::TestPyPI simple index never listed mcpg==${VER}"
           exit 1
-      - name: Install mcpg from TestPyPI (no deps)
+      - name: Install mcpg from TestPyPI (no deps, hash-pinned)
         # A short retry on the install itself too: even after the simple
         # index origin has the version, a CDN edge cache in front of it can
-        # lag a few more seconds.
+        # lag a few more seconds. The hash comes from the wheel this same
+        # workflow run built and uploaded a few steps ago (downloaded
+        # above) — TestPyPI serves that identical file back byte-for-byte,
+        # so pinning to it also catches any upload-path tampering, not
+        # just dependency confusion.
         run: |
           VER="${GITHUB_REF_NAME#v}"
+          WHEEL="$(ls dist/mcpg-"${VER}"-*.whl)"
+          HASH="$(python -m pip hash "$WHEEL" | sed -n 's/^--hash=sha256://p')"
+          echo "mcpg==${VER} --hash=sha256:${HASH}" > /tmp/mcpg-pin.txt
           for i in 1 2 3; do
             if python -m pip install --no-deps \
                 --index-url https://test.pypi.org/simple/ \
-                "mcpg==${VER}"; then
+                -r /tmp/mcpg-pin.txt; then
               exit 0
             fi
             echo "pip install attempt $i/3 failed; retrying in 10s..."

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,2 @@
+version: 1
+verification: "21ea4bfd62e446e674040d0da57bdd3c1cd1dba72dcbe832bb90a55b47d6e11c"


### PR DESCRIPTION
## Summary
- Closes Scorecard **Pinned-Dependencies** alert #49 — the real-PyPI runtime-deps install in `smoke-testpypi` now uses `uv export`'s own hash resolution (dropped `--no-hashes`) instead of bare version pins.
- Closes alert #50 — the `mcpg==${VER}` install from TestPyPI is now pinned to the sha256 of the wheel this same workflow run built (downloaded via the existing `dist` artifact). TestPyPI serves that identical file back byte-for-byte, so this also catches upload-path tampering, not just dependency confusion — strictly stronger than the index-pinning it already had.
- Adds `smithery.yaml` (previously untracked; contains the Smithery registry verification hash).

Alerts #48 (`huggingface_hub` pin in the non-gating HF-Space-refresh job) and #43 (`ci-postgres.Dockerfile`'s intentionally-unpinned, `PG_MAJOR`-parameterized `FROM`) were dismissed via the code-scanning API with documented rationale rather than force-fixed — both are proportionality calls (non-gating/low-risk convenience step; a real fix would require hardcoding a hash list, or would break the PG 14-19 CI matrix, respectively).

## Test plan
- [x] `ruff check` / `ruff format --check` / `mypy --strict src/mcpg` / `bandit` / `uv audit` / full `pytest tests/unit` (2853 passed, 3 skipped) — all via the repo's pre-commit hook
- [x] Local verification: `uv export --format requirements-txt` (with hashes) into a fresh `uv venv --seed` installs the full 44-package dependency set cleanly via pip's hash-checking mode
- [x] YAML syntax validated (`yaml.safe_load`)
- [ ] Will confirm on next actual release cut that `smoke-testpypi` passes with the hash-pinned installs end-to-end (this can't be dry-run outside a real tag push, since it depends on the TestPyPI-published artifact)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

## Summary by Sourcery

Strengthen the publish workflow’s dependency and artifact integrity checks for TestPyPI smoke tests.

New Features:
- Add hash-pinned installation of the TestPyPI mcpg wheel using the artifact built in the same workflow.
- Track Smithery registry verification data in a new smithery.yaml file.

Enhancements:
- Ensure runtime dependencies installed from real PyPI during smoke tests use uv-generated requirement hashes instead of bare version pins.