### PR TITLE
docs: use AllMCPs verify link in badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ graph queries, data movement, live ops, and more.
 [![Stars](https://img.shields.io/github/stars/devopam/MCPg)](https://github.com/devopam/MCPg)
 [![smithery badge](https://smithery.ai/badge/devopam/mcpg)](https://smithery.ai/servers/devopam/mcpg)
 [![MCPg MCP server](https://glama.ai/mcp/servers/devopam/MCPg/badges/score.svg)](https://glama.ai/mcp/servers/devopam/MCPg)
-[![AllMCPs](https://allmcps.com/api/badge/devopam-mcpg)](https://allmcps.com/mcp/devopam-mcpg)
+[![AllMCPs Verified](https://allmcps.com/api/badge/devopam-mcpg)](https://allmcps.com/mcp/devopam-mcpg?verify=63d9d537-be6b-4e07-a720-77dd0c41411b)
 
 > **Try it live:** point an MCP client — or the [MCP Inspector](https://github.com/modelcontextprotocol/inspector) — at the hosted, read-only demo endpoint `https://devopam-mcpg-demo.hf.space/mcp`. It serves read tools against throwaway demo data; for real use, run MCPg next to your own database (see [Quick start](#quick-start)).
 


### PR DESCRIPTION
Updates the AllMCPs badge added in #318 to link through the ownership-verification URL instead of the plain listing link, so AllMCPs can confirm the badge is served from the claimed repo.

Advances roadmap row: n/a (docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Use the AllMCPs verification URL for the README badge.

Enhancements:
- Update the README AllMCPs badge to use the verified ownership link and label.

Documentation:
- Point the AllMCPs README badge to its ownership-verification URL.