### PR TITLE
chore: prep Docker MCP Registry submission (roadmap 21.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,19 @@ adheres to [Semantic Versioning](https://semver.org/).
 - **OpenSSF Best Practices badge** added to the README badge row
   (project [13958](https://www.bestpractices.dev/projects/13958),
   `passing`).
+- **Docker MCP Registry submission prep** (roadmap 21.1). Added
+  `packaging/docker-mcp-registry/` with a `server.yaml` draft and a
+  `generate_tools_json.py` script that derives the registry's `tools.json`
+  bypass file (`{name, description, arguments}` — confirmed against real
+  registry entries, not MCP-native `inputSchema`) from
+  `tests/contract/tool_surface.snapshot.json`, guarded by
+  `tests/contract/test_docker_mcp_registry_tools_json.py` so it can't
+  drift. The bypass is needed because MCPg requires a live
+  `MCPG_DATABASE_URL` to start, which their build sandbox can't supply.
+  Confirmed via a local build that `run.env: MCPG_TRANSPORT: stdio`
+  cleanly overrides the image's baked-in `streamable-http` default with a
+  real `initialize` + `tools/list` smoke test — no `Dockerfile` change
+  needed. Submission (fork + PR into `docker/mcp-registry`) not yet sent.
 
 ### Fixed
 

--- a/docs/feature-shortlist.md
+++ b/docs/feature-shortlist.md
@@ -319,6 +319,25 @@ API, redesigns per-request tenancy onto `mcp`'s new `ServerMiddleware` model
 | 20.2 | ✅ **Shipped.** **Tenancy redesign onto `ServerMiddleware`.** Replaced the `mcp.server.lowlevel.server.request_ctx` ambient-contextvar hack (removed in mcp 2.0) with a `ServerMiddleware` that sets the existing `current_role` ContextVar per-request — reliable on every transport now that the SDK dispatches each request to its own asyncio task, not just stdio as before. | M | Medium-High | Security-sensitive seam; see `mcpg.tenancy.TenantRoleContextMiddleware`. |
 | 20.3 | ✅ **Shipped.** **Elicitation confirmation for write-tier tools.** `ctx.elicit()`-based confirmation before any non-read-only tool call, gated by `MCPG_ELICIT_CONFIRM_WRITES` (opt-in) and the connected client's declared elicitation capability. Centralized in `AuditedMCPServer.call_tool`; no per-tool changes. | S-M | Medium | First concrete use of an mcp 2.0-only capability (elicitation didn't exist in 1.x `FastMCP`). |
 
+## 21. Docker MCP Registry submission
+
+MCPg ships to PyPI, GHCR, the official MCP registry, Smithery, and an HF
+Spaces demo, but not [Docker's MCP Catalog](https://github.com/docker/mcp-registry)
+— the registry backing Docker Desktop's MCP Toolkit and `docker mcp`
+CLI. A 2026-08-14 eligibility check found no existing general-purpose
+PostgreSQL entry there (only `prisma-postgres`, which is Prisma-specific),
+and MCPg clears every eligibility bar in their `CONTRIBUTING.md`: MIT
+license, a root `Dockerfile`, and a live-verified `run.env:
+MCPG_TRANSPORT: stdio` override (confirmed against a local build — the
+image's baked-in `streamable-http` default is cleanly overridden per-run,
+no `Dockerfile` change needed).
+
+| # | Item | Effort | Value | Notes |
+|---|---|---|---|---|
+| 21.1 | **In progress.** **`tools.json` bypass generator.** MCPg requires a live, reachable `MCPG_DATABASE_URL` to start (`load_settings` raises otherwise), so Docker's build sandbox can't run the container to auto-discover tools the way it does for DB-less servers. `packaging/docker-mcp-registry/generate_tools_json.py` derives the registry's bypass-file shape (`{name, description, arguments: [{name, type, desc}]}` — confirmed against real registry entries, NOT MCP-native `inputSchema`) from `tests/contract/tool_surface.snapshot.json`, guarded by `tests/contract/test_docker_mcp_registry_tools_json.py` so it can't drift as the tool surface grows. | S | Medium | Generated beats hand-maintained, per this file's own rule — 254 entries, no hand-authoring. |
+| 21.2 | **Open.** **Submit the fork + PR.** `packaging/docker-mcp-registry/server.yaml` drafted (category `database`, `MCPG_DATABASE_URL` as the sole required secret, `MCPG_ACCESS_MODE` exposed read-only-default). Needs: `task validate` / `task build --tools mcpg` run against a real fork of `docker/mcp-registry` (requires the `Task` CLI, not yet installed anywhere this was drafted), then a PR per their `add_mcp_server.md` flow. | S-M | Medium-High | Outward-facing (third-party public repo) — needs explicit go-ahead before the fork/PR, not just the eligibility research. |
+| 21.3 | **Open, known gap.** **254-tool surface size.** Unusually large for a single catalog entry relative to other registry servers; MCPg has no bucket/tool-filter env var today to ship a slimmer default surface (checked `config.py` — doesn't exist). Address proactively in the PR description rather than waiting for reviewer pushback; a follow-up `MCPG_ENABLED_BUCKETS`-style filter is a candidate if Docker's reviewers push back in practice. | — | — | Surfaced during 21.1; not blocking submission, just flagged. |
+
 ---
 
 ## Currently deferred (no commitments)

--- a/packaging/docker-mcp-registry/generate_tools_json.py
+++ b/packaging/docker-mcp-registry/generate_tools_json.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Generate the Docker MCP Registry ``tools.json`` bypass file.
+
+The Docker MCP Registry (``github.com/docker/mcp-registry``) normally
+verifies a submitted server's tool list by running its container and
+calling ``tools/list``. MCPg can't clear that bar in their build sandbox:
+``MCPG_DATABASE_URL`` is a hard-required setting (see
+``mcpg.config.load_settings``), so the process exits before it can answer
+any MCP request unless a live, reachable Postgres is supplied. Their
+CONTRIBUTING.md offers an explicit escape hatch for exactly this case: a
+hand-authored (or, better, generated) ``tools.json`` listing every tool's
+``name`` / ``description`` / ``arguments`` bypasses the live-container
+check entirely.
+
+This script derives that file from the one artifact in this repo that
+already has the full, guarded tool surface: the contract snapshot at
+``tests/contract/tool_surface.snapshot.json`` (regenerated via
+``MCPG_REGENERATE_TOOL_SNAPSHOT=1``, per CLAUDE.md). Per this project's
+"generated beats hand-maintained" rule, nobody should ever hand-edit the
+output — rerun this script whenever the snapshot changes.
+
+The registry's ``tools.json`` shape (confirmed 2026-08-14 against real
+entries in docker/mcp-registry, e.g. ``servers/database-server``) is a
+flattened argument list, NOT the MCP-native JSON-Schema ``inputSchema``:
+
+    [
+      {
+        "name": "<tool name>",
+        "description": "<tool description>",
+        "arguments": [
+          {"name": "<param>", "type": "<json type>", "desc": "<param description>"}
+        ]
+      },
+      ...
+    ]
+
+Usage:
+    python packaging/docker-mcp-registry/generate_tools_json.py
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SNAPSHOT_PATH = REPO_ROOT / "tests" / "contract" / "tool_surface.snapshot.json"
+OUTPUT_PATH = Path(__file__).resolve().parent / "tools.json"
+
+# Fallback when a property has no resolvable type (bare ``{"title": "..."}``
+# schemas, seen for a couple of Any-typed passthrough params) — every
+# observed real-world tools.json entry uses "string" as the type for
+# untyped/loosely-typed arguments, so this matches established convention
+# rather than inventing a new one.
+_FALLBACK_TYPE = "string"
+
+
+def _resolve_type(prop_schema: dict[str, Any]) -> str:
+    """Best-effort JSON-Schema-property -> flat type-string mapping.
+
+    Handles the three shapes seen across MCPg's 254-tool surface: a plain
+    ``type`` key, an ``anyOf`` (Pydantic's ``Optional[X]`` rendering, e.g.
+    ``[{"type": "string"}, {"type": "null"}]`` — the first non-null branch
+    wins), and schemas missing ``type`` entirely (Any-typed params).
+    """
+    if "type" in prop_schema:
+        return str(prop_schema["type"])
+    if "anyOf" in prop_schema:
+        for branch in prop_schema["anyOf"]:
+            branch_type = branch.get("type")
+            if branch_type and branch_type != "null":
+                return str(branch_type)
+    return _FALLBACK_TYPE
+
+
+def _flatten_arguments(input_schema: dict[str, Any]) -> list[dict[str, str]]:
+    properties: dict[str, Any] = input_schema.get("properties", {})
+    arguments = []
+    for name, prop_schema in properties.items():
+        desc = prop_schema.get("description") or prop_schema.get("title") or ""
+        arguments.append(
+            {
+                "name": name,
+                "type": _resolve_type(prop_schema),
+                "desc": desc,
+            }
+        )
+    return arguments
+
+
+def main() -> None:
+    snapshot = json.loads(SNAPSHOT_PATH.read_text(encoding="utf-8"))
+    tools = snapshot["tools"]
+
+    entries = [
+        {
+            "name": tool["name"],
+            "description": tool["description"],
+            "arguments": _flatten_arguments(tool["inputSchema"]),
+        }
+        for tool in tools
+    ]
+
+    OUTPUT_PATH.write_text(json.dumps(entries, indent=2) + "\n", encoding="utf-8")
+    print(f"Wrote {len(entries)} tool entries to {OUTPUT_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/packaging/docker-mcp-registry/generate_tools_json.py
+++ b/packaging/docker-mcp-registry/generate_tools_json.py
@@ -59,13 +59,21 @@ _FALLBACK_TYPE = "string"
 def _resolve_type(prop_schema: dict[str, Any]) -> str:
     """Best-effort JSON-Schema-property -> flat type-string mapping.
 
-    Handles the three shapes seen across MCPg's 254-tool surface: a plain
-    ``type`` key, an ``anyOf`` (Pydantic's ``Optional[X]`` rendering, e.g.
-    ``[{"type": "string"}, {"type": "null"}]`` — the first non-null branch
-    wins), and schemas missing ``type`` entirely (Any-typed params).
+    Handles the shapes seen across MCPg's 254-tool surface plus one not
+    currently emitted but legal under JSON Schema 2020-12: a plain ``type``
+    key (string or, per spec, a list like ``["string", "null"]`` — the
+    first non-null entry wins, same rule as ``anyOf`` below), an ``anyOf``
+    (Pydantic's ``Optional[X]`` rendering, e.g.
+    ``[{"type": "string"}, {"type": "null"}]``), and schemas missing
+    ``type`` entirely (Any-typed params).
     """
-    if "type" in prop_schema:
-        return str(prop_schema["type"])
+    raw_type = prop_schema.get("type")
+    if isinstance(raw_type, list):
+        for candidate in raw_type:
+            if candidate and candidate != "null":
+                return str(candidate)
+    elif raw_type is not None:
+        return str(raw_type)
     if "anyOf" in prop_schema:
         for branch in prop_schema["anyOf"]:
             branch_type = branch.get("type")

--- a/packaging/docker-mcp-registry/server.yaml
+++ b/packaging/docker-mcp-registry/server.yaml
@@ -1,0 +1,49 @@
+name: mcpg
+image: mcp/mcpg
+type: server
+meta:
+  category: database
+  tags:
+    - postgres
+    - postgresql
+    - database
+    - sql
+    - devops
+about:
+  title: MCPg
+  description: >-
+    A production-grade PostgreSQL MCP server — 254 tools spanning schema
+    introspection, query execution and EXPLAIN analysis, index/vacuum/config
+    advisors, vector (pgvector) and full-text (pg_search) search, audited
+    DDL/DML, migrations, and multi-database support across PostgreSQL 14-19,
+    TimescaleDB, and WarehousePG. Ships with a read-only default and three
+    graduated access tiers (read-only / restricted / unrestricted).
+  icon: https://avatars.githubusercontent.com/u/5661555?v=4
+source:
+  project: https://github.com/devopam/MCPg
+  commit: 3310154f5971d5c39606fb3f75925fa5748aded7
+run:
+  env:
+    MCPG_TRANSPORT: stdio
+config:
+  description: >-
+    Configure the connection to your PostgreSQL database and (optionally)
+    the access tier MCPg runs under.
+  secrets:
+    - name: mcpg.database_url
+      env: MCPG_DATABASE_URL
+      example: postgresql://user:password@host:5432/dbname
+  env:
+    - name: MCPG_ACCESS_MODE
+      example: read-only
+      value: '{{mcpg.access_mode}}'
+  parameters:
+    type: object
+    properties:
+      access_mode:
+        type: string
+        description: >-
+          read-only (default, safe for untrusted clients) | restricted
+          (adds DML writes) | unrestricted (adds DDL/shell/listen, each
+          gated by its own MCPG_ALLOW_* env var)
+        default: read-only

--- a/packaging/docker-mcp-registry/tools.json
+++ b/packaging/docker-mcp-registry/tools.json
@@ -1,0 +1,5675 @@
+[
+  {
+    "name": "add_compression_policy",
+    "description": "Enable TimescaleDB column-store compression on a hypertable and schedule a policy that compresses chunks older than `compress_after` (e.g. '7 days'). Requires unrestricted mode + MCPG_ALLOW_DDL. Returns an object with `available` (bool), `function` ('add_compression_policy'), and `details` (the scheduled job id or an extension-missing note).",
+    "arguments": [
+      {
+        "name": "compress_after",
+        "type": "string",
+        "desc": "Compress After"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "add_retention_policy",
+    "description": "Schedule a TimescaleDB retention policy that drops hypertable chunks older than `drop_after` (e.g. '30 days'). Requires unrestricted mode + MCPG_ALLOW_DDL.",
+    "arguments": [
+      {
+        "name": "drop_after",
+        "type": "string",
+        "desc": "Drop After"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "analyze_distance_metric",
+    "description": "Recommend a pgvector distance metric (cosine | l2 | inner_product) from the embedding-magnitude distribution. Samples up to `sample_size` non-NULL rows of schema.table.column, computes each embedding's L2 norm, and applies a small heuristic: pre-normalised (CV < 5% and mean \u2248 1.0) \u2192 inner_product; nearly-constant magnitude but not unit-norm \u2192 cosine (same ranking as L2, safer default); variable magnitude \u2192 cosine (normalises out heterogeneous sources). Returns the metric + a rationale + the underlying distribution stats. Reports available=false if the pgvector extension is not installed.",
+    "arguments": [
+      {
+        "name": "column",
+        "type": "string",
+        "desc": "Column"
+      },
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "sample_size",
+        "type": "integer",
+        "desc": "Sample Size"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "analyze_hnsw_recall",
+    "description": "Sweeps ef_search values to measure the latency and recall trade-off curve for a given pgvector query vector against exact brute-force ground truth. Requires the vector extension. Returns a list of objects with `ef_search`, `recall_at_k`, `mean_latency_ms`, and `p95_latency_ms` \u2014 one row per ef_search value tested.",
+    "arguments": [
+      {
+        "name": "column",
+        "type": "string",
+        "desc": "Column"
+      },
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "k",
+        "type": "integer",
+        "desc": "K"
+      },
+      {
+        "name": "metric",
+        "type": "string",
+        "desc": "Metric"
+      },
+      {
+        "name": "query_vector",
+        "type": "array",
+        "desc": "Query Vector"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "analyze_lock_hotspots",
+    "description": "Rank PG 19 `pg_stat_lock` rows by wait dominance and surface stable reason codes. Read-only \u2014 never modifies state. Pair with `find_blocking_chains` for the active culprits on a specific hot lock_type. Returns an object with `available` (bool), `server_version_num`, `detail`, and `hotspots` \u2014 a list of objects with `lock_type`, `waits`, `wait_time_us`, `reason` (one of `contention_dominant` / `high_wait_time` / `high_wait_count` / `low_contention`), and `suggested_followup` (a human-readable next-step string).\n\nExample: `analyze_lock_hotspots()`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "analyze_mpp_query_plan",
+    "description": "Run `EXPLAIN (ANALYZE, FORMAT JSON)` on `sql` and roll up MPP-specific facts: slice count, motion nodes (`Redistribute Motion` / `Broadcast Motion` / `Gather Motion`), and per-motion metadata (senders, receivers, estimated rows). Uses the same safety pre-flight as `analyze_query_plan(io=True)` \u2014 writes / DDL stay rejected. `redistribute_count` flags 'data is not co-located with the join key'. On vanilla PG returns `available=false`.\n\nExample: `analyze_mpp_query_plan(sql='SELECT * FROM big JOIN small ON big.k = small.k')`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "sql",
+        "type": "string",
+        "desc": "Sql"
+      }
+    ]
+  },
+  {
+    "name": "analyze_query_plan",
+    "description": "Summarise a query's execution plan: total estimated cost, estimated rows, node types used, and any sequentially-scanned tables. Set `io=true` to run `EXPLAIN (ANALYZE, BUFFERS, TIMING)` instead of the plan-only variant \u2014 adds `actual_total_time_ms`, `shared_blocks_read/hit`, `io_read_time_ms`, `io_write_time_ms`, and (PG 19) `aio_read_blocks` / `aio_write_blocks` rolled up across the plan tree. Reasoning about AIO needs `io=true`.\n\nExample: `analyze_query_plan(sql='SELECT * FROM orders WHERE customer_id = 42', io=true)`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "io",
+        "type": "boolean",
+        "desc": "Io"
+      },
+      {
+        "name": "sql",
+        "type": "string",
+        "desc": "Sql"
+      }
+    ]
+  },
+  {
+    "name": "analyze_rerank_ndcg",
+    "description": "NDCG@k under bi-encoder ordering vs cross-encoder ordering, averaged across labeled queries (``ground_truth_relevance IS NOT NULL``). Reports the delta (cross - bi) \u2014 positive = the rerank is adding real ranking quality, negative = it's hurting. Surfaces ``rerank_hurts_ndcg`` (CRITICAL) or ``rerank_lifts_ndcg`` (GOOD evidence). Reads from mcpg_rag.rerank_events; returns zero counts when no labeled rows exist in the window.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "days",
+        "type": "integer",
+        "desc": "Days"
+      },
+      {
+        "name": "k",
+        "type": "integer",
+        "desc": "K"
+      },
+      {
+        "name": "model",
+        "type": "string",
+        "desc": "Model"
+      },
+      {
+        "name": "retrieval_index",
+        "type": "string",
+        "desc": "Retrieval Index"
+      }
+    ]
+  },
+  {
+    "name": "analyze_rerank_score_distribution",
+    "description": "Equal-width histogram of cross_encoder_score values over the window plus the top-decile share. Surfaces ``score_clustering`` (WARNING) when the reranker isn't discriminating (more than half of scores land in the top decile of the range). Reads from mcpg_rag.rerank_events. Returns an object with `window_days`, `event_count`, `histogram` (list of counts), `bucket_edges` (list of bucket boundaries), `top_decile_share`, and `findings` (list of advisory findings).",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "days",
+        "type": "integer",
+        "desc": "Days"
+      },
+      {
+        "name": "model",
+        "type": "string",
+        "desc": "Model"
+      },
+      {
+        "name": "n_buckets",
+        "type": "integer",
+        "desc": "N Buckets"
+      },
+      {
+        "name": "retrieval_index",
+        "type": "string",
+        "desc": "Retrieval Index"
+      }
+    ]
+  },
+  {
+    "name": "analyze_reranker_lift",
+    "description": "Per-query Spearman + Kendall correlation between bi-encoder and cross-encoder ranks, aggregated across queries in the window. Low correlation = the reranker is actively reordering (doing real work); high correlation = the reranker mostly confirms the bi-encoder order. Optional ``model`` / ``retrieval_index`` filters. Surfaces ``reranker_idle`` (WARNING) when the reranker rarely changes ordering. Reads from mcpg_rag.rerank_events; returns a report with zero counts when the table doesn't exist or the window is empty.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "days",
+        "type": "integer",
+        "desc": "Days"
+      },
+      {
+        "name": "model",
+        "type": "string",
+        "desc": "Model"
+      },
+      {
+        "name": "retrieval_index",
+        "type": "string",
+        "desc": "Retrieval Index"
+      }
+    ]
+  },
+  {
+    "name": "analyze_session_cost",
+    "description": "Surface hot-path inefficiencies from the audit log. Reads `mcpg_audit.events` over the last `lookback_minutes` (default 60, capped at 1440) and flags tools called more than `hot_threshold` times (default 10). Catalogue-listing tools (`list_tables` / `list_schemas` / `list_indexes` / etc.) get a `redundant_listing` finding pointing at `get_compact_schema`; other tools get a `hot_repeated_call` finding suggesting caching. Idle sessions get an `idle_session` finding. When `mcpg_audit.events` doesn't exist (audit subsystem off) returns `audit_table_present=False` with a diagnostic. Returns an object with `audit_table_present` (bool), `events_examined` (int), `lookback_minutes`, `findings` (list of objects with `reason`, `tool`, `call_count`, `suggestion`), and `detail`.\n\nExample: `analyze_session_cost(lookback_minutes=30, hot_threshold=15)`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "hot_threshold",
+        "type": "integer",
+        "desc": "Hot Threshold"
+      },
+      {
+        "name": "lookback_minutes",
+        "type": "integer",
+        "desc": "Lookback Minutes"
+      }
+    ]
+  },
+  {
+    "name": "analyze_table_bloat",
+    "description": "Rank a schema's tables and indexes by estimated bloat, worst first. By default uses a cheap catalog-only estimate (relpages vs a reltuples/row-width floor) plus the dead-tuple ratio from pg_stat_user_tables. Set `precise=true` to use pgstattuple / pgstatindex for an exact (but I/O-heavy) read when the extension is installed \u2014 it falls back to the estimate and reports `method='estimate'` if it isn't. Returns `tables` and `indexes` (each capped at `limit`) with per-object `est_bloat_pct`, plus `available` and `method`.\n\nExample: `analyze_table_bloat(schema='public', limit=20, precise=false)`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Limit"
+      },
+      {
+        "name": "precise",
+        "type": "boolean",
+        "desc": "Precise"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "analyze_topk_stability",
+    "description": "Jaccard overlap between top-K-by-bi-rank and top-K-by-cross-rank per query, aggregated. High mean Jaccard means the reranker isn't actually changing the top-K membership. Surfaces ``topk_stable`` (WARNING) when the rerank is barely earning its place at this K. Reads from mcpg_rag.rerank_events; returns a report with zero counts when the table doesn't exist or the window is empty.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "days",
+        "type": "integer",
+        "desc": "Days"
+      },
+      {
+        "name": "k",
+        "type": "integer",
+        "desc": "K"
+      },
+      {
+        "name": "model",
+        "type": "string",
+        "desc": "Model"
+      },
+      {
+        "name": "retrieval_index",
+        "type": "string",
+        "desc": "Retrieval Index"
+      }
+    ]
+  },
+  {
+    "name": "analyze_vector_search_efficiency",
+    "description": "Cross-backend retrieval-quality report for a pgvector or pg_turboquant ANN index. Detects the backend (HNSW / IVFFlat / turboquant), sweeps the matching per-backend knob (ef_search / probes / candidate_limit) across a multiplier curve, computes recall@k vs a brute-force exact baseline, Spearman + Kendall rank correlation, per-query p50/p95 wall-clock latency, and (for turboquant) the page-pruning ratio from tq_last_scan_stats. Emits findings: ``baseline_recall_low`` (CRITICAL), ``rerank_lift_flat`` / ``rerank_lift_steep`` / ``ranking_degraded`` / ``pruning_ineffective`` (WARNING). Burns sample_size x (1 + len(candidate_multipliers)) queries; ad-hoc diagnostic, not a cron tool. Requires the vector extension; turboquant-arm metrics require pg_turboquant.",
+    "arguments": [
+      {
+        "name": "candidate_multipliers",
+        "type": "array",
+        "desc": "Candidate Multipliers"
+      },
+      {
+        "name": "column",
+        "type": "string",
+        "desc": "Column"
+      },
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "id_column",
+        "type": "string",
+        "desc": "Id Column"
+      },
+      {
+        "name": "index_name",
+        "type": "string",
+        "desc": "Index Name"
+      },
+      {
+        "name": "k",
+        "type": "integer",
+        "desc": "K"
+      },
+      {
+        "name": "metric",
+        "type": "string",
+        "desc": "Metric"
+      },
+      {
+        "name": "sample_size",
+        "type": "integer",
+        "desc": "Sample Size"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "analyze_workload",
+    "description": "Return the slowest queries by mean execution time, via the pg_stat_statements extension. Reports availability=false if the extension is not installed.\n\nExample: `analyze_workload(limit=10)`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Limit"
+      }
+    ]
+  },
+  {
+    "name": "audit_database",
+    "description": "Run a deep, comprehensive DBA-level database performance, logs, and health audit over the specified schema. Scans memory, checkpoints, temp file spills, contention locks, dead tuple cleanliness, and optionally scans custom logging tables. Set `fresh=true` to bypass the cache and re-read live (e.g. after a schema change). Returns an object with `timestamp`, `database`, `version`, `overall_health` ('GOOD' / 'WARNING' / 'CRITICAL'), `health_score` (int), `categories` (per-area results), `top_issues`, `recommendations`, and `raw_stats_snapshot`.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "fresh",
+        "type": "boolean",
+        "desc": "Fresh"
+      },
+      {
+        "name": "log_table",
+        "type": "string",
+        "desc": "Log Table"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "audit_sequences",
+    "description": "Flag sequences nearing their ceiling \u2014 serial / identity / explicit sequences whose `last_value / max_value` exceeds `warning_pct` (default 80) or `critical_pct` (default 95). Sequence overflow is catastrophic and silent until the next `nextval()` raises 'reached maximum value' \u2014 the int4 `serial` ceiling (2^31-1) is hit far more often than expected. Pure read; `available=false` on PG < 10 (no pg_sequences). Returns an object with `available`, `total_examined`, `warning_pct`, `critical_pct`, `detail`, and `sequences` (at-risk only, sorted by `used_pct` desc \u2014 each with `schema`, `sequence`, `last_value`, `max_value`, `used_pct`, `remaining`, `status`).\n\nExample: `audit_sequences(warning_pct=80, critical_pct=95)`",
+    "arguments": [
+      {
+        "name": "critical_pct",
+        "type": "number",
+        "desc": "Critical Pct"
+      },
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "warning_pct",
+        "type": "number",
+        "desc": "Warning Pct"
+      }
+    ]
+  },
+  {
+    "name": "audit_settings",
+    "description": "Sanity-sweep `postgresql.conf` via `pg_settings`. Flags dangerous toggles (`fsync=off`, `full_page_writes=off`, `autovacuum=off`, `synchronous_commit=off`), cross-setting issues (`maintenance_work_mem` < `work_mem`, tiny `shared_buffers`, low `checkpoint_completion_target`), and \u2014 when `total_ram_mb` is supplied \u2014 RAM-relative ratios for `shared_buffers` / `effective_cache_size` (PostgreSQL can't see host RAM itself). Pure read. Returns an object with `ram_aware` (bool), `examined_settings` (list), `detail`, and `findings` (tripped rules only \u2014 each with `code`, `setting`, `current`, `status`, `suggestion`).\n\nExample: `audit_settings(total_ram_mb=16384)`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "total_ram_mb",
+        "type": "integer",
+        "desc": "Total Ram Mb"
+      }
+    ]
+  },
+  {
+    "name": "cancel_migration",
+    "description": "Drop a prepared migration's shadow schema and mark it cancelled. Idempotent \u2014 calling cancel on a non-existent or already-completed migration returns shadow_dropped=false without raising.",
+    "arguments": [
+      {
+        "name": "migration_id",
+        "type": "string",
+        "desc": "Migration Id"
+      }
+    ]
+  },
+  {
+    "name": "cancel_query",
+    "description": "Cancel the query running on a backend PID (pg_cancel_backend); the connection stays open. Available only in unrestricted mode. Returns an object with `pid`, `action` ('cancel'), and `succeeded` (bool).",
+    "arguments": [
+      {
+        "name": "pid",
+        "type": "integer",
+        "desc": "Pid"
+      }
+    ]
+  },
+  {
+    "name": "check_database_health",
+    "description": "Run database health checks: connection utilisation, buffer cache hit ratio, tables needing vacuum, and invalid indexes. Returns an object with `status` ('ok' / 'warning' / 'critical') and `checks` (a list of `{name, status, detail}` per check).\n\nExample: `check_database_health()`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "check_pitr_readiness",
+    "description": "Assess whether the cluster is ready for point-in-time recovery (PITR) \u2014 the one-call 'could I actually recover to an arbitrary point right now, and if not what's missing?' check. Composes `get_wal_archive_status` (5.2) with the GUCs that gate PITR: continuous archiving must be healthy, `wal_level` >= replica, `max_wal_senders` >= 1 (so pg_basebackup can stream a base backup), and `full_page_writes` on (torn-page safety during replay). Read-only advisor \u2014 changes nothing, emits no secrets. Returns an object with `available`, `ready` (bool \u2014 true only when all gates pass), `wal_level`, `archiving_healthy`, `gates` (list of objects with `name`, `ok`, `observed`, `remediation`), `remediation` (ordered fixes for failing gates), and `detail`.\n\nExample: `check_pitr_readiness()`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "check_segment_health",
+    "description": "Walk `gp_segment_configuration` and surface MPP segment posture. Returns per-segment `status` ('u' = up), `mode` ('s' = sync / 'n' = not-in-sync / 'c' = changetracking), and `role` vs `preferred_role` to detect post-failover state. Top-level `unhealthy_count` + `out_of_sync_count` let agents branch without walking the segments array. Read-only. On vanilla PG returns `available=false`.\n\nExample: `check_segment_health()`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "clear_cache",
+    "description": "Flush MCPg's server-side result cache \u2014 the cache that speeds up schema introspection and advisor reads. MCPg clears this cache automatically after its own write / DDL tools, but it cannot observe schema changes made out-of-band (another connection, or a change made outside MCPg) until each entry's TTL (MCPG_CACHE_TTL_SECONDS, default 300s) expires \u2014 call this after such a change so the next read is live. For a single tool, prefer its `fresh=true` argument. Touches no database data. Available when writes are permitted (restricted or unrestricted mode). Returns an object with `status` ('cleared') and `detail`.",
+    "arguments": []
+  },
+  {
+    "name": "close_cursor",
+    "description": "Close a server-side cursor and release its dedicated connection. Idempotent \u2014 returns closed=false when the cursor was not open (already closed, expired, or never existed).",
+    "arguments": [
+      {
+        "name": "cursor_id",
+        "type": "string",
+        "desc": "Cursor Id"
+      }
+    ]
+  },
+  {
+    "name": "cluster_vectors",
+    "description": "k-means cluster a pgvector column. Samples up to `sample_size` (default 5000) non-NULL rows of schema.table.embedding_column, runs Lloyd's algorithm with k-means++ seeding (`seed` for determinism), and returns `centroids` (one per cluster, with size) + `assignments` (per-row cluster index + distance). When `id_column` is set each assignment carries that column's value; otherwise the row's positional sample index. metric='l2' (default \u2014 squared Euclidean) or 'cosine' (vectors normalised; centroids re-normalised every iteration). `k` >= 2 and there must be at least 2k parseable rows. Reports available=false if pgvector is not installed.\n\nExample: `cluster_vectors(schema='public', table='docs', embedding_column='embedding', k=8, metric='cosine')`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "embedding_column",
+        "type": "string",
+        "desc": "Embedding Column"
+      },
+      {
+        "name": "id_column",
+        "type": "string",
+        "desc": "Id Column"
+      },
+      {
+        "name": "k",
+        "type": "integer",
+        "desc": "K"
+      },
+      {
+        "name": "max_iterations",
+        "type": "integer",
+        "desc": "Max Iterations"
+      },
+      {
+        "name": "metric",
+        "type": "string",
+        "desc": "Metric"
+      },
+      {
+        "name": "sample_size",
+        "type": "integer",
+        "desc": "Sample Size"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "seed",
+        "type": "integer",
+        "desc": "Seed"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "compare_schemas",
+    "description": "Return the structural diff between two schemas \u2014 tables/columns/indexes/constraints/foreign-keys added, removed, or changed. Base tables only; views and custom types are not compared. Renames surface as a paired add + remove.\n\nExample: `compare_schemas(left_schema='public', right_schema='staging')`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "left_schema",
+        "type": "string",
+        "desc": "Left Schema"
+      },
+      {
+        "name": "right_schema",
+        "type": "string",
+        "desc": "Right Schema"
+      }
+    ]
+  },
+  {
+    "name": "complete_migration",
+    "description": "Apply a prepared migration's candidate SQL to its target schema. Refuses if the migration is not in 'prepared' status or its TTL has expired. Drops the shadow on success and marks the row completed. Performs DDL \u2014 requires unrestricted mode + MCPG_ALLOW_DDL.",
+    "arguments": [
+      {
+        "name": "migration_id",
+        "type": "string",
+        "desc": "Migration Id"
+      }
+    ]
+  },
+  {
+    "name": "copy_table_between_databases",
+    "description": "Copy a single table from one database to another by piping pg_dump (source) into pg_restore (destination). The source URL is the caller-supplied source_url; the destination is the configured database URL. Specify at least one of include_schema / include_data. Credentials pass through libpq env vars on each leg, never on the command line. If the captured pg_dump archive would exceed MCPG_SHELL_MAX_OUTPUT_BYTES, the tool errors BEFORE pg_restore runs (a truncated custom-format archive cannot be safely restored). Performs subprocess execution \u2014 requires unrestricted mode + MCPG_ALLOW_SHELL.",
+    "arguments": [
+      {
+        "name": "include_data",
+        "type": "boolean",
+        "desc": "Include Data"
+      },
+      {
+        "name": "include_schema",
+        "type": "boolean",
+        "desc": "Include Schema"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "source_url",
+        "type": "string",
+        "desc": "Source Url"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "create_graph",
+    "description": "Create a new Apache AGE property graph space in the database. Performs DDL \u2014 requires DDL permission enabled. Returns an object with `graph_name` and `created` (bool).",
+    "arguments": [
+      {
+        "name": "graph_name",
+        "type": "string",
+        "desc": "Graph Name"
+      }
+    ]
+  },
+  {
+    "name": "create_hypertable",
+    "description": "Convert an existing table into a TimescaleDB hypertable on `time_column`. Validates schema / table / column names against the plain-identifier allowlist and the chunk interval against a TimescaleDB-style pattern (e.g. '7 days', '1 hour'). Requires unrestricted mode + MCPG_ALLOW_DDL. Returns an object with `available` (bool), `function` ('create_hypertable'), and `details` (the create_hypertable return text or an extension-missing note).",
+    "arguments": [
+      {
+        "name": "chunk_time_interval",
+        "type": "string",
+        "desc": "Chunk Time Interval"
+      },
+      {
+        "name": "if_not_exists",
+        "type": "boolean",
+        "desc": "If Not Exists"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      },
+      {
+        "name": "time_column",
+        "type": "string",
+        "desc": "Time Column"
+      }
+    ]
+  },
+  {
+    "name": "create_pg_search_index",
+    "description": "Build a CREATE INDEX \u2026 USING bm25 statement under tight allowlists and run it on autocommit (CONCURRENTLY can't run inside a transaction). ``columns`` is the list of attribute names the index covers; ``key_field`` is the primary-key column (required by upstream). All 13 documented bm25 reloptions are exposed as kwargs \u2014 the 7 JSONB-shaped options (``text_fields``, ``numeric_fields``, ``boolean_fields``, ``json_fields``, ``range_fields``, ``datetime_fields``, ``search_tokenizer``) accept Python dicts and serialize via json.dumps; the 2 int options (``target_segment_count``, ``mutable_segment_rows``) and 3 text options (``layer_sizes``, ``background_layer_sizes``, ``sort_by``) pass through type-aware validation. The rendered CREATE INDEX SQL is returned in ``create_sql`` for auditability. Performs DDL \u2014 requires unrestricted mode + MCPG_ALLOW_DDL; pg_search installed.",
+    "arguments": [
+      {
+        "name": "background_layer_sizes",
+        "type": "string",
+        "desc": "Background Layer Sizes"
+      },
+      {
+        "name": "boolean_fields",
+        "type": "object",
+        "desc": "Boolean Fields"
+      },
+      {
+        "name": "columns",
+        "type": "array",
+        "desc": "Columns"
+      },
+      {
+        "name": "concurrently",
+        "type": "boolean",
+        "desc": "Concurrently"
+      },
+      {
+        "name": "datetime_fields",
+        "type": "object",
+        "desc": "Datetime Fields"
+      },
+      {
+        "name": "index_name",
+        "type": "string",
+        "desc": "Index Name"
+      },
+      {
+        "name": "json_fields",
+        "type": "object",
+        "desc": "Json Fields"
+      },
+      {
+        "name": "key_field",
+        "type": "string",
+        "desc": "Key Field"
+      },
+      {
+        "name": "layer_sizes",
+        "type": "string",
+        "desc": "Layer Sizes"
+      },
+      {
+        "name": "mutable_segment_rows",
+        "type": "integer",
+        "desc": "Mutable Segment Rows"
+      },
+      {
+        "name": "numeric_fields",
+        "type": "object",
+        "desc": "Numeric Fields"
+      },
+      {
+        "name": "range_fields",
+        "type": "object",
+        "desc": "Range Fields"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "search_tokenizer",
+        "type": "object",
+        "desc": "Search Tokenizer"
+      },
+      {
+        "name": "sort_by",
+        "type": "string",
+        "desc": "Sort By"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      },
+      {
+        "name": "target_segment_count",
+        "type": "integer",
+        "desc": "Target Segment Count"
+      },
+      {
+        "name": "text_fields",
+        "type": "object",
+        "desc": "Text Fields"
+      }
+    ]
+  },
+  {
+    "name": "create_property_graph",
+    "description": "Create a SQL/PGQ property graph. The tool composes the `CREATE PROPERTY GRAPH \"schema\".\"name\"` header itself; `definition_body` carries the `VERTEX TABLES (...)` (and optional `EDGE TABLES (...)`) clauses. The body must begin with `VERTEX TABLES` and must not contain `;` \u2014 that boundary rules out smuggling a different DDL statement via the parameter. Requires PG 19+ and DDL mode. Returns an object with `schema`, `name`, and `created=true`.\n\nExample: `create_property_graph(schema='public', name='org_chart', definition_body=\"VERTEX TABLES (employees KEY (id) LABEL Employee PROPERTIES (id, name)) EDGE TABLES (reports_to SOURCE KEY (id) REFERENCES employees (id) DESTINATION KEY (manager_id) REFERENCES employees (id) LABEL REPORTS_TO)\")`",
+    "arguments": [
+      {
+        "name": "definition_body",
+        "type": "string",
+        "desc": "Definition Body"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "create_publication",
+    "description": "Create a logical-replication publication. Exactly one of `all_tables=True` or a non-empty `tables` tuple must be supplied. Each table in `tables` must be a `schema.table`-qualified name; both pieces are identifier-validated and quoted. Returns the rendered SQL for audit. Requires `MCPG_ALLOW_DDL`.\n\nExample: `create_publication(name='sales_pub', tables=('public.orders', 'public.line_items'))`",
+    "arguments": [
+      {
+        "name": "all_tables",
+        "type": "boolean",
+        "desc": "All Tables"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name"
+      },
+      {
+        "name": "tables",
+        "type": "array",
+        "desc": "Tables"
+      }
+    ]
+  },
+  {
+    "name": "create_redis_cache_server",
+    "description": "Create a foreign server backed by ``redis_fdw`` (``CREATE SERVER \u2026 FOREIGN DATA WRAPPER redis_fdw OPTIONS (\u2026)``). TLS is enabled by default; the tool refuses ``tls=false`` against a non-loopback Redis host unless ``allow_insecure_tls=true`` is passed explicitly. ``name`` must be a valid unquoted SQL identifier. Idempotent via ``IF NOT EXISTS``. Requires DDL mode. Returns an object with `name`, `address`, `port`, `database`, `tls`, and `created=true`.\n\nExample: `create_redis_cache_server(name='redis_primary', address='redis.internal', port=6379)`",
+    "arguments": [
+      {
+        "name": "address",
+        "type": "string",
+        "desc": "Address"
+      },
+      {
+        "name": "allow_insecure_tls",
+        "type": "boolean",
+        "desc": "Allow Insecure Tls"
+      },
+      {
+        "name": "database",
+        "type": "integer",
+        "desc": "Database"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name"
+      },
+      {
+        "name": "port",
+        "type": "integer",
+        "desc": "Port"
+      },
+      {
+        "name": "tls",
+        "type": "boolean",
+        "desc": "Tls"
+      }
+    ]
+  },
+  {
+    "name": "create_redis_cache_table",
+    "description": "Create a foreign table backed by ``redis_fdw``. ``key_type`` is the Redis-side structure (one of ``hash`` / ``list`` / ``string`` / ``set`` / ``zset``). ``columns`` is a list of ``{name, type}`` dicts \u2014 every name must be a valid unquoted SQL identifier and every type a bare Postgres type. Optional ``key_prefix`` and ``ttl_seconds`` are passed through as redis_fdw options. Idempotent via ``IF NOT EXISTS``. Requires DDL mode. Returns an object with `schema`, `name`, `server`, `key_type`, `columns` (tuple of column names), and `created=true`.\n\nExample: `create_redis_cache_table(schema='public', name='sessions_cache', server='redis_primary', key_type='hash', columns=[{'name': 'key', 'type': 'text'}, {'name': 'value', 'type': 'text'}], key_prefix='session:', ttl_seconds=3600)`",
+    "arguments": [
+      {
+        "name": "columns",
+        "type": "array",
+        "desc": "Columns"
+      },
+      {
+        "name": "key_prefix",
+        "type": "string",
+        "desc": "Key Prefix"
+      },
+      {
+        "name": "key_type",
+        "type": "string",
+        "desc": "Key Type"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "server",
+        "type": "string",
+        "desc": "Server"
+      },
+      {
+        "name": "ttl_seconds",
+        "type": "integer",
+        "desc": "Ttl Seconds"
+      }
+    ]
+  },
+  {
+    "name": "create_redis_user_mapping",
+    "description": "Create a user mapping for a redis_fdw foreign server. The Redis password is never accepted as a tool argument \u2014 pass ``secret_ref`` (the name of a secret in the configured ``MCPG_SECRETS_BACKEND``) and the tool resolves it before interpolating into the OPTIONS clause. ``user='public'`` creates a PUBLIC mapping; otherwise the user name must be a valid unquoted SQL identifier. Idempotent via ``IF NOT EXISTS``. Requires DDL mode. Returns an object with `server`, `user`, `secret_ref` (echoed by name, not value), and `created=true`.\n\nExample: `create_redis_user_mapping(server='redis_primary', user='public', secret_ref='REDIS_PASSWORD')`",
+    "arguments": [
+      {
+        "name": "secret_ref",
+        "type": "string",
+        "desc": "Secret Ref"
+      },
+      {
+        "name": "server",
+        "type": "string",
+        "desc": "Server"
+      },
+      {
+        "name": "user",
+        "type": "string",
+        "desc": "User"
+      }
+    ]
+  },
+  {
+    "name": "create_subscription",
+    "description": "Create a logical-replication subscription to one or more publications on a publisher cluster. `connection_string` is a libpq DSN; it's NOT echoed back in the result (may contain credentials). Options: `enabled` (start immediately), `copy_data` (initial sync), `create_slot` (let subscriber create the upstream slot), `slot_name` (override default), `synchronous_commit` (one of 'on'/'off'/'local'/'remote_write'/'remote_apply'). Requires `MCPG_ALLOW_DDL`.\n\nExample: `create_subscription(name='sales_sub', connection_string='host=publisher dbname=app user=replicator', publications=('sales_pub',))`",
+    "arguments": [
+      {
+        "name": "connection_string",
+        "type": "string",
+        "desc": "Connection String"
+      },
+      {
+        "name": "copy_data",
+        "type": "boolean",
+        "desc": "Copy Data"
+      },
+      {
+        "name": "create_slot",
+        "type": "boolean",
+        "desc": "Create Slot"
+      },
+      {
+        "name": "enabled",
+        "type": "boolean",
+        "desc": "Enabled"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name"
+      },
+      {
+        "name": "publications",
+        "type": "array",
+        "desc": "Publications"
+      },
+      {
+        "name": "slot_name",
+        "type": "string",
+        "desc": "Slot Name"
+      },
+      {
+        "name": "synchronous_commit",
+        "type": "string",
+        "desc": "Synchronous Commit"
+      }
+    ]
+  },
+  {
+    "name": "create_turboquant_index",
+    "description": "Build a CREATE INDEX \u2026 USING turboquant statement under tight allowlists and run it on autocommit (CONCURRENTLY can't run inside a transaction). ``metric`` is 'cosine' | 'inner_product' | 'l2' (mapped to the matching tq_*_ops opclass). Index options ``bits`` (1..64), ``lists`` (0..1_000_000), ``transform`` (allowlist: 'hadamard'), ``normalized`` (bool) are all optional; any not supplied are omitted from the WITH clause so upstream's defaults apply. The rendered CREATE INDEX SQL is returned in ``create_sql`` for auditability. Performs DDL \u2014 requires unrestricted mode + MCPG_ALLOW_DDL; pg_turboquant installed.",
+    "arguments": [
+      {
+        "name": "bits",
+        "type": "integer",
+        "desc": "Bits"
+      },
+      {
+        "name": "column",
+        "type": "string",
+        "desc": "Column"
+      },
+      {
+        "name": "concurrently",
+        "type": "boolean",
+        "desc": "Concurrently"
+      },
+      {
+        "name": "index_name",
+        "type": "string",
+        "desc": "Index Name"
+      },
+      {
+        "name": "lists",
+        "type": "integer",
+        "desc": "Lists"
+      },
+      {
+        "name": "metric",
+        "type": "string",
+        "desc": "Metric"
+      },
+      {
+        "name": "normalized",
+        "type": "boolean",
+        "desc": "Normalized"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      },
+      {
+        "name": "transform",
+        "type": "string",
+        "desc": "Transform"
+      }
+    ]
+  },
+  {
+    "name": "cross_table_similarity",
+    "description": "Find the k rows in target_schema.target_table most similar to a specific row in source_schema.source_table. Locates the source row via source_id_column = source_id_value, reads its embedding from source_embedding_column, then issues a pgvector k-NN query against target_embedding_column. Both columns must be vector(N) of the same N \u2014 verified from the catalog up front so a mismatch fails with a clear error rather than a cast error. Useful for entity-resolution / linking across tables whose embeddings come from different models but share a dimension. Returns source_embedding_found=false when no row matches the id value. Reports available=false if pgvector is not installed.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "k",
+        "type": "integer",
+        "desc": "K"
+      },
+      {
+        "name": "metric",
+        "type": "string",
+        "desc": "Metric"
+      },
+      {
+        "name": "source_embedding_column",
+        "type": "string",
+        "desc": "Source Embedding Column"
+      },
+      {
+        "name": "source_id_column",
+        "type": "string",
+        "desc": "Source Id Column"
+      },
+      {
+        "name": "source_id_value",
+        "type": "string",
+        "desc": "Source Id Value"
+      },
+      {
+        "name": "source_schema",
+        "type": "string",
+        "desc": "Source Schema"
+      },
+      {
+        "name": "source_table",
+        "type": "string",
+        "desc": "Source Table"
+      },
+      {
+        "name": "target_embedding_column",
+        "type": "string",
+        "desc": "Target Embedding Column"
+      },
+      {
+        "name": "target_schema",
+        "type": "string",
+        "desc": "Target Schema"
+      },
+      {
+        "name": "target_table",
+        "type": "string",
+        "desc": "Target Table"
+      }
+    ]
+  },
+  {
+    "name": "describe_ao_table",
+    "description": "Describe append-optimized (AO) / append-optimized columnar (AO/CO) storage metadata for one table: row vs column orientation, `compression_type`, `compression_level`, `block_size`, `checksum`. Reads `pg_appendonly`. Returns `is_ao=false` cleanly when the table is a regular heap. Read-only. On vanilla PG returns `available=false`.\n\nExample: `describe_ao_table(schema='public', table='events_ao')`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "describe_graph",
+    "description": "Describe the schema structure, vertex labels, and edge labels of a specific property graph. Returns an object with `graph_name`, `vertex_labels`, and `edge_labels`.",
+    "arguments": [
+      {
+        "name": "graph_name",
+        "type": "string",
+        "desc": "Graph Name"
+      }
+    ]
+  },
+  {
+    "name": "describe_property_graph",
+    "description": "Describe one SQL/PGQ property graph by schema-qualified name. Requires PG 19+; raises an error otherwise. Useful when an agent has located a graph via `list_property_graphs` and needs the full membership before composing a `run_pgq` query. Returns an object with `schema`, `name`, `vertex_tables` (list of `schema.table` strings), and `edge_tables` (same shape).\n\nExample: `describe_property_graph(schema='public', name='org_chart')`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "describe_redis_cache_table",
+    "description": "Describe one foreign table backed by ``redis_fdw``: which server it's mapped to, the Redis-side key structure (`hash` / `list` / `string` / `set` / `zset`), key-prefix, TTL, and SQL-side column shape. Raises an error when the table doesn't exist or isn't backed by redis_fdw. Returns an object with `schema`, `name`, `server`, `key_type`, `key_prefix`, `ttl_seconds`, `columns` (list of `{name, data_type}`), and `options` (the full foreign-table options dict).\n\nExample: `describe_redis_cache_table(schema='public', table='sessions_cache')`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "describe_self",
+    "description": "Return a high-level summary of what mcpg can do, organised into capability buckets (schema introspection, query execution, vector search, RAG telemetry, audit trail, migrations, time-series, etc.). Call this first when discovering mcpg's surface \u2014 it's much more compact than walking the full tool catalogue. Returns an object with `headline`, `version`, `tool_count`, `capability_count`, and a `capabilities` list, where each capability has `id`, `name`, `summary`, `detail`, `headline_tools` (top 3-6 tools to reach for first), `tool_count`, and `all_tools` (the full list in that bucket). Read-only; no database access. Pair with `list_tools` (MCP-protocol) when you need every tool's full schema.",
+    "arguments": []
+  },
+  {
+    "name": "describe_table",
+    "description": "Describe the columns of a table, in ordinal order. Set `fresh=true` to bypass the cache and re-read live (e.g. after a schema change). Returns a list of objects with `name`, `data_type`, `nullable`, `default`, and `vector_dimension` (set only for pgvector `vector(N)` columns).\n\nExample: `describe_table(schema='public', table='users')`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "fresh",
+        "type": "boolean",
+        "desc": "Fresh"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "describe_tool",
+    "description": "Return the full registered schema for one MCP tool by name \u2014 `description`, `input_schema`, `output_schema`, and which capability bucket it belongs to. Use this when an agent hits a tool error and needs to verify the call shape without re-walking the full `describe_self` payload (handy when the transport surfaces only `tools/call`, not `tools/list`). Returns `registered=false` plus a `did_you_mean` suggestion list when the name isn't on this server. Read-only; no database access. Example: `describe_tool(name='run_select')`",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name"
+      }
+    ]
+  },
+  {
+    "name": "detect_n_plus_one",
+    "description": "Surface query templates in pg_stat_statements that look like an N+1 loop: hundreds of calls, each returning at most a row or two, with meaningful total wall-clock time spent. Returns the candidates sorted by total time descending so the worst offender appears first. Thresholds (min_calls, max_rows_per_call, min_total_ms) are tunable. Treat results as candidates for investigation, NOT verdicts \u2014 a hot cache-miss pattern on a primary-key lookup can trip the same shape. Reports availability=false if pg_stat_statements is not installed.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Limit"
+      },
+      {
+        "name": "max_rows_per_call",
+        "type": "number",
+        "desc": "Max Rows Per Call"
+      },
+      {
+        "name": "min_calls",
+        "type": "integer",
+        "desc": "Min Calls"
+      },
+      {
+        "name": "min_total_ms",
+        "type": "number",
+        "desc": "Min Total Ms"
+      }
+    ]
+  },
+  {
+    "name": "detect_vector_outliers",
+    "description": "Flag pgvector rows whose embedding sits far from any cluster centroid. Samples up to `sample_size` (default 5000) non-NULL rows of schema.table.embedding_column, clusters them with k-means (same engine as `cluster_vectors`), then per cluster computes a z-score on the distance from each row to its centroid and flags rows whose z-score exceeds `zscore_threshold` (default 3.0). Per-cluster scoring catches rows that are weird-for-their-group rather than weird-overall, which is usually what 'find outliers' should mean. Returns `outliers` sorted by z-score descending (capped at `max_results`), `total_outliers` (the unclipped count), and `cluster_stats` (per-cluster mean / std of within-cluster distances). When `id_column` is set each outlier carries that column's value; otherwise the row's positional sample index. `k` >= 2 and there must be at least 2k parseable rows. Reports available=false if pgvector is not installed.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "embedding_column",
+        "type": "string",
+        "desc": "Embedding Column"
+      },
+      {
+        "name": "id_column",
+        "type": "string",
+        "desc": "Id Column"
+      },
+      {
+        "name": "k",
+        "type": "integer",
+        "desc": "K"
+      },
+      {
+        "name": "max_iterations",
+        "type": "integer",
+        "desc": "Max Iterations"
+      },
+      {
+        "name": "max_results",
+        "type": "integer",
+        "desc": "Max Results"
+      },
+      {
+        "name": "metric",
+        "type": "string",
+        "desc": "Metric"
+      },
+      {
+        "name": "sample_size",
+        "type": "integer",
+        "desc": "Sample Size"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "seed",
+        "type": "integer",
+        "desc": "Seed"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      },
+      {
+        "name": "zscore_threshold",
+        "type": "number",
+        "desc": "Zscore Threshold"
+      }
+    ]
+  },
+  {
+    "name": "disable_data_checksums",
+    "description": "Turn `data_checksums` off without restarting the cluster. Calls PG 19's `pg_disable_data_checksums()` SQL function. No-op (`changed=false`) when checksums are already off. Requires PG 19+. Returns an object with `was_enabled`, `now_enabled` (`false`), `changed`, and `toggle_sql`.\n\nExample: `disable_data_checksums()`",
+    "arguments": []
+  },
+  {
+    "name": "drop_graph",
+    "description": "Delete an Apache AGE property graph space, dropping all its nodes, edges, and backing tables. Performs DDL \u2014 requires DDL permission enabled. Returns an object with `graph_name` and `dropped` (bool).",
+    "arguments": [
+      {
+        "name": "cascade",
+        "type": "boolean",
+        "desc": "Cascade"
+      },
+      {
+        "name": "graph_name",
+        "type": "string",
+        "desc": "Graph Name"
+      }
+    ]
+  },
+  {
+    "name": "drop_property_graph",
+    "description": "Drop a SQL/PGQ property graph. ``if_exists=true`` (the default) makes the operation idempotent. Requires PG 19+ and DDL mode. Returns an object with `schema`, `name`, and `dropped=true`.\n\nExample: `drop_property_graph(schema='public', name='org_chart')`",
+    "arguments": [
+      {
+        "name": "if_exists",
+        "type": "boolean",
+        "desc": "If Exists"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "drop_publication",
+    "description": "Drop a logical-replication publication. `if_exists=True` suppresses 'does not exist' errors; `cascade=True` lets the drop cascade through dependent objects. Identifier-validated. Requires `MCPG_ALLOW_DDL`.\n\nExample: `drop_publication(name='sales_pub', if_exists=True)`",
+    "arguments": [
+      {
+        "name": "cascade",
+        "type": "boolean",
+        "desc": "Cascade"
+      },
+      {
+        "name": "if_exists",
+        "type": "boolean",
+        "desc": "If Exists"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name"
+      }
+    ]
+  },
+  {
+    "name": "drop_subscription",
+    "description": "Drop a logical-replication subscription. PostgreSQL requires the subscription be disabled first (or its slot dropped on the publisher); this tool does NOT auto-disable \u2014 pair with `run_ddl` for `ALTER SUBSCRIPTION ... DISABLE` when needed. Identifier-validated. Requires `MCPG_ALLOW_DDL`.\n\nExample: `drop_subscription(name='sales_sub', if_exists=True)`",
+    "arguments": [
+      {
+        "name": "if_exists",
+        "type": "boolean",
+        "desc": "If Exists"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name"
+      }
+    ]
+  },
+  {
+    "name": "dry_run_ddl",
+    "description": "Run a DDL statement inside a transaction with a bounded lock_timeout, measure its impact \u2014 lock modes held (`max_lock_mode`), wall-clock `duration_ms`, and `wal_bytes` generated \u2014 then ALWAYS roll back so NOTHING persists. Use it to see the blast radius of an ALTER TABLE before committing on a busy table. IMPORTANT: rollback undoes the catalog change, but a *rewriting* DDL (e.g. a type change that rewrites every row) still does the rewrite work and holds its lock for the full duration before the rollback \u2014 the dry run measures impact by incurring it. CONCURRENTLY / non-transactional statements (CREATE INDEX CONCURRENTLY, VACUUM, ALTER SYSTEM) cannot run in the wrapping transaction and are reported as `eligible=false`. On a lock_timeout it returns `lock_timed_out=true`; other errors land in `error`. Available only with MCPG_ALLOW_DDL enabled.",
+    "arguments": [
+      {
+        "name": "ddl_sql",
+        "type": "string",
+        "desc": "Ddl Sql"
+      },
+      {
+        "name": "lock_timeout_ms",
+        "type": "integer",
+        "desc": "Lock Timeout Ms"
+      }
+    ]
+  },
+  {
+    "name": "dump_database",
+    "description": "Run pg_dump against the connected database and return the SQL dump as a string (for `format='plain'`) or base64-encoded bytes (for `custom`/`tar`). Credentials pass through libpq env vars, never on the command line. The result includes `output_truncated` and `timed_out` flags so the caller can re-run with a higher cap or a narrower scope. Pass `schemas` to scope the dump to specific schemas instead of the whole database. Performs subprocess execution \u2014 requires unrestricted mode + MCPG_ALLOW_SHELL.",
+    "arguments": [
+      {
+        "name": "format",
+        "type": "string",
+        "desc": "Format"
+      },
+      {
+        "name": "schema_only",
+        "type": "boolean",
+        "desc": "Schema Only"
+      },
+      {
+        "name": "schemas",
+        "type": "array",
+        "desc": "Schemas"
+      }
+    ]
+  },
+  {
+    "name": "enable_data_checksums",
+    "description": "Turn `data_checksums` on without restarting the cluster. Calls PG 19's `pg_enable_data_checksums()` SQL function; the rewrite of affected pages happens in the background via the new `data_checksum_worker`. No-op (`changed=false`) when checksums are already on. Requires PG 19+; raises an error on older servers (pair with `get_data_checksums_status` to feature-detect, or fall back to the offline `pg_checksums` tool on PG \u2264 18). Returns an object with `was_enabled` (bool / null), `now_enabled` (bool), `changed` (bool), and `toggle_sql` (the rendered SQL that actually executed).\n\nExample: `enable_data_checksums()`",
+    "arguments": []
+  },
+  {
+    "name": "enable_extension",
+    "description": "Enable a known PostgreSQL extension (CREATE EXTENSION IF NOT EXISTS). Only allowlisted extensions may be enabled. Available only in unrestricted access mode with MCPG_ALLOW_DDL enabled. Returns an object with `name` and `enabled` (bool).",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name"
+      }
+    ]
+  },
+  {
+    "name": "enable_logical_replication_on_demand",
+    "description": "Flip `wal_level` to `'logical'` without restarting the cluster. Issues `ALTER SYSTEM SET wal_level = 'logical'` followed by `pg_reload_conf()`; on PG 19+ the change takes effect for new WAL traffic immediately. No-op when `wal_level` is already `'logical'`. Requires PG 19+; raises on older servers where the flip still needs a planned restart. Returns an object with `previous_wal_level` (str / null), `new_wal_level` (str), `requires_restart` (bool), and `detail`.\n\nExample: `enable_logical_replication_on_demand()`",
+    "arguments": []
+  },
+  {
+    "name": "enable_redis_fdw",
+    "description": "Install the ``redis_fdw`` extension. Thin wrapper over ``enable_extension('redis_fdw')`` \u2014 convenient for agents that have located the cache-and-foreign-data bucket but haven't found the generic extension installer. redis_fdw runs in-process inside Postgres; operators should be aware of that operational implication before installing. Requires DDL mode. Returns an object with `name='redis_fdw'` and `enabled=true`.\n\nExample: `enable_redis_fdw()`",
+    "arguments": []
+  },
+  {
+    "name": "explain_query",
+    "description": "Return the PostgreSQL execution plan for a query. By default uses `EXPLAIN (FORMAT JSON)` \u2014 plan only, the query is not executed. Set `io=true` to switch to `EXPLAIN (ANALYZE, BUFFERS, TIMING)` \u2014 runs the query and includes buffer + I/O timing per node (PG 19 additionally surfaces asynchronous-I/O block counts). Validated by the same safety allowlist as `run_select`, so writes / DDL are rejected.\n\nExample: `explain_query(sql='SELECT * FROM orders WHERE customer_id = 42', io=true)`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "io",
+        "type": "boolean",
+        "desc": "Io"
+      },
+      {
+        "name": "sql",
+        "type": "string",
+        "desc": "Sql"
+      }
+    ]
+  },
+  {
+    "name": "export_query",
+    "description": "Run a read-only SQL query and serialise its rows to CSV or JSON. Reuses the SQL-safety checks of run_select. Truncates at `limit` rows and flags it in the result so callers can paginate.\n\nExample: `export_query(sql='SELECT id, email FROM users', format='csv', limit=10000)`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "format",
+        "type": "string",
+        "desc": "Format"
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Limit"
+      },
+      {
+        "name": "sql",
+        "type": "string",
+        "desc": "Sql"
+      }
+    ]
+  },
+  {
+    "name": "export_table",
+    "description": "Serialise every row in schema.table (up to `limit`) to CSV or JSON. Schema and table names must be plain identifiers. Returns an object with `format`, `row_count`, `truncated` (bool \u2014 true when the row count hit `limit`), and `content` (the serialised payload as a string).",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "format",
+        "type": "string",
+        "desc": "Format"
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Limit"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "fetch_cursor",
+    "description": "Fetch the next batch from an open server-side cursor. exhausted=true means the FETCH returned fewer rows than requested \u2014 stop polling. batch_size defaults to 100; hard cap is 10000 per call.",
+    "arguments": [
+      {
+        "name": "batch_size",
+        "type": "integer",
+        "desc": "Batch Size"
+      },
+      {
+        "name": "cursor_id",
+        "type": "string",
+        "desc": "Cursor Id"
+      }
+    ]
+  },
+  {
+    "name": "find_blocking_chains",
+    "description": "Return (blocked, blocking) backend pairs via pg_blocking_pids. Each row pairs a backend waiting on a Lock with one PID holding the lock that's preventing progress. Cycles are possible (A blocks B, B blocks A); render with care. Read-only.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Limit"
+      }
+    ]
+  },
+  {
+    "name": "find_sensitive_columns",
+    "description": "Flag columns whose names or types look like they hold sensitive data (passwords, tokens, PII, financial info, health records). Pure heuristic \u2014 no row sampling, no value introspection. Categories: credential, financial, contact, identifier, health, government_id, location. Each finding carries a confidence (high / medium / low) so an agent can filter for a first review pass. Treat as a SIGNAL, not a verdict \u2014 a column named email_template_id matches the email pattern but isn't itself an email address. Returns an object with `findings` (list of `{schema, table, column, data_type, category, confidence, matched_pattern}`) and `summary` counts by category.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "find_unused_objects",
+    "description": "Find tables and indexes with zero scans since pg_stat was last reset \u2014 a strong signal of dead code, but NOT a verdict. Tables report seq+idx scan counts, write counts, and estimated row count; indexes report size and definition. Excludes PRIMARY KEY and UNIQUE indexes (PG needs those regardless of scans). Run this after the database has been hot for a meaningful period \u2014 fresh stats produce false positives. Returns an object with `tables` (list of candidate tables with their stats) and `indexes` (list of candidate indexes with size and definition).",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "full_text_search",
+    "description": "Rank a text column's documents against a full-text query using PostgreSQL's built-in tsvector/tsquery. The query accepts web-search syntax (quoted phrases, or, - exclusion). Returns a list of objects with the matched row's primary key columns plus `rank` (ts_rank score, higher = better match).\n\nExample: `full_text_search(schema='public', table='articles', column='body', search_query='\"new york\" OR -draft')`",
+    "arguments": [
+      {
+        "name": "column",
+        "type": "string",
+        "desc": "Column"
+      },
+      {
+        "name": "config",
+        "type": "string",
+        "desc": "Config"
+      },
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Limit"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "search_query",
+        "type": "string",
+        "desc": "Search Query"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "fuzzy_search",
+    "description": "Rank a text column's values by pg_trgm trigram similarity to a search term. mode='word' (default) matches fragments within longer text; mode='full' compares whole strings. Reports available=false if pg_trgm is not installed. Returns an object with `available` (bool), `matches` (list of `{value, similarity}` ranked by similarity descending), and `mode`.\n\nExample: `fuzzy_search(schema='public', table='users', column='name', term='janne', mode='word')`",
+    "arguments": [
+      {
+        "name": "column",
+        "type": "string",
+        "desc": "Column"
+      },
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Limit"
+      },
+      {
+        "name": "mode",
+        "type": "string",
+        "desc": "Mode"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      },
+      {
+        "name": "term",
+        "type": "string",
+        "desc": "Term"
+      },
+      {
+        "name": "threshold",
+        "type": "number",
+        "desc": "Threshold"
+      }
+    ]
+  },
+  {
+    "name": "generate_diesel_schema",
+    "description": "Read a PostgreSQL schema and emit a Diesel ORM (Rust) schema.rs. One `table!` macro per table with column SQL types, `Nullable<T>` for nullable columns, plus `joinable!` declarations for single-column intra-schema FKs and an `allow_tables_to_appear_in_same_query!` macro so multi-table joins type-check. Enum types are emitted as Text-backed wrapper enums in a `pg_enum` module so the output works without `diesel_derive_enum`. Composite FKs are a documented v1 gap.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "generate_drizzle_schema",
+    "description": "Read a PostgreSQL schema and emit a Drizzle ORM TypeScript schema string (drizzle-orm/pg-core). Covers tables, columns with PG-native types, primary/foreign keys, unique constraints, indexes, defaults, and enums. Single-column FKs emit column-level .references(); composite FKs are a documented v1 gap. Views, foreign tables, partitions, triggers, and functions are out of scope. Returns the rendered TypeScript `schema.ts` source as a single string.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "generate_ecto_schemas",
+    "description": "Read a PostgreSQL schema and emit Ecto (Elixir) schema modules \u2014 one .ex file per table, named after the singularised table. Each module uses Ecto.Schema with field declarations, belongs_to for single-column intra-schema FKs, and timestamps() when both inserted_at and updated_at exist. The Elixir top-level module is configurable via app_module (default MyApp). Returns a JSON object {filename: source} so the agent can write each file.",
+    "arguments": [
+      {
+        "name": "app_module",
+        "type": "string",
+        "desc": "App Module"
+      },
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "generate_ent_schemas",
+    "description": "Read a PostgreSQL schema and emit Ent (Go) Schema struct files \u2014 one .go file per table. Each file exports a struct that lists field.X(...) calls for every column, edge.To(...) for single-column intra-schema FKs, and field.Enum().Values() for enum-typed columns. Composite FKs are a documented v1 gap. Returns a JSON object {filename: source} so the agent can write each file.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "generate_fk_cascade_graph",
+    "description": "Build a Mermaid graph LR of foreign-key cascade chains in a schema. Each edge runs from the referencing table to the referenced table, labelled with the cascade action(s) on DELETE / UPDATE. By default only FKs with at least one CASCADE / SET NULL / SET DEFAULT action are included \u2014 those are the ones that produce a write blast radius. Pass include_all=true to include NO ACTION / RESTRICT FKs too (full FK topology view). Cross-schema FK targets are rendered as separate nodes prefixed with their schema. Returns the Mermaid `graph LR` diagram as a string.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "include_all",
+        "type": "boolean",
+        "desc": "Include All"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "generate_graph_diagram",
+    "description": "Generate a Mermaid flowchart diagram representing nodes and relationships in a property graph to visualize its schema and topology. Returns the Mermaid flowchart as a string.",
+    "arguments": [
+      {
+        "name": "graph_name",
+        "type": "string",
+        "desc": "Graph Name"
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Limit"
+      }
+    ]
+  },
+  {
+    "name": "generate_graph_projection",
+    "description": "Generate openCypher CREATE/MERGE statements that project a relational schema into an Apache AGE property graph \u2014 rows become vertices (one label per table), foreign keys become edges. EMITS the Cypher for review; NEVER executes it (like `generate_test_data`). With `row_limit=0` (default) it returns a schema-level template plan (one CREATE per label, one MERGE per edge type, `$prop` placeholders) reading only the catalog. With `row_limit>0` it also emits concrete per-row statements (values escaped, NULLs omitted, capped at 1000 rows/table). Tables without a primary key still get node CREATEs but their edges are skipped (they can't be reliably MATCHed). NOTE: AGE materialises the data (this is a LOAD, not a virtual view); run the node statements before the edge statements; the projection is 1-hop faithful to the FK graph. Returns an object with `available` (AGE installed, advisory), `schema`, `graph_name`, `row_limit`, `node_labels` (list of `label`, `source_table`, `key_columns`, `property_columns`), `edge_types` (list of `edge_type`, `from_label`, `to_label`, `from_key`, `to_key`, `fk_name`), `cypher_statements` (generated, never executed), `warnings`, and `detail`.\n\nExample: `generate_graph_projection(schema='public', graph_name='g', row_limit=0)`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "graph_name",
+        "type": "string",
+        "desc": "Graph Name"
+      },
+      {
+        "name": "row_limit",
+        "type": "integer",
+        "desc": "Row Limit"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "tables",
+        "type": "array",
+        "desc": "Tables"
+      }
+    ]
+  },
+  {
+    "name": "generate_jooq_config",
+    "description": "Read a PostgreSQL schema and emit a jooq-codegen configuration XML pointing at it. Unlike the other exporters, jOOQ generates Java code itself from a live database \u2014 the artefact here is the configuration file the user feeds to mvn jooq-codegen:generate (or the Gradle task). The XML lists every base table explicitly via an <includes> regex, excludes MCPg's bookkeeping tables, and emits a <forcedType> for every json / jsonb column so they map to org.jooq.JSON / org.jooq.JSONB out of the box. Default Java package is com.example.jooq; override via the target_package arg.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "target_directory",
+        "type": "string",
+        "desc": "Target Directory"
+      },
+      {
+        "name": "target_package",
+        "type": "string",
+        "desc": "Target Package"
+      }
+    ]
+  },
+  {
+    "name": "generate_prisma_schema",
+    "description": "Read a PostgreSQL schema and emit a valid Prisma `.prisma` schema string (mirrors `prisma db pull`). Covers tables, columns, primary/foreign keys, unique constraints, indexes, and enums. Views, foreign tables, partitions, triggers, functions, and policies are out of scope; unmappable types fall back to `Unsupported(\"...\")`. Returns the rendered `schema.prisma` source as a single string.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "generate_schema_diagram",
+    "description": "Render a Mermaid ER diagram for a schema. Views and foreign tables are excluded; partitions are excluded by default \u2014 pass include_partitions=true to draw each partition as its own entity. Returns the Mermaid `erDiagram` as a string ready to paste into a Markdown block.\n\nExample: `generate_schema_diagram(schema='public', include_partitions=false)`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "include_partitions",
+        "type": "boolean",
+        "desc": "Include Partitions"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "generate_schema_docs",
+    "description": "Generate a detailed Markdown reference of a schema's tables, columns, constraints, indexes, views, foreign tables, and custom enums along with comments / descriptions. Optional include_samples fetches a few distinct, non-null values for each column. Returns a single Markdown document as a string.\n\nExample: `generate_schema_docs(schema='public', include_samples=true)`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "include_samples",
+        "type": "boolean",
+        "desc": "Include Samples"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "generate_sqlalchemy_models",
+    "description": "Read a PostgreSQL schema and emit a SQLAlchemy 2.0 declarative models file (DeclarativeBase + Mapped[T] + mapped_column). Covers tables, columns with PG-native types (incl. jsonb via sqlalchemy.dialects.postgresql.JSONB), primary keys, single-column FKs via ForeignKey(), unique constraints (column-level + composite via __table_args__), defaults, and enums (emitted as Python enum.Enum classes). Composite FKs are a documented v1 gap. Returns the rendered Python `models.py` source as a single string.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "generate_sqlc_schema",
+    "description": "Read a PostgreSQL schema and emit a sqlc-friendly schema.sql (plain DDL). Order: CREATE SCHEMA, CREATE TYPE for each enum, CREATE TABLE statements (columns only), ALTER TABLE ADD CONSTRAINT (PK / unique / check / foreign key in that order), then CREATE INDEX for non-constraint indexes. The file replays cleanly against an empty database so FKs land after all referenced tables exist. In-process \u2014 no MCPG_ALLOW_SHELL needed. Returns the rendered `schema.sql` text as a single string.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "generate_test_data",
+    "description": "Generate synthetic INSERT statements for a table \u2014 typed values respecting column type, NOT NULL, and DEFAULT. Returns the SQL as strings; does NOT execute it. Useful for seeding dev / staging environments. The generator is deterministic when a seed is provided. Foreign keys are NOT resolved \u2014 the caller must pre-seed referenced rows or drop the FK before applying. Hard cap of 10000 rows per call. Pure read (the actual writes go through run_write under unrestricted mode).",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "rows",
+        "type": "integer",
+        "desc": "Rows"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "seed",
+        "type": "integer",
+        "desc": "Seed"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "generate_test_row_for",
+    "description": "Generate ONE realistic test row for a table \u2014 catalogue-aware. Skips identity / generated columns (server fills them in), samples one existing row from each referenced table for FK columns (so the row inserts cleanly), and uses column-name heuristics (`*_email` \u2192 `user_N@example.com`, `*_url` \u2192 `https://example.com/r/N`, `*_at` \u2192 recent timestamp, etc.) to make values look like data. Sibling of `generate_test_data` (bulk) \u2014 designed for the shadow-migration workflow where a single realistic row matters more than volume. Returns an object with `insert_sql` (one ready-to-execute INSERT), `columns` (per-column ColumnFill with `sql_literal` + `heuristic` explanation), `schema`, `table`. Does NOT execute the INSERT \u2014 caller applies via `run_write` when ready.\n\nExample: `generate_test_row_for(schema='public', table='orders', seed=42)`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "follow_foreign_keys",
+        "type": "boolean",
+        "desc": "Follow Foreign Keys"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "seed",
+        "type": "integer",
+        "desc": "Seed"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "geo_search",
+    "description": "Find the rows nearest to a lon/lat point by PostGIS distance. Reports available=false if the postgis extension is not installed.",
+    "arguments": [
+      {
+        "name": "column",
+        "type": "string",
+        "desc": "Column"
+      },
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "latitude",
+        "type": "number",
+        "desc": "Latitude"
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Limit"
+      },
+      {
+        "name": "longitude",
+        "type": "number",
+        "desc": "Longitude"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "get_aio_status",
+    "description": "Report whether PG 19's async-I/O subsystem is usable. On PG < 19 returns `available=false` with a diagnostic pointing the agent at the existing `read_pg_stat_io` / `run_maintenance` tools. Never raises \u2014 driver-level errors during the version or settings probe also surface as `available=false`. Returns an object with `available` (bool), `server_version_num` (int), `server_version`, `io_method` ('sync' / 'worker' / 'io_uring' / null), `io_min_workers`, `io_max_workers`, and `detail` (a guidance string).\n\nExample: `get_aio_status()`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "get_compact_schema",
+    "description": "Return a highly condensed, token-efficient text summary of a schema's tables, columns, primary keys, nullability, and relations to save context window tokens. Set `fresh=true` to bypass the cache and re-read live (e.g. after a schema change).",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "fresh",
+        "type": "boolean",
+        "desc": "Fresh"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "get_current_wal_lsn",
+    "description": "Return the current WAL LSN \u2014 write-side on a primary (`pg_current_wal_lsn()`) or replay-side on a standby (`pg_last_wal_replay_lsn()`). Natural pairing for the read-your-writes workflow: capture on the primary right after a write, then pass to `wait_for_lsn` on the standby session before the follow-up read. Works on every supported PG version. Returns an object with `role` (`'primary'` or `'standby'`) and `lsn` (PostgreSQL LSN literal, e.g. `'0/1234ABCD'`).\n\nExample: `get_current_wal_lsn()`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "get_data_checksums_status",
+    "description": "Report whether PG 19's online `data_checksums` toggle is usable + the current setting. Never raises \u2014 driver-level errors surface as `available=false`. On PG \u2264 18 reports `available=false` but still surfaces the current state (set at initdb time) so the agent has context, and points at the offline `pg_checksums` fallback. Returns an object with `available` (bool), `server_version_num` (int), `server_version`, `enabled` (bool / null), and `detail` (guidance string).\n\nExample: `get_data_checksums_status()`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "get_database_ddl",
+    "description": "Return the `CREATE DATABASE` DDL for a named database using PG 19's `pg_get_databasedef(oid)` function. Returns `found=false` with an empty `ddl` when the database doesn't exist. Requires PG 19+. Returns an object with `object_type` (`'database'`), `object_name`, `found`, and `ddl`.\n\nExample: `get_database_ddl(database_name='analytics')`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "database_name",
+        "type": "string",
+        "desc": "Database Name"
+      }
+    ]
+  },
+  {
+    "name": "get_logical_replication_status",
+    "description": "Report whether PG 19's on-demand wal_level flip is usable, plus the configured `wal_level`, the new PG 19 `effective_wal_level` preset GUC, and `max_replication_slots`. When configured and effective diverge the agent can tell that an `ALTER SYSTEM` has been done but a reload is still pending. Never raises. Returns an object with `available` (bool), `server_version_num`, `server_version`, `wal_level`, `effective_wal_level`, `max_replication_slots`, and `detail`.\n\nExample: `get_logical_replication_status()`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "get_metrics_exposition",
+    "description": "Return the in-process Prometheus-format metrics for this MCPg server. Three series: mcpg_tool_calls_total (counter by tool / status), mcpg_tool_duration_seconds (histogram by tool with sum and count). Useful when the HTTP transport's /metrics endpoint is unreachable (e.g. running over stdio) or to fetch via the MCP protocol itself.",
+    "arguments": []
+  },
+  {
+    "name": "get_pg19_ddl_status",
+    "description": "Report whether PG 19's `pg_get_roledef()` / `pg_get_databasedef()` / `pg_get_tablespacedef()` DDL-dump functions are usable on this server. Never raises \u2014 driver-level errors surface as `available=false`. On PG \u2264 18 reports `available=false` and points the agent at `pg_dumpall --roles-only` / `--globals-only` / `--tablespaces-only` as the fallback. Returns an object with `available` (bool), `server_version_num` (int), `server_version`, `has_pg_get_roledef` (bool), `has_pg_get_databasedef` (bool), `has_pg_get_tablespacedef` (bool), and `detail` (guidance string).\n\nExample: `get_pg19_ddl_status()`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "get_pg19_partitions_status",
+    "description": "Report whether PG 19's `ALTER TABLE \u2026 MERGE PARTITIONS` and `ALTER TABLE \u2026 SPLIT PARTITION` forms are usable on this server. Never raises \u2014 driver-level errors surface as `available=false`. On PG \u2264 18 reports `available=false` and points the agent at the detach / create / attach fallback path. Returns an object with `available` (bool), `server_version_num` (int), `server_version`, and `detail` (guidance string).\n\nExample: `get_pg19_partitions_status()`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "get_pg19_stats_status",
+    "description": "Report whether PG 19's `pg_stat_lock` and `pg_stat_recovery` views are usable on this server. Never raises \u2014 driver-level errors surface as `available=false`. On PG < 19 returns `available=false` with a diagnostic pointing the agent at `find_blocking_chains` / `pg_stat_replication`. Returns an object with `available` (bool), `server_version_num` (int), `server_version`, `has_pg_stat_lock` (bool), `has_pg_stat_recovery` (bool), and `detail` (guidance string).\n\nExample: `get_pg19_stats_status()`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "get_pg_search_index_metadata",
+    "description": "Fetch the parsed reloptions for a single BM25 index (schema.index). Same shape as one entry of ``list_pg_search_indexes`` \u2014 typed accessors for the 13 documented options plus the raw ``index_options`` dict. Raises when the extension is not installed or no BM25 index by that name exists. Returns an object with `schema`, `index`, the typed option fields, and `index_options` (raw reloptions dict for forward-compat).",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "index",
+        "type": "string",
+        "desc": "Index"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "get_pgq_status",
+    "description": "Report whether SQL/PGQ (the SQL standard for property graph queries, new in PG 19) is usable on this server. SQL/PGQ coexists with the AGE-style `graph_operations` bucket \u2014 `get_pgq_status` is the agent's hint about which surface to reach for. Never raises; on PG < 19 reports `available=false` with a diagnostic pointing at `run_cypher`. Returns an object with `available` (bool), `server_version_num` (int), `server_version` (the human-readable string), and `detail` (a guidance string the agent can surface to the user).\n\nExample: `get_pgq_status()`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "get_prewarm_extension_status",
+    "description": "Report whether ``pg_prewarm`` (and the supporting ``pg_buffercache``) are installed, and whether ``pg_prewarm`` is listed in ``shared_preload_libraries`` (the autoprewarm worker requires it). Returns an object with `pg_prewarm_installed` (bool), `pg_buffercache_installed` (bool), `autoprewarm_libraries_present` (bool), and `shared_preload_libraries` (the raw setting).\n\nExample: `get_prewarm_extension_status()`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "get_redis_cache_stats",
+    "description": "Best-effort cache metrics for a redis_fdw server. redis_fdw does not ship a uniform stats SQL surface across versions, so the tool validates that the server exists and otherwise reports `available=false` with a diagnostic. Operators wanting live metrics should query Redis directly (INFO / DBSIZE). Returns an object with `server`, `available` (bool), `key_count`, `used_memory_bytes`, and `detail` (a human-readable note).\n\nExample: `get_redis_cache_stats(server='redis_primary')`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "server",
+        "type": "string",
+        "desc": "Server"
+      }
+    ]
+  },
+  {
+    "name": "get_repack_status",
+    "description": "Report whether PG 19's in-server `REPACK` command is usable. On PG < 19 returns `available=false` with a diagnostic pointing the agent at the long-standing pg_repack extension shell-out path so the fallback is clear. The in-server `REPACK CONCURRENTLY` is the headline PG 19 operational win \u2014 online table rebuild with no blocking writers. Returns an object with `available` (bool), `server_version_num` (int), `server_version` (the human-readable string), and `detail` (a guidance string the agent can surface to the user).\n\nExample: `get_repack_status()`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "get_role_ddl",
+    "description": "Return the `CREATE ROLE` DDL for a named role using PG 19's `pg_get_roledef(oid)` function \u2014 no shell-out to `pg_dumpall --roles-only` required. Returns `found=false` with an empty `ddl` when the role doesn't exist. Requires PG 19+; raises on older servers (pair with `get_pg19_ddl_status` to feature-detect). Returns an object with `object_type` (`'role'`), `object_name`, `found` (bool), and `ddl` (the verbatim CREATE statement).\n\nExample: `get_role_ddl(role_name='app_user')`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "role_name",
+        "type": "string",
+        "desc": "Role Name"
+      }
+    ]
+  },
+  {
+    "name": "get_server_info",
+    "description": "Return the MCPg server version, access mode, transport, database connection status, and PostgreSQL `wal_level` / `effective_wal_level` (the latter is `None` on PG \u2264 18 where the GUC doesn't exist; on PG 19+ a divergence between the two indicates a reload is still pending).",
+    "arguments": []
+  },
+  {
+    "name": "get_skip_scan_status",
+    "description": "Report whether PG 19's B-tree skip-scan optimisation is the planner default on this server. Never raises \u2014 driver-level errors surface as `available=false`. On PG \u2264 18 reports `available=false` and points the agent at the standard 'add a dedicated single-column index' fallback. Returns an object with `available` (bool), `server_version_num` (int), `server_version`, and `detail` (guidance string).\n\nExample: `get_skip_scan_status()`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "get_tablespace_ddl",
+    "description": "Return the `CREATE TABLESPACE` DDL for a named tablespace using PG 19's `pg_get_tablespacedef(oid)` function. Returns `found=false` with an empty `ddl` when the tablespace doesn't exist. Requires PG 19+. Returns an object with `object_type` (`'tablespace'`), `object_name`, `found`, and `ddl`.\n\nExample: `get_tablespace_ddl(tablespace_name='fast_ssd')`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "tablespace_name",
+        "type": "string",
+        "desc": "Tablespace Name"
+      }
+    ]
+  },
+  {
+    "name": "get_turboquant_heap_stats",
+    "description": "Return the exact heap row count tq_index_heap_stats() reports for a single turboquant index (schema.index). The raw upstream payload is preserved in ``raw`` for any extra counters upstream may add. Requires the pg_turboquant extension.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "index",
+        "type": "string",
+        "desc": "Index"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "get_turboquant_index_metadata",
+    "description": "Fetch the tq_index_metadata payload for a single turboquant index (schema.index). Documented fields are surfaced as typed attributes; the full upstream payload is preserved in ``raw_metadata`` so advisors can reach unanticipated fields. Raises when the extension is not installed or no turboquant index by that name exists. Returns an object with `schema`, `index`, `algorithm_version`, `quantizer_family`, `residual_sketch_kind`, `fast_path_eligible`, `capability_flags`, `delta_state`, `maintenance_recommended`, and `raw_metadata` (full upstream payload).",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "index",
+        "type": "string",
+        "desc": "Index"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "get_turboquant_last_scan_stats",
+    "description": "Return the backend-local JSON tq_last_scan_stats() reports for the most recent turboquant scan: score_mode, simd_kernel, pages_scanned, pages_pruned, plus the raw payload. Returns ``null`` when the extension is absent or no turboquant scan has run on this connection yet.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "get_wait_for_lsn_status",
+    "description": "Report whether PG 19's `WAIT FOR LSN` is usable on this server. Also reports whether the current backend is a standby (the only context where the wait does meaningful work). Never raises. On PG \u2264 18 returns `available=false` and points at the poll-loop fallback. Returns an object with `available` (bool), `server_version_num` (int), `server_version`, `is_in_recovery` (bool), and `detail`.\n\nExample: `get_wait_for_lsn_status()`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "get_wal_archive_status",
+    "description": "Report WAL-archiving health from `pg_stat_archiver` + the archive-mode GUCs \u2014 the early-warning signal for a failing `archive_command` / `archive_library` (full archive volume, bad object-store credentials, network partition), which otherwise silently accumulates WAL in `pg_wal/` until the volume fills. Companion to `read_pg_wal_records` (which inspects WAL *records*); this covers the WAL *archive*. Read-only; never raises. The `archive_command` string is NOT echoed (it can embed credentials) \u2014 only a boolean `archive_command_set`. Returns an object with `available`, `archiving_enabled`, `archive_mode`, `archive_command_set`, `archived_count`, `last_archived_wal`, `last_archived_time`, `failed_count`, `last_failed_wal`, `last_failed_time`, `stats_reset`, `healthy` (bool \u2014 false when archiving is on and the latest attempt failed), and `detail`.\n\nExample: `get_wal_archive_status()`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "get_warehousepg_status",
+    "description": "Probe the connected server for the WarehousePG (Greenplum-derived MPP) signature. Reports `available=true` only when BOTH the version string mentions WarehousePG / Greenplum AND the `gp_segment_configuration` catalog view exists. Surfaces `coordinator_role`, `segment_count` (primary segments only), and `mirroring` (bool). On vanilla PostgreSQL clusters returns `available=false` with a clean diagnostic \u2014 the rest of the `mcpg.warehousepg.*` family advertise themselves inert via this probe. Read-only; never raises.\n\nExample: `get_warehousepg_status()`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "hybrid_bm25_vector_search",
+    "description": "Combine a BM25 search and a pgvector search via Reciprocal Rank Fusion \u2014 the canonical v2 pattern ParadeDB documents in the 2025-10-22 'Hybrid Search Missing Manual' blog post. Returns hits as {id, score, bm25_rank, vector_rank}. ``score`` is the summed ``sum(weight * 1.0 / (k + rank))`` across both legs; per-leg ranks are surfaced for transparency (either can be NULL if a row only appeared in one leg's top-K). ``distance_op`` is the pgvector operator ('<=>'/'<->'/'<#>' \u2014 RRF is operator-agnostic). ``bm25_columns=None`` searches the whole BM25 index; ``bm25_columns=[\"col\"]`` restricts the BM25 leg to a single field. Defaults mirror upstream's demonstrated form (cosine, k=60, equal weights, per_leg_limit=20). Requires the pg_search and pgvector extensions.",
+    "arguments": [
+      {
+        "name": "bm25_columns",
+        "type": "array",
+        "desc": "Bm25 Columns"
+      },
+      {
+        "name": "bm25_weight",
+        "type": "number",
+        "desc": "Bm25 Weight"
+      },
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "distance_op",
+        "type": "string",
+        "desc": "Distance Op"
+      },
+      {
+        "name": "final_limit",
+        "type": "integer",
+        "desc": "Final Limit"
+      },
+      {
+        "name": "k",
+        "type": "integer",
+        "desc": "K"
+      },
+      {
+        "name": "key_field",
+        "type": "string",
+        "desc": "Key Field"
+      },
+      {
+        "name": "per_leg_limit",
+        "type": "integer",
+        "desc": "Per Leg Limit"
+      },
+      {
+        "name": "query_text",
+        "type": "string",
+        "desc": "Query Text"
+      },
+      {
+        "name": "query_vector",
+        "type": "array",
+        "desc": "Query Vector"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      },
+      {
+        "name": "vector_column",
+        "type": "string",
+        "desc": "Vector Column"
+      },
+      {
+        "name": "vector_weight",
+        "type": "number",
+        "desc": "Vector Weight"
+      }
+    ]
+  },
+  {
+    "name": "hybrid_search",
+    "description": "Combine vector and full-text ranking via reciprocal-rank fusion (RRF) \u2014 pulls candidates from each source, then fuses them so rows ranked highly in EITHER source surface. Closes the gap between pure vector (misses keyword/identifier matches) and pure full-text (misses semantic synonyms). Parameters: vector_column, text_column, query_vector, text_query, plus metric / text_config / limit / candidate_pool / rrf_k tunables. Each match carries vector_rank, fts_rank, the fused rrf_score, and (when present) the original distance + ts_rank values.\n\nExample: `hybrid_search(schema='public', table='docs', vector_column='embedding', text_column='body', query_vector=[0.1, ...], text_query='postgresql tuning')`",
+    "arguments": [
+      {
+        "name": "candidate_pool",
+        "type": "integer",
+        "desc": "Candidate Pool"
+      },
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Limit"
+      },
+      {
+        "name": "metric",
+        "type": "string",
+        "desc": "Metric"
+      },
+      {
+        "name": "query_vector",
+        "type": "array",
+        "desc": "Query Vector"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      },
+      {
+        "name": "text_column",
+        "type": "string",
+        "desc": "Text Column"
+      },
+      {
+        "name": "text_config",
+        "type": "string",
+        "desc": "Text Config"
+      },
+      {
+        "name": "text_query",
+        "type": "string",
+        "desc": "Text Query"
+      },
+      {
+        "name": "vector_column",
+        "type": "string",
+        "desc": "Vector Column"
+      }
+    ]
+  },
+  {
+    "name": "import_csv",
+    "description": "Bulk-load CSV content into schema.table via COPY ... FROM STDIN. The CSV text is sent verbatim \u2014 the caller is responsible for correctness (matching column count, proper quoting). `header=true` skips the first line. Optional `columns` restricts loading to the named columns in order; unlisted columns take their default. Performs writes \u2014 requires unrestricted mode.",
+    "arguments": [
+      {
+        "name": "columns",
+        "type": "array",
+        "desc": "Columns"
+      },
+      {
+        "name": "content",
+        "type": "string",
+        "desc": "Content"
+      },
+      {
+        "name": "delimiter",
+        "type": "string",
+        "desc": "Delimiter"
+      },
+      {
+        "name": "header",
+        "type": "boolean",
+        "desc": "Header"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "import_json",
+    "description": "Bulk-load a JSON array of objects into schema.table. Parses the array, derives column names from the first row (or from `columns` when given), and runs a parametrised INSERT once per row. Nested dict/list values are JSON-serialised so they round-trip into jsonb columns. Missing keys in later rows bind as NULL. Performs writes \u2014 requires unrestricted mode.",
+    "arguments": [
+      {
+        "name": "columns",
+        "type": "array",
+        "desc": "Columns"
+      },
+      {
+        "name": "content",
+        "type": "string",
+        "desc": "Content"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "import_vectors",
+    "description": "Bulk-load embeddings into a pgvector vector(N) column. Reads the column's declared N from the catalog and validates every row in `content` against it BEFORE any INSERT \u2014 a dimension mismatch on row 1000 fails the whole call rather than leaving 999 partial inserts behind. format='json' (default) expects a JSON array of objects whose `embedding_column` field is a list of numbers or a pgvector text literal; format='csv' expects a header row with `embedding_column` (and `id_column` when set) and cells that are bracketed literals or comma-separated numbers. When `id_column` is given, the parallel column receives each row's identifier. Errors when the column isn't pgvector vector(N) (so dimension validation can't run). Performs writes \u2014 requires unrestricted mode.",
+    "arguments": [
+      {
+        "name": "content",
+        "type": "string",
+        "desc": "Content"
+      },
+      {
+        "name": "embedding_column",
+        "type": "string",
+        "desc": "Embedding Column"
+      },
+      {
+        "name": "format",
+        "type": "string",
+        "desc": "Format"
+      },
+      {
+        "name": "id_column",
+        "type": "string",
+        "desc": "Id Column"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "lint_naming_conventions",
+    "description": "Lint table / column / index naming in a schema. Detects the majority case style (snake_case / camelCase / PascalCase / SCREAMING_SNAKE) per schema and per table, then flags outliers. Also flags indexes whose names do not start with a conventional prefix (idx_, ix_, pk_, uq_, fk_ by default). Findings carry the offender's style and the detected majority \u2014 agents can use the style field to filter for renames vs accept-as-is. Pure read. Returns an object with `schema_style` (detected majority), `findings` (list of style outliers), and `index_prefix_findings` (indexes with non-conventional prefixes).",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "list_active_queries",
+    "description": "List the queries currently running on the server, with each backend's wait event, duration, and the PIDs blocking it. Returns a list of objects with `pid`, `username`, `application`, `state`, `wait_event` (null when not waiting), `duration_seconds`, `query`, and `blocked_by` (list of PIDs holding locks this backend is waiting on).",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "list_audit_events",
+    "description": "List recent rows from mcpg_audit.events (newest first). Returns an empty list when MCPG_AUDIT_PERSIST has never been turned on (no audit table yet). Optionally filter by tool name.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Limit"
+      },
+      {
+        "name": "tool",
+        "type": "string",
+        "desc": "Tool"
+      }
+    ]
+  },
+  {
+    "name": "list_autowarm_jobs",
+    "description": "List the pg_cron jobs MCPg registered for autowarm (``jobname LIKE 'mcpg_autowarm%'``). Returns an empty list when ``pg_cron`` is not installed. Returns a list of objects with `jobid`, `jobname`, `schedule` (the cron expression), and `command` (the SELECT the job runs).\n\nExample: `list_autowarm_jobs()`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "list_available_extensions",
+    "description": "List every extension available to the database, with whether it is installed. Returns a list of objects with `name`, `default_version`, `installed_version` (null when not installed), and `installed` (bool).",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "list_chunks",
+    "description": "List the chunks of a TimescaleDB hypertable with each chunk's range_start / range_end and whether it has been compressed. Empty list when the table is not a hypertable. Returns an object with `available` (bool) and `chunks` (list of `{chunk_name, range_start, range_end, is_compressed, total_size_bytes}`).",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "list_composite_types",
+    "description": "List the standalone composite types in a schema with their attributes. Returns a list of objects with `name` and `attributes` (list of `{name, data_type}` for each field).",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "list_constraints",
+    "description": "List a table's constraints \u2014 primary/foreign keys, unique, check, exclusion. Set `fresh=true` to bypass the cache and re-read live (e.g. after a schema change). Returns a list of objects with `name`, `type`, and `definition` (the constraint SQL).\n\nExample: `list_constraints(schema='public', table='orders')`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "fresh",
+        "type": "boolean",
+        "desc": "Fresh"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "list_cron_jobs",
+    "description": "List the pg_cron jobs registered in the database. Returns an empty list when pg_cron is not installed.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "list_cursors",
+    "description": "List every currently-open server-side cursor with its SQL, rows_returned so far, age in seconds, and the TTL after which it'll be auto-closed.",
+    "arguments": []
+  },
+  {
+    "name": "list_databases",
+    "description": "List every database this MCPg server is configured to serve: the primary (the default target of every tool) plus any read-only secondaries from MCPG_SECONDARY_DATABASE_URLS. Read-capable tools accept an optional `database` argument naming one of these ids; omitting it targets the primary. Secondaries are read-only (PostgreSQL-enforced) \u2014 writes / DDL / shell / migrate always run against the primary. Returns an object with `primary_id`, `database_ids` (primary first), and `databases` \u2014 a list of objects with `id`, `is_primary`, `read_only`, `reachable` (a live SELECT 1 probe), and `detail` (an error string when unreachable).",
+    "arguments": []
+  },
+  {
+    "name": "list_distribution_policies",
+    "description": "List the data-distribution policy for each table in a WarehousePG schema (`HASH(col,...)`, `RANDOM`, or `REPLICATED`). Joins `gp_distribution_policy` to `pg_attribute` for the distribution-key column names in catalog order. `schema=None` returns every non-system schema. Read-only. On vanilla PG returns `available=false` with a diagnostic.\n\nExample: `list_distribution_policies(schema='public')`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "list_domains",
+    "description": "List the domain types in a schema, with base type, default, and check constraints. Returns a list of objects with `name`, `base_type`, `nullable`, `default`, and `constraints` (list of CHECK clauses).",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "list_enums",
+    "description": "List the enum types in a schema, with their labels in sort order. Returns a list of objects with `name` and `values` (list of label strings, in the order defined).",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "list_extensions",
+    "description": "List the extensions installed in the database. Returns a list of objects with `name` and `version`.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "list_foreign_data_wrappers",
+    "description": "List the foreign-data wrappers installed in the database. Returns a list of objects with `name`, `handler` (qualified function name), `validator`, and `options` (dict of wrapper-specific options).",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "list_foreign_keys",
+    "description": "List foreign keys in a schema, resolved to columns and referenced table. Set `fresh=true` to bypass the cache and re-read live (e.g. after a schema change). Returns a list of objects with `name`, `from_table`, `from_columns`, `to_schema`, `to_table`, `to_columns`.\n\nExample: `list_foreign_keys(schema='public')`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "fresh",
+        "type": "boolean",
+        "desc": "Fresh"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "list_foreign_servers",
+    "description": "List the foreign servers defined in the database, with their FDW and options. Returns a list of objects with `name`, `wrapper` (foreign-data wrapper name), `type`, `version`, and `options` (dict of server options).",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "list_foreign_tables",
+    "description": "List the foreign tables in a schema, with their server and options. Returns a list of objects with `name`, `server` (foreign-server name), and `options` (dict of per-table options).",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "list_functions",
+    "description": "List the functions and procedures defined in a schema. Returns a list of objects with `name`, `kind` ('function' or 'procedure'), `arguments` (signature string), `returns` (return-type string), and `language` (plpgsql / sql / c / etc.).",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "list_generated_columns",
+    "description": "List every GENERATED ALWAYS AS (...) STORED column in a schema, with its data type, the underlying expression, and whether it's stored or virtual. PostgreSQL today supports only the stored form; the kind field is reported anyway so the response shape is forward-compatible when PG adds virtual columns. Returns a list of objects with `schema`, `table`, `column`, `data_type`, `expression`, `kind` ('stored' today; reserved for 'virtual').",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "list_grants",
+    "description": "List the privileges granted on a table \u2014 who may do what to it. Returns a list of objects with `grantee`, `privilege` (SELECT / INSERT / UPDATE / DELETE / TRUNCATE / REFERENCES / TRIGGER), `grantable` (bool \u2014 may the grantee regrant), and `grantor`.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "list_graphs",
+    "description": "List all active Apache AGE property graphs in the database. Returns a list of objects with `name` (graph name) and `oid`.",
+    "arguments": []
+  },
+  {
+    "name": "list_hypertables",
+    "description": "List every TimescaleDB hypertable visible to the current role, with chunk count, compression flag, and total size. Reports available=false when the timescaledb extension is not installed. Returns an object with `available` (bool) and `hypertables` (list of `{schema, table, num_chunks, compression_enabled, total_size_bytes}`).",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "list_indexes",
+    "description": "List the indexes defined on a table. Set `fresh=true` to bypass the cache and re-read live (e.g. after a schema change). Returns a list of objects with `name`, `method` (btree / gin / gist / brin / hash / spgist / hnsw / ivfflat / \u2026), `definition` (the CREATE INDEX statement), and `partitioned`.\n\nExample: `list_indexes(schema='public', table='users')`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "fresh",
+        "type": "boolean",
+        "desc": "Fresh"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "list_locks",
+    "description": "List currently-held and waiting locks, joined with backend state from pg_stat_activity. Ordered by (granted ASC, pid) so waiting locks float to the top. Returns lock type, mode, qualified relation name when applicable, transaction / virtualxid, the application_name + state + wait event of the owning backend, and the first 200 chars of its query. Read-only.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Limit"
+      }
+    ]
+  },
+  {
+    "name": "list_notification_subscriptions",
+    "description": "List active LISTEN subscriptions in this server process as {subscription_id, channel} pairs. Subscriptions are process-local and lost on restart. Returns a list of objects with `subscription_id` and `channel`.",
+    "arguments": []
+  },
+  {
+    "name": "list_partitions",
+    "description": "Describe how a table is partitioned (strategy and bounds) and list its partitions. Returns an object with `partitioned` (bool), `strategy` ('range' / 'list' / 'hash' or null), and `partitions` (a list of `{name, bounds}` for each partition).",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "list_pending_migrations",
+    "description": "List migrations currently in 'prepared' status, newest first. Sweeps expired entries (drops their shadows, flips status to 'expired') before listing.",
+    "arguments": []
+  },
+  {
+    "name": "list_pg_search_indexes",
+    "description": "List every pg_search BM25 index in the database along with the parsed reloptions (the ``WITH (...)`` config) for each. Surfaces the 13 documented bm25 options (key_field, the six *_fields jsonb configs, layer_sizes, background_layer_sizes, target_segment_count, mutable_segment_rows, sort_by, search_tokenizer). The full parsed dict is preserved in ``index_options`` so unsurfaced or future options stay reachable. Returns an empty list when the pg_search extension is not installed.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "list_policies",
+    "description": "List the Row-Level-Security policies on a table, and whether row security is enabled. Returns an object with `rls_enabled` (bool) and `policies` \u2014 a list of `{name, command (SELECT/INSERT/UPDATE/DELETE/ALL), permissive (bool), roles, using_expression, check_expression}`.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "list_prewarmed_relations",
+    "description": "Report current shared-buffer residency per relation, ranked by blocks-cached descending. Requires the ``pg_buffercache`` extension; returns an empty list when it's missing. Returns a list of objects with `schema`, `table`, `blocks_cached` (8 KiB pages currently in shared buffers), `total_blocks` (the relation's on-disk size in the same unit), `pct_cached` (the residency ratio rounded to 2 decimals), and `dirty_blocks` (pages with pending writes).\n\nExample: `list_prewarmed_relations(schema='public', limit=50)`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Limit"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "list_property_graphs",
+    "description": "List SQL/PGQ property graphs defined in the database (reads `information_schema.sql_property_graphs`). Returns an empty list on PG < 19 or when the catalog view is missing (early Beta builds may not expose it yet \u2014 pair with `get_pgq_status` to disambiguate). Returns a list of objects with `schema`, `name`, `vertex_tables` (list of `schema.table` strings), and `edge_tables` (same shape).\n\nExample: `list_property_graphs()`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "list_publications",
+    "description": "List logical-replication publications with the tables and operations they include. Returns a list of objects with `name`, `owner`, `all_tables` (bool), `publishes_insert` / `publishes_update` / `publishes_delete` / `publishes_truncate` (bools), and `tables` (list of `schema.table` strings).",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "list_redis_foreign_servers",
+    "description": "List the foreign servers backed by ``redis_fdw`` \u2014 the FDW that exposes a Redis instance as SQL-queryable foreign tables. Reports each server's connection address, port, database, TLS posture, and whether a user mapping (credential) is configured. Returns an empty list when the redis_fdw extension is not installed. Returns a list of objects with `name`, `address`, `port`, `database`, `tls` (bool), `password_configured` (bool), and `options` (the full server-options dict).\n\nExample: `list_redis_foreign_servers()`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "list_replicas",
+    "description": "Report the health of every configured read replica. Each entry shows index, password-obfuscated DSN, whether the replica is currently degraded (skipped from routing), the last error that took it out, and how many seconds remain before it's re-probed. Returns an empty list when no replicas are configured.",
+    "arguments": []
+  },
+  {
+    "name": "list_resource_groups",
+    "description": "List configured WarehousePG resource groups + their utilisation. Reads `gp_toolkit.gp_resgroup_status` for `concurrency`, `cpu_max_percent`, `cpu_weight`, `memory_limit`, `memory_shared_quota`, plus live `num_running` / `num_queueing`. Pairs with `analyze_workload` for 'where's my workload time going' diagnosis. Read-only. On vanilla PG returns `available=false`.\n\nExample: `list_resource_groups()`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "list_roles",
+    "description": "List the database roles and their attributes, excluding PostgreSQL's own roles unless include_system is true. Returns a list of objects with `name`, `superuser`, `create_role`, `create_db`, `can_login`, `replication`, `bypass_rls`, `connection_limit`, `member_of`.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "include_system",
+        "type": "boolean",
+        "desc": "Include System"
+      }
+    ]
+  },
+  {
+    "name": "list_schemas",
+    "description": "List database schemas, excluding PostgreSQL's own schemas unless include_system is true. Returns a list of objects with `name`.\n\nExample: `list_schemas(include_system=false)`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "include_system",
+        "type": "boolean",
+        "desc": "Include System"
+      }
+    ]
+  },
+  {
+    "name": "list_sequences",
+    "description": "List the sequences defined in a schema, with their range, increment, and last value. Returns a list of objects with `name`, `data_type`, `start_value`, `min_value`, `max_value`, `increment`, `cycle` (bool), `last_value`.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "list_subscriptions",
+    "description": "List logical-replication subscriptions; requires superuser to see any rows.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "list_tables",
+    "description": "List the tables and views in a schema, flagging partitioned tables and partitions. Returns a list of objects with `name`, `type` ('table' or 'view'), `partitioned`, `is_partition`.\n\nExample: `list_tables(schema='public')`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "list_triggers",
+    "description": "List the user-defined triggers on a table. Returns a list of objects with `name`, `function` (the called function's qualified name), and `definition` (the CREATE TRIGGER SQL).",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "list_turboquant_indexes",
+    "description": "List every pg_turboquant ANN index in the database along with the metadata payload that tq_index_metadata() reports for it: algorithm_version, quantizer_family, residual_sketch_kind, fast_path_eligible, capability_flags, delta_state, and maintenance_recommended. Returns an empty list when the pg_turboquant extension is not installed.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "list_unapplied_migration_scripts",
+    "description": "List on-disk migration scripts that haven't been applied yet. Walks `scripts_dir` (one level deep) for framework-specific files \u2014 Flyway `V<version>__<desc>.sql`, Alembic `<revision>_<slug>.py`, Liquibase `<changeset>.sql` \u2014 extracts each script's identifier from its filename, then cross-references against the framework's history table (`flyway_schema_history`, `alembic_version`, `databasechangelog`). Returns the pending list, the applied identifiers, and a one-line first-comment preview per pending script. `available=false` when no history table exists yet (greenfield database); the pending list still surfaces every on-disk script so a from-scratch plan is possible. Read-only DB-side; filesystem access is gated by `MCPG_MIGRATION_SCRIPTS_ROOTS` \u2014 by default the tool refuses every path.",
+    "arguments": [
+      {
+        "name": "framework",
+        "type": "string",
+        "desc": "Framework"
+      },
+      {
+        "name": "history_schema",
+        "type": "string",
+        "desc": "History Schema"
+      },
+      {
+        "name": "scripts_dir",
+        "type": "string",
+        "desc": "Scripts Dir"
+      }
+    ]
+  },
+  {
+    "name": "list_user_mappings",
+    "description": "List role-to-foreign-server mappings; the catch-all appears as user='public'. Returns a list of objects with `user` (role name or 'public'), `server` (foreign-server name), and `options` (dict of mapping options, e.g. credentials).",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "list_views",
+    "description": "List the views and materialized views in a schema, with their definitions. Returns a list of objects with `name`, `materialized` (bool), and `definition` (the SELECT SQL).",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "log_rerank_event",
+    "description": "Insert one row into mcpg_rag.rerank_events \u2014 one (query, candidate) pair from a RAG reranker step. ``query_hash`` is the caller-computed join key (raw bytes; SHA-256 is conventional but not required). ``bi_encoder_score`` may be null (some retrieval paths don't expose a score); ``cross_encoder_score`` is required. ``extra`` is a free-form dict serialised as jsonb (caller-specific fields: latency_ms, variant tag, user_id, etc). Available only in unrestricted mode; the table must be created first via ``setup_rag_telemetry``. Returns an object with `event_id` (the new mcpg_rag.rerank_events row id).",
+    "arguments": [
+      {
+        "name": "bi_encoder_rank",
+        "type": "integer",
+        "desc": "Bi Encoder Rank"
+      },
+      {
+        "name": "bi_encoder_score",
+        "type": "number",
+        "desc": "Bi Encoder Score"
+      },
+      {
+        "name": "candidate_id",
+        "type": "integer",
+        "desc": "Candidate Id"
+      },
+      {
+        "name": "cross_encoder_rank",
+        "type": "integer",
+        "desc": "Cross Encoder Rank"
+      },
+      {
+        "name": "cross_encoder_score",
+        "type": "number",
+        "desc": "Cross Encoder Score"
+      },
+      {
+        "name": "extra",
+        "type": "object",
+        "desc": "Extra"
+      },
+      {
+        "name": "ground_truth_relevance",
+        "type": "integer",
+        "desc": "Ground Truth Relevance"
+      },
+      {
+        "name": "query_hash",
+        "type": "string",
+        "desc": "Query Hash"
+      },
+      {
+        "name": "reranker_model",
+        "type": "string",
+        "desc": "Reranker Model"
+      },
+      {
+        "name": "retrieval_backend",
+        "type": "string",
+        "desc": "Retrieval Backend"
+      },
+      {
+        "name": "retrieval_index",
+        "type": "string",
+        "desc": "Retrieval Index"
+      },
+      {
+        "name": "used_in_context",
+        "type": "boolean",
+        "desc": "Used In Context"
+      }
+    ]
+  },
+  {
+    "name": "maintain_turboquant_index",
+    "description": "Run tq_maintain_index on a turboquant index \u2014 lightweight merge / compaction of the physical delta tier. The wrapper pre-flights that the named index is actually a turboquant index (catalog lookup on pg_am) before invoking upstream, so the call can't be turned into a way to probe arbitrary indexes for error messages. Returns wall-clock timestamps and elapsed duration measured client-side; the PG return value of tq_maintain_index is intentionally not parsed (upstream doesn't document a return shape). Available only in unrestricted mode; requires pg_turboquant installed.",
+    "arguments": [
+      {
+        "name": "index",
+        "type": "string",
+        "desc": "Index"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "merge_partitions",
+    "description": "Consolidate two or more partitions into a single new partition using PG 19's `ALTER TABLE \u2026 MERGE PARTITIONS (p1, p2, \u2026) INTO new`. Reuses the existing partition data files \u2014 no row-by-row copy. PG validates that the source partition bounds are contiguous; non-adjacent ranges are rejected by the server. Requires PG 19+; raises on older versions with the detach / create / attach fallback in the message. Returns an object with `parent_schema`, `parent_table`, `source_partitions` (list of strings), `target_partition`, and `merge_sql` (the rendered DDL that actually executed).\n\nExample: `merge_partitions(parent_schema='public', parent_table='measurement', source_partitions=['measurement_y2024_q1', 'measurement_y2024_q2'], target_partition_name='measurement_y2024_h1')`",
+    "arguments": [
+      {
+        "name": "parent_schema",
+        "type": "string",
+        "desc": "Parent Schema"
+      },
+      {
+        "name": "parent_table",
+        "type": "string",
+        "desc": "Parent Table"
+      },
+      {
+        "name": "source_partitions",
+        "type": "array",
+        "desc": "Source Partitions"
+      },
+      {
+        "name": "target_partition_name",
+        "type": "string",
+        "desc": "Target Partition Name"
+      }
+    ]
+  },
+  {
+    "name": "migrate_vector_to_halfvec",
+    "description": "Generate a DDL plan that converts a pgvector vector(N) column to halfvec(N) \u2014 halving per-element storage (4 \u2192 2 bytes) with typically negligible recall impact at d \u2265 768. Reads the column's current type + dimension from the catalog, finds every index on the column, and emits an ordered `migration_sql` plan: DROP each affected index, ALTER COLUMN to halfvec(N) via a `USING` cast, then recreate each index with its halfvec opclass. Also returns a mirror `rollback_sql` that restores the original vector(N) type plus the original index definitions. Nothing is executed \u2014 feed the plan through the shadow-migration workflow (`prepare_migration` / `validate_migration_schema`) before applying. Returns `already_halfvec=true` (and an empty plan) when the column is already halfvec, and refuses any index whose opclass has no halfvec sibling rather than rewriting it incorrectly. Requires the vector extension.",
+    "arguments": [
+      {
+        "name": "column",
+        "type": "string",
+        "desc": "Column"
+      },
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "mmr_search",
+    "description": "Diversity-aware vector search: fetch `fetch_k` nearest candidates by pgvector distance, then re-rank with Maximal Marginal Relevance to return `k` rows that are relevant but not near-duplicates \u2014 better LLM context than raw top-k. `lambda_mult` in [0,1] trades relevance (1.0) for diversity (0.0); default 0.5. Relevance + diversity are cosine similarities computed over candidate embeddings, so the result is independent of the recall-pass `metric`. Each hit carries its relevance, mmr_score, and selection rank. Reports available=false if the pgvector extension is not installed.\n\nExample: `mmr_search(schema='public', table='docs', column='embedding', query_vector=[0.1, ...], k=10, lambda_mult=0.5)`",
+    "arguments": [
+      {
+        "name": "column",
+        "type": "string",
+        "desc": "Column"
+      },
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "fetch_k",
+        "type": "integer",
+        "desc": "Fetch K"
+      },
+      {
+        "name": "k",
+        "type": "integer",
+        "desc": "K"
+      },
+      {
+        "name": "lambda_mult",
+        "type": "number",
+        "desc": "Lambda Mult"
+      },
+      {
+        "name": "metric",
+        "type": "string",
+        "desc": "Metric"
+      },
+      {
+        "name": "query_vector",
+        "type": "array",
+        "desc": "Query Vector"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "monitor_embedding_drift",
+    "description": "Compare two time windows of a pgvector column and flag distributional drift. Samples up to `sample_size` (default 5000) non-NULL embeddings from each window (filtered by `timestamp_column`), computes the centroid (per-dimension mean vector) and L2-norm distribution of each, then reports the cosine distance between the two centroids (the main drift signal), the relative change in mean / std of the L2-norm distribution, and a boolean `drift_detected` that flips when cosine distance exceeds `drift_threshold` (default 0.05). Each window is treated as a half-open `[start, end)` interval. Useful for ops monitoring of embedding pipelines \u2014 an upstream model swap typically shows up as a large centroid cosine distance even if the norm distribution looks stable. `insufficient_data` is returned distinctly from `drift_detected=false` when either window is empty. Reports `available=false` if pgvector is not installed.\n\nExample: `monitor_embedding_drift(schema='public', table='docs', embedding_column='embedding', timestamp_column='created_at', baseline_start='2026-01-01', baseline_end='2026-02-01', current_start='2026-02-01', current_end='2026-03-01')`",
+    "arguments": [
+      {
+        "name": "baseline_end",
+        "type": "string",
+        "desc": "Baseline End"
+      },
+      {
+        "name": "baseline_start",
+        "type": "string",
+        "desc": "Baseline Start"
+      },
+      {
+        "name": "current_end",
+        "type": "string",
+        "desc": "Current End"
+      },
+      {
+        "name": "current_start",
+        "type": "string",
+        "desc": "Current Start"
+      },
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "drift_threshold",
+        "type": "number",
+        "desc": "Drift Threshold"
+      },
+      {
+        "name": "embedding_column",
+        "type": "string",
+        "desc": "Embedding Column"
+      },
+      {
+        "name": "sample_size",
+        "type": "integer",
+        "desc": "Sample Size"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      },
+      {
+        "name": "timestamp_column",
+        "type": "string",
+        "desc": "Timestamp Column"
+      }
+    ]
+  },
+  {
+    "name": "monitor_index_build",
+    "description": "Surface every active CREATE INDEX and its progress from pg_stat_progress_create_index (PG12+, no extension). One row per build with pid, schema.relation.index_name, the command, phase label, blocks_done/total, tuples_done/total, and a computed progress_pct (blocks first, tuples as fallback, null when neither phase reports a denominator). Useful next to list_active_queries when an HNSW / IVFFlat build on a big table is taking longer than expected. Returns a list of objects with `pid`, `schema`, `relation`, `index_name`, `command`, `phase`, `blocks_done`, `blocks_total`, `tuples_done`, `tuples_total`, and `progress_pct` (null when no denominator is reported).",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "open_cursor",
+    "description": "Open a server-side cursor for a SELECT query. The cursor holds the result set on the server side so an agent can page through millions of rows without loading them all. SQL is validated by the same safety allowlist as run_select. Returns the cursor_id; fetch the rows with fetch_cursor and close with close_cursor (or let the 5-minute TTL clean up). Hard cap of 16 concurrent cursors.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "sql",
+        "type": "string",
+        "desc": "Sql"
+      }
+    ]
+  },
+  {
+    "name": "optimize_query",
+    "description": "Analyze a SQL query for syntax anti-patterns and performance issues using EXPLAIN plan costs and index scans, returning an optimized version.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "sql",
+        "type": "string",
+        "desc": "Sql"
+      }
+    ]
+  },
+  {
+    "name": "partman_create_parent",
+    "description": "Register a partitioned table with pg_partman. ``partition_type`` must be 'range', 'list', or 'native'. Performs DDL \u2014 requires unrestricted mode + MCPG_ALLOW_DDL; pg_partman installed. Returns an object with `parent_table` and `detail` (the partman registration status string).",
+    "arguments": [
+      {
+        "name": "control_column",
+        "type": "string",
+        "desc": "Control Column"
+      },
+      {
+        "name": "parent_table",
+        "type": "string",
+        "desc": "Parent Table"
+      },
+      {
+        "name": "partition_interval",
+        "type": "string",
+        "desc": "Partition Interval"
+      },
+      {
+        "name": "partition_type",
+        "type": "string",
+        "desc": "Partition Type"
+      }
+    ]
+  },
+  {
+    "name": "partman_drop_partition",
+    "description": "Drop pg_partman partitions older than ``retention``. Time-controlled parents take a PG interval (e.g. '30 days'); id-controlled parents take an integer-like string with control_is_time=false. Returns the dropped partition names. Performs DDL \u2014 requires unrestricted mode + MCPG_ALLOW_DDL.",
+    "arguments": [
+      {
+        "name": "control_is_time",
+        "type": "boolean",
+        "desc": "Control Is Time"
+      },
+      {
+        "name": "parent_table",
+        "type": "string",
+        "desc": "Parent Table"
+      },
+      {
+        "name": "retention",
+        "type": "string",
+        "desc": "Retention"
+      }
+    ]
+  },
+  {
+    "name": "partman_run_maintenance",
+    "description": "Run pg_partman maintenance \u2014 add forward partitions and drop retired ones. Pass parent_table to scope to one parent; omit to run for every managed parent. Performs DDL \u2014 requires unrestricted mode + MCPG_ALLOW_DDL. Returns an object with `parent_table` (the scoped name or '*' for all) and `detail` (maintenance summary string).",
+    "arguments": [
+      {
+        "name": "parent_table",
+        "type": "string",
+        "desc": "Parent Table"
+      }
+    ]
+  },
+  {
+    "name": "pg_search_more_like_this",
+    "description": "Find rows similar to a seed document via ``pdb.more_like_this`` + ``@@@``. ``document_id`` is the value of ``key_field`` for the seed row. All nine documented pdb.more_like_this tuning args (``fields`` jsonb, ``min_doc_frequency``, ``max_doc_frequency``, ``min_term_frequency``, ``max_query_terms``, ``min_word_length``, ``max_word_length``, ``boost_factor``, ``stop_words``) are optional kwargs \u2014 when omitted the wrapper does not mention them in the SQL so upstream's defaults apply. Returns the same {id, score} hit shape as ``pg_search_run``. Requires the pg_search extension.",
+    "arguments": [
+      {
+        "name": "boost_factor",
+        "type": "number",
+        "desc": "Boost Factor"
+      },
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "document_id",
+        "type": "string",
+        "desc": "Document Id"
+      },
+      {
+        "name": "fields",
+        "type": "object",
+        "desc": "Fields"
+      },
+      {
+        "name": "key_field",
+        "type": "string",
+        "desc": "Key Field"
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Limit"
+      },
+      {
+        "name": "max_doc_frequency",
+        "type": "integer",
+        "desc": "Max Doc Frequency"
+      },
+      {
+        "name": "max_query_terms",
+        "type": "integer",
+        "desc": "Max Query Terms"
+      },
+      {
+        "name": "max_word_length",
+        "type": "integer",
+        "desc": "Max Word Length"
+      },
+      {
+        "name": "min_doc_frequency",
+        "type": "integer",
+        "desc": "Min Doc Frequency"
+      },
+      {
+        "name": "min_term_frequency",
+        "type": "integer",
+        "desc": "Min Term Frequency"
+      },
+      {
+        "name": "min_word_length",
+        "type": "integer",
+        "desc": "Min Word Length"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "stop_words",
+        "type": "array",
+        "desc": "Stop Words"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "pg_search_parse_query",
+    "description": "Parse a query string through ``pdb.parse`` and return its canonical text form for debugging \u2014 useful for confirming the parser interpreted a phrase as expected. ``lenient=True`` relaxes syntax checking; ``conjunction_mode=True`` treats space-separated terms as AND-joined rather than OR-joined. Requires the pg_search extension.",
+    "arguments": [
+      {
+        "name": "conjunction_mode",
+        "type": "boolean",
+        "desc": "Conjunction Mode"
+      },
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "lenient",
+        "type": "boolean",
+        "desc": "Lenient"
+      },
+      {
+        "name": "query_string",
+        "type": "string",
+        "desc": "Query String"
+      }
+    ]
+  },
+  {
+    "name": "pg_search_run",
+    "description": "Run a BM25 keyword search against a pg_search-indexed table. Returns hits as {id, score, snippets} where ``id`` is the value of the caller-supplied ``key_field`` and ``score`` is ``pdb.score(t)``. ``columns=None`` searches the whole index; ``columns=[\"col\"]`` restricts to a single text field. Multi-column search needs the pdb.parse per-field config JSON and is deferred to a follow-up phase. ``return_snippets=True`` requires ``snippet_field`` and projects ``pdb.snippets`` over that column. Requires the pg_search extension. SECURITY: ``snippet_start_tag`` / ``snippet_end_tag`` are not sanitized (they pass through to upstream as-is). The defaults match pg_search's HTML defaults; if callers forward untrusted values and a downstream consumer renders snippets as HTML, that's an XSS vector \u2014 output escaping is the renderer's responsibility.",
+    "arguments": [
+      {
+        "name": "columns",
+        "type": "array",
+        "desc": "Columns"
+      },
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "key_field",
+        "type": "string",
+        "desc": "Key Field"
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Limit"
+      },
+      {
+        "name": "query",
+        "type": "string",
+        "desc": "Query"
+      },
+      {
+        "name": "return_snippets",
+        "type": "boolean",
+        "desc": "Return Snippets"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "snippet_end_tag",
+        "type": "string",
+        "desc": "Snippet End Tag"
+      },
+      {
+        "name": "snippet_field",
+        "type": "string",
+        "desc": "Snippet Field"
+      },
+      {
+        "name": "snippet_max_num_chars",
+        "type": "integer",
+        "desc": "Snippet Max Num Chars"
+      },
+      {
+        "name": "snippet_start_tag",
+        "type": "string",
+        "desc": "Snippet Start Tag"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "poll_notifications",
+    "description": "Drain up to `max_messages` notifications from `subscription_id`. When the queue is empty, waits at most `timeout_ms` for the first notification (0 = return immediately). Each notification carries {channel, payload, delivered_at, dropped_count}; dropped_count is non-zero only on the first message after a queue overflow.",
+    "arguments": [
+      {
+        "name": "max_messages",
+        "type": "integer",
+        "desc": "Max Messages"
+      },
+      {
+        "name": "subscription_id",
+        "type": "string",
+        "desc": "Subscription Id"
+      },
+      {
+        "name": "timeout_ms",
+        "type": "integer",
+        "desc": "Timeout Ms"
+      }
+    ]
+  },
+  {
+    "name": "prepare_migration",
+    "description": "Stage a candidate migration against a shadow clone of `target_schema`. Replicates the target schema's structure into mcpg_shadow_<id>, applies `candidate_sql` there, then runs compare_schemas(target, shadow) so the agent can review the structural diff before completing. Returns the migration id, shadow schema name, TTL, and the diff. Performs DDL \u2014 requires unrestricted mode + MCPG_ALLOW_DDL.\n\nExample: `prepare_migration(name='add_user_avatar', target_schema='public', candidate_sql='ALTER TABLE users ADD COLUMN avatar_url text')`",
+    "arguments": [
+      {
+        "name": "candidate_sql",
+        "type": "string",
+        "desc": "Candidate Sql"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name"
+      },
+      {
+        "name": "target_schema",
+        "type": "string",
+        "desc": "Target Schema"
+      },
+      {
+        "name": "ttl_minutes",
+        "type": "integer",
+        "desc": "Ttl Minutes"
+      }
+    ]
+  },
+  {
+    "name": "prewarm_recommended",
+    "description": "Invoke ``recommend_prewarm_targets`` and prewarm every recommendation in order. ``dry_run=true`` reports what would be prewarmed without invoking pg_prewarm. Per-relation errors are captured and reported in the ``outcomes`` list so one bad relation doesn't fail the whole bulk pass. Returns an object with `dry_run` (bool), `total_blocks` (sum of blocks_prewarmed across successful outcomes), and `outcomes` \u2014 a list of objects with `schema`, `relation`, `mode`, `blocks_prewarmed`, and `error` (null on success).\n\nExample: `prewarm_recommended(shared_buffers_budget_pct=60.0, dry_run=False)`",
+    "arguments": [
+      {
+        "name": "dry_run",
+        "type": "boolean",
+        "desc": "Dry Run"
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Limit"
+      },
+      {
+        "name": "min_heap_blks_read",
+        "type": "integer",
+        "desc": "Min Heap Blks Read"
+      },
+      {
+        "name": "prewarm_mode",
+        "type": "string",
+        "desc": "Prewarm Mode"
+      },
+      {
+        "name": "shared_buffers_budget_pct",
+        "type": "number",
+        "desc": "Shared Buffers Budget Pct"
+      }
+    ]
+  },
+  {
+    "name": "prewarm_relation",
+    "description": "Run ``SELECT pg_prewarm('schema.relation'::regclass, mode)`` once. ``mode`` is one of ``buffer`` (load into shared buffers), ``prefetch`` (OS page cache), or ``read`` (blocking read). Requires pg_prewarm installed. Returns an object with `schema`, `relation`, `mode`, and `blocks_prewarmed`.\n\nExample: `prewarm_relation(schema='public', relation='orders', mode='buffer')`",
+    "arguments": [
+      {
+        "name": "mode",
+        "type": "string",
+        "desc": "Mode"
+      },
+      {
+        "name": "relation",
+        "type": "string",
+        "desc": "Relation"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "prune_audit_events",
+    "description": "Delete persisted audit events older than older_than_days from mcpg_audit.events \u2014 a cron-friendly retention helper for the otherwise-unbounded audit table. Returns the number deleted, the cutoff timestamp, and the rows remaining. Refuses to run when MCPG_AUDIT_INTEGRITY is enabled (pruning would break the HMAC signature chain). Available only in unrestricted mode.",
+    "arguments": [
+      {
+        "name": "older_than_days",
+        "type": "integer",
+        "desc": "Older Than Days"
+      }
+    ]
+  },
+  {
+    "name": "read_autovacuum_priority",
+    "description": "Return the tables most urgently needing autovacuum, ranked by how close their dead-tuple count is to the per-table autovacuum threshold (`autovacuum_vacuum_threshold + autovacuum_vacuum_scale_factor * reltuples`, honouring per-table `reloptions` overrides). Each row carries `priority` ('overdue' if past the threshold, 'watchlist' if within 50%, 'borderline' otherwise) plus the inputs (`n_dead_tup`, `vacuum_threshold`, `last_autovacuum`, `autovacuum_enabled`) so the agent can explain *why* a table landed on the shortlist. Top-level `overdue_count` lets an agent branch without walking the list. Read-only catalog query.\n\nExample: `read_autovacuum_priority(limit=25)`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Limit"
+      }
+    ]
+  },
+  {
+    "name": "read_migration_history",
+    "description": "Query and summarize historical migrations applied to the database by popular migration frameworks (Alembic, Flyway, Diesel, Django, Prisma, Golang Migrate, Goose, Sequelize). Allows filtering by schema. Returns an object with one optional list per detected framework: `alembic`, `flyway`, `diesel`, `django`, `prisma`, `golang_migrate`, `goose`, `sequelize`. Each entry is null when the framework's table isn't present; otherwise it carries the framework-specific row shape (e.g. alembic has `{version_num}`; flyway has `{installed_rank, version, description, type, ...}`).",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "read_pg_buffercache_relations",
+    "description": "Read the list of database relations taking up the most space in the PostgreSQL shared buffer cache. Reports buffered size, percentage of shared buffers, percent of relation buffered, average usage count, and dirty pages. Allows filtering by schema. Requires the pg_buffercache extension. If not installed, returns available=false.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Limit"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "read_pg_buffercache_summary",
+    "description": "Read a high-level summary of the PostgreSQL shared buffer cache usage. Reports total buffers, free/used buffers, dirty buffers, and average usage count. Requires the pg_buffercache extension. If not installed, returns available=false.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "read_pg_stat_io",
+    "description": "Read the pg_stat_io view (PostgreSQL 16+). Reports per (backend_type, object, context) cumulative I/O activity \u2014 reads, writes, extends, evictions, hits, fsyncs. Useful for spotting buffer-cache misses and write amplification. On PostgreSQL 14 / 15 the view doesn't exist, so the tool returns available=false and an empty list.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "read_pg_stat_lock",
+    "description": "Return every row from PG 19's `pg_stat_lock` view (per-lock-type acquire / wait / wait-time counters since the most recent `pg_stat_reset`). Empty list on PG < 19 or when the view isn't present. Returns a list of objects with `lock_type` (relation / page / tuple / xid / virtualxid / advisory / ...), `acquires`, `waits`, and `wait_time_us`.\n\nExample: `read_pg_stat_lock()`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "read_pg_stat_recovery",
+    "description": "Return rows from PG 19's `pg_stat_recovery` view \u2014 replay progress, lag, and startup state for a standby. Empty list on PG < 19, when the view isn't present, or when the server isn't in recovery (a primary running standalone returns no rows). Returns a list of objects with `replay_lsn`, `replay_lag_seconds`, `last_replayed_at`, and `startup_state` (any of which may be null when not applicable).\n\nExample: `read_pg_stat_recovery()`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "read_pg_wal_records",
+    "description": "Read Write-Ahead Log (WAL) records information over a specified LSN range. Requires the pg_walinspect extension. If not installed, returns available=false.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "end_lsn",
+        "type": "string",
+        "desc": "End Lsn"
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Limit"
+      },
+      {
+        "name": "start_lsn",
+        "type": "string",
+        "desc": "Start Lsn"
+      }
+    ]
+  },
+  {
+    "name": "read_pg_wal_stats",
+    "description": "Read Write-Ahead Log (WAL) record statistics over a specified LSN range, grouped by resource manager or record type. Requires the pg_walinspect extension. If not installed, returns available=false.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "end_lsn",
+        "type": "string",
+        "desc": "End Lsn"
+      },
+      {
+        "name": "per_record",
+        "type": "boolean",
+        "desc": "Per Record"
+      },
+      {
+        "name": "start_lsn",
+        "type": "string",
+        "desc": "Start Lsn"
+      }
+    ]
+  },
+  {
+    "name": "recommend_efficiency_thresholds",
+    "description": "Compute corpus-percentile thresholds from accumulated ``mcpg_rag.efficiency_observations`` history. Phase E currently adapts three thresholds: ``baseline_recall_low`` (p10 of recall_baseline), ``ranking_degraded_spearman`` (p10 of spearman), and ``pruning_ineffective`` (p10 of pages_pruned_ratio_p50). The remaining four thresholds stay at their hardcoded defaults. Filters by ``days`` window + optional ``backend`` / ``metric`` / ``k`` so callers can ask 'what's normal for HNSW+cosine+k=10 in this deployment' vs 'what's normal globally'. Falls back to defaults (with ``derived_from_corpus=false``) when the corpus is smaller than the minimum required. Returns an object with `corpus_size`, `derived_from_corpus` (bool), and the threshold fields (`baseline_recall_low`, `baseline_recall_low_adapted`, `ranking_degraded_spearman`, `ranking_degraded_spearman_adapted`, `pruning_ineffective`, `pruning_ineffective_adapted`, `rerank_lift_flat_delta`, `rerank_lift_steep_low`, `rerank_lift_steep_high`, and `ranking_degraded_recall`).",
+    "arguments": [
+      {
+        "name": "backend",
+        "type": "string",
+        "desc": "Backend"
+      },
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "days",
+        "type": "integer",
+        "desc": "Days"
+      },
+      {
+        "name": "k",
+        "type": "integer",
+        "desc": "K"
+      },
+      {
+        "name": "metric",
+        "type": "string",
+        "desc": "Metric"
+      }
+    ]
+  },
+  {
+    "name": "recommend_headline_tools",
+    "description": "Empirically curate `describe_self`'s per-bucket `headline_tools` from the audit log. Reads `mcpg_audit.events` over the last `lookback_days` (default 7, capped at 90), groups successful calls by capability bucket, and reports the top-`top_n` (default 6) tools per bucket with `newcomers` (recommended but not in the hand-curated current list) and `departures` (currently headlined but not in the recommendation). The output is a REVIEWABLE recommendation, not an auto-applied override \u2014 operators decide whether to update `mcpg.about.CAPABILITIES`. Returns `audit_table_present=False` with a diagnostic when the audit subsystem is off. Returns an object with `audit_table_present`, `lookback_days`, `top_n`, `events_examined`, `detail`, and `buckets` (list of objects with `bucket_id`, `current`, `recommended`, `newcomers`, `departures`, `call_counts`).\n\nExample: `recommend_headline_tools(lookback_days=14, top_n=6)`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "lookback_days",
+        "type": "integer",
+        "desc": "Lookback Days"
+      },
+      {
+        "name": "top_n",
+        "type": "integer",
+        "desc": "Top N"
+      }
+    ]
+  },
+  {
+    "name": "recommend_hnsw_ef_search",
+    "description": "Recommend an `hnsw.ef_search` value for a target recall@k \u2014 the actionable companion to `analyze_hnsw_recall`. Samples `sample_queries` rows (default 10) as query vectors, builds an exact brute-force top-k ground truth per query, sweeps `ef_values` (default 16/32/64/128/256) measuring mean recall@k and p50/p95 latency at each, and recommends the smallest value clearing `target_recall` (default 0.95). Unlike the single-query curve tool, this VERIFIES an HNSW index actually exists on the column (returns `has_hnsw_index=false` with guidance otherwise \u2014 a sweep without one just measures sequential scans). The query row is excluded from its own results. Requires the vector extension. Returns an object with `available`, `has_hnsw_index`, `index_name`, `metric`, `k`, `target_recall`, `sample_queries`, `recommended_ef_search` (int or null), `detail`, and `sweep` (list of objects with `ef_search`, `mean_recall_at_k`, `p50_latency_ms`, `p95_latency_ms`, `meets_target`).\n\nExample: `recommend_hnsw_ef_search(schema='public', table='docs', column='embedding', k=10, target_recall=0.95)`",
+    "arguments": [
+      {
+        "name": "column",
+        "type": "string",
+        "desc": "Column"
+      },
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "k",
+        "type": "integer",
+        "desc": "K"
+      },
+      {
+        "name": "metric",
+        "type": "string",
+        "desc": "Metric"
+      },
+      {
+        "name": "sample_queries",
+        "type": "integer",
+        "desc": "Sample Queries"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      },
+      {
+        "name": "target_recall",
+        "type": "number",
+        "desc": "Target Recall"
+      }
+    ]
+  },
+  {
+    "name": "recommend_index_drops",
+    "description": "Sibling of `recommend_indexes` for indexes to remove. Walks `pg_stat_user_indexes` + `pg_stat_user_tables` for existing indexes that look like pure cost \u2014 large on disk but never (or barely) scanned. Three reason codes, descending strength: `never_used` (no recorded idx_scans since the last stats reset \u2014 candidate for drop, but verify before removal), `scan_no_fetch` (planner picks it but it returns no rows \u2014 usually existence-check pattern), `rarely_used` (scan rate below `low_scan_ratio` of the table's total scan activity). Primary-key / unique / exclusion-constraint indexes are excluded (dropping those would be a schema change, not a performance win); indexes below `min_index_size_bytes` are skipped too. Returns a ready-to-run `DROP INDEX CONCURRENTLY` statement per candidate. Read-only advisor \u2014 execution is on the operator.\n\nExample: `recommend_index_drops(schema='public', min_index_size_bytes=1000000, low_scan_ratio=0.01)`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "low_scan_ratio",
+        "type": "number",
+        "desc": "Low Scan Ratio"
+      },
+      {
+        "name": "min_index_size_bytes",
+        "type": "integer",
+        "desc": "Min Index Size Bytes"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "recommend_indexes",
+    "description": "Recommend tables that may benefit from indexing \u2014 large tables read mostly by sequential scan. Set `fresh=true` to bypass the cache and re-read live (e.g. after a schema change). Returns a list of objects with `schema`, `table`, `live_tuples`, `sequential_scans`, `index_scans`, and a `reason` explaining why the table is a candidate.\n\nExample: `recommend_indexes(min_live_tuples=10000)`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "fresh",
+        "type": "boolean",
+        "desc": "Fresh"
+      },
+      {
+        "name": "min_live_tuples",
+        "type": "integer",
+        "desc": "Min Live Tuples"
+      }
+    ]
+  },
+  {
+    "name": "recommend_io_method",
+    "description": "Recommend a PG 19 `io_method` ('sync' / 'worker' / 'io_uring') for the current workload. Reads `pg_stat_database` aggregates (blks_read / blks_hit / stats_reset) and the current setting, then maps the workload signals to one of: `high_concurrent_read_load` (\u2192 io_uring), `bursty_io_with_cache_pressure` (\u2192 worker), `low_io_pressure` (\u2192 sync), `current_setting_optimal` (no change), or `insufficient_stats` (window too short). Read-only \u2014 never invokes ALTER SYSTEM; emits a ready_to_run_sql snippet the operator can paste when the recommendation differs from the current setting. Returns an object with `available` (bool), `server_version_num`, `detail`, and `recommendations` \u2014 a list of objects with `recommended_method`, `reason`, `current_method`, `cache_miss_ratio`, `reads_per_second`, `stats_window_seconds`, and `ready_to_run_sql` (null when no change suggested).\n\nExample: `recommend_io_method()`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "recommend_ivfflat_probes",
+    "description": "Recommend an `ivfflat.probes` value for a target recall@k \u2014 the IVFFlat analogue of `recommend_hnsw_ef_search`. Samples `sample_queries` rows (default 10) as query vectors, builds an exact brute-force top-k ground truth per query, sweeps `probe_values` (default 1/2/5/10/20/50) measuring mean recall@k and p50/p95 latency at each, and recommends the smallest value clearing `target_recall` (default 0.95). VERIFIES an IVFFlat index actually exists on the column (returns `has_ivfflat_index=false` with guidance otherwise \u2014 a sweep without one just measures sequential scans). The query row is excluded from its own results. Requires the vector extension. Returns an object with `available`, `has_ivfflat_index`, `index_name`, `metric`, `k`, `target_recall`, `sample_queries`, `recommended_probes` (int or null), `detail`, and `sweep` (list of objects with `probes`, `mean_recall_at_k`, `p50_latency_ms`, `p95_latency_ms`, `meets_target`).\n\nExample: `recommend_ivfflat_probes(schema='public', table='docs', column='embedding', k=10, target_recall=0.95)`",
+    "arguments": [
+      {
+        "name": "column",
+        "type": "string",
+        "desc": "Column"
+      },
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "k",
+        "type": "integer",
+        "desc": "K"
+      },
+      {
+        "name": "metric",
+        "type": "string",
+        "desc": "Metric"
+      },
+      {
+        "name": "sample_queries",
+        "type": "integer",
+        "desc": "Sample Queries"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      },
+      {
+        "name": "target_recall",
+        "type": "number",
+        "desc": "Target Recall"
+      }
+    ]
+  },
+  {
+    "name": "recommend_pg_search_maintenance",
+    "description": "Walk every pg_search BM25 index and emit advisor findings. Rules currently surfaced: ``missing_key_field`` (CRITICAL \u2014 the key_field reloption is required by upstream; an index without it can't satisfy queries) and ``no_field_configs`` (WARNING \u2014 none of the six *_fields reloptions are set, so the index falls back to default tokenization for every indexed column). Each finding carries a ready-to-run ``suggested_action`` SQL statement. Returns an empty list when the extension is not installed. Also feeds the ``pg_search BM25 Indexes`` category in audit_database.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "recommend_postgres_conf",
+    "description": "Compute pgtune-style `postgresql.conf` recommendations. Pure calculator \u2014 touches no database. Given `total_ram_mb` (required), `cpu_count` (default 4), `workload` (one of `web`/`oltp`/`dw`/`desktop`/`mixed`, default `mixed`), `storage` (one of `ssd`/`hdd`/`san`, default `ssd`), and an optional `max_connections` override, returns recommended values for `shared_buffers`, `effective_cache_size`, `work_mem`, `maintenance_work_mem`, `wal_buffers`, `min_wal_size`/`max_wal_size`, `checkpoint_completion_target`, `default_statistics_target`, `random_page_cost`, `effective_io_concurrency`, and the parallel-worker knobs. Memory fields are postgres-ready strings; `settings` is the same data as a flat {guc: value} dict for direct rendering. Pair with `audit_settings` (audit first, then size).\n\nExample: `recommend_postgres_conf(total_ram_mb=16384, cpu_count=8, workload='oltp', storage='ssd')`",
+    "arguments": [
+      {
+        "name": "cpu_count",
+        "type": "integer",
+        "desc": "Cpu Count"
+      },
+      {
+        "name": "max_connections",
+        "type": "integer",
+        "desc": "Max Connections"
+      },
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": "Storage"
+      },
+      {
+        "name": "total_ram_mb",
+        "type": "integer",
+        "desc": "Total Ram Mb"
+      },
+      {
+        "name": "workload",
+        "type": "string",
+        "desc": "Workload"
+      }
+    ]
+  },
+  {
+    "name": "recommend_prewarm_targets",
+    "description": "Recommend relations whose first-query latency would benefit from ``pg_prewarm``. Inspects ``pg_stat_user_tables`` + ``pg_statio_user_tables`` to find high cold-miss-rate / seq_scan-dominant relations, and caps the cumulative cost at ``shared_buffers_budget_pct`` * ``shared_buffers`` so the recommendation never silently exceeds shared_buffers. The advisor is read-only \u2014 never invokes pg_prewarm itself. Returns an object with `shared_buffers_blocks` (configured shared_buffers in 8 KiB pages), `budget_blocks` (the cap), `total_cost_blocks` (sum of recommendations actually returned), and `candidates` \u2014 a list of objects with `schema`, `relation`, `reason` (`seq_scan_dominant` / `high_cold_miss_rate` / `small_hot_relation_uncached` / `index_in_critical_path`), `prewarm_mode`, `estimated_buffer_cost`, `heap_blks_read`, `heap_blks_hit`, `cache_miss_ratio`, and `ready_to_run_sql`.\n\nExample: `recommend_prewarm_targets(shared_buffers_budget_pct=60.0, limit=10)`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Limit"
+      },
+      {
+        "name": "min_heap_blks_read",
+        "type": "integer",
+        "desc": "Min Heap Blks Read"
+      },
+      {
+        "name": "prewarm_mode",
+        "type": "string",
+        "desc": "Prewarm Mode"
+      },
+      {
+        "name": "shared_buffers_budget_pct",
+        "type": "number",
+        "desc": "Shared Buffers Budget Pct"
+      }
+    ]
+  },
+  {
+    "name": "recommend_read_your_writes",
+    "description": "Advise whether the caller should use `WAIT FOR LSN` for read-your-writes consistency. Combines server role (primary vs standby), replay lag, and PG version into a structured recommendation. Never raises. `reason` is one of `primary_no_wait_needed`, `standby_no_lag`, `standby_lag_unknown`, `standby_with_lag`, `standby_pg18_or_older`, `unavailable`. Returns an object with `recommend_use` (bool), `reason`, `is_in_recovery`, `server_version_num`, `current_lag_bytes` (int / null), and `detail`.\n\nExample: `recommend_read_your_writes()`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "recommend_redis_cache_targets",
+    "description": "Recommend tables that would benefit from a Redis cache layer. Inspects ``pg_stat_user_tables`` for read-heavy, low-write relations whose working set fits comfortably in Redis (default: read/write ratio \u2265 10, \u2265 1000 reads, \u2264 1M rows). When ``server`` is provided the generated ``ready_to_run_sql`` stub targets that server name; otherwise the stub uses a placeholder operators must substitute. Advisor is read-only \u2014 never touches Redis itself. Returns an object with `server` and `candidates` \u2014 a list of objects with `schema`, `table`, `reads`, `writes`, `read_write_ratio`, `estimated_row_count`, `reason` (`read_only_lookup_table` / `small_hot_relation` / `read_heavy_low_write` / `moderate_read_dominant`), and `ready_to_run_sql` (a CREATE FOREIGN TABLE stub).\n\nExample: `recommend_redis_cache_targets(server='redis_primary', limit=10)`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Limit"
+      },
+      {
+        "name": "max_rows",
+        "type": "integer",
+        "desc": "Max Rows"
+      },
+      {
+        "name": "min_read_write_ratio",
+        "type": "number",
+        "desc": "Min Read Write Ratio"
+      },
+      {
+        "name": "min_reads_per_day",
+        "type": "integer",
+        "desc": "Min Reads Per Day"
+      },
+      {
+        "name": "server",
+        "type": "string",
+        "desc": "Server"
+      }
+    ]
+  },
+  {
+    "name": "recommend_redistribute",
+    "description": "Distribution-skew advisor for a hash-distributed table. Reads `pg_stats.n_distinct` for every column on the table and suggests a better hash key when the current one is low-cardinality. Pure catalog read \u2014 no per-segment scans. Returns ranked `candidates`, optional `recommendation`, and ready-to-review `suggested_ddl` (`ALTER TABLE \u2026 SET WITH (REORGANIZE=TRUE) DISTRIBUTED BY (col)`). Diagnosis-only \u2014 never executes. On vanilla PG returns `available=false`.\n\nExample: `recommend_redistribute(schema='public', table='fact_sales')`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "recommend_rerank_strategy",
+    "description": "Roll-up advisor over the four analytics for one window. Returns a single headline ``summary`` + the full list of findings. Built from whichever combination of ``reranker_idle`` / ``topk_stable`` / ``score_clustering`` / ``rerank_hurts_ndcg`` / ``rerank_lifts_ndcg`` fires. Also feeds the ``RAG Reranker Pipeline`` category in audit_database. Reads from mcpg_rag.rerank_events.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "days",
+        "type": "integer",
+        "desc": "Days"
+      },
+      {
+        "name": "retrieval_index",
+        "type": "string",
+        "desc": "Retrieval Index"
+      }
+    ]
+  },
+  {
+    "name": "recommend_skip_scan_indexes",
+    "description": "Find composite B-tree indexes whose leading column has low NDV \u2014 these are the ones PG 19's skip-scan optimisation unlocks. Each candidate's trailing columns can now be served by the composite index alone, so any dedicated single-column indexes on those trailing columns become review candidates for `recommend_index_drops`. Returns an empty list on PG \u2264 18 or driver failure \u2014 pair with `get_skip_scan_status` for the diagnostic. `max_leading_ndv` (default 1000) caps the leading-column NDV that's considered low enough for skip-scan to be profitable. Returns a list of objects with `schema`, `table`, `index_name`, `leading_column`, `trailing_columns` (list of strings), `estimated_leading_ndv` (int), and `rationale` (human-readable explanation).\n\nExample: `recommend_skip_scan_indexes()`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "max_leading_ndv",
+        "type": "integer",
+        "desc": "Max Leading Ndv"
+      }
+    ]
+  },
+  {
+    "name": "recommend_turboquant_maintenance",
+    "description": "Walk every pg_turboquant index and emit advisor findings. Rules currently surfaced: ``prerequisites_unmet`` (CRITICAL \u2014 pgvector is missing) and ``delta_tier_large`` (WARNING \u2014 upstream's own ``delta_health.merge_recommended=true`` advisory, emits a ``tq_maintain_index`` suggested_action). Each finding carries a ready-to-run ``suggested_action`` SQL statement. Returns an empty list when the extension is not installed. Also feeds the ``pg_turboquant Indexes`` category in audit_database.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "recommend_turboquant_query_knobs",
+    "description": "Run tq_recommended_query_knobs \u2014 per-query knob advisor. Two modes: plain (just ``candidate_limit`` + optional ``final_limit``) gives generic recommendations; index-aware (supply both ``index_schema`` and ``index_name``, plus optional ``filter_selectivity``) specialises the recommendations to the named index's catalog state. Returns ``probes``, ``oversample_factor``, ``max_visited_codes``, ``max_visited_pages`` \u2014 pass these to ``turboquant_approx_candidates`` / ``turboquant_rerank_candidates``. Requires pg_turboquant.",
+    "arguments": [
+      {
+        "name": "candidate_limit",
+        "type": "integer",
+        "desc": "Candidate Limit"
+      },
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "filter_selectivity",
+        "type": "number",
+        "desc": "Filter Selectivity"
+      },
+      {
+        "name": "final_limit",
+        "type": "integer",
+        "desc": "Final Limit"
+      },
+      {
+        "name": "index_name",
+        "type": "string",
+        "desc": "Index Name"
+      },
+      {
+        "name": "index_schema",
+        "type": "string",
+        "desc": "Index Schema"
+      }
+    ]
+  },
+  {
+    "name": "recommend_vector_quantization",
+    "description": "Scan a schema for `vector(N)` columns whose storage could be halved by switching to pgvector v0.7+'s `halfvec(N)` type (16-bit float). Returns one recommendation per qualifying column with current vs suggested bytes, the savings ratio, and a one-line rationale. Skips columns that are already non-`vector` and small tables where the absolute saving wouldn't justify the migration.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "record_efficiency_observation",
+    "description": "Insert one row into mcpg_rag.efficiency_observations - one observation per analyze_vector_search_efficiency run. Fields mirror VectorEfficiencyReport one-to-one; pass the report's schema_name / table_name / column_name / index_name / backend / metric / k / sample_size / recall_baseline / rerank_lift_curve (as list[dict]) / spearman / kendall / pages_pruned_ratio_p50 / duration_seconds + optional extra dict. Tool arguments recall_baseline / spearman / kendall correspond to VectorEfficiencyReport.recall_at_k_baseline / score_rank_correlation_spearman / score_rank_correlation_kendall respectively. Available only in unrestricted mode; the table must be created first via setup_efficiency_observations. Returns an object with `observation_id` (the new mcpg_rag.efficiency_observations row id).",
+    "arguments": [
+      {
+        "name": "backend",
+        "type": "string",
+        "desc": "Backend"
+      },
+      {
+        "name": "column_name",
+        "type": "string",
+        "desc": "Column Name"
+      },
+      {
+        "name": "duration_seconds",
+        "type": "number",
+        "desc": "Duration Seconds"
+      },
+      {
+        "name": "extra",
+        "type": "object",
+        "desc": "Extra"
+      },
+      {
+        "name": "index_name",
+        "type": "string",
+        "desc": "Index Name"
+      },
+      {
+        "name": "k",
+        "type": "integer",
+        "desc": "K"
+      },
+      {
+        "name": "kendall",
+        "type": "number",
+        "desc": "Kendall"
+      },
+      {
+        "name": "metric",
+        "type": "string",
+        "desc": "Metric"
+      },
+      {
+        "name": "pages_pruned_ratio_p50",
+        "type": "number",
+        "desc": "Pages Pruned Ratio P50"
+      },
+      {
+        "name": "recall_baseline",
+        "type": "number",
+        "desc": "Recall Baseline"
+      },
+      {
+        "name": "rerank_lift_curve",
+        "type": "array",
+        "desc": "Rerank Lift Curve"
+      },
+      {
+        "name": "sample_size",
+        "type": "integer",
+        "desc": "Sample Size"
+      },
+      {
+        "name": "schema_name",
+        "type": "string",
+        "desc": "Schema Name"
+      },
+      {
+        "name": "spearman",
+        "type": "number",
+        "desc": "Spearman"
+      },
+      {
+        "name": "table_name",
+        "type": "string",
+        "desc": "Table Name"
+      }
+    ]
+  },
+  {
+    "name": "reindex_pg_search_index",
+    "description": "REINDEX a pg_search BM25 index. Pre-flight confirms the named index actually uses the bm25 access method (catalog lookup on pg_am) before running. ``concurrently=True`` is the default and runs on autocommit since REINDEX CONCURRENTLY can't run inside a transaction. Performs DDL \u2014 requires unrestricted mode + MCPG_ALLOW_DDL; pg_search installed. Returns an object with `schema`, `index`, `concurrently` (bool), and `reindex_sql` (the rendered REINDEX statement that ran).",
+    "arguments": [
+      {
+        "name": "concurrently",
+        "type": "boolean",
+        "desc": "Concurrently"
+      },
+      {
+        "name": "index",
+        "type": "string",
+        "desc": "Index"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "reindex_turboquant_index",
+    "description": "REINDEX a turboquant index. Pre-flight confirms the named index is actually a turboquant index (catalog lookup on pg_am) before running. ``concurrently=True`` is the default and runs on autocommit since REINDEX CONCURRENTLY can't run inside a transaction. Performs DDL \u2014 requires unrestricted mode + MCPG_ALLOW_DDL; pg_turboquant installed. Returns an object with `schema`, `index`, `concurrently` (bool), and `reindex_sql` (the rendered REINDEX statement that ran).",
+    "arguments": [
+      {
+        "name": "concurrently",
+        "type": "boolean",
+        "desc": "Concurrently"
+      },
+      {
+        "name": "index",
+        "type": "string",
+        "desc": "Index"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "repack_table",
+    "description": "Rebuild a table using PG 19's in-server `REPACK` command. Defaults to `concurrently=true` \u2014 the non-blocking variant is the common ops choice. Cannot run inside a transaction block (same constraint as `VACUUM`); runs on an autocommit connection via `Database.run_unmanaged`. Requires PG 19+; raises an error otherwise (pair with `get_repack_status` to feature-detect, or fall back to pg_repack on PG \u2264 18). Returns an object with `schema`, `table`, `concurrently` (bool), and `repack_sql` (the rendered DDL that actually executed \u2014 same audit-friendly shape as `maintenance_sql` on `run_maintenance`).\n\nExample: `repack_table(schema='public', table='orders', concurrently=True)`",
+    "arguments": [
+      {
+        "name": "concurrently",
+        "type": "boolean",
+        "desc": "Concurrently"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "restore_database",
+    "description": "Restore a dump into the connected database. `format='plain'` pipes the SQL text in `content` through psql with --single-transaction + ON_ERROR_STOP; `custom`/`tar` base64-decode `content` and pipe the bytes through pg_restore. Credentials pass through libpq env vars, never on the command line. Performs subprocess execution \u2014 requires unrestricted mode + MCPG_ALLOW_SHELL. Returns an object with `succeeded` (bool), `stdout`, `stderr`, `exit_code`, `timed_out` (bool), and `output_truncated` (bool).",
+    "arguments": [
+      {
+        "name": "content",
+        "type": "string",
+        "desc": "Content"
+      },
+      {
+        "name": "format",
+        "type": "string",
+        "desc": "Format"
+      }
+    ]
+  },
+  {
+    "name": "retrieve_with_context",
+    "description": "Context-packed k-NN retrieval (a one-shot RAG building block). Runs a pgvector k-NN against schema.table.embedding_column for a caller-supplied `query_vector` (no embedding model needed), then expands each hit one hop along foreign keys and returns the hit row + its related parent / child records in one object. Parents (when `include_parents`, default true) are the rows a hit references via outbound FKs; children (when `include_children`, default true) are rows referencing the hit via inbound FKs, capped at `max_related` (default 5) per FK. Limitations: 1 hop only; inbound (child) expansion is same-schema only. The embedding column is dropped from every returned row. Requires the vector extension. Returns `available`, `dimension`, `detail`, and `hits` (each with `distance`, `row`, and `related` \u2014 a list of `fk_name`/`direction`/`related_schema`/`related_table`/`rows`).\n\nExample: `retrieve_with_context(schema='public', table='docs', embedding_column='embedding', query_vector=[0.1, 0.2, 0.3], k=5)`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "embedding_column",
+        "type": "string",
+        "desc": "Embedding Column"
+      },
+      {
+        "name": "include_children",
+        "type": "boolean",
+        "desc": "Include Children"
+      },
+      {
+        "name": "include_parents",
+        "type": "boolean",
+        "desc": "Include Parents"
+      },
+      {
+        "name": "k",
+        "type": "integer",
+        "desc": "K"
+      },
+      {
+        "name": "max_related",
+        "type": "integer",
+        "desc": "Max Related"
+      },
+      {
+        "name": "metric",
+        "type": "string",
+        "desc": "Metric"
+      },
+      {
+        "name": "query_vector",
+        "type": "array",
+        "desc": "Query Vector"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "run_advisors",
+    "description": "Run a set of catalog-driven advisor rules against a schema and return the aggregated findings. Rules cover missing primary keys, unindexed foreign keys, duplicate indexes, and nullable timestamps without time zone. Advisory only \u2014 no writes.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      }
+    ]
+  },
+  {
+    "name": "run_analytical_query",
+    "description": "Run a read-only SELECT that may take longer than the standard limit \u2014 for genuine analytical work (large aggregations, multi-table joins, window functions, DISTINCT/GROUP BY over millions of rows). Validated by the same allowlist as run_select, but executed on a DEDICATED connection pool (isolated from the fast-path tools) with an elevated, bounded timeout. Prefer run_select for ordinary queries; reach for this only when a query legitimately needs more time. `timeout_ms` overrides the per-call budget (clamped to the server's configured maximum, MCPG_ANALYTICAL_MAX_TIMEOUT_MS); `work_mem` (e.g. '256MB') elevates sort/hash memory for this statement. Runs against the primary database. Returns an object with `columns`, `rows`, `row_count`, and `truncated` (true when more rows than `max_rows` were produced) \u2014 same shape as run_select.\n\nExample: `run_analytical_query(sql='SELECT c, count(*) FROM big GROUP BY c', timeout_ms=180000)`",
+    "arguments": [
+      {
+        "name": "max_rows",
+        "type": "integer",
+        "desc": "Max Rows"
+      },
+      {
+        "name": "sql",
+        "type": "string",
+        "desc": "Sql"
+      },
+      {
+        "name": "timeout_ms",
+        "type": "integer",
+        "desc": "Timeout Ms"
+      },
+      {
+        "name": "work_mem",
+        "type": "string",
+        "desc": "Work Mem"
+      }
+    ]
+  },
+  {
+    "name": "run_cypher",
+    "description": "Execute an openCypher query on a specific graph database. Supports read queries (MATCH) and write/modifying queries (CREATE, SET, DELETE, MERGE, REMOVE). Returns an object with `columns` (list of result column names) and `rows` (list of result rows as dicts keyed by column).",
+    "arguments": [
+      {
+        "name": "cypher_query",
+        "type": "string",
+        "desc": "Cypher Query"
+      },
+      {
+        "name": "graph_name",
+        "type": "string",
+        "desc": "Graph Name"
+      }
+    ]
+  },
+  {
+    "name": "run_ddl",
+    "description": "Execute a single DDL statement (CREATE/ALTER/DROP and related). Available only in unrestricted access mode with MCPG_ALLOW_DDL enabled. When schema+table hints are supplied, the result includes a before/after column snapshot for that table. When MCPG_AUDIT_PERSIST is on, one row is appended to mcpg_audit.events for every call.",
+    "arguments": [
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "sql",
+        "type": "string",
+        "desc": "Sql"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "run_maintenance",
+    "description": "Run VACUUM or ANALYZE against one table (operation: vacuum, analyze, or vacuum_analyze). Available only in unrestricted mode. Returns an object with `operation`, `target` (the qualified table name), and `maintenance_sql` (the rendered DDL that actually ran).",
+    "arguments": [
+      {
+        "name": "operation",
+        "type": "string",
+        "desc": "Operation"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "run_pgq",
+    "description": "Execute a SQL/PGQ `SELECT ... GRAPH_TABLE` query and return the rows. The query must be a single `SELECT` (or `WITH ... SELECT`) statement that references `GRAPH_TABLE` \u2014 anything else is refused at the boundary (use `run_select` for non-graph reads). `max_rows` caps the result set; when the cap is hit, `truncated=true`. Requires PG 19+. Returns an object with `columns` (list of column names from the query's `COLUMNS (...)` clause), `rows` (list of dicts keyed by those columns), `row_count`, and `truncated` (bool).\n\nExample: `run_pgq(query=\"SELECT * FROM GRAPH_TABLE (org_chart MATCH (e:Employee)-[:REPORTS_TO]->(m:Manager) COLUMNS (e.name AS employee, m.name AS manager))\", max_rows=50)`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "max_rows",
+        "type": "integer",
+        "desc": "Max Rows"
+      },
+      {
+        "name": "query",
+        "type": "string",
+        "desc": "Query"
+      }
+    ]
+  },
+  {
+    "name": "run_select",
+    "description": "Validate and run a read-only SQL query. Writes, DDL, and other unsafe statements are rejected before execution.\n\nExample: `run_select(sql='SELECT id, email FROM users LIMIT 10', max_rows=1000)`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "max_rows",
+        "type": "integer",
+        "desc": "Max Rows"
+      },
+      {
+        "name": "sql",
+        "type": "string",
+        "desc": "Sql"
+      }
+    ]
+  },
+  {
+    "name": "run_select_parallel",
+    "description": "Run up to parallel_limit read-only SELECTs concurrently. Each statement is validated by the same safety allowlist as run_select; one bad query does not abort the others \u2014 its error is captured in its own outcome slot. Useful for dashboard-style fan-out where round-trip latency dominates (e.g. fetching counters / aggregates from several tables at once). Each outcome includes an index so the caller can correlate results without relying on ordering.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "max_rows",
+        "type": "integer",
+        "desc": "Max Rows"
+      },
+      {
+        "name": "parallel_limit",
+        "type": "integer",
+        "desc": "Parallel Limit"
+      },
+      {
+        "name": "statements",
+        "type": "array",
+        "desc": "Statements"
+      }
+    ]
+  },
+  {
+    "name": "run_select_tuned",
+    "description": "Run a read-only SELECT with an elevated, bounded `work_mem` (and optionally `maintenance_work_mem`) for THIS statement only. Useful for heavy analytical SELECTs (large sorts / hash joins / GROUP BY) that spill to disk under the default work_mem. The knob is set via `SET LOCAL` inside the same read-only transaction, so it never leaks back into the pool. Both knobs must match `^\\d+(kB|MB|GB)$` and are hard-capped at 2GB (unbounded values are an OOM risk). SQL is validated read-only by the same allowlist as run_select. SET LOCAL only affects transactional statements \u2014 non-transactional maintenance (CREATE INDEX CONCURRENTLY, VACUUM) is out of scope.\n\nExample: `run_select_tuned(sql='SELECT a, count(*) FROM big GROUP BY a', work_mem='256MB')`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "maintenance_work_mem",
+        "type": "string",
+        "desc": "Maintenance Work Mem"
+      },
+      {
+        "name": "max_rows",
+        "type": "integer",
+        "desc": "Max Rows"
+      },
+      {
+        "name": "sql",
+        "type": "string",
+        "desc": "Sql"
+      },
+      {
+        "name": "work_mem",
+        "type": "string",
+        "desc": "Work Mem"
+      }
+    ]
+  },
+  {
+    "name": "run_write",
+    "description": "Execute a single INSERT, UPDATE, or DELETE statement in a read-write transaction. Add a RETURNING clause to receive affected rows. Available only in unrestricted access mode. When MCPG_AUDIT_PERSIST is on, one row is appended to mcpg_audit.events for every call.",
+    "arguments": [
+      {
+        "name": "sql",
+        "type": "string",
+        "desc": "Sql"
+      }
+    ]
+  },
+  {
+    "name": "schedule_autowarm",
+    "description": "Register a pg_cron job that calls the bulk prewarm helper at ``schedule``. Default schedule is ``@reboot`` \u2014 the canonical 'warm after restart' loop. Requires pg_cron installed. The cron command embeds the budget / limit / mode arguments and calls a `mcpg.prewarm_recommended_cron(...)` SQL function the operator must install separately (template in ``docs/plans/pg-prewarm-advisor.md``). Returns an object with `jobid`, `name`, and `schedule`.\n\nExample: `schedule_autowarm(name='mcpg_autowarm', schedule='@reboot')`",
+    "arguments": [
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Limit"
+      },
+      {
+        "name": "min_heap_blks_read",
+        "type": "integer",
+        "desc": "Min Heap Blks Read"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name"
+      },
+      {
+        "name": "prewarm_mode",
+        "type": "string",
+        "desc": "Prewarm Mode"
+      },
+      {
+        "name": "schedule",
+        "type": "string",
+        "desc": "Schedule"
+      },
+      {
+        "name": "shared_buffers_budget_pct",
+        "type": "number",
+        "desc": "Shared Buffers Budget Pct"
+      }
+    ]
+  },
+  {
+    "name": "schedule_cron_job",
+    "description": "Register a pg_cron job. ``schedule`` is a cron expression or pg_cron interval shortcut (e.g. '30 seconds'). Available only in unrestricted mode; requires pg_cron installed. Returns an object with `jobid` (the pg_cron job id), `name`, and `schedule`.",
+    "arguments": [
+      {
+        "name": "command",
+        "type": "string",
+        "desc": "Command"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name"
+      },
+      {
+        "name": "schedule",
+        "type": "string",
+        "desc": "Schedule"
+      }
+    ]
+  },
+  {
+    "name": "schedule_logical_backup",
+    "description": "Schedule a recurring pg_dump via pg_cron + COPY TO PROGRAM. The scheduled job runs pg_dump on the database host's filesystem and writes the dump to ``destination`` on that host. ``database`` is required \u2014 pg_dump invoked through COPY TO PROGRAM does not inherit the connection's database and falls back to the OS user name without ``-d``. ``destination`` must be an absolute POSIX path with only [A-Za-z0-9_./-] (no shell metacharacters) so it cannot escape the COPY TO PROGRAM shell string; ``database`` additionally allows the hyphen common in real DB names. ``format`` is 'plain' | 'custom' | 'tar'; ``compress`` pipes through gzip; ``port`` defaults to 5432. COPY TO PROGRAM is PostgreSQL-superuser-only, so the connected role must be superuser for the scheduled job to succeed at runtime. Available only in unrestricted mode; requires pg_cron installed.",
+    "arguments": [
+      {
+        "name": "compress",
+        "type": "boolean",
+        "desc": "Compress"
+      },
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Database"
+      },
+      {
+        "name": "destination",
+        "type": "string",
+        "desc": "Destination"
+      },
+      {
+        "name": "format",
+        "type": "string",
+        "desc": "Format"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name"
+      },
+      {
+        "name": "pg_dump_path",
+        "type": "string",
+        "desc": "Pg Dump Path"
+      },
+      {
+        "name": "port",
+        "type": "integer",
+        "desc": "Port"
+      },
+      {
+        "name": "schedule",
+        "type": "string",
+        "desc": "Schedule"
+      },
+      {
+        "name": "schema_only",
+        "type": "boolean",
+        "desc": "Schema Only"
+      }
+    ]
+  },
+  {
+    "name": "seed_table_with_sample_data",
+    "description": "Generate and execute synthetic INSERT statements to seed a table with sample data. Values respect column types, NOT NULL, and DEFAULT constraints. Foreign keys are NOT resolved \u2014 you must pre-seed referenced rows or drop the FK before seeding. Hard cap of 10000 rows. Available only in unrestricted access mode.",
+    "arguments": [
+      {
+        "name": "rows",
+        "type": "integer",
+        "desc": "Rows"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "seed",
+        "type": "integer",
+        "desc": "Seed"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "setup_efficiency_observations",
+    "description": "Create the ``mcpg_rag.efficiency_observations`` table + two indexes (``observed_at``, composite ``(backend, metric, k, observed_at)``). Idempotent \u2014 safe to re-run; returns ``{schema_created, table_created, indexes_created}``. Required before any ``record_efficiency_observation`` call or before ``recommend_efficiency_thresholds`` can return corpus-derived values. Performs DDL \u2014 requires unrestricted mode + MCPG_ALLOW_DDL.",
+    "arguments": []
+  },
+  {
+    "name": "setup_rag_telemetry",
+    "description": "Create the ``mcpg_rag`` schema, ``rerank_events`` table, and the three supporting indexes (occurred_at, query_hash, (reranker_model, occurred_at)). Idempotent \u2014 safe to re-run. Returns ``{schema_created, table_created, indexes_created}`` so the caller can tell first-run from no-op. Required before any ``log_rerank_event`` call or the Phase-D reranker analytics. Performs DDL \u2014 requires unrestricted mode + MCPG_ALLOW_DDL.",
+    "arguments": []
+  },
+  {
+    "name": "split_partition",
+    "description": "Split one partition into two or more new partitions using PG 19's `ALTER TABLE \u2026 SPLIT PARTITION existing INTO (PARTITION new1 FOR VALUES \u2026, PARTITION new2 FOR VALUES \u2026)`. `new_partitions` is a list of `{name, for_values_clause}` objects \u2014 the `name` is quoted as an identifier; the `for_values_clause` is embedded verbatim (DDL grammar can't parameter-bind partition bounds \u2014 caller composes safe fragments from validated values). Example RANGE form: `\"FROM ('2024-01-01') TO ('2024-04-01')\"`. Requires PG 19+. Returns an object with `parent_schema`, `parent_table`, `source_partition`, `new_partitions` (the new names), and `split_sql`.\n\nExample: `split_partition(parent_schema='public', parent_table='measurement', source_partition='measurement_y2024', new_partitions=[{'name': 'measurement_y2024_h1', 'for_values_clause': \"FROM ('2024-01-01') TO ('2024-07-01')\"}, {'name': 'measurement_y2024_h2', 'for_values_clause': \"FROM ('2024-07-01') TO ('2025-01-01')\"}])`",
+    "arguments": [
+      {
+        "name": "new_partitions",
+        "type": "array",
+        "desc": "New Partitions"
+      },
+      {
+        "name": "parent_schema",
+        "type": "string",
+        "desc": "Parent Schema"
+      },
+      {
+        "name": "parent_table",
+        "type": "string",
+        "desc": "Parent Table"
+      },
+      {
+        "name": "source_partition",
+        "type": "string",
+        "desc": "Source Partition"
+      }
+    ]
+  },
+  {
+    "name": "subscribe_channel",
+    "description": "Open a PostgreSQL LISTEN on `channel` and return a subscription id. Notifications buffer in process memory; poll for them via poll_notifications. Channel name must match [A-Za-z_][A-Za-z0-9_]*. Subscriptions are lost on server restart. Requires unrestricted mode + MCPG_ALLOW_LISTEN.",
+    "arguments": [
+      {
+        "name": "channel",
+        "type": "string",
+        "desc": "Channel"
+      }
+    ]
+  },
+  {
+    "name": "summarize_table",
+    "description": "Return a one-stop snapshot of a table: columns, primary key, foreign keys, every other constraint, indexes, storage + row-count + last-vacuum/analyze stats, and (optionally) a short sample of rows. Replaces what would otherwise be 4-5 individual tool calls. Set sample_rows=0 on wide / jsonb-heavy tables where the sample isn't useful.\n\nExample: `summarize_table(schema='public', table='users', sample_rows=5)`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "sample_rows",
+        "type": "integer",
+        "desc": "Sample Rows"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "terminate_backend",
+    "description": "Terminate a backend PID (pg_terminate_backend), closing its connection. Available only in unrestricted mode. Returns an object with `pid`, `action` ('terminate'), and `succeeded` (bool).",
+    "arguments": [
+      {
+        "name": "pid",
+        "type": "integer",
+        "desc": "Pid"
+      }
+    ]
+  },
+  {
+    "name": "test_rls_for_role",
+    "description": "Test what an RLS-bound role can read from a table. Reports whether RLS is enabled on the table, lists the policies that apply to the given role, counts the rows the role can read, and returns up to sample_size rows so the agent can inspect them. Runs as the target role inside a READ ONLY transaction \u2014 no writes can leak. Pure read.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "role",
+        "type": "string",
+        "desc": "Role"
+      },
+      {
+        "name": "sample_size",
+        "type": "integer",
+        "desc": "Sample Size"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "translate_nl_to_sql",
+    "description": "Translate a natural-language question into a read-only PostgreSQL query against `schema`. The LLM provider (anthropic / openai / gemini / deepseek / qwen / openrouter / perplexity, plus any operator-declared custom OpenAI-compatible provider) sees a compact brief of the schema (tables, columns, foreign keys) and is instructed to return JSON with `sql` and `explanation`. When execute=true, the generated SQL goes through the SAME safety allowlist as run_select before running \u2014 writes / DDL / multi-statement input are rejected even if the model produced them. Returns the SQL, model rationale, and (when executed) rows / columns / row_count. table_filter narrows the brief to a known subset when the question is clearly scoped. `provider`, when supplied, selects which configured LLM provider to call (use this to route between the configured vendors per-call when multiple are configured); when omitted, MCPg uses the default (MCPG_NL2SQL_PROVIDER, otherwise the first available in preference order anthropic \u2192 openai \u2192 gemini \u2192 deepseek \u2192 qwen \u2192 openrouter \u2192 perplexity). Call get_server_info to see which providers are configured.\n\nExample: `translate_nl_to_sql(question='top 10 customers by revenue last month', schema='public', execute=true)`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "execute",
+        "type": "boolean",
+        "desc": "Execute"
+      },
+      {
+        "name": "explain_preflight",
+        "type": "boolean",
+        "desc": "Explain Preflight"
+      },
+      {
+        "name": "max_rows",
+        "type": "integer",
+        "desc": "Max Rows"
+      },
+      {
+        "name": "provider",
+        "type": "string",
+        "desc": "Provider"
+      },
+      {
+        "name": "question",
+        "type": "string",
+        "desc": "Question"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table_filter",
+        "type": "array",
+        "desc": "Table Filter"
+      }
+    ]
+  },
+  {
+    "name": "tune_vector_index",
+    "description": "Recommend an ivfflat or hnsw configuration for a pgvector column. Reads the live row count and column dimension, applies the standard pgvector heuristics, and returns the parameters plus a ready-to-run CREATE INDEX statement. Requires the vector extension.",
+    "arguments": [
+      {
+        "name": "column",
+        "type": "string",
+        "desc": "Column"
+      },
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "index_type",
+        "type": "string",
+        "desc": "Index Type"
+      },
+      {
+        "name": "metric",
+        "type": "string",
+        "desc": "Metric"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "turboquant_approx_candidates",
+    "description": "Run tq_approx_candidates against a turboquant index \u2014 approximate k-NN retrieval, no exact rerank. ``metric`` is 'cosine' | 'inner_product' | 'l2' (mapped to upstream's runtime metric text). ``half_precision=True`` switches to the halfvec overload. ``probes`` / ``oversample_factor`` are optional per-query knobs (consider calling ``recommend_turboquant_query_knobs`` first). Requires the pg_turboquant extension. Returns a list of candidate objects with `candidate_id`, `approximate_distance`, and `approximate_rank`.",
+    "arguments": [
+      {
+        "name": "candidate_limit",
+        "type": "integer",
+        "desc": "Candidate Limit"
+      },
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "embedding_column",
+        "type": "string",
+        "desc": "Embedding Column"
+      },
+      {
+        "name": "half_precision",
+        "type": "boolean",
+        "desc": "Half Precision"
+      },
+      {
+        "name": "id_column",
+        "type": "string",
+        "desc": "Id Column"
+      },
+      {
+        "name": "metric",
+        "type": "string",
+        "desc": "Metric"
+      },
+      {
+        "name": "oversample_factor",
+        "type": "integer",
+        "desc": "Oversample Factor"
+      },
+      {
+        "name": "probes",
+        "type": "integer",
+        "desc": "Probes"
+      },
+      {
+        "name": "query_vector",
+        "type": "array",
+        "desc": "Query Vector"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "turboquant_rerank_candidates",
+    "description": "Run tq_rerank_candidates against a turboquant index \u2014 approximate retrieval followed by SQL-side exact rerank to ``final_limit`` results. Returns the candidates with both approximate and exact ranks / distances. ``half_precision=True`` switches to the halfvec overload. Requires the pg_turboquant extension.",
+    "arguments": [
+      {
+        "name": "candidate_limit",
+        "type": "integer",
+        "desc": "Candidate Limit"
+      },
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "embedding_column",
+        "type": "string",
+        "desc": "Embedding Column"
+      },
+      {
+        "name": "final_limit",
+        "type": "integer",
+        "desc": "Final Limit"
+      },
+      {
+        "name": "half_precision",
+        "type": "boolean",
+        "desc": "Half Precision"
+      },
+      {
+        "name": "id_column",
+        "type": "string",
+        "desc": "Id Column"
+      },
+      {
+        "name": "metric",
+        "type": "string",
+        "desc": "Metric"
+      },
+      {
+        "name": "oversample_factor",
+        "type": "integer",
+        "desc": "Oversample Factor"
+      },
+      {
+        "name": "probes",
+        "type": "integer",
+        "desc": "Probes"
+      },
+      {
+        "name": "query_vector",
+        "type": "array",
+        "desc": "Query Vector"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "unschedule_autowarm",
+    "description": "Remove an autowarm pg_cron job by name. Idempotent \u2014 returns ``removed=false`` when the job didn't exist (or pg_cron isn't installed). Returns an object with `name` and `removed` (bool).\n\nExample: `unschedule_autowarm(name='mcpg_autowarm')`",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name"
+      }
+    ]
+  },
+  {
+    "name": "unschedule_cron_job",
+    "description": "Unschedule a pg_cron job by name. Returns ``removed=true`` when the job existed. Available only in unrestricted mode.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name"
+      }
+    ]
+  },
+  {
+    "name": "unsubscribe_channel",
+    "description": "Remove a subscription. Returns true if it existed. The underlying LISTEN is dropped when the last subscription on the channel goes away. Requires unrestricted mode + MCPG_ALLOW_LISTEN.",
+    "arguments": [
+      {
+        "name": "subscription_id",
+        "type": "string",
+        "desc": "Subscription Id"
+      }
+    ]
+  },
+  {
+    "name": "validate_check_constraint",
+    "description": "Run `ALTER TABLE schema.table VALIDATE CONSTRAINT name` to validate a constraint that was originally added with `NOT VALID`. Idempotent \u2014 when the constraint is already validated, returns `changed=false` and emits no DDL. Works on every supported PG version (the SQL has been around since 9.x); ships in the PG 19 DDL helpers module because it closes the create-NOT-VALID / validate-later loop on the agent surface. Returns an object with `table_schema`, `table`, `constraint_name`, `was_valid` (bool / null), `now_valid` (bool), `changed` (bool), and `validate_sql` (the rendered DDL that actually executed, or a `-- no-op` comment when nothing was needed). The field is named `table_schema` (not `schema`) to avoid colliding with Pydantic's reserved name in the auto-derived outputSchema.\n\nExample: `validate_check_constraint(schema='public', table='orders', constraint_name='orders_total_nonneg')`",
+    "arguments": [
+      {
+        "name": "constraint_name",
+        "type": "string",
+        "desc": "Constraint Name"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "validate_migration",
+    "description": "Apply candidate_sql to a TRANSIENT shadow of target_schema that's pre-populated with up to sample_rows_per_table rows copied from each base table. The shadow is dropped before returning regardless of outcome. Catches failure modes a pure structural diff misses: NOT NULL added to a column with existing NULLs, CHECK constraints violated by live rows, type narrowings that fail on real values, triggers that error against actual data. Reports per-table rows_before / rows_after so the effect of a DELETE-shaped candidate is visible. error is non-null iff the candidate raised. Performs DDL \u2014 requires unrestricted mode + MCPG_ALLOW_DDL.",
+    "arguments": [
+      {
+        "name": "candidate_sql",
+        "type": "string",
+        "desc": "Candidate Sql"
+      },
+      {
+        "name": "sample_rows_per_table",
+        "type": "integer",
+        "desc": "Sample Rows Per Table"
+      },
+      {
+        "name": "target_schema",
+        "type": "string",
+        "desc": "Target Schema"
+      }
+    ]
+  },
+  {
+    "name": "validate_migration_schema",
+    "description": "Verify a candidate migration against a reference schema. Clones target_schema's structure into a transient shadow schema, applies candidate_sql, and compares the shadow schema with reference_schema using compare_schemas. The shadow is dropped before returning. Returns whether the candidate applied, any error, and the structural diff if applied. Performs DDL \u2014 requires unrestricted mode + MCPG_ALLOW_DDL.",
+    "arguments": [
+      {
+        "name": "candidate_sql",
+        "type": "string",
+        "desc": "Candidate Sql"
+      },
+      {
+        "name": "reference_schema",
+        "type": "string",
+        "desc": "Reference Schema"
+      },
+      {
+        "name": "target_schema",
+        "type": "string",
+        "desc": "Target Schema"
+      }
+    ]
+  },
+  {
+    "name": "vector_range_search",
+    "description": "Return every row within `max_distance` of a query vector (a threshold-based query rather than top-k). Useful for de-dup, similarity gating, and clustering pre-passes. Still ordered by distance and capped at `limit` to avoid pulling huge result sets. Reports available=false if the pgvector extension is not installed.",
+    "arguments": [
+      {
+        "name": "column",
+        "type": "string",
+        "desc": "Column"
+      },
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Limit"
+      },
+      {
+        "name": "max_distance",
+        "type": "number",
+        "desc": "Max Distance"
+      },
+      {
+        "name": "metric",
+        "type": "string",
+        "desc": "Metric"
+      },
+      {
+        "name": "query_vector",
+        "type": "array",
+        "desc": "Query Vector"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "vector_recall_at_k",
+    "description": "Measure recall@k of an existing pgvector index against a brute-force ground truth (function-form distance, which pgvector documents as non-indexed). Returns the mean overlap over a sample of rows from the table. Requires the vector extension.",
+    "arguments": [
+      {
+        "name": "column",
+        "type": "string",
+        "desc": "Column"
+      },
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "id_column",
+        "type": "string",
+        "desc": "Id Column"
+      },
+      {
+        "name": "k",
+        "type": "integer",
+        "desc": "K"
+      },
+      {
+        "name": "metric",
+        "type": "string",
+        "desc": "Metric"
+      },
+      {
+        "name": "sample_size",
+        "type": "integer",
+        "desc": "Sample Size"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "vector_search",
+    "description": "Find the rows nearest to a query vector by pgvector distance (metric: l2, cosine, or inner_product). Reports available=false if the pgvector extension is not installed.\n\nExample: `vector_search(schema='public', table='docs', column='embedding', query_vector=[0.1, 0.2, ...], metric='cosine', limit=10)`",
+    "arguments": [
+      {
+        "name": "column",
+        "type": "string",
+        "desc": "Column"
+      },
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Limit"
+      },
+      {
+        "name": "metric",
+        "type": "string",
+        "desc": "Metric"
+      },
+      {
+        "name": "query_vector",
+        "type": "array",
+        "desc": "Query Vector"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema"
+      },
+      {
+        "name": "table",
+        "type": "string",
+        "desc": "Table"
+      }
+    ]
+  },
+  {
+    "name": "verify_audit_chain",
+    "description": "Verify the HMAC-SHA256 signature chain of persisted audit events in mcpg_audit.events. Returns an object with `verified` (bool), `events_checked` (int), the `first_event_id` and `last_event_id` covered by the walk, and (on failure) `error` and `first_invalid_id` pointing at where the chain broke.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "verify_connection_encryption",
+    "description": "Report whether MCPg's own connection to PostgreSQL is TLS-encrypted, including the negotiated protocol version, cipher, and key bits (from pg_stat_ssl). Also returns a cluster-wide tally of encrypted vs unencrypted backends (a lower bound under non-superuser privileges). Complements the startup TLS-enforcement check by confirming the live connection actually came up encrypted.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      }
+    ]
+  },
+  {
+    "name": "wait_for_lsn",
+    "description": "Issue `WAIT FOR LSN '<lsn>' TIMEOUT <ms>` and block until WAL replay catches up on the connected backend. `timeout_ms` defaults to 0 (wait indefinitely); a positive value bounds the wait \u2014 on timeout the helper returns `timed_out=true` rather than raising so the caller can decide whether to retry or fall through. LSN format is strictly validated (`hex/hex`) before any SQL is composed. Requires PG 19+; raises on older servers with the poll-loop fallback in the message. Returns an object with `lsn`, `timeout_ms` (int), `timed_out` (bool), and `wait_sql` (the rendered statement).\n\nExample: `wait_for_lsn(lsn='0/1234ABCD', timeout_ms=5000)`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "lsn",
+        "type": "string",
+        "desc": "Lsn"
+      },
+      {
+        "name": "timeout_ms",
+        "type": "integer",
+        "desc": "Timeout Ms"
+      }
+    ]
+  },
+  {
+    "name": "walk_blocking_chains",
+    "description": "Walk and reconstruct the lock-wait graph of the database. Detects deadlock cycles, traces linear blocking paths to their root blockers, and renders a Mermaid flowchart representing the lock dependency graph. Read-only. Returns an object with `cycles` (list of detected cycle PID lists), `paths` (linear blocking paths as PID lists), `roots` (root blocker PIDs), `nodes` (dict keyed by PID with per-backend lock detail), and `mermaid` (the pre-rendered flowchart string).",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Limit"
+      }
+    ]
+  },
+  {
+    "name": "why_is_this_slow",
+    "description": "Diagnose why a SQL query might be slow, in one call. Runs EXPLAIN (FORMAT JSON) \u2014 does NOT execute the query \u2014 walks the plan tree, snapshots concurrent active queries + blocking lock pairs, reads the cluster-wide cache hit ratio, and produces categorised suggestions (plan / contention / cache / maintenance). Read-only; safe to run on a statement the agent doesn't want to materialise yet.\n\nExample: `why_is_this_slow(sql='SELECT * FROM orders WHERE customer_id = 42')`",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": "Optional: target a configured secondary (read-only) database by name; omit for the primary. Call list_databases to see the configured ids."
+      },
+      {
+        "name": "sql",
+        "type": "string",
+        "desc": "Sql"
+      }
+    ]
+  }
+]

