### PR TITLE
ci: pipeline-security tooling — Harden-Runner (audit) + zizmor + actionlint

### DIFF
--- a/.github/workflows/actions-security.yml
+++ b/.github/workflows/actions-security.yml
@@ -40,8 +40,11 @@ jobs:
           python-version: "3.14"
       - name: Run zizmor
         # zizmor exits non-zero when it finds issues; keep the job green while
-        # we baseline (findings still upload to the dashboard). Drop
-        # continue-on-error to make it blocking later.
+        # we baseline (findings still upload to the dashboard).
+        # TODO(security): remove `continue-on-error` to make zizmor blocking
+        # once the baseline is triaged to zero High/Medium findings (tracked
+        # as the "zizmor baseline" follow-up PR). Don't let audit mode become
+        # permanent by default.
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
@@ -68,5 +71,8 @@ jobs:
       - name: Run actionlint
         uses: raven-actions/actionlint@3d39aea434753780c3b3d4a1a31c854b4dbf49d7 # v2.2.0
         with:
-          # Reporting mode for the introduction — flip to true to gate merges.
+          # Reporting mode for the introduction.
+          # TODO(security): flip to `fail-on-error: true` to gate merges once
+          # the existing workflows are clean of actionlint findings (same
+          # "baseline triage" follow-up as zizmor above).
           fail-on-error: false

--- a/.github/workflows/actions-security.yml
+++ b/.github/workflows/actions-security.yml
@@ -1,0 +1,72 @@
+name: Actions Security
+
+# Static-analysis of the GitHub Actions workflows themselves:
+#   * zizmor    — security analysis (template injection, artifact poisoning,
+#                 unpinned/over-privileged actions) → SARIF to code scanning.
+#   * actionlint — workflow linter (syntax, expression + shell-script bugs).
+#
+# Introduced in reporting mode (findings surface without failing the build),
+# matching the Harden-Runner audit rollout. Promote to blocking once the
+# baseline is triaged.
+
+on:
+  push:
+    branches: [main, "claude/**"]
+  pull_request:
+  schedule:
+    # Weekly, so newly-published zizmor rules catch drift even without a push.
+    - cron: "27 4 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: zizmor (Actions security analysis)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # upload the SARIF to the code-scanning dashboard
+    steps:
+      - name: Harden the runner (audit egress)
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          python-version: "3.14"
+      - name: Run zizmor
+        # zizmor exits non-zero when it finds issues; keep the job green while
+        # we baseline (findings still upload to the dashboard). Drop
+        # continue-on-error to make it blocking later.
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: uvx zizmor@1.9.0 --format sarif . > zizmor.sarif
+      - name: Upload zizmor SARIF
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v3
+        with:
+          sarif_file: zizmor.sarif
+          category: zizmor
+
+  actionlint:
+    name: actionlint (workflow linter)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Harden the runner (audit egress)
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Run actionlint
+        uses: raven-actions/actionlint@3d39aea434753780c3b3d4a1a31c854b4dbf49d7 # v2.2.0
+        with:
+          # Reporting mode for the introduction — flip to true to gate merges.
+          fail-on-error: false

--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -13,6 +13,10 @@ jobs:
           - address
           - undefined
     steps:
+      - name: Harden the runner (audit egress)
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2
+        with:
+          egress-policy: audit
       - name: Build Fuzzers (${{ matrix.sanitizer }})
         id: build
         uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -18,6 +18,10 @@ jobs:
           - address
           - undefined
     steps:
+      - name: Harden the runner (audit egress)
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2
+        with:
+          egress-policy: audit
       - name: Build Fuzzers (${{ matrix.sanitizer }})
         id: build
         uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ jobs:
     name: Lint & type-check
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (audit egress)
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Set up uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
@@ -40,6 +44,10 @@ jobs:
     name: Security audit (SAST & Dependencies)
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (audit egress)
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Set up uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
@@ -84,6 +92,10 @@ jobs:
           - postgres: "warehousepg-latest"
             experimental: true
     steps:
