### PR TITLE
security: pin ClusterFuzzLite base image digest, close residual Scorecard alerts

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -4,7 +4,12 @@
 # surface. Atheris and the OSS-Fuzz Python toolchain are pre-installed on
 # this base image — see
 # https://google.github.io/oss-fuzz/getting-started/new-project-guide/python-lang/
-FROM gcr.io/oss-fuzz-base/base-builder-python
+#
+# Pinned to the digest current as of 2026-08-05 (verified against the gcr.io
+# registry, matches Scorecard's own remediation tip). Bump manually when
+# OSS-Fuzz ships toolchain/atheris updates — same convention the rest of
+# this repo's Dockerfiles already follow.
+FROM gcr.io/oss-fuzz-base/base-builder-python@sha256:6b2b3a7e4a2da50de47f94925cffbe34747e1aae4f33d7f07ba6c681dd648b23
 
 COPY . $SRC/mcpg
 WORKDIR $SRC/mcpg


### PR DESCRIPTION
## Summary
Follow-up to #299/#300 — after those merged, a fresh Scorecard scan surfaced 4 alerts (#49 recurred, #61/#62/#63 new). Root-caused before touching anything:

- **#49/#61** (`publish.yml`'s two pip installs): the security property was already real (`uv.lock` pins every dep to exact version+hash; both steps run seconds apart in the same ephemeral runner), but Scorecard's Pinned-Dependencies check is a **static text scan** of the workflow YAML — it can't see hash values that only exist in a file generated at runtime (`uv export ... > /tmp/...`). Verified this was the actual PR #299 fix's blind spot, not a regression. **Dismissed** rather than re-fixed: a Scorecard-visible fix would need a hand-maintained hash lockfile or ~140 inline hashes, worse maintenance trade than the residual risk.
- **#62** (`.clusterfuzzlite/Dockerfile`): genuine miss — added in #300 without applying this repo's own Docker-digest-pinning convention. **Fixed** here: pinned to the digest current as of today, verified directly against the gcr.io registry (matches Scorecard's own remediation tip exactly).
- **#63** (`.clusterfuzzlite/build.sh`): `pip3 install .` installs the current commit's own unversioned local source — nothing to hash-pin against structurally, same category as the existing `ci-postgres.Dockerfile` exception. **Dismissed**.

## Test plan
- [x] Verified the pinned digest (`sha256:6b2b3a7e4a2da50de47f94925cffbe34747e1aae4f33d7f07ba6c681dd648b23`) directly against `gcr.io/v2/oss-fuzz-base/base-builder-python/manifests/latest` before committing to it
- [x] Full pre-commit suite (ruff/mypy/bandit/uv-audit/2853 unit tests) passed
- [x] All 4 alerts (#49, #61, #62 fix pending merge, #63) triaged with documented reasoning via the code-scanning API — dismissal comments visible on each alert
- [ ] Will confirm the ClusterFuzzLite build still succeeds against the pinned digest on this PR's own CI run

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>