--- a/tests/contract/test_docker_mcp_registry_tools_json.py
+++ b/tests/contract/test_docker_mcp_registry_tools_json.py
@@ -69,3 +69,21 @@ def test_tools_json_covers_every_registered_tool() -> None:
 
     assert len(checked_in) == snapshot["_meta"]["tool_count"]
     assert {t["name"] for t in checked_in} == {t["name"] for t in snapshot["tools"]}
+
+
+def test_resolve_type_handles_every_json_schema_shape() -> None:
+    """Covers shapes not currently present in MCPg's own tool surface.
+
+    ``type`` as a list (``["string", "null"]``) is legal JSON Schema
+    2020-12 but isn't emitted by MCPg's Pydantic-generated schemas today
+    (they use ``anyOf`` for ``Optional[X]`` instead) — flagged by review
+    on #310 as an unhandled shape that would otherwise silently degrade to
+    the Python list's ``str()`` repr instead of a clean type string.
+    """
+    generator = _load_generator()
+
+    assert generator._resolve_type({"type": "string"}) == "string"
+    assert generator._resolve_type({"type": ["string", "null"]}) == "string"
+    assert generator._resolve_type({"type": ["null", "integer"]}) == "integer"
+    assert generator._resolve_type({"anyOf": [{"type": "string"}, {"type": "null"}]}) == "string"
+    assert generator._resolve_type({"title": "Untyped"}) == "string"