+      - name: Harden the runner (audit egress)
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       # The ubuntu-latest runner ships an older PostgreSQL client by
       # default; `pg_dump` refuses to dump from a newer server (PG 17 /

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,6 +40,10 @@ jobs:
         language: ["python", "actions"]
 
     steps:
+      - name: Harden the runner (audit egress)
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2
+        with:
+          egress-policy: audit
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -38,6 +38,10 @@ jobs:
     name: Build Jekyll site
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (audit egress)
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Configure Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
@@ -60,6 +64,10 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - name: Harden the runner (audit egress)
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2
+        with:
+          egress-policy: audit
       - name: Deploy
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,10 @@ jobs:
       id-token: write
       attestations: write
     steps:
+      - name: Harden the runner (audit egress)
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
@@ -84,6 +88,10 @@ jobs:
       name: testpypi
       url: https://test.pypi.org/project/mcpg/
     steps:
+      - name: Harden the runner (audit egress)
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2
+        with:
+          egress-policy: audit
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: dist
@@ -97,6 +105,10 @@ jobs:
     needs: publish-testpypi
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (audit egress)
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2
+        with:
+          egress-policy: audit
       # ``uv export`` needs the source tree; the smoke install
       # itself runs against the published artifact.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -195,6 +207,10 @@ jobs:
       name: pypi
       url: https://pypi.org/project/mcpg/
     steps:
+      - name: Harden the runner (audit egress)
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2
+        with:
+          egress-policy: audit
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: dist
@@ -208,6 +224,10 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Harden the runner (audit egress)
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -263,6 +283,10 @@ jobs:
     needs: publish-pypi
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (audit egress)
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2
+        with:
+          egress-policy: audit
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Sync server.json version to the release tag
@@ -299,6 +323,10 @@ jobs:
       contents: read
       packages: write
     steps:
+      - name: Harden the runner (audit egress)
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Log in to GHCR
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
@@ -344,6 +372,10 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
+      - name: Harden the runner (audit egress)
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
@@ -381,6 +413,10 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
+      - name: Harden the runner (audit egress)
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2
+        with:
+          egress-policy: audit
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.14"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -33,6 +33,10 @@ jobs:
       # actions: read
 
     steps:
