### PR TITLE
chore: stop server.json's checked-in version from drifting, add websiteUrl

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -234,27 +234,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Sync server.json version to the release tag
-        # server.json is checked in with a fixed version (bumped manually at
-        # the 0.6.1 registry launch and never since — every subsequent
-        # release silently re-submitted "0.6.1" and the registry rejected it
-        # as a duplicate). Deriving the version from the tag here means this
-        # step can never go stale again, the same way the sdist/wheel build
-        # derives its version from pyproject.toml rather than a hand-maintained
-        # constant.
+        # server.json's checked-in version is bumped manually as part of
+        # the release (docs/release-process.md §4.2, guarded by
+        # tests/unit/test_server_json.py) via the same
+        # tools/sync_server_json_version.py this step calls. Re-running it
+        # here against the tag is a safety net, not the primary
+        # mechanism — it's what stops a forgotten manual bump from making
+        # the registry reject the release as a duplicate version (the
+        # failure mode from the 0.6.1 launch that motivated this step
+        # originally, when the checked-in version never got re-synced).
         run: |
           VER="${GITHUB_REF_NAME#v}"
-          python3 -c "
-          import json
-          path = 'server.json'
-          with open(path) as f:
-              data = json.load(f)
-          data['version'] = '$VER'
-          for pkg in data.get('packages', []):
-              pkg['version'] = '$VER'
-          with open(path, 'w') as f:
-              json.dump(data, f, indent=2)
-              f.write('\n')
-          "
+          python3 tools/sync_server_json_version.py "$VER"
           cat server.json
       - name: Install mcp-publisher
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`server.json` now sets `websiteUrl`** (`https://devopam.github.io/MCPg/`),
+  the field the MCP Registry surfaces as the server's homepage link.
+
+### Fixed
+
+- **`server.json`'s checked-in version no longer drifts.** It tracked
+  a stale release (last hand-bumped at `0.6.8`) because the registry
+  publish job only patched a version derived from the tag in the CI
+  checkout, never committing it back. Added
+  `tools/sync_server_json_version.py` (mirrors the existing `.mcpb`
+  bundle sync script) plus `tests/unit/test_server_json.py`, which
+  fails CI if the checked-in version stops matching
+  `mcpg.__version__` — same guard pattern as `test_mcpb_bundle.py`.
+  `docs/release-process.md` §4.2 now lists the sync as an explicit
+  release step.
+
 ## [0.7.1] - 2026-08-04
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 - **`server.json` now sets `websiteUrl`** (`https://devopam.github.io/MCPg/`),
   the field the MCP Registry surfaces as the server's homepage link.
