### PR TITLE
release: cut MCPg v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-08-19
+
 ### Security
 
 - **Release SBOM + build provenance, and a `CODEOWNERS` file.** Cutting a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,22 @@ adheres to [Semantic Versioning](https://semver.org/).
   the MCP-registry login, the build-provenance attestation, and the Pages
   deploy (`excessive-permissions`) — and set `persist-credentials: false` on all
   repo checkouts so a persisted git credential can't be captured in an artifact
-  (`artipacked`). zizmor now reports no findings.
+  (`artipacked`).
+- **zizmor baseline cleared, round 2 — the vendored `pg_turboquant` workflow.**
+  `actions-security.yml` invokes zizmor against `.` (repo root), which
+  recursively picks up **every** nested `.github/workflows/*.yml`, including
+  `scratch/pg_turboquant/.github/workflows/ci.yml` — a first-party PostgreSQL
+  extension's own CI config, checked in whole but never actually triggered by
+  GitHub Actions (nested `.github` dirs aren't discovered as workflow sources).
+  Round 1 missed it; the code-scanning dashboard still showed 12 open
+  findings (1 `unpinned-uses`, 6 `excessive-permissions`, 5 `artipacked`)
+  against it. Applied the same hardening as round 1 — pinned
+  `actions/checkout`, `actions/upload-artifact`, `actions/download-artifact`,
+  and `SonarSource/sonarqube-scan-action` to SHAs, added a workspace-level
+  `permissions: contents: read`, and `persist-credentials: false` on every
+  checkout. Verified clean with the exact same `uvx zizmor@1.9.0` invocation
+  CI uses. zizmor now genuinely reports no findings across the whole repo
+  tree, not just the top-level workflows.
 
 ### Added
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ a read-only HF Spaces demo.
   bundle pins are synced by `packaging/mcpb/sync_version.py`;
   `tests/unit/test_mcpb_bundle.py` enforces the match. A release bumps
   exactly one line.
-- **Tool surface:** `tests/contract/tool_surface.snapshot.json` (252
+- **Tool surface:** `tests/contract/tool_surface.snapshot.json` (256
   tools) is the contract. `about.py`'s `tool_count = len(tool_names)`.
   Two contract snapshots (surface + return shapes) — regenerate with
   `MCPG_REGENERATE_TOOL_SNAPSHOT=1` / `MCPG_REGENERATE_TOOL_RETURN_SHAPES=1`

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -6,8 +6,8 @@
 
 ## Current state
 
-- **Phase:** post-v0.6.10. Every Batch (A–G) from the original
-  shortlist plus the 0.6.x waves have shipped — security (IP
+- **Phase:** post-v0.8.0. Every Batch (A–G) from the original
+  shortlist plus the 0.6.x/0.7.x/0.8.x waves have shipped — security (IP
   allowlist, TLS/mTLS, cloud secrets backends), observability
   (slow-call logging + OpenTelemetry), staged migrations + history,
   pgvector analytics, BM25/`pg_search`, `pg_turboquant`, the RAG
@@ -15,13 +15,16 @@
   `WAIT FOR LSN`, data-checksum/logical-rep toggles, partition
   merge/split), WarehousePG (MPP) coverage, Redis FDW, `pg_prewarm`,
   the 22-provider NL→SQL fleet, the generated-doc-table drift guard,
-  and the **first-party SQL-safety kernel** (18.1 de-vendor complete —
-  no vendored runtime code remains).
-- **Last updated:** 2026-07-09
+  the **first-party SQL-safety kernel** (18.1 de-vendor complete — no
+  vendored runtime code remains), the `mcp` 2.0 SDK migration (0.7.0),
+  the Docker MCP Registry submission (21.1/21.2), and **dynamic session
+  intent** (roadmap 22 — a `core` session-intent preset plus an opt-in
+  runtime tool-surface growth layer).
+- **Last updated:** 2026-08-19
 - **Branch:** `main`
-- **Tool count:** 252 (source of truth:
+- **Tool count:** 256 maximal / 186 default read-only (source of truth:
   `tests/contract/tool_surface.snapshot.json`)
-- **Released:** v0.6.10 (2026-07-09)
+- **Released:** v0.8.0 (2026-08-19)
 
 > **Note on this log.** The dated session log below is a historical
 > record that trails off at **2026-05-26** (~90 tools). The nine
@@ -32,12 +35,14 @@
 
 ## Next action
 
-> Trunk is at 0.6.10. The feature roadmap (`docs/feature-shortlist.md`
-> §1–18) is fully shipped. The next concrete item is the **0.6.11
-> per-request-tenancy fix** for the HTTP/SSE transports (the
-> `X-MCPG-Role` / OIDC override is pinned to a session's first request;
-> see the known-limitation note in `docs/security-hardening.md`). Beyond
-> that, pick from any newly-surfaced rows in `docs/feature-shortlist.md`.
+> Trunk is at 0.8.0. The feature roadmap (`docs/feature-shortlist.md`
+> §1–22) is fully shipped; the per-request-tenancy fix for HTTP/SSE
+> landed in 0.7.0 (tenancy redesigned onto `ServerMiddleware`). Two
+> open, non-urgent todos live in agent memory rather than as roadmap
+> rows: evaluating `mcp-failure-lab` as an MCPg testing tool, and
+> investigating the `warehousepg-latest` CI job's consistently high
+> latency. Otherwise, pick from any newly-surfaced rows in
+> `docs/feature-shortlist.md`.
 
 ## Phase 0 — Spike & foundation  ✅ COMPLETE
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,6 +61,7 @@ them" — pick the section that matches what you're trying to do.
   retrospectives.
 - [**Progress log**](PROGRESS.md) — chronological build log.
 - Release notes:
+  [v0.8.0](release-notes-0.8.0.md) ·
   [v0.7.0](release-notes-0.7.0.md) ·
   [v0.6.12](release-notes-0.6.12.md) ·
   [v0.6.11](release-notes-0.6.11.md) ·

--- a/docs/release-notes-0.8.0.md
+++ b/docs/release-notes-0.8.0.md
@@ -1,0 +1,128 @@
+# MCPg v0.8.0 — release notes
+
+**Released:** 2026-08-19
+**Tool surface:** **254** tools across 19 capability buckets at the
+maximal (all flags on) ceiling — unchanged in count from 0.7.1. This
+release adds 2 new always-visible meta-tools gated behind the new
+`MCPG_DYNAMIC_SESSION_INTENT` flag, which only raise the ceiling to 256
+when explicitly enabled; the default (read-only, nothing else set)
+surface is unaffected by them.
+**Tests:** 2909 passed, 3 skipped in the full unit suite, plus contract
+snapshots, on this exact commit ahead of the tag; the full `ci.yml`
+matrix (lint, mypy, security audit, PG 14–19 + WarehousePG integration)
+passed on GitHub Actions.
+**Runtime:** Python 3.12–3.14 (`requires-python >=3.12`; CI/mypy target
+3.14)
+
+A **0.7.1 → 0.8.0** release: a MINOR bump — new opt-in behaviour,
+defaults unchanged. The headline is **dynamic session intent**
+(roadmap 22), which lets a deployment start a session with a small,
+focused tool surface and grow it on demand, instead of every session
+seeing the full read-only default of 186 tools up front.
+
+## New: the `core` session-intent preset
+
+A sixth `MCPG_SESSION_INTENT` preset, `"core"`, built from `about.py`'s
+curated headline tools rather than capability buckets. Setting
+`MCPG_SESSION_INTENT=core` on a default read-only deployment narrows the
+tool surface from 186 tools down to **12** — the ten headline
+schema-introspection and query-execution tools plus the two
+always-kept introspection tools. No new flag needed; this extends the
+existing, shipped `session_intent.py` static filter (roadmap 8.8)
+rather than replacing it.
+
+## New: opt-in dynamic session-intent growth
+
+**`MCPG_DYNAMIC_SESSION_INTENT`** (default `false`): when set, a session
+starts at its static intent (`core` by default) and can grow its own
+visible tool surface at runtime — without a server restart, and without
+affecting any other concurrent session. Two new always-visible
+meta-tools:
+
+- `list_session_intents()` — shows which named intents (`lookup`,
+  `migration`, `vector_rag`, `monitor`, `admin`) are available and which
+  are currently enabled for this session.
+- `enable_session_intent(name)` — enables one, growing this session's
+  `tools/list` to include everything that intent covers, up to whatever
+  the static `MCPG_SESSION_INTENT` filter already left registered.
+
+**Important:** this is a **visibility** filter, not an **authorization**
+boundary. A tool absent from `tools/list` was always still callable via
+`tools/call` if a client already knew its name — that was true before
+this release too. `MCPG_ACCESS_MODE` (`read-only` / `restricted` /
+`unrestricted`) and the `MCPG_ALLOW_*` capability gates remain the real
+permission boundary, unaffected by either the static or dynamic
+session-intent layer. See the user guide's "Dynamic session intent"
+section for the full model.
+
+Off by default; adds the 2 meta-tools to the maximal 254-tool ceiling
+(→ 256) only when enabled. Lives in `mcpg.session_intent` and the new
+`mcpg.dynamic_session_intent`.
+
+## New: Docker MCP Registry submission
+
+Submitted MCPg to the [Docker MCP Registry](https://github.com/docker/mcp-registry/pull/4689)
+(roadmap 21). Added `packaging/docker-mcp-registry/` with a
+`server.yaml` draft and a generated `tools.json` bypass file (their
+registry's own `{name, description, arguments}` shape, not MCP-native
+`inputSchema`) derived from and guarded against drift by the tool
+surface contract snapshot — needed because MCPg requires a live
+`MCPG_DATABASE_URL` to start, which their build sandbox can't supply.
+
+## Also added
+
+- **`server.json` now sets `websiteUrl`**
+  (`https://devopam.github.io/MCPg/`), the field the MCP Registry
+  surfaces as the server's homepage link.
+- **OpenSSF Best Practices badge** added to the README badge row
+  (project [13958](https://www.bestpractices.dev/projects/13958),
+  `passing`).
+
+## Security hardening
+
+- **Release SBOM + build provenance.** Cutting a release now generates
+  a CycloneDX SBOM and attests GitHub-native build provenance for the
+  wheel + sdist, complementing the PEP 740 attestations PyPI Trusted
+  Publishing already emits. Added `.github/CODEOWNERS`.
+- **Pipeline-security tooling**: StepSecurity Harden-Runner (egress
+  monitoring on every job), zizmor (static analysis of the Actions
+  workflows), and actionlint — all in reporting mode initially.
+- **zizmor baseline cleared**: scoped `id-token: write` down to only the
+  five OIDC jobs that need it, and set `persist-credentials: false` on
+  all checkouts. zizmor now reports no findings.
+
+## Fixed
+
+- **`server.json`'s checked-in version no longer drifts.** It tracked a
+  stale release (last hand-bumped at `0.6.8`) because the registry
+  publish job only patched a version derived from the tag in the CI
+  checkout, never committing it back. Added
+  `tools/sync_server_json_version.py` (mirrors the existing `.mcpb`
+  bundle sync script), guarded by `tests/unit/test_server_json.py`.
+
+## Upgrade impact
+
+- **No breaking changes.** All new behaviour is opt-in
+  (`MCPG_SESSION_INTENT=core`, `MCPG_DYNAMIC_SESSION_INTENT=1`); an
+  unconfigured deployment sees the same 186-tool read-only /
+  254-tool maximal surface as before.
+- Deployments that want a smaller default surface for a given
+  connection profile (e.g. a read-only lookup client) can now set
+  `MCPG_SESSION_INTENT=core` without waiting for a per-session dynamic
+  flow; deployments that want sessions to self-serve a larger surface
+  on demand can add `MCPG_DYNAMIC_SESSION_INTENT=1` on top.
+
+## Upgrade
+
+```bash
+pip install --upgrade mcpg
+docker pull ghcr.io/devopam/mcpg:0.8.0   # or :latest
+```
+
+Or grab `mcpg-0.8.0.mcpb` from this release and double-click it into
+Claude Desktop.
+
+## Full changelog
+
+See [`../CHANGELOG.md`](../CHANGELOG.md) `[0.8.0]` for the complete
+itemised list.

--- a/docs/release-notes-0.8.0.md
+++ b/docs/release-notes-0.8.0.md
@@ -1,12 +1,12 @@
 # MCPg v0.8.0 — release notes
 
 **Released:** 2026-08-19
-**Tool surface:** **254** tools across 19 capability buckets at the
-maximal (all flags on) ceiling — unchanged in count from 0.7.1. This
-release adds 2 new always-visible meta-tools gated behind the new
-`MCPG_DYNAMIC_SESSION_INTENT` flag, which only raise the ceiling to 256
-when explicitly enabled; the default (read-only, nothing else set)
-surface is unaffected by them.
+**Tool surface:** **254** tools — the same ceiling as 0.7.1 for every
+existing deployment, unchanged unless you opt into something new. This
+release adds 2 new always-visible meta-tools behind the new, off-by-default
+`MCPG_DYNAMIC_SESSION_INTENT` flag, which raises the true all-flags-on
+maximal to **256** only when that flag is explicitly enabled; the default
+(read-only, nothing else set) surface stays at 186 either way.
 **Tests:** 2909 passed, 3 skipped in the full unit suite, plus contract
 snapshots, on this exact commit ahead of the tag; the full `ci.yml`
 matrix (lint, mypy, security audit, PG 14–19 + WarehousePG integration)
@@ -34,10 +34,13 @@ rather than replacing it.
 ## New: opt-in dynamic session-intent growth
 
 **`MCPG_DYNAMIC_SESSION_INTENT`** (default `false`): when set, a session
-starts at its static intent (`core` by default) and can grow its own
-visible tool surface at runtime — without a server restart, and without
-affecting any other concurrent session. Two new always-visible
-meta-tools:
+starts at whatever `MCPG_SESSION_INTENT` already declares — or, if that's
+left unset (its own default), the dynamic layer falls back to `core`
+specifically as its own starting point, rather than the unfiltered full
+surface an unset `MCPG_SESSION_INTENT` would otherwise mean. From there
+the session can grow its own visible tool surface at runtime — without a
+server restart, and without affecting any other concurrent session. Two
+new always-visible meta-tools:
 
 - `list_session_intents()` — shows which named intents (`lookup`,
   `migration`, `vector_rag`, `monitor`, `admin`) are available and which
@@ -55,9 +58,9 @@ permission boundary, unaffected by either the static or dynamic
 session-intent layer. See the user guide's "Dynamic session intent"
 section for the full model.
 
-Off by default; adds the 2 meta-tools to the maximal 254-tool ceiling
-(→ 256) only when enabled. Lives in `mcpg.session_intent` and the new
-`mcpg.dynamic_session_intent`.
+Off by default; adds the 2 meta-tools to the existing 254-tool ceiling
+(→ 256, the new all-flags-on maximal) only when enabled. Lives in
+`mcpg.session_intent` and the new `mcpg.dynamic_session_intent`.
 
 ## New: Docker MCP Registry submission
 
@@ -104,8 +107,9 @@ surface contract snapshot — needed because MCPg requires a live
 
 - **No breaking changes.** All new behaviour is opt-in
   (`MCPG_SESSION_INTENT=core`, `MCPG_DYNAMIC_SESSION_INTENT=1`); an
-  unconfigured deployment sees the same 186-tool read-only /
-  254-tool maximal surface as before.
+  unconfigured deployment sees the same 186-tool read-only / 254-tool
+  all-flags-on-except-dynamic surface as before (256 only if the new
+  dynamic flag is also turned on).
 - Deployments that want a smaller default surface for a given
   connection profile (e.g. a read-only lookup client) can now set
   `MCPG_SESSION_INTENT=core` without waiting for a per-session dynamic

--- a/docs/release-notes-0.8.0.md
+++ b/docs/release-notes-0.8.0.md
@@ -90,9 +90,13 @@ surface contract snapshot — needed because MCPg requires a live
 - **Pipeline-security tooling**: StepSecurity Harden-Runner (egress
   monitoring on every job), zizmor (static analysis of the Actions
   workflows), and actionlint — all in reporting mode initially.
-- **zizmor baseline cleared**: scoped `id-token: write` down to only the
-  five OIDC jobs that need it, and set `persist-credentials: false` on
-  all checkouts. zizmor now reports no findings.
+- **zizmor baseline cleared, including a vendored nested workflow**: scoped
+  `id-token: write` down to only the five OIDC jobs that need it, and set
+  `persist-credentials: false` on all checkouts. A second pass caught 12
+  findings zizmor's recursive `.` scan picked up in
+  `scratch/pg_turboquant/.github/workflows/ci.yml` (a first-party extension's
+  own, never-triggered CI config) that round 1 missed — same hardening
+  applied there too. zizmor now reports no findings, repo-wide.
 
 ## Fixed
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -449,7 +449,7 @@ against the actual code / CLI before shipping:
 | `docs/installation.md` | Python / PostgreSQL version ranges match `pyproject.toml` + `ci.yml`; env-var scenarios current; secrets-backend vars correct. |
 | `docs/integrations.md` | One-click install links work; provider/model examples name real models; NL→SQL key env vars match `nl2sql.py`. |
 | `docs/tools.md` | **Guarded** by `test_doc_tables.py` (index). Prose sections: capability gates + "requires X mode" match `policy.py`. |
-| `docs/tour.md` | Hard-coded tool count (`252`) matches the snapshot; specialist-area caveat still accurate; sample params match tool signatures. |
+| `docs/tour.md` | Hard-coded tool count matches the snapshot (and the `#tool-index-N-tools` anchor it links to in `tools.md`); specialist-area caveat still accurate; sample params match tool signatures. |
 | `docs/cookbook.md` | Every recipe's tool call — names, params, return keys — matches `tools.py` (copy-paste must actually run). |
 | `docs/architecture.md` | **Guarded** by `test_doc_tables.py` (module map). Prose: access-mode table matches `policy.py`; CI-matrix + test-suite facts match `ci.yml`; the Mermaid diagram still reflects the request path. |
 | `docs/user-guide.md` | Access-mode + capability-gate tables match `policy.py`; **the NL→SQL provider table (names / env vars / default models) matches `nl2sql.py`'s `_PROVIDERS`** (see the quarterly model sweep in [§9](#9-recurring-chores)); TOC covers every `##` heading. |

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -6,12 +6,13 @@ surface, not the full catalogue — the exhaustive per-tool reference is
 in [`tools.md`](tools.md), and task-oriented recipes live in
 [`cookbook.md`](cookbook.md).
 
-**254 tools** across 19 capability areas as of trunk. Each line shows
+**256 tools** across 19 capability areas as of trunk (254 without the
+opt-in `MCPG_DYNAMIC_SESSION_INTENT` flag). Each line shows
 the tool name + how its parameters land (required first, common
 defaults after). Capability gates are noted in section titles where
 they apply. A few specialist areas (PITR, WarehousePG MPP, Redis FDW,
 SQL/PGQ property graphs, `pg_prewarm`, `pg_repack`, PG 19 runtime
-toggles) aren't walked below — see the [tool index](tools.md#tool-index-254-tools)
+toggles) aren't walked below — see the [tool index](tools.md#tool-index-256-tools)
 for those.
 
 ---

--- a/packaging/mcpb/manifest.json
+++ b/packaging/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "mcpg",
   "display_name": "MCPg \u2014 PostgreSQL",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Production-grade PostgreSQL MCP server: 254 tools for querying, tuning, and operating Postgres \u2014 read-only by default.",
   "long_description": "MCPg lets AI agents safely inspect, query, operate, and tune a PostgreSQL database. 254 tools spanning catalog introspection, query intelligence, natural-language SQL, structural diffs, hybrid search, graph queries, live ops, and more.\n\n**Safe by default**: read-only access mode, AST-validated SQL, and every tool publishes MCP annotations (`readOnlyHint`/`destructiveHint`) so the client knows exactly which calls are safe. Write, DDL, shell, and LISTEN capabilities stay off until explicitly enabled via environment variables.\n\nNo data yet? Run `mcpg --demo` against a scratch database to seed a curated demo dataset and take the tools for a spin \u2014 see the guided tour at https://github.com/devopam/MCPg/blob/main/docs/demo.md.",
   "author": {

--- a/packaging/mcpb/pyproject.toml
+++ b/packaging/mcpb/pyproject.toml
@@ -5,9 +5,9 @@
 # to the release tag by the publish workflow, exactly like server.json.
 [project]
 name = "mcpg-desktop-extension"
-version = "0.7.1"
+version = "0.8.0"
 description = "MCPB launcher shim for the MCPg PostgreSQL MCP server."
 requires-python = ">=3.12"
 dependencies = [
-    "mcpg==0.7.1",
+    "mcpg==0.8.0",
 ]

--- a/scratch/pg_turboquant/.github/workflows/ci.yml
+++ b/scratch/pg_turboquant/.github/workflows/ci.yml
@@ -4,6 +4,12 @@ on:
   push:
   pull_request:
 
+# Least-privilege default: none of these jobs push commits, create releases,
+# or need an OIDC token — build/test/coverage/SonarQube all only need to
+# read the checked-out source. (zizmor `excessive-permissions`.)
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
@@ -13,7 +19,9 @@ jobs:
         postgresql_version: [16, 17]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Add PostgreSQL apt repository
         run: |
@@ -69,7 +77,9 @@ jobs:
             pgvector_ref: v0.8.1
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Add PostgreSQL apt repository
         run: |
@@ -121,7 +131,9 @@ jobs:
       UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Add PostgreSQL apt repository
         run: |
@@ -174,7 +186,9 @@ jobs:
       PG_CONFIG: /usr/lib/postgresql/17/bin/pg_config
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Add PostgreSQL apt repository
         run: |
@@ -232,7 +246,7 @@ jobs:
         run: gcovr -a coverage_integration.json -a coverage_unit.json --sonarqube coverage.xml -r . -f 'src/'
 
       - name: Upload coverage artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage
           path: |
@@ -244,18 +258,19 @@ jobs:
     runs-on: mayflower-k8s-runners
     needs: [build-and-test, compatibility-matrix, sanitizer, coverage]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Download coverage artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: coverage
           path: .
 
       - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@v6
+        uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_BASE_URL }}

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.devopam/mcpg",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Production-grade PostgreSQL MCP server \u2014 254 tools for query, tuning & ops, read-only by default.",
   "websiteUrl": "https://devopam.github.io/MCPg/",
   "repository": {
@@ -13,7 +13,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "mcpg",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/mcpg/__init__.py
+++ b/src/mcpg/__init__.py
@@ -2,7 +2,7 @@
 
 import warnings
 
-__version__ = "0.7.1"
+__version__ = "0.8.0"
 
 # ``schema`` is the natural field name for "which Postgres schema" across
 # ~180 tool-return dataclasses. The ``mcp`` SDK dynamically builds a

--- a/uv.lock
+++ b/uv.lock
@@ -2814,7 +2814,7 @@ wheels = [
 
 [[package]]
 name = "twine"
-version = "6.2.0"
+version = "7.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "id" },
@@ -2827,9 +2827,9 @@ dependencies = [
     { name = "rich" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/a8/949edebe3a82774c1ec34f637f5dd82d1cf22c25e963b7d63771083bbee5/twine-6.2.0.tar.gz", hash = "sha256:e5ed0d2fd70c9959770dce51c8f39c8945c574e18173a7b81802dab51b4b75cf", size = 172262, upload-time = "2025-09-04T15:43:17.255Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/3c/58f808a359700f39a967dffede33efeac809262c03303fa3eec6afff8f49/twine-7.0.0.tar.gz", hash = "sha256:85cdb29c518efef867360ae4acd4b0dfd61c8654a22fca08e6f8539f05022177", size = 215032, upload-time = "2026-07-27T15:59:00.825Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl", hash = "sha256:418ebf08ccda9a8caaebe414433b0ba5e25eb5e4a927667122fbe8f829f985d8", size = 42727, upload-time = "2025-09-04T15:43:15.994Z" },
+    { url = "https://files.pythonhosted.org/packages/96/08/ddcdc06225eaad6de0e48e1002b06d919dbde20582d0662c7af51308e5d6/twine-7.0.0-py3-none-any.whl", hash = "sha256:b854164df26db268af05f49aa5c0344b10e27a494343ff05b1e0bad3b135f5a7", size = 43204, upload-time = "2026-07-27T15:58:59.26Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Release preparation for **MCPg v0.8.0** (MINOR bump — new opt-in behaviour, defaults unchanged), following `docs/release-process.md` §5/§5.1.

- Version bump: `__init__.py` → `0.8.0`, synced to `packaging/mcpb/{manifest.json,pyproject.toml}` and `server.json` via their respective scripted syncers.
- `CHANGELOG.md`: rolled `[Unreleased]` into a dated `[0.8.0]` section; fresh empty `[Unreleased]` added above it.
- New `docs/release-notes-0.8.0.md`, mirroring the `0.7.0` notes' structure, linked from `docs/index.md`.
- Documentation validation pass (§5.1): fixed stale hand-written tool-count references that had drifted behind the real 256-tool maximal snapshot (dynamic session intent's 2 new meta-tools, roadmap 22) — `CLAUDE.md`, `docs/tour.md` (count + a broken `#tool-index-N-tools` anchor), and `docs/release-process.md`'s own checklist row (now count-agnostic to avoid the same drift recurring). `docs/PROGRESS.md`'s stale post-0.6.10 header brought current.
- Dev-tooling fix found during the pre-flight build check: `uv run twine check` failed on `Metadata-Version: 2.5` (hatchling 1.32.0, released 2026-08-11, made 2.5 its default) — root-caused to a stale locked `twine==6.2.0`; `twine` 7.0.0 (2026-07-27) fixes exactly this. Upgraded via `uv lock --upgrade-package twine`; both `dist/` artifacts now pass `twine check`. No production dependency touched.

## Verification

- `ruff check` / `ruff format --check`: clean
- `mypy --strict src/mcpg`: clean
- `bandit -r src/mcpg`: clean (0 High/Medium)
- `pip-audit --strict`: no known vulnerabilities
- Full unit suite: 2909 passed, 3 skipped
- Full contract suite: green
- `python -m build && twine check dist/*`: both artifacts PASSED

Advances roadmap row: 22

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prepare and document the MCPg v0.8.0 release with synchronized metadata, updated release documentation, and strengthened CI security.

New Features:
- Add MCPg v0.8.0 release notes covering the new core session-intent preset, opt-in dynamic session-intent growth, and Docker MCP Registry submission.

Bug Fixes:
- Synchronize the checked-in server metadata version and correct stale documentation and progress references.

Enhancements:
- Update the project version and release metadata to 0.8.0 while preserving existing default behavior.
- Document the expanded 256-tool maximal surface and release the changelog from Unreleased.
- Harden the nested pg_turboquant CI workflow and clear repository-wide zizmor findings.

Build:
- Upgrade the locked Twine tooling so built distribution artifacts pass metadata validation.

CI:
- Pin GitHub Actions to immutable commits and restrict workflow permissions and checkout credentials in the nested CI workflow.

Documentation:
- Add and index the v0.8.0 release notes and refresh tool-count, roadmap, and release-process documentation.