--- a/tests/contract/test_docker_mcp_registry_tools_json.py
+++ b/tests/contract/test_docker_mcp_registry_tools_json.py
@@ -1,0 +1,71 @@
+"""Docker MCP Registry ``tools.json`` drift guard.
+
+``packaging/docker-mcp-registry/tools.json`` is the bypass file submitted
+alongside ``server.yaml`` to github.com/docker/mcp-registry — MCPg requires
+a live ``MCPG_DATABASE_URL`` to start (see ``mcpg.config.load_settings``),
+so their build sandbox can't run the container to auto-discover tools the
+way it does for DB-less servers. Per their CONTRIBUTING.md, a checked-in
+``tools.json`` (name / description / arguments per tool) bypasses that
+live-container verification.
+
+It's generated from ``tests/contract/tool_surface.snapshot.json`` — the
+same contract snapshot ``test_doc_tables.py`` and ``about.py`` treat as the
+tool-surface source of truth — by
+``packaging/docker-mcp-registry/generate_tools_json.py``. This test asserts
+the checked-in file still matches what the generator produces, so a tool
+added, removed, or reshaped without regenerating can't silently drift the
+registry submission out of sync with the real server.
+
+When you add/remove a tool or change its schema, regenerate::
+
+    python packaging/docker-mcp-registry/generate_tools_json.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+_REPO = Path(__file__).resolve().parents[2]
+_GENERATOR_PATH = _REPO / "packaging" / "docker-mcp-registry" / "generate_tools_json.py"
+_TOOLS_JSON_PATH = _REPO / "packaging" / "docker-mcp-registry" / "tools.json"
+
+
+def _load_generator() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("generate_tools_json", _GENERATOR_PATH)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_tools_json_matches_generator_output() -> None:
+    generator = _load_generator()
+    snapshot = json.loads(generator.SNAPSHOT_PATH.read_text(encoding="utf-8"))
+    expected = [
+        {
+            "name": tool["name"],
+            "description": tool["description"],
+            "arguments": generator._flatten_arguments(tool["inputSchema"]),
+        }
+        for tool in snapshot["tools"]
+    ]
+
+    checked_in = json.loads(_TOOLS_JSON_PATH.read_text(encoding="utf-8"))
+
+    assert checked_in == expected, (
+        "packaging/docker-mcp-registry/tools.json is out of sync with "
+        "tests/contract/tool_surface.snapshot.json — regenerate via "
+        "`python packaging/docker-mcp-registry/generate_tools_json.py`"
+    )
+
+
+def test_tools_json_covers_every_registered_tool() -> None:
+    """Guards against a silently-truncated or stale bypass file."""
+    snapshot = json.loads((_REPO / "tests" / "contract" / "tool_surface.snapshot.json").read_text(encoding="utf-8"))
+    checked_in = json.loads(_TOOLS_JSON_PATH.read_text(encoding="utf-8"))
+
+    assert len(checked_in) == snapshot["_meta"]["tool_count"]
+    assert {t["name"] for t in checked_in} == {t["name"] for t in snapshot["tools"]}


### PR DESCRIPTION
## Summary

Prep work for submitting MCPg to [docker/mcp-registry](https://github.com/docker/mcp-registry) — the registry backing Docker Desktop's MCP Toolkit / `docker mcp` CLI. This PR is submission **prep** only (roadmap 21.1); the actual fork + PR into `docker/mcp-registry` is a separate, outward-facing step (roadmap 21.2) pending explicit go-ahead, since it's a third-party public repo.

**Eligibility check (2026-08-14):** no existing general-purpose PostgreSQL entry in their registry (only `prisma-postgres`, which is Prisma-specific). MCPg clears every eligibility bar in their `CONTRIBUTING.md`: MIT license, root `Dockerfile`, and a live-verified `stdio` transport override.

## What's added

- `packaging/docker-mcp-registry/server.yaml` — draft registry entry (category `database`, `MCPG_DATABASE_URL` as the sole required secret, `MCPG_ACCESS_MODE` exposed read-only-default, `run.env` forces `MCPG_TRANSPORT: stdio`).
- `packaging/docker-mcp-registry/generate_tools_json.py` — generates the registry's `tools.json` bypass file from `tests/contract/tool_surface.snapshot.json`. MCPg requires a live `MCPG_DATABASE_URL` to start, so Docker's build sandbox can't run the container to auto-discover tools the normal way; their CONTRIBUTING.md documents `tools.json` as the bypass. Confirmed the real shape (`{name, description, arguments: [{name, type, desc}]}` — **not** MCP-native `inputSchema`) against live registry entries (`servers/database-server`, `servers/context7`) before generating, rather than guessing.
- `tests/contract/test_docker_mcp_registry_tools_json.py` — drift guard, per this repo's "generated beats hand-maintained" rule.

## Verification

- Built the image locally from the current root `Dockerfile` and ran a real `initialize` + `tools/list` JSON-RPC exchange over stdio against a throwaway Postgres container, with `-e MCPG_TRANSPORT=stdio` — confirms `run.env: MCPG_TRANSPORT: stdio` cleanly overrides the image's baked-in `streamable-http` default. No `Dockerfile` changes needed.
- `python packaging/docker-mcp-registry/generate_tools_json.py` produces all 254 entries; spot-checked simple and complex (nested object/array/anyOf-typed) tool schemas.
- `pytest tests/contract/` — 49 passed.
- `pytest tests/unit` — 2856 passed, 3 skipped.
- `ruff check` / `ruff format --check` / `mypy src/mcpg` — clean.

## Known gap (flagged, not blocking)

254 tools is unusually large for a single catalog entry; MCPg has no bucket/tool-filter env var today to ship a slimmer default surface (checked — doesn't exist). Tracked as roadmap 21.3; will address proactively in the actual registry PR description.

Advances roadmap row: 21.1

## Summary by Sourcery

Prepare MCPg for submission to Docker’s MCP Registry by adding registry packaging metadata and a generated tools bypass file tied to the existing contract snapshot.

New Features:
- Add Docker MCP Registry server definition for MCPg, including catalog metadata, secrets, and configuration parameters.
- Introduce a generator script that derives the registry-compatible tools.json bypass file from the contract tool-surface snapshot.

Enhancements:
- Document the Docker MCP Registry submission roadmap and current prep work in the feature shortlist and changelog.
- Add a drift-guard test ensuring the checked-in tools.json stays in sync with the generator and the authoritative tool-surface snapshot.

Tests:
- Add contract tests that validate tools.json matches the generated output and fully covers all registered tools.