+- **OpenSSF Best Practices badge** added to the README badge row
+  (project [13958](https://www.bestpractices.dev/projects/13958),
+  `passing`).
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ graph queries, data movement, live ops, and more.
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/devopam/MCPg/blob/main/LICENSE)
 [![CI](https://github.com/devopam/MCPg/actions/workflows/ci.yml/badge.svg)](https://github.com/devopam/MCPg/actions/workflows/ci.yml)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/devopam/MCPg/badge)](https://scorecard.dev/viewer/?uri=github.com/devopam/MCPg)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13958/badge)](https://www.bestpractices.dev/projects/13958)
 [![Stars](https://img.shields.io/github/stars/devopam/MCPg)](https://github.com/devopam/MCPg)
 [![smithery badge](https://smithery.ai/badge/devopam/mcpg)](https://smithery.ai/servers/devopam/mcpg)
 [![MCPg MCP server](https://glama.ai/mcp/servers/devopam/MCPg/badges/score.svg)](https://glama.ai/mcp/servers/devopam/MCPg)

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -268,6 +268,20 @@ hatchling reads it from that file, so **bump `__init__.py` and nothing
 else** — the PyPI metadata, `mcpg --version`, and the MCP `serverInfo`
 handshake all derive from that one line and can't drift apart.
 
+Two other checked-in files carry their own copy of the version and
+need syncing in the same commit — both are scripted, not hand-edited,
+and both are guarded by a unit test that fails CI if you forget:
+
+```bash
+python3 packaging/mcpb/sync_version.py X.Y.Z    # .mcpb bundle — test_mcpb_bundle.py
+python3 tools/sync_server_json_version.py X.Y.Z  # MCP registry manifest — test_server_json.py
+```
+
+(The `publish-mcp-registry` CI job re-runs the second script against
+the tag as a belt-and-braces safety net, but that's not a substitute
+for this step — it only fires *after* PyPI publish, by which point a
+stale `server.json` has already been reviewed and merged.)
+
 Then update `CHANGELOG.md`: rename the `[Unreleased]` heading to
 `[X.Y.Z] - YYYY-MM-DD`, add a fresh empty `[Unreleased]` above it.
 
@@ -380,6 +394,11 @@ when running locally.
       /tmp/r.txt` reports no known CVEs.
 - [ ] `__version__` in `src/mcpg/__init__.py` is bumped to the release
       (this is the single source; `pyproject.toml` derives it dynamically).
+- [ ] `.mcpb` bundle + `server.json` re-synced to the release version
+      (§4.2's two `sync_*.py` commands — `tests/unit/test_mcpb_bundle.py`
+      and `tests/unit/test_server_json.py` fail loudly if skipped, so
+      this is covered by the unit-suite gate above, but run it explicitly
+      rather than relying on CI to notice).
 - [ ] `CHANGELOG.md` rolls `[Unreleased]` into the new dated section,
       and a fresh `[Unreleased]` is added on top.
 - [ ] `docs/release-notes-X.Y.Z.md` written (mirror the previous

--- a/server.json
+++ b/server.json
@@ -1,8 +1,9 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.devopam/mcpg",
-  "version": "0.6.8",
+  "version": "0.7.1",
   "description": "Production-grade PostgreSQL MCP server \u2014 254 tools for query, tuning & ops, read-only by default.",
+  "websiteUrl": "https://devopam.github.io/MCPg/",
   "repository": {
     "url": "https://github.com/devopam/MCPg",
     "source": "github"
@@ -12,7 +13,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "mcpg",
-      "version": "0.6.8",
+      "version": "0.7.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/tests/unit/test_server_json.py
+++ b/tests/unit/test_server_json.py
@@ -15,10 +15,11 @@ import sys
 from pathlib import Path
 
 _ROOT = Path(__file__).resolve().parents[2]
-_SERVER_JSON = _ROOT / "server.json"
 
 sys.path.insert(0, str(_ROOT / "tools"))
-from sync_server_json_version import sync  # noqa: E402
+from sync_server_json_version import WEBSITE_URL, server_json_path, sync  # noqa: E402
+
+_SERVER_JSON = server_json_path()
 
 
 def test_sync_patches_version_and_every_package(tmp_path: Path) -> None:
@@ -53,4 +54,4 @@ def test_server_json_pins_the_current_release() -> None:
 
 def test_server_json_has_website_url() -> None:
     data = json.loads(_SERVER_JSON.read_text(encoding="utf-8"))
-    assert data["websiteUrl"] == "https://devopam.github.io/MCPg/"
+    assert data["websiteUrl"] == WEBSITE_URL

--- a/tests/unit/test_server_json.py
+++ b/tests/unit/test_server_json.py
@@ -1,0 +1,56 @@
+"""Tests for server.json — the MCP registry manifest.
+
+Published automatically by the ``publish-mcp-registry`` job in
+publish.yml, which re-derives ``version`` from the release tag via
+``tools/sync_server_json_version.py`` right before ``mcp-publisher
+publish`` (same pattern as the .mcpb bundle's sync_version.py — see
+test_mcpb_bundle.py). That CI step is a safety net; these tests are
+the primary guard, pinning the sync script and catching the checked-in
+file drifting between releases the way
+``test_bundle_pyproject_pins_the_current_release`` does for the bundle.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[2]
+_SERVER_JSON = _ROOT / "server.json"
+
+sys.path.insert(0, str(_ROOT / "tools"))
+from sync_server_json_version import sync  # noqa: E402
+
+
+def test_sync_patches_version_and_every_package(tmp_path: Path) -> None:
+    scratch = tmp_path / "server.json"
+    scratch.write_text(_SERVER_JSON.read_text(encoding="utf-8"), encoding="utf-8")
+
+    sync(scratch, "9.9.9")
+
+    data = json.loads(scratch.read_text(encoding="utf-8"))
+    assert data["version"] == "9.9.9"
+    assert data["packages"] and all(pkg["version"] == "9.9.9" for pkg in data["packages"])
+
+
+def test_server_json_pins_the_current_release() -> None:
+    """The checked-in version tracks mcpg's own version between releases.
+
+    The publish workflow re-syncs from the tag at release time, but
+    keeping the checked-in copy current means the repo never shows a
+    stale version to anyone reading server.json directly, and a
+    forgotten manual bump fails CI instead of silently shipping.
+    """
+    from mcpg import __version__
+
+    data = json.loads(_SERVER_JSON.read_text(encoding="utf-8"))
+    assert data["version"] == __version__, (
+        "server.json's checked-in version is stale — run "
+        f"`python3 tools/sync_server_json_version.py {__version__}` "
+        "as part of the release version bump (docs/release-process.md §4.2)."
+    )
+    assert all(pkg["version"] == __version__ for pkg in data["packages"])
+
+
+def test_server_json_has_website_url() -> None:
+    data = json.loads(_SERVER_JSON.read_text(encoding="utf-8"))
+    assert data["websiteUrl"] == "https://devopam.github.io/MCPg/"

--- a/tools/sync_server_json_version.py
+++ b/tools/sync_server_json_version.py
@@ -24,7 +24,21 @@ import json
 import sys
 from pathlib import Path
 
-_SERVER_JSON = Path(__file__).resolve().parents[1] / "server.json"
+# The registry-facing homepage link (server.json's `websiteUrl`).
+# tests/unit/test_server_json.py imports this rather than hardcoding a
+# second copy of the literal, so there's exactly one Python-side place
+# to update if the URL ever changes.
+WEBSITE_URL = "https://devopam.github.io/MCPg/"
+
+
+def server_json_path() -> Path:
+    """Return the repo's checked-in server.json path.
+
+    A function rather than a module-level constant so callers (this
+    script and the test suite) share one path-calculation instead of
+    each computing ``parents[N] / "server.json"`` independently.
+    """
+    return Path(__file__).resolve().parents[1] / "server.json"
 
 
 def sync(path: Path, version: str) -> None:
@@ -39,5 +53,5 @@ def sync(path: Path, version: str) -> None:
 if __name__ == "__main__":
     if len(sys.argv) != 2 or not sys.argv[1]:
         raise SystemExit("usage: sync_server_json_version.py <version>")
-    sync(_SERVER_JSON, sys.argv[1])
+    sync(server_json_path(), sys.argv[1])
     print(f"server.json pinned to {sys.argv[1]}")

--- a/tools/sync_server_json_version.py
+++ b/tools/sync_server_json_version.py
@@ -1,0 +1,43 @@
+"""Sync server.json's version fields to a release version.
+
+Used two ways:
+
+- By the release version bump (docs/release-process.md §4.2), so the
+  checked-in file tracks the release instead of drifting — the same
+  role ``packaging/mcpb/sync_version.py`` plays for the .mcpb bundle.
+- By the ``publish-mcp-registry`` job in publish.yml, which re-runs it
+  against the tag-derived version right before ``mcp-publisher
+  publish``. That's a safety net, not the primary mechanism: it's what
+  stops a forgotten manual bump from making the registry reject the
+  release as a duplicate version (the failure mode that motivated
+  deriving from the tag in the first place — see git blame on that
+  step). ``tests/unit/test_server_json.py`` guards the manual side so
+  it's rarely needed in practice.
+
+Patches ``server.json`` in place: the top-level ``version`` and every
+``packages[].version``.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_SERVER_JSON = Path(__file__).resolve().parents[1] / "server.json"
+
+
+def sync(path: Path, version: str) -> None:
+    """Rewrite ``path``'s version pins in place."""
+    data = json.loads(path.read_text(encoding="utf-8"))
+    data["version"] = version
+    for pkg in data.get("packages", []):
+        pkg["version"] = version
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2 or not sys.argv[1]:
+        raise SystemExit("usage: sync_server_json_version.py <version>")
+    sync(_SERVER_JSON, sys.argv[1])
+    print(f"server.json pinned to {sys.argv[1]}")


### PR DESCRIPTION
## Summary

Two things:

1. **`server.json` now sets `websiteUrl`** → `https://devopam.github.io/MCPg/` (verified live, real Jekyll-rendered content, not a placeholder). Confirmed against the raw registry schema (`server.schema.json`) that `websiteUrl` is a valid top-level field.
2. **Stopped `server.json`'s checked-in `version` from drifting.** It showed `0.6.8` in the repo — a stale snapshot from whenever it was last hand-edited — while the actual MCP Registry was correctly up to date (`0.7.1`, confirmed live via the registry API). The registry side worked because `publish-mcp-registry` in `publish.yml` re-derives the version from the release tag *in the CI checkout only*; it never commits that bump back, so the repo copy silently lagged. The `.mcpb` bundle had already solved this identical problem with a scripted sync (`packaging/mcpb/sync_version.py`) + a guard test (`test_mcpb_bundle.py`); `server.json` didn't have the equivalent, so it's added here:
   - `tools/sync_server_json_version.py` — sync script, same shape as the `.mcpb` one.
   - `tests/unit/test_server_json.py` — fails CI if the checked-in version stops matching `mcpg.__version__`, pins the sync script, and asserts `websiteUrl` is set.
   - `publish.yml`'s tag-time sync step now calls the shared script instead of an inline heredoc (identical behavior, one tested code path instead of two).
   - `docs/release-process.md` §4.2 and the pre-flight checklist now list the sync as an explicit release step, alongside the existing (previously undocumented) `.mcpb` bundle sync.
   - `server.json` bumped to `0.7.1` to match the current release.

No functional/runtime code changed — this is release-process tooling + a data file.

## Roadmap linkage

Advances roadmap row: N/A — chore/infra (release-process reliability, not a roadmap feature)

## Checklist

- [x] Tests added/updated first (TDD); suite passes locally (2856 passed, 3 skipped)
- [x] `ruff`, `ruff format`, and `mypy src/mcpg` pass
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Roadmap row cited above (N/A — chore/infra)
- [x] No hand-edits to `src/mcpg/_vendor/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a scripted and tested workflow to keep the checked-in MCP registry manifest (server.json) version in sync with releases and document it in the release process, while also setting its websiteUrl homepage field.

New Features:
- Expose the MCP server homepage in server.json via the websiteUrl field pointing to the project website.

Bug Fixes:
- Prevent server.json's checked-in version from drifting by syncing its version fields to the release version and guarding this with tests.

Enhancements:
- Replace the inline JSON editing in the publish-mcp-registry workflow with a shared sync_server_json_version.py script used both locally and in CI.
- Document the version sync steps for server.json and the .mcpb bundle in the release-process guide and checklist to make them explicit and repeatable.

Documentation:
- Update docs/release-process.md to describe scripted version syncing for server.json and the .mcpb bundle and add them to the release pre-flight checklist.

Tests:
- Add unit tests for server.json that pin the sync script’s behavior, enforce that its version matches mcpg.__version__, and assert that websiteUrl is set.