### PR TITLE
ci: clear zizmor baseline — scope id-token, persist-credentials: false

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - name: Set up uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
@@ -49,6 +51,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - name: Set up uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
@@ -97,6 +101,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       # The ubuntu-latest runner ships an older PostgreSQL client by
       # default; `pg_dump` refuses to dump from a newer server (PG 17 /
       # 18 in this matrix). Install the matching client tools from the

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,6 +46,8 @@ jobs:
           egress-policy: audit
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@e60ea984bd3baa95954f2856bcf24f9eaba46637 # v3

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,11 +19,10 @@ on:
   # Lets you re-publish from the Actions tab without a content change.
   workflow_dispatch:
 
-# The token scopes actions/deploy-pages needs.
+# Least privilege at the workflow level: only the deploy job needs the
+# elevated Pages scopes, so they're granted there (below), not here.
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 # Serialise Pages deployments. `cancel-in-progress: false` is the
 # GitHub-recommended setting for Pages — an in-flight deploy is allowed
@@ -43,6 +42,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - name: Configure Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
       - name: Build with Jekyll
@@ -60,6 +61,11 @@ jobs:
     name: Deploy to GitHub Pages
     needs: build
     runs-on: ubuntu-latest
+    # The Pages deployment (actions/deploy-pages) is the only step that needs
+    # the elevated scopes — grant them here, not workflow-wide.
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,11 +4,11 @@ on:
   push:
     tags: ["v*.*.*"]
 
-# OIDC token exchange with PyPI Trusted Publishing. ``id-token: write``
-# is the privilege the action trades for a one-time PyPI upload
-# credential; ``contents: read`` is the source checkout.
+# Least-privilege default for every job: read-only checkout. The OIDC
+# ``id-token: write`` privilege (PyPI Trusted Publishing, the MCP-registry
+# login, and the build-provenance attestation) is granted per-job below —
+# only where it's actually used — rather than workflow-wide.
 permissions:
-  id-token: write
   contents: read
 
 jobs:
@@ -28,6 +28,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           python-version: "3.14"
@@ -84,6 +86,9 @@ jobs:
     name: Publish → TestPyPI
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # PyPI Trusted Publishing (OIDC)
     environment:
       name: testpypi
       url: https://test.pypi.org/project/mcpg/
@@ -112,6 +117,8 @@ jobs:
       # ``uv export`` needs the source tree; the smoke install
       # itself runs against the published artifact.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           python-version: "3.14"
@@ -199,6 +206,9 @@ jobs:
     name: Publish → PyPI (gated on maintainer approval)
     needs: smoke-testpypi
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # PyPI Trusted Publishing (OIDC)
     # The ``pypi`` environment is configured with a required
     # reviewer (the maintainer). The workflow pauses on this job
     # until that approval click lands; that's the last chance to
@@ -229,6 +239,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: dist
@@ -282,6 +294,9 @@ jobs:
     name: Publish to MCP Registry
     needs: publish-pypi
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # `mcp-publisher login github-oidc` (OIDC)
     steps:
       - name: Harden the runner (audit egress)
         uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2
@@ -289,6 +304,8 @@ jobs:
           egress-policy: audit
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - name: Sync server.json version to the release tag
         # server.json's checked-in version is bumped manually as part of
         # the release (docs/release-process.md §4.2, guarded by
@@ -328,6 +345,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - name: Log in to GHCR
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
@@ -377,6 +396,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.14"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,11 +33,11 @@ adheres to [Semantic Versioning](https://semver.org/).
     baseline is triaged.
 - **zizmor baseline cleared.** Fixed every finding zizmor flagged on the
   workflows: scoped `id-token: write` from the workflow level down to only the