+      - name: Harden the runner (audit egress)
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2
+        with:
+          egress-policy: audit
       - name: "Checkout code"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,9 @@ adheres to [Semantic Versioning](https://semver.org/).
 - **Pipeline-security tooling: Harden-Runner, zizmor, actionlint.**
   - **StepSecurity Harden-Runner** added (audit/egress-monitoring mode) as the
     first step of every job across all workflows — captures a runtime egress
-    baseline so outbound traffic can later be allow-listed (block mode). The
-    defence against compromised-Action call-home / exfiltration.
+    baseline so outbound traffic can later be allow-listed (block mode). This
+    provides defence against a compromised Action calling home or exfiltrating
+    secrets.
   - **zizmor** (`.github/workflows/actions-security.yml`) — static security
     analysis of the Actions workflows (template injection, artifact
     credential persistence, over-broad permissions) → SARIF to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ adheres to [Semantic Versioning](https://semver.org/).
   kernel, access-mode policy, and CI/release pipeline to the maintainer.
   (Complements the already-landed Actions SHA-pinning, Docker digest pinning,
   Scorecard, CodeQL, and fuzzing.)
+- **Pipeline-security tooling: Harden-Runner, zizmor, actionlint.**
+  - **StepSecurity Harden-Runner** added (audit/egress-monitoring mode) as the
+    first step of every job across all workflows — captures a runtime egress
+    baseline so outbound traffic can later be allow-listed (block mode). The
+    defence against compromised-Action call-home / exfiltration.
+  - **zizmor** (`.github/workflows/actions-security.yml`) — static security
+    analysis of the Actions workflows (template injection, artifact
+    credential persistence, over-broad permissions) → SARIF to the
+    code-scanning dashboard.
+  - **actionlint** — workflow linter (syntax, expression + shell bugs).
+  - Both scanners start in reporting mode (findings surface without blocking),
+    matching the Harden-Runner audit rollout; promote to blocking after the
+    baseline is triaged.
 
 ### Added
 


### PR DESCRIPTION
## Summary

Adds the CI/CD-pipeline security controls we agreed on after reviewing the `awesome-cicd-security` and Orca lists. Everything else on those lists was already covered by your existing stack (Scorecard, CodeQL, bandit, pip-audit, Dependabot, fuzzing, signed releases, OIDC) or was offensive/audit-only tooling — the genuine gaps were **runtime egress control** and **GitHub-Actions-specific static analysis**.

**1. StepSecurity Harden-Runner (audit mode)** — added as the **first step of every job** across all 7 workflows (18 jobs). In `egress-policy: audit` it only *monitors* outbound traffic (can't block anything), capturing the egress baseline. The defence against the compromised-Action call-home/exfiltration class (tj-actions-style). Next step, once the baseline is reviewed: allow-list egress and flip the sensitive workflows (publish first) to `block`.

**2. zizmor** (`actions-security.yml`) — static security analysis of the workflows (template injection, artifact credential persistence, over-broad permissions) via `uvx zizmor@1.9.0` → SARIF to the code-scanning dashboard.

**3. actionlint** — workflow linter (syntax + shell-script bugs) via SHA-pinned `raven-actions/actionlint`.

Both scanners start in **reporting mode** (findings surface, don't block), matching the Harden-Runner audit posture. Promote to blocking after triaging the baseline.

## zizmor already found a useful baseline
Run locally (offline) as a pre-check — **22 findings (3 high, 11 medium)**, all real and worth a focused follow-up:
- **High — `excessive-permissions`:** `id-token: write` at the *workflow* level in `publish.yml` (only the trusted-publishing jobs need it).
- **Medium — `artipacked`:** several `actions/checkout` steps lack `persist-credentials: false`.

Kept out of this PR to keep it scoped to *introducing* the tooling; the new `actions-security.yml` checkouts already set `persist-credentials: false` as the pattern to follow.

## ⚠️ Merge ordering vs #307
This PR and **#307** (SBOM/provenance/CODEOWNERS) both modify `publish.yml`, so they'll conflict. Suggest **merge #307 first**, then I'll rebase this branch onto it (mechanical — different regions of the build job).

## Validation
- ✅ All 8 workflows YAML-valid; new action refs SHA-pinned
- ✅ zizmor executed locally (offline audits) — runs clean, produces SARIF
- ⚠️ Harden-Runner audit steps + the scanners only exercise on their triggers; audit mode can't break existing jobs (monitor-only). No source/test change.

## Roadmap linkage

Advances roadmap row: N/A — CI/supply-chain hardening.

## Checklist
- [x] Tests — N/A (CI-only); workflows validated + zizmor run locally
- [x] `ruff`/`mypy` — no source change
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Roadmap row cited (N/A)
- [x] No hand-edits to `src/mcpg/_vendor/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Introduce CI/CD pipeline security tooling focused on GitHub Actions egress auditing and workflow analysis.

New Features:
- Add StepSecurity Harden-Runner in audit mode as the first step of every job across all GitHub Actions workflows to monitor runtime egress.
- Add a dedicated Actions Security workflow running zizmor for GitHub Actions security analysis with SARIF reporting to the code-scanning dashboard.
- Add actionlint-based workflow linting to validate GitHub Actions syntax, expressions, and shell usage in reporting mode.

Enhancements:
- Document the new pipeline security tooling and its audit-first rollout under the Unreleased Security section of the changelog.