-  five OIDC jobs that use it (PyPI Trusted Publishing, the MCP-registry login,
-  the build-provenance attestation, and the Pages deploy — `excessive-permissions`),
-  and set `persist-credentials: false` on all repo checkouts so a persisted git
-  credential can't be captured in an artifact (`artipacked`). zizmor now reports
-  no findings.
+  five OIDC jobs that use it — PyPI Trusted Publishing (TestPyPI **and** PyPI),
+  the MCP-registry login, the build-provenance attestation, and the Pages
+  deploy (`excessive-permissions`) — and set `persist-credentials: false` on all
+  repo checkouts so a persisted git credential can't be captured in an artifact
+  (`artipacked`). zizmor now reports no findings.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ adheres to [Semantic Versioning](https://semver.org/).
   - Both scanners start in reporting mode (findings surface without blocking),
     matching the Harden-Runner audit rollout; promote to blocking after the
     baseline is triaged.
+- **zizmor baseline cleared.** Fixed every finding zizmor flagged on the
+  workflows: scoped `id-token: write` from the workflow level down to only the
+  five OIDC jobs that use it (PyPI Trusted Publishing, the MCP-registry login,
+  the build-provenance attestation, and the Pages deploy — `excessive-permissions`),
+  and set `persist-credentials: false` on all repo checkouts so a persisted git
+  credential can't be captured in an artifact (`artipacked`). zizmor now reports
+  no findings.
 
 ### Added
 


### PR DESCRIPTION
## Summary

Triage of the findings **zizmor itself surfaced** when we introduced it (#308). zizmor now reports **"No findings"** on the workflows.

**1. `excessive-permissions` (High) — scoped `id-token: write`**
Removed the workflow-level `id-token: write` from `publish.yml` and `pages.yml`; granted it **per-job, only where OIDC is used**:
- `publish.yml`: `build` (build-provenance attestation), `publish-testpypi` + `publish-pypi` (PyPI Trusted Publishing), `publish-mcp-registry` (`mcp-publisher login github-oidc`)
- `pages.yml`: `deploy` (`actions/deploy-pages`)

Every other job now runs with `contents: read`. Verified the OIDC jobs all retain the scope — no release path loses its token.

**2. `artipacked` (Medium) — `persist-credentials: false`**
Added to all **11** repo checkouts, so the git credential isn't written into the workspace (and can't leak via an uploaded artifact). None of these jobs push via git — they use `gh`/OIDC/tokens — so it's safe.

## Validation
- ✅ `uvx zizmor@1.9.0 --no-online-audits` → **No findings to report**
- ✅ All workflows YAML-valid; `id-token: write` present in exactly the 5 OIDC jobs
- No source/test change; the scanners' online audits also run on this PR (the `actions-security.yml` zizmor job).

## Follow-up
Once this lands and the online zizmor baseline confirms clean on the dashboard, **flip zizmor `continue-on-error` and actionlint `fail-on-error` to blocking** (the `TODO(security)` markers are already in place) — a one-line change.

## Roadmap linkage
Advances roadmap row: N/A — CI/supply-chain hardening.

## Checklist
- [x] Tests — N/A (CI-only); zizmor run locally, workflows validated
- [x] `ruff`/`mypy` — no source change
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Roadmap row cited (N/A)
- [x] No hand-edits to `src/mcpg/_vendor/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc

---
_Generated by [Claude Code](https://claude.ai/code/session_0122yLZLJ8t4W43sdN6BmTZc)_

## Summary by Sourcery

Harden CI workflows by tightening GitHub Actions permissions and clearing zizmor security findings.

Enhancements:
- Restrict OIDC `id-token: write` permissions from workflow-wide to only the specific jobs that require them in publish and Pages workflows.
- Set `persist-credentials: false` on all Actions checkouts to avoid persisting Git credentials into the workspace and potential artifact leakage.
- Document the cleared zizmor baseline and permission changes in the changelog.

CI:
- Update publish, Pages, CI, and CodeQL workflows to use least-privilege defaults while preserving required functionality for PyPI publishing, MCP registry login, build provenance, and Pages deployment.