### PR TITLE
release: cut MCPg v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.8.2] - 2026-09-04
+
+### Fixed
+
+- **`dump_database` rejected valid PostgreSQL schema names that need delimited-identifier quoting**
+  ([#329](https://github.com/devopam/MCPg/issues/329)). The `schemas` parameter was validated against
+  the plain-identifier allowlist (`[A-Za-z_][A-Za-z0-9_]*`), so an actual schema such as `adm-pgbench`
+  failed with `ShellError: invalid schema name: 'adm-pgbench'` before `pg_dump` was ever spawned.
+  `pg_dump --schema` takes a *pattern* (the same rules as psql's `\d` commands), not a literal name:
+  an unquoted `*` / `?` / `[` is a wildcard and bare letters fold to lowercase. Each entry in `schemas`
+  is now encoded as a double-quoted literal `pg_dump` pattern (`_encode_schema_pattern`) instead of
+  being validated against the shared allowlist — every character, pattern metacharacters included, is
+  matched literally and case-sensitively, so the named schema is dumped and no wildcard can accidentally
+  expand. Callers still pass the bare name (no SQL or shell quoting); only an empty name or an embedded
+  NUL is rejected. This is a dump-specific encoding, deliberately left separate from the plain-identifier
+  validator the in-process SQL paths (`export_table`, `import_csv`/`import_json`/`import_vectors`,
+  `copy_table_between_databases`) still rely on. The access-mode requirement is unchanged
+  (`unrestricted` + `MCPG_ALLOW_SHELL=true`), as is the `DumpResult` contract. Regression tests cover
+  hyphens, spaces, mixed case, embedded double quotes, and pattern metacharacters.
+
 ## [0.8.1] - 2026-09-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,23 +8,45 @@ adheres to [Semantic Versioning](https://semver.org/).
 
 ## [0.8.2] - 2026-09-04
 
+### Added
+
+- **`mcpg.identifiers` — one escape-based SQL identifier quoter (`quote_identifier` / `ensure_identifier`).**
+  It doubles embedded double quotes (`"` → `""`) so any name PostgreSQL accepts as a *delimited*
+  identifier can be spliced safely, and rejects only the values that are not addressable identifiers at
+  all: the empty string, an embedded NUL, and names over PostgreSQL's 63-byte limit (which the server
+  would silently truncate). It replaces the copy-pasted `[A-Za-z_][A-Za-z0-9_]*` regex that ~20 modules
+  each carried, where that regex was doing double duty as both the injection guard *and* (accidentally)
+  a blanket ban on every hyphen / space / mixed-case / quoted name. Covered by an adversarial test suite
+  (`tests/unit/test_identifiers.py`).
+
 ### Fixed
 
-- **`dump_database` rejected valid PostgreSQL schema names that need delimited-identifier quoting**
-  ([#329](https://github.com/devopam/MCPg/issues/329)). The `schemas` parameter was validated against
-  the plain-identifier allowlist (`[A-Za-z_][A-Za-z0-9_]*`), so an actual schema such as `adm-pgbench`
-  failed with `ShellError: invalid schema name: 'adm-pgbench'` before `pg_dump` was ever spawned.
-  `pg_dump --schema` takes a *pattern* (the same rules as psql's `\d` commands), not a literal name:
-  an unquoted `*` / `?` / `[` is a wildcard and bare letters fold to lowercase. Each entry in `schemas`
-  is now encoded as a double-quoted literal `pg_dump` pattern (`_encode_schema_pattern`) instead of
-  being validated against the shared allowlist — every character, pattern metacharacters included, is
-  matched literally and case-sensitively, so the named schema is dumped and no wildcard can accidentally
-  expand. Callers still pass the bare name (no SQL or shell quoting); only an empty name or an embedded
-  NUL is rejected. This is a dump-specific encoding, deliberately left separate from the plain-identifier
-  validator the in-process SQL paths (`export_table`, `import_csv`/`import_json`/`import_vectors`,
-  `copy_table_between_databases`) still rely on. The access-mode requirement is unchanged
-  (`unrestricted` + `MCPG_ALLOW_SHELL=true`), as is the `DumpResult` contract. Regression tests cover
-  hyphens, spaces, mixed case, embedded double quotes, and pattern metacharacters.
+- **Tools rejected valid PostgreSQL object names that need delimited-identifier quoting**
+  ([#329](https://github.com/devopam/MCPg/issues/329)). The reported case was `dump_database`: a real
+  schema such as `adm-pgbench` failed with `ShellError: invalid schema name: 'adm-pgbench'` before
+  `pg_dump` was ever spawned. `pg_dump --schema` takes a *pattern* (psql `\d` rules) — an unquoted
+  `*` / `?` / `[` is a wildcard and bare letters fold to lowercase — so each `schemas` entry is now
+  encoded as a double-quoted literal pattern (`_encode_schema_pattern`); `copy_table_between_databases`
+  encodes its `--table` the same way. The access-mode requirement (`unrestricted` + `MCPG_ALLOW_SHELL`)
+  and the `DumpResult` contract are unchanged.
+
+  A sweep fixed the same class of over-restriction across the in-process SQL tools, which now quote
+  via `mcpg.identifiers` instead of validating against the plain-identifier allowlist:
+  `export_table` / `import_csv` / `import_json` / `import_vectors` (data movement), the pgvector suites
+  (`vector_ops`, `vector_tuning`, `rag_efficiency`, `pg_search`, `turboquant`), `textsearch`,
+  `composite`, `rls` and `tenancy` / `config` roles (`SET LOCAL ROLE`), `logical_replication`,
+  `migrations`, `test_data` / `test_row_factory`, `redis_fdw`, `listen` (LISTEN/NOTIFY channels), and
+  `timescaledb` (whose `create_hypertable` / policy calls take the relation as a `regclass` *text*
+  argument, so the quoted relation is wrapped in a single-quoted literal with both layers escaped).
+  Hyphens, spaces, mixed case, and embedded quotes now work and are safely escaped everywhere; only
+  empty / NUL / overlong names are rejected.
+
+  Left deliberately strict, because the name is not being used as a PostgreSQL identifier there:
+  the Apache AGE graph tools (`graph`, `graph_projection`, `cypher`, `graph_diagram`), where labels
+  follow AGE's own naming rules; the ORM/query-builder code generators (`prisma`, `drizzle`, `diesel`,
+  `ecto`, `ent`, `jooq`, `sqlc`, `sqlalchemy_export`), where the name becomes an identifier in generated
+  Go/Rust/Elixir/Python source; and SQL/PGQ property-graph names (`pgq`). `textsearch` also keeps the
+  strict allowlist for the one value it embeds in a string literal (a `regconfig` name).
 
 ## [0.8.1] - 2026-09-01
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -64,7 +64,7 @@ flowchart TD
 ---
 
 <!-- BEGIN generated: module-map (python tools/generate_doc_tables.py --modules) -->
-## Module map (106 modules)
+## Module map (107 modules)
 
 Every `mcpg.*` module and what it owns, alphabetical. The layered
 request path through these lives in the [Overview](#overview) diagram;
@@ -109,6 +109,7 @@ this table is the exhaustive index. Regenerate with
 | `mcpg.headline_curator` | Dynamic `headline_tools` recommender — empirical curation from the audit log. |
 | `mcpg.health` | Database health checks. |
 | `mcpg.http_runtime` | HTTP-transport extensions: bearer-token auth + Prometheus /metrics. |
+| `mcpg.identifiers` | Safe SQL identifier quoting — the shared, escape-based replacement for the per-module `[A-Za-z_][A-Za-z0-9_]*` allowlists. |
 | `mcpg.indexing` | Index recommendations from table scan statistics and column types. |
 | `mcpg.introspection` | Schema-introspection queries against the PostgreSQL catalog. |
 | `mcpg.io_stats` | I/O stats reader — wraps `pg_stat_io` (PostgreSQL 16+). |

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,6 +61,7 @@ them" — pick the section that matches what you're trying to do.
   retrospectives.
 - [**Progress log**](PROGRESS.md) — chronological build log.
 - Release notes:
+  [v0.8.2](release-notes-0.8.2.md) ·
   [v0.8.1](release-notes-0.8.1.md) ·
   [v0.8.0](release-notes-0.8.0.md) ·
   [v0.7.0](release-notes-0.7.0.md) ·

--- a/docs/release-notes-0.8.2.md
+++ b/docs/release-notes-0.8.2.md
@@ -11,10 +11,11 @@ snapshot drift) on this exact commit ahead of the tag; lint, `ruff format`,
 **Runtime:** Python 3.12–3.14 (`requires-python >=3.12`; CI/mypy target
 3.14)
 
-A focused **0.8.1 → 0.8.2** bug-fix release resolving the project's first
+A **0.8.1 → 0.8.2** bug-fix release resolving the project's first
 user-reported issue, [#329](https://github.com/devopam/MCPg/issues/329):
 `dump_database` refused to export a schema whose name isn't a plain
-identifier. No breaking changes; no configuration changes.
+identifier — and, on inspection, so did ~20 other tools that shared the same
+over-strict identifier check. No breaking changes; no configuration changes.
 
 ## Fixed: `dump_database` now accepts quoted PostgreSQL schema names
 
@@ -67,6 +68,61 @@ necessary and sufficient; there is no shell-injection surface to widen.
 Regression tests cover hyphens, spaces, mixed case, embedded double quotes,
 pattern metacharacters, and semicolons, plus the empty-name / NUL-byte
 rejection path.
+
+## The sweep: same bug, ~20 other tools
+
+Investigating #329 surfaced that the rejecting regex
+(`[A-Za-z_][A-Za-z0-9_]*`) was copy-pasted across roughly twenty modules,
+each using it to guard names it then spliced into SQL as `"{name}"`. That
+regex was doing double duty: it kept the interpolation injection-safe (by
+forbidding the `"` that could close the identifier) **and** it rejected every
+schema, table, column, role, or channel name PostgreSQL only supports through
+*delimited* (double-quoted) identifiers. So the exact same "valid name
+refused" bug lurked well beyond `dump_database`.
+
+### One shared, escape-based quoter
+
+The fix separates the two concerns into `mcpg.identifiers`:
+
+- **`quote_identifier(name)`** doubles embedded double quotes (`"` → `""`)
+  and wraps the result, so any delimited identifier is spliced safely — the
+  value can't break out of its quotes.
+- **`ensure_identifier(name)`** rejects only what isn't an addressable
+  identifier at all: the empty string, an embedded NUL, or a name past
+  PostgreSQL's 63-byte limit (which the server would silently truncate).
+
+It ships with an adversarial test suite (`tests/unit/test_identifiers.py`)
+covering break-out attempts, doubled quotes, and byte-vs-codepoint length.
+
+### Migrated (delimited names now work, safely escaped)
+
+Data movement (`export_table`, `import_csv` / `import_json` /
+`import_vectors`; `copy_table_between_databases` encodes its `pg_dump
+--table` the same way `dump_database` does `--schema`), the pgvector suites
+(`vector_ops`, `vector_tuning`, `rag_efficiency`, `pg_search`, `turboquant`),
+`textsearch`, `composite`, row-level-security and multi-tenant roles (`rls`,
+`tenancy`, `config` — `SET LOCAL ROLE "my-role"` now works), logical
+replication, staged migrations, test-data generators, `redis_fdw`, LISTEN/
+NOTIFY channels, and TimescaleDB. TimescaleDB was the subtle one: its
+`create_hypertable` / policy functions take the relation as a `regclass`
+*text* argument, so the double-quoted relation is itself wrapped in a
+single-quoted literal — both layers are now escaped.
+
+### Deliberately left strict
+
+Some checks stay strict because the name is **not** used as a PostgreSQL
+identifier there, so relaxing would be wrong (or a separate feature):
+
+- **Apache AGE graph tools** (`graph`, `graph_projection`, `cypher`,
+  `graph_diagram`) — labels follow AGE's own naming rules.
+- **ORM / query-builder code generators** (`prisma`, `drizzle`, `diesel`,
+  `ecto`, `ent`, `jooq`, `sqlc`, `sqlalchemy_export`) — the name becomes an
+  identifier in generated Go / Rust / Elixir / Python source, which can't
+  hold arbitrary characters without a name-mapping layer.
+- **SQL/PGQ** property-graph names (`pgq`).
+- The one **`regconfig`** value `textsearch` embeds in a string literal
+  (`to_tsvector('<config>', …)`), where the plain-identifier rule is the
+  safety boundary.
 
 ## Upgrade
 

--- a/docs/release-notes-0.8.2.md
+++ b/docs/release-notes-0.8.2.md
@@ -1,0 +1,84 @@
+# MCPg v0.8.2 — release notes
+
+**Released:** 2026-09-04
+**Tool surface:** **254** tools (256 all-flags-on maximal with
+`MCPG_DYNAMIC_SESSION_INTENT` enabled) — unchanged from 0.8.1. This release
+adds no tools and changes no tool's registered name, schema, or count; it
+fixes input validation inside one existing tool.
+**Tests:** 3013 passed, 1 skipped (`tests/unit` + `tests/contract`, zero
+snapshot drift) on this exact commit ahead of the tag; lint, `ruff format`,
+`mypy src/mcpg`, and `bandit` all clean.
+**Runtime:** Python 3.12–3.14 (`requires-python >=3.12`; CI/mypy target
+3.14)
+
+A focused **0.8.1 → 0.8.2** bug-fix release resolving the project's first
+user-reported issue, [#329](https://github.com/devopam/MCPg/issues/329):
+`dump_database` refused to export a schema whose name isn't a plain
+identifier. No breaking changes; no configuration changes.
+
+## Fixed: `dump_database` now accepts quoted PostgreSQL schema names
+
+Exporting a schema such as `adm-pgbench` failed before `pg_dump` was ever
+spawned:
+
+```text
+ShellError: invalid schema name: 'adm-pgbench'
+```
+
+The `schemas` parameter was checked against the plain-identifier allowlist
+(`[A-Za-z_][A-Za-z0-9_]*`), which excludes hyphens, spaces, mixed case, and
+every other character PostgreSQL supports through delimited (double-quoted)
+identifiers.
+
+`pg_dump --schema` takes a *pattern*, not a literal name — it follows the
+same rules as psql's `\d` commands, where an unquoted `*` / `?` / `[` acts
+as a wildcard and bare letters fold to lowercase. MCPg now encodes each
+entry in `schemas` as a **double-quoted literal `pg_dump` pattern** rather
+than validating it against the shared allowlist. Inside the quotes every
+character — pattern metacharacters included — is matched literally and
+case-sensitively, so:
+
+- the actual schema you name is the one dumped (`adm-pgbench`, `My Schema`,
+  `MixedCase` all work);
+- a name containing `*`, `?`, or `[abc]` can never accidentally expand into
+  a wildcard match;
+- an embedded double quote is doubled (`weird"name` → `"weird""name"`) per
+  the same quoting rules.
+
+Callers still pass the **bare** schema name — no SQL or shell quoting
+required. Only an empty name or one containing an embedded NUL byte is
+rejected up-front. MCPg's subprocess layer already invokes `pg_dump` via
+argv (never a shell — see `mcpg.shell`), so quoting the pattern is both
+necessary and sufficient; there is no shell-injection surface to widen.
+
+### Scope, deliberately narrow
+
+- **Dump-specific.** The new `_encode_schema_pattern` helper lives in
+  `data_movement.py` and is used *only* by `dump_database`. The
+  plain-identifier validator that the in-process SQL paths rely on
+  (`export_table`, `import_csv` / `import_json` / `import_vectors`,
+  `copy_table_between_databases`) is unchanged — those splice names into
+  SQL text, a different contract, so relaxing them was explicitly avoided.
+- **Access mode unchanged.** `dump_database` still requires `unrestricted`
+  mode **and** `MCPG_ALLOW_SHELL=true`.
+- **Contract unchanged.** `DumpResult` is identical, including SQL text in
+  `content` when `format="plain"`.
+
+Regression tests cover hyphens, spaces, mixed case, embedded double quotes,
+pattern metacharacters, and semicolons, plus the empty-name / NUL-byte
+rejection path.
+
+## Upgrade
+
+```bash
+pip install --upgrade mcpg
+docker pull ghcr.io/devopam/mcpg:0.8.2   # or :latest
+```
+
+Or grab `mcpg-0.8.2.mcpb` from this release and double-click it into
+Claude Desktop.
+
+## Full changelog
+
+See [`../CHANGELOG.md`](../CHANGELOG.md) `[0.8.2]` for the complete
+itemised list.

--- a/docs/release-notes-0.8.2.md
+++ b/docs/release-notes-0.8.2.md
@@ -54,12 +54,15 @@ necessary and sufficient; there is no shell-injection surface to widen.
 
 ### Scope, deliberately narrow
 
-- **Dump-specific.** The new `_encode_schema_pattern` helper lives in
-  `data_movement.py` and is used *only* by `dump_database`. The
-  plain-identifier validator that the in-process SQL paths rely on
-  (`export_table`, `import_csv` / `import_json` / `import_vectors`,
-  `copy_table_between_databases`) is unchanged — those splice names into
-  SQL text, a different contract, so relaxing them was explicitly avoided.
+- **Two encodings, one for each contract.** The new `_encode_schema_pattern`
+  helper lives in `data_movement.py` and is used by the two tools that drive
+  `pg_dump` / `pg_restore` via argv patterns: `dump_database` (`--schema`)
+  and `copy_table_between_databases` (`--schema` **and** `--table`). The
+  in-process SQL tools — `export_table`, `import_csv` / `import_json` /
+  `import_vectors`, and the ~20 others below — splice names into SQL text
+  instead, a different contract, so they're migrated separately to
+  `mcpg.identifiers.quote_identifier` rather than to this helper; see
+  "The sweep" below for that list.
 - **Access mode unchanged.** `dump_database` still requires `unrestricted`
   mode **and** `MCPG_ALLOW_SHELL=true`.
 - **Contract unchanged.** `DumpResult` is identical, including SQL text in

--- a/packaging/mcpb/manifest.json
+++ b/packaging/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "mcpg",
   "display_name": "MCPg \u2014 PostgreSQL",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Production-grade PostgreSQL MCP server: 254 tools for querying, tuning, and operating Postgres \u2014 read-only by default.",
   "long_description": "MCPg lets AI agents safely inspect, query, operate, and tune a PostgreSQL database. 254 tools spanning catalog introspection, query intelligence, natural-language SQL, structural diffs, hybrid search, graph queries, live ops, and more.\n\n**Safe by default**: read-only access mode, AST-validated SQL, and every tool publishes MCP annotations (`readOnlyHint`/`destructiveHint`) so the client knows exactly which calls are safe. Write, DDL, shell, and LISTEN capabilities stay off until explicitly enabled via environment variables.\n\nNo data yet? Run `mcpg --demo` against a scratch database to seed a curated demo dataset and take the tools for a spin \u2014 see the guided tour at https://github.com/devopam/MCPg/blob/main/docs/demo.md.",
   "author": {

--- a/packaging/mcpb/pyproject.toml
+++ b/packaging/mcpb/pyproject.toml
@@ -5,9 +5,9 @@
 # to the release tag by the publish workflow, exactly like server.json.
 [project]
 name = "mcpg-desktop-extension"
-version = "0.8.1"
+version = "0.8.2"
 description = "MCPB launcher shim for the MCPg PostgreSQL MCP server."
 requires-python = ">=3.12"
 dependencies = [
-    "mcpg==0.8.1",
+    "mcpg==0.8.2",
 ]

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.devopam/mcpg",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Production-grade PostgreSQL MCP server \u2014 254 tools for query, tuning & ops, read-only by default.",
   "websiteUrl": "https://devopam.github.io/MCPg/",
   "repository": {
@@ -13,7 +13,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "mcpg",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/mcpg/__init__.py
+++ b/src/mcpg/__init__.py
@@ -2,7 +2,7 @@
 
 import warnings
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"
 
 # ``schema`` is the natural field name for "which Postgres schema" across
 # ~180 tool-return dataclasses. The ``mcp`` SDK dynamically builds a

--- a/src/mcpg/composite.py
+++ b/src/mcpg/composite.py
@@ -25,6 +25,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from mcpg.errors import MCPgError
+from mcpg.identifiers import IdentifierError, ensure_identifier, quote_identifier
 from mcpg.introspection import (
     ColumnInfo,
     ConstraintInfo,
@@ -39,16 +40,18 @@ from mcpg.liveops import list_active_queries
 from mcpg.query import analyze_query_plan, explain_query
 from mcpg.sql import SqlDriver
 
-_IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
-
 
 class CompositeError(MCPgError):
     """Raised when a composite tool's inputs are invalid."""
 
 
 def _check_identifier(name: str, kind: str) -> None:
-    if not _IDENTIFIER.match(name):
-        raise CompositeError(f"invalid {kind} name: {name!r}")
+    # Accept any addressable PostgreSQL identifier; the splice site quotes
+    # it safely via _quoted. Only empty / NUL / overlong names are refused.
+    try:
+        ensure_identifier(name, kind)
+    except IdentifierError as exc:
+        raise CompositeError(str(exc)) from exc
 
 
 # --- summarize_table -------------------------------------------------
@@ -94,7 +97,7 @@ class TableSummary:
 
 
 def _quoted(name: str) -> str:
-    return f'"{name}"'
+    return quote_identifier(name)
 
 
 def _pk_columns(constraints: list[ConstraintInfo]) -> list[str]:

--- a/src/mcpg/config.py
+++ b/src/mcpg/config.py
@@ -16,14 +16,10 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 from mcpg.errors import MCPgError
+from mcpg.identifiers import IdentifierError, ensure_identifier
 from mcpg.nl2sql import AUTO_PICK_ORDER, VENDOR_ENV_VAR_HINT, VENDOR_KEY_ENV_VARS
 from mcpg.secrets import SecretsError, build_secrets_provider
 from mcpg.sql import obfuscate_password
-
-# PG role names must be safe identifiers — we inline them into
-# ``SET ROLE "<name>"`` so anything outside ``[A-Za-z_][A-Za-z0-9_]*``
-# is rejected up front rather than allowed to inject.
-_ROLE_IDENTIFIER = re.compile(r"\A[A-Za-z_][A-Za-z0-9_]*\Z")
 
 # Secondary-database ids are inlined into tool descriptions and used as dict
 # keys; we pin them to a conservative, lowercase, simple-identifier shape so
@@ -450,8 +446,14 @@ def _require_tls_or_loopback(var: str, dsn: str) -> None:
 
 
 def _validate_role_identifier(var: str, value: str) -> None:
-    if not _ROLE_IDENTIFIER.match(value):
-        raise ConfigError(f"{var} role name {value!r} must match [A-Za-z_][A-Za-z0-9_]* (no quotes / spaces / dashes)")
+    # A configured role is quoted (with embedded quotes doubled) where it is
+    # spliced into ``SET LOCAL ROLE`` (see mcpg.tenancy), so any role name
+    # PostgreSQL supports through delimited quoting is accepted here. Only an
+    # empty string, an embedded NUL, or an over-63-byte name is rejected.
+    try:
+        ensure_identifier(value, f"{var} role")
+    except IdentifierError as exc:
+        raise ConfigError(str(exc)) from exc
 
 
 def _parse_enum[E: StrEnum](var: str, raw: str, enum: type[E]) -> E:

--- a/src/mcpg/data_movement.py
+++ b/src/mcpg/data_movement.py
@@ -23,20 +23,16 @@ from __future__ import annotations
 import csv
 import io
 import json
-import re
 from dataclasses import dataclass
 from typing import Any
 from urllib.parse import unquote, urlparse
 
 from mcpg.database import Database
 from mcpg.errors import MCPgError
+from mcpg.identifiers import IdentifierError, quote_identifier
 from mcpg.query import QueryError, run_select
 from mcpg.shell import ShellError, SubprocessLimits, run_pg_binary
 from mcpg.sql import SqlDriver
-
-# Same identifier allowlist as mcpg.textsearch / mcpg.prisma / mcpg.vector_tuning —
-# refuse names that need delimited-identifier quoting, accept plain ones.
-_IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
 
 EXPORT_FORMATS = frozenset({"csv", "json"})
 
@@ -64,9 +60,11 @@ class ExportResult:
     truncated: bool
 
 
-def _check_identifier(name: str, kind: str) -> None:
-    if not _IDENTIFIER.match(name):
-        raise ExportError(f"invalid {kind} name: {name!r}")
+def _quote_ident_export(name: str, kind: str) -> str:
+    try:
+        return quote_identifier(name, kind)
+    except IdentifierError as exc:
+        raise ExportError(str(exc)) from exc
 
 
 def _csv_cell(value: Any) -> Any:
@@ -151,12 +149,13 @@ async def export_table(
 ) -> ExportResult:
     """Serialise every row in ``schema.table`` (up to ``limit``).
 
-    Schema and table names must match the plain identifier pattern —
-    anything that requires delimited-identifier quoting is rejected.
+    Schema and table names are accepted as actual PostgreSQL identifiers —
+    including names that need delimited-identifier quoting (hyphens, mixed
+    case, spaces) — and safely double-quoted before interpolation, so an
+    embedded quote cannot break out of the identifier.
     """
-    _check_identifier(schema, "schema")
-    _check_identifier(table, "table")
-    sql = f'SELECT * FROM "{schema}"."{table}"'
+    relation = f"{_quote_ident_export(schema, 'schema')}.{_quote_ident_export(table, 'table')}"
+    sql = f"SELECT * FROM {relation}"
     return await export_query(driver, sql, format=format, limit=limit)
 
 
@@ -211,33 +210,32 @@ def _libpq_env_from_url(database_url: str) -> dict[str, str]:
 _PG_DUMP_FORMATS = frozenset({"plain", "custom", "directory", "tar"})
 
 
-def _encode_schema_pattern(name: str) -> str:
-    r"""Encode a literal schema name as a ``pg_dump --schema`` pattern.
+def _encode_schema_pattern(name: str, kind: str = "schema") -> str:
+    r"""Encode a literal name as a ``pg_dump`` object pattern.
 
-    ``pg_dump --schema`` takes a *pattern*, not a literal name: it follows
-    the same rules as psql's ``\d`` commands, where an unquoted ``*`` /
-    ``?`` / ``[`` acts as a wildcard and bare letters are folded to
-    lowercase. Wrapping the whole name in double quotes turns both off —
-    every character inside, pattern metacharacters included, is matched
-    literally and case-sensitively — so an actual schema name like
+    ``pg_dump --schema`` / ``--table`` take a *pattern*, not a literal
+    name: they follow the same rules as psql's ``\d`` commands, where an
+    unquoted ``*`` / ``?`` / ``[`` acts as a wildcard and bare letters are
+    folded to lowercase. Wrapping the whole name in double quotes turns
+    both off — every character inside, pattern metacharacters included, is
+    matched literally and case-sensitively — so an actual schema name like
     ``adm-pgbench`` reaches pg_dump as the exact schema it names rather
     than being rejected or mis-expanded. A literal double quote inside the
     name is written as two double quotes, per the same quoting rules.
 
-    This is a dump-specific encoding, deliberately separate from the
-    plain-identifier allowlist the in-process paths use: those splice
-    names into SQL text where delimited-identifier quoting is the caller's
-    contract, whereas here the name only ever reaches pg_dump's argv (no
-    shell — see :mod:`mcpg.shell`), so quoting the pattern is both
-    necessary and sufficient. The name is never run through a shell, so
-    the only characters that can't survive are an empty string (matches
-    nothing) and an embedded NUL (can't cross the ``execve`` boundary);
-    both are rejected up-front.
+    This is a dump-specific encoding, deliberately separate from the SQL
+    identifier quoting the in-process paths use (:func:`quote_identifier`):
+    those splice names into SQL text, whereas here the name only ever
+    reaches pg_dump's argv (no shell — see :mod:`mcpg.shell`), so quoting
+    the pattern is both necessary and sufficient. The name is never run
+    through a shell, so the only characters that can't survive are an empty
+    string (matches nothing) and an embedded NUL (can't cross the
+    ``execve`` boundary); both are rejected up-front.
     """
     if not name:
-        raise ShellError("invalid schema name: must not be empty")
+        raise ShellError(f"invalid {kind} name: must not be empty")
     if "\x00" in name:
-        raise ShellError(f"invalid schema name: {name!r} contains a NUL byte")
+        raise ShellError(f"invalid {kind} name: {name!r} contains a NUL byte")
     return '"' + name.replace('"', '""') + '"'
 
 
@@ -510,8 +508,6 @@ async def copy_table_between_databases(
     """
     if not include_schema and not include_data:
         raise ShellError("copy_table_between_databases requires include_schema or include_data (or both)")
-    _check_identifier_for_copy(schema, "schema")
-    _check_identifier_for_copy(table, "table")
 
     source_env = _libpq_env_from_url(source_url)
     if "PGDATABASE" not in source_env:
@@ -520,10 +516,12 @@ async def copy_table_between_databases(
     if "PGDATABASE" not in dest_env:
         raise ShellError("dest_url must specify a database name")
 
-    # pg_dump's --table pattern accepts a literal schema-qualified name
-    # since we've already validated both halves against the plain-
-    # identifier allowlist (no wildcard chars).
-    dump_argv = ["--format=custom", f"--table={schema}.{table}"]
+    # pg_dump's --table takes a schema-qualified *pattern*, so both halves
+    # are encoded as literal quoted patterns (see _encode_schema_pattern):
+    # metacharacters can't expand, case is preserved, and an embedded quote
+    # can't break out. This also rejects empty / NUL names up-front.
+    table_pattern = f"{_encode_schema_pattern(schema, 'schema')}.{_encode_schema_pattern(table, 'table')}"
+    dump_argv = ["--format=custom", f"--table={table_pattern}"]
     if not include_data:
         dump_argv.append("--schema-only")
     if not include_schema:
@@ -605,11 +603,6 @@ async def copy_table_between_databases(
     )
 
 
-def _check_identifier_for_copy(name: str, kind: str) -> None:
-    if not _IDENTIFIER.match(name):
-        raise ShellError(f"invalid {kind} name: {name!r}")
-
-
 def _tail(buf: bytes, *, max_bytes: int = 4096) -> str:
     text = buf.decode("utf-8", errors="replace")
     return text if len(text) <= max_bytes else text[-max_bytes:]
@@ -644,22 +637,24 @@ class ImportResult:
 def _build_copy_sql(schema: str, table: str, columns: list[str] | None, *, header: bool, delimiter: str) -> str:
     """Compose a ``COPY ... FROM STDIN`` statement with safe identifiers.
 
-    The schema, table, and (optional) column names are validated against
-    the plain-identifier allowlist before this is called; delimited
-    quoting still applies so reserved words don't break the statement.
-    The delimiter is restricted to a single non-newline character so it
-    can't terminate the COPY options list early.
+    The schema, table, and (optional) column names are checked as
+    addressable identifiers by the caller and safely double-quoted here
+    (embedded quotes doubled), so a name needing delimited quoting works
+    and can't break out of the statement. The delimiter is restricted to a
+    single non-newline character so it can't terminate the COPY options
+    list early.
     """
     column_clause = ""
     if columns:
-        joined = ", ".join(f'"{col}"' for col in columns)
+        joined = ", ".join(quote_identifier(col, "column") for col in columns)
         column_clause = f" ({joined})"
     options = [
         "FORMAT csv",
         f"HEADER {'true' if header else 'false'}",
         f"DELIMITER '{delimiter}'",
     ]
-    return f'COPY "{schema}"."{table}"{column_clause} FROM STDIN WITH ({", ".join(options)})'
+    relation = f"{quote_identifier(schema, 'schema')}.{quote_identifier(table, 'table')}"
+    return f"COPY {relation}{column_clause} FROM STDIN WITH ({', '.join(options)})"
 
 
 async def import_csv(
@@ -762,8 +757,9 @@ async def import_json(
         _check_identifier_for_import(col, "column")
 
     placeholders = ", ".join(["%s"] * len(columns))
-    column_clause = ", ".join(f'"{col}"' for col in columns)
-    sql = f'INSERT INTO "{schema}"."{table}" ({column_clause}) VALUES ({placeholders})'
+    column_clause = ", ".join(quote_identifier(col, "column") for col in columns)
+    relation = f"{quote_identifier(schema, 'schema')}.{quote_identifier(table, 'table')}"
+    sql = f"INSERT INTO {relation} ({column_clause}) VALUES ({placeholders})"
     params_seq = [tuple(_json_cell(row.get(col)) for col in columns) for row in parsed]
     try:
         rowcount = await database.execute_many(sql, params_seq)
@@ -777,8 +773,16 @@ async def import_json(
 
 
 def _check_identifier_for_import(name: str, kind: str) -> None:
-    if not _IDENTIFIER.match(name):
-        raise ImportDataError(f"invalid {kind} name: {name!r}")
+    """Reject only names that aren't addressable identifiers at all.
+
+    A name needing delimited quoting (hyphens, spaces, mixed case) is
+    accepted here; the SQL splice sites double-quote it safely. Only the
+    empty string, an embedded NUL, or an over-63-byte name is rejected.
+    """
+    try:
+        quote_identifier(name, kind)
+    except IdentifierError as exc:
+        raise ImportDataError(str(exc)) from exc
 
 
 def _json_cell(value: Any) -> Any:
@@ -974,9 +978,16 @@ async def import_vectors(
         literals.append((ident, literal) if id_column else (literal,))
 
     if id_column:
-        sql = f'INSERT INTO "{schema}"."{table}" ("{id_column}", "{embedding_column}") VALUES (%s, %s::vector)'
+        sql = (
+            f"INSERT INTO {quote_identifier(schema, 'schema')}.{quote_identifier(table, 'table')} "
+            f"({quote_identifier(id_column, 'column')}, {quote_identifier(embedding_column, 'column')}) "
+            "VALUES (%s, %s::vector)"
+        )
     else:
-        sql = f'INSERT INTO "{schema}"."{table}" ("{embedding_column}") VALUES (%s::vector)'
+        sql = (
+            f"INSERT INTO {quote_identifier(schema, 'schema')}.{quote_identifier(table, 'table')} "
+            f"({quote_identifier(embedding_column, 'column')}) VALUES (%s::vector)"
+        )
 
     try:
         rowcount = await database.execute_many(sql, literals)

--- a/src/mcpg/data_movement.py
+++ b/src/mcpg/data_movement.py
@@ -211,13 +211,42 @@ def _libpq_env_from_url(database_url: str) -> dict[str, str]:
 _PG_DUMP_FORMATS = frozenset({"plain", "custom", "directory", "tar"})
 
 
-# C901 rationale: pg_dump argv construction (format validation, schema-name
-# identifier validation, credential-via-env-not-argv handling) plus
-# format-dependent output decoding -- the validation branches are exactly
-# what keeps this shell-out safe (identifiers checked before reaching argv,
-# unsupported formats rejected before spawn); splitting them apart doesn't
-# reduce risk, just relocates it.
-async def dump_database(  # noqa: C901
+def _encode_schema_pattern(name: str) -> str:
+    r"""Encode a literal schema name as a ``pg_dump --schema`` pattern.
+
+    ``pg_dump --schema`` takes a *pattern*, not a literal name: it follows
+    the same rules as psql's ``\d`` commands, where an unquoted ``*`` /
+    ``?`` / ``[`` acts as a wildcard and bare letters are folded to
+    lowercase. Wrapping the whole name in double quotes turns both off —
+    every character inside, pattern metacharacters included, is matched
+    literally and case-sensitively — so an actual schema name like
+    ``adm-pgbench`` reaches pg_dump as the exact schema it names rather
+    than being rejected or mis-expanded. A literal double quote inside the
+    name is written as two double quotes, per the same quoting rules.
+
+    This is a dump-specific encoding, deliberately separate from the
+    plain-identifier allowlist the in-process paths use: those splice
+    names into SQL text where delimited-identifier quoting is the caller's
+    contract, whereas here the name only ever reaches pg_dump's argv (no
+    shell — see :mod:`mcpg.shell`), so quoting the pattern is both
+    necessary and sufficient. The name is never run through a shell, so
+    the only characters that can't survive are an empty string (matches
+    nothing) and an embedded NUL (can't cross the ``execve`` boundary);
+    both are rejected up-front.
+    """
+    if not name:
+        raise ShellError("invalid schema name: must not be empty")
+    if "\x00" in name:
+        raise ShellError(f"invalid schema name: {name!r} contains a NUL byte")
+    return '"' + name.replace('"', '""') + '"'
+
+
+# pg_dump argv construction: format validation and schema-name pattern
+# encoding both happen before spawn, and credentials travel via env vars
+# (never argv) -- the checks here are what keep this shell-out safe (schema
+# names encoded as literal patterns before reaching argv, unsupported
+# formats rejected before spawn).
+async def dump_database(
     database_url: str,
     *,
     timeout_sec: int,
@@ -238,29 +267,31 @@ async def dump_database(  # noqa: C901
     dump to specific schemas (one ``--schema=NAME`` flag per entry)
     instead of the whole database — useful to re-run with a narrower
     scope, or to sidestep schemas the caller doesn't want captured
-    (e.g. an MPP catalog schema like WarehousePG's ``gp_toolkit``).
+    (e.g. an MPP catalog schema like WarehousePG's ``gp_toolkit``). Each
+    entry is treated as an actual schema name — any valid PostgreSQL
+    schema name is accepted, including one needing delimited-identifier
+    quoting (hyphens, spaces, mixed case) — and encoded as a literal
+    ``pg_dump`` pattern so wildcard / pattern metacharacters never expand
+    (see :func:`_encode_schema_pattern`). Callers pass the bare name; no
+    SQL or shell quoting is required.
 
     Raises:
         ShellError: ``pg_dump`` is not on the allowlist or PATH, the
             URL is unparseable, the format is not supported, a name in
-            ``schemas`` is not a valid identifier, or the subprocess
-            fails to spawn.
+            ``schemas`` is empty or contains a NUL byte, or the
+            subprocess fails to spawn.
     """
     if format not in _PG_DUMP_FORMATS:
         raise ShellError(f"unsupported pg_dump format {format!r}; expected one of {sorted(_PG_DUMP_FORMATS)}")
     env = _libpq_env_from_url(database_url)
     if "PGDATABASE" not in env:
         raise ShellError("database_url must specify a database name")
-    if schemas is not None:
-        for name in schemas:
-            if not _IDENTIFIER.match(name):
-                raise ShellError(f"invalid schema name: {name!r}")
 
     argv = [f"--format={format}"]
     if schema_only:
         argv.append("--schema-only")
     if schemas is not None:
-        argv.extend(f"--schema={name}" for name in schemas)
+        argv.extend(f"--schema={_encode_schema_pattern(name)}" for name in schemas)
     # Always pipe to stdout (the default for plain/custom/tar; directory
     # writes to disk and isn't supported in v1).
     if format == "directory":

--- a/src/mcpg/identifiers.py
+++ b/src/mcpg/identifiers.py
@@ -1,0 +1,87 @@
+"""Safe SQL identifier quoting — the shared, escape-based replacement for
+the per-module ``[A-Za-z_][A-Za-z0-9_]*`` allowlists.
+
+For most of MCPg's history each tool module carried its own copy of a
+plain-identifier regex and validated schema / table / column / role names
+against it *before* splicing them into SQL as ``f'"{name}"'``. That regex
+was doing double duty: it kept the interpolation injection-safe (by
+forbidding the ``"`` that could close the quoted identifier), but it also
+rejected every schema PostgreSQL supports only through *delimited*
+(double-quoted) identifiers — hyphens, spaces, mixed case, unicode. A user
+with a schema literally named ``adm-pgbench`` could not dump, export, or
+operate on it at all (issue #329).
+
+This module separates the two concerns. :func:`quote_identifier` makes any
+value that PostgreSQL accepts as a quoted identifier safe to splice, by
+doubling embedded double quotes rather than by forbidding them — so the
+name round-trips to the exact object it names, and the result still cannot
+break out of the identifier. Callers that genuinely need a *bare* (unquoted)
+identifier — Apache AGE labels, or a name that becomes an identifier in
+generated Go/Rust/Elixir source — keep their own stricter validation; this
+helper is only for names that reach PostgreSQL as SQL identifiers.
+
+The rejections are the few things that are not addressable identifiers at
+all rather than a style choice:
+
+- the empty string (``""`` is not a legal identifier);
+- an embedded NUL (``\x00`` cannot cross the wire protocol);
+- anything longer than 63 bytes (``NAMEDATALEN - 1``), which PostgreSQL
+  *silently truncates* — a footgun that turns ``a_very_long…_v1`` and
+  ``a_very_long…_v2`` into the same object, so we refuse it explicitly.
+"""
+
+from __future__ import annotations
+
+from mcpg.errors import MCPgError
+
+# PostgreSQL's default NAMEDATALEN is 64; identifiers are capped at 63 bytes
+# and anything longer is truncated server-side without error.
+MAX_IDENTIFIER_BYTES = 63
+
+
+class IdentifierError(MCPgError):
+    """Raised when a value cannot be used as a SQL identifier at all.
+
+    Not raised for names that merely need quoting — those are exactly what
+    :func:`quote_identifier` accepts. Raised only for the empty string, an
+    embedded NUL, or a name past PostgreSQL's 63-byte identifier limit.
+    """
+
+
+def ensure_identifier(name: str, kind: str = "identifier") -> str:
+    """Return ``name`` unchanged after checking it is an addressable identifier.
+
+    Raises :class:`IdentifierError` (message ``"invalid {kind} name: …"``)
+    for the empty string, an embedded NUL, or a name longer than
+    :data:`MAX_IDENTIFIER_BYTES`. Every other value — including one needing
+    delimited quoting — passes through untouched, so a caller can build a
+    dotted or otherwise composite reference and quote the parts itself.
+    """
+    if not name:
+        raise IdentifierError(f"invalid {kind} name: must not be empty")
+    if "\x00" in name:
+        raise IdentifierError(f"invalid {kind} name: {name!r} contains a NUL byte")
+    if len(name.encode("utf-8")) > MAX_IDENTIFIER_BYTES:
+        raise IdentifierError(
+            f"invalid {kind} name: {name!r} exceeds PostgreSQL's {MAX_IDENTIFIER_BYTES}-byte identifier limit"
+        )
+    return name
+
+
+def quote_identifier(name: str, kind: str = "identifier") -> str:
+    r"""Return ``name`` as a safely double-quoted SQL delimited identifier.
+
+    Embedded double quotes are doubled (``"`` → ``""``) per the SQL
+    delimited-identifier rules, so the value cannot terminate the quoted
+    identifier and inject SQL. Every character PostgreSQL permits in a
+    quoted identifier is accepted and preserved verbatim, case included:
+
+    >>> quote_identifier("adm-pgbench")
+    '"adm-pgbench"'
+    >>> quote_identifier('weird"name')
+    '"weird""name"'
+
+    Raises :class:`IdentifierError` for the values :func:`ensure_identifier`
+    rejects (empty, embedded NUL, over 63 bytes).
+    """
+    return '"' + ensure_identifier(name, kind).replace('"', '""') + '"'

--- a/src/mcpg/listen.py
+++ b/src/mcpg/listen.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
-import re
 import time
 import uuid
 from collections.abc import Awaitable, Callable
@@ -31,15 +30,10 @@ from types import TracebackType
 from typing import Any, Protocol, Self
 
 from mcpg.errors import MCPgError
+from mcpg.identifiers import IdentifierError, ensure_identifier
+from mcpg.identifiers import quote_identifier as _qi
 
 logger = logging.getLogger(__name__)
-
-# PostgreSQL identifier policy for channel names. Matches the rest of
-# MCPg's identifier allowlist (introspection / data_movement / etc).
-# Channels go through SQL as ``LISTEN "name"`` so the double-quoted form
-# survives reserved words, but the allowlist still refuses anything
-# that would need escape handling.
-_CHANNEL_NAME = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
 
 
 class ListenError(MCPgError):
@@ -137,9 +131,10 @@ class ListenManager:
     async def subscribe(self, channel: str) -> str:
         """Register a subscription on ``channel`` and return its id.
 
-        The channel name must match ``[A-Za-z_][A-Za-z0-9_]*`` so the
-        ``LISTEN "name"`` statement is safe under double-quoting.
-        Multiple subscriptions on the same channel share a single
+        The channel name is quoted (embedded quotes doubled) in the
+        ``LISTEN "name"`` statement, so any name PostgreSQL accepts as a
+        delimited identifier works; empty / NUL / overlong names are
+        rejected. Multiple subscriptions on the same channel share a single
         underlying ``LISTEN``; each gets its own queue.
 
         Raises:
@@ -309,20 +304,20 @@ class ListenManager:
         # register.
         if self._needs_resubscribe:
             for channel in self._channels:
-                await self._conn.execute(f'LISTEN "{channel}"')
+                await self._conn.execute(f"LISTEN {_qi(channel)}")
             self._needs_resubscribe = False
         self._task = asyncio.create_task(self._reader_loop(), name="mcpg-listen-reader")
         return self._conn
 
     async def _listen(self, channel: str) -> None:
         conn = await self._ensure_connection()
-        await conn.execute(f'LISTEN "{channel}"')
+        await conn.execute(f"LISTEN {_qi(channel)}")
 
     async def _unlisten(self, channel: str) -> None:
         if self._conn is None:
             return
         try:
-            await self._conn.execute(f'UNLISTEN "{channel}"')
+            await self._conn.execute(f"UNLISTEN {_qi(channel)}")
         except Exception:
             # The connection may have died between subscribe and
             # unsubscribe; don't let cleanup raise.
@@ -375,5 +370,10 @@ class ListenManager:
 
 
 def _check_channel(channel: str) -> None:
-    if not _CHANNEL_NAME.match(channel):
-        raise ListenError(f"invalid channel name: {channel!r}")
+    # A channel name needing delimited quoting is legal (LISTEN "my-chan")
+    # and is quoted safely at the splice site. Only empty / NUL / overlong
+    # names are rejected.
+    try:
+        ensure_identifier(channel, "channel")
+    except IdentifierError as exc:
+        raise ListenError(str(exc)) from exc

--- a/src/mcpg/logical_replication.py
+++ b/src/mcpg/logical_replication.py
@@ -53,12 +53,7 @@ from dataclasses import dataclass
 
 from mcpg.database import Database
 from mcpg.errors import MCPgError
-
-# Unquoted PostgreSQL identifier: starts with letter / underscore,
-# then letters / digits / underscores. Same shape as
-# `mcpg.pg_search._IDENTIFIER`; duplicated here to keep modules
-# independent rather than importing across feature boundaries.
-_IDENTIFIER = re.compile(r"\A[A-Za-z_][A-Za-z0-9_]*\Z")
+from mcpg.identifiers import IdentifierError, ensure_identifier
 
 
 class LogicalReplicationError(MCPgError):
@@ -66,8 +61,12 @@ class LogicalReplicationError(MCPgError):
 
 
 def _validate_identifier(name: str, kind: str) -> None:
-    if not _IDENTIFIER.match(name):
-        raise LogicalReplicationError(f"invalid {kind} name: {name!r}")
+    # Accept any addressable identifier; _pg_quote_ident escapes it safely.
+    # Only empty / NUL / overlong names are refused.
+    try:
+        ensure_identifier(name, kind)
+    except IdentifierError as exc:
+        raise LogicalReplicationError(str(exc)) from exc
 
 
 def _pg_quote_ident(name: str) -> str:

--- a/src/mcpg/migrations.py
+++ b/src/mcpg/migrations.py
@@ -28,13 +28,14 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from mcpg.errors import MCPgError
+from mcpg.identifiers import IdentifierError, ensure_identifier
+from mcpg.identifiers import quote_identifier as _qi
 from mcpg.introspection import describe_table, list_constraints, list_indexes, list_tables
 from mcpg.schema_diff import SchemaDiff, compare_schemas
 from mcpg.sql import SqlDriver
 
 logger = logging.getLogger(__name__)
 
-_IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
 _SHADOW_PREFIX = "mcpg_shadow_"
 _NAME_SUFFIX_RE = re.compile(r"[^A-Za-z0-9_]")
 
@@ -174,8 +175,15 @@ async def _ensure_state_table(driver: SqlDriver) -> None:
 
 
 def _check_identifier(name: str, kind: str) -> None:
-    if not _IDENTIFIER.match(name):
-        raise MigrationError(f"invalid {kind} name: {name!r}")
+    # Accept any addressable identifier (delimited target/reference schema
+    # and catalog table names included); every SQL splice quotes it via _qi
+    # (embedded quotes doubled). Only empty / NUL / overlong names are
+    # rejected. The generated shadow-schema name is always a plain
+    # identifier (see _make_migration_id), so it needs no relaxation.
+    try:
+        ensure_identifier(name, kind)
+    except IdentifierError as exc:
+        raise MigrationError(str(exc)) from exc
 
 
 def _make_migration_id(name: str) -> str:
@@ -233,7 +241,7 @@ async def _replay_target_into_shadow(driver: SqlDriver, target_schema: str, shad
         if not columns:
             continue
         column_clauses = [_column_clause(col) for col in columns]
-        ddl = f'CREATE TABLE "{shadow_schema}"."{table.name}" ({", ".join(column_clauses)})'
+        ddl = f'CREATE TABLE "{shadow_schema}".{_qi(table.name)} ({", ".join(column_clauses)})'
         await driver.execute_query(ddl)
 
     # 2. Add constraints + indexes. PK first so unique-constraint /
@@ -252,7 +260,7 @@ async def _replay_target_into_shadow(driver: SqlDriver, target_schema: str, shad
             else:
                 definition = con.definition
             await driver.execute_query(
-                f'ALTER TABLE "{shadow_schema}"."{table.name}" ADD CONSTRAINT "{con.name}" {definition}'
+                f'ALTER TABLE "{shadow_schema}".{_qi(table.name)} ADD CONSTRAINT {_qi(con.name)} {definition}'
             )
         indexes = await list_indexes(driver, target_schema, table.name)
         for idx in indexes:
@@ -270,7 +278,7 @@ def _column_clause(column: Any) -> str:
     """Build a CREATE TABLE column clause from a ``ColumnInfo``-like object."""
     nullable = "" if column.nullable else " NOT NULL"
     default = f" DEFAULT {column.default}" if column.default is not None else ""
-    return f'"{column.name}" {column.data_type}{nullable}{default}'
+    return f"{_qi(column.name)} {column.data_type}{nullable}{default}"
 
 
 _CONSTRAINT_ORDER = {"primary_key": 0, "unique": 1, "check": 2, "foreign_key": 3, "exclusion": 4}
@@ -503,12 +511,12 @@ async def _execute_in_schema(driver: SqlDriver, schema: str, sql: str) -> None:
     if not getattr(driver, "is_pool", False):
         # Direct-connection mode is a test/edge path; run SET + SQL on it.
         async with driver.conn.cursor() as cur:
-            await cur.execute(f'SET LOCAL search_path TO "{schema}", public')
+            await cur.execute(f"SET LOCAL search_path TO {_qi(schema)}, public")
             await cur.execute(sql)
         return
     pool_obj = await driver.conn.pool_connect()
     async with pool_obj.connection() as conn, conn.cursor() as cur:
-        await cur.execute(f'SET LOCAL search_path TO "{schema}", public')
+        await cur.execute(f"SET LOCAL search_path TO {_qi(schema)}, public")
         await cur.execute(sql)
 
 
@@ -561,7 +569,7 @@ async def _count_rows(driver: SqlDriver, schema: str, table: str) -> int:
     pre-validated by the caller (no untrusted identifier reaches this
     function), so the inline interpolation is safe."""
     rows = await driver.execute_query(
-        f'SELECT COUNT(*) AS n FROM "{schema}"."{table}"',
+        f"SELECT COUNT(*) AS n FROM {_qi(schema)}.{_qi(table)}",
         force_readonly=True,
     )
     if not rows:
@@ -634,8 +642,8 @@ async def validate_migration(
             # validation continues.
             with contextlib.suppress(Exception):
                 await driver.execute_query(
-                    f'INSERT INTO "{shadow_schema}"."{table.name}" '
-                    f'SELECT * FROM "{target_schema}"."{table.name}" LIMIT %s',
+                    f'INSERT INTO "{shadow_schema}".{_qi(table.name)} '
+                    f"SELECT * FROM {_qi(target_schema)}.{_qi(table.name)} LIMIT %s",
                     params=[sample_rows_per_table],
                 )
 

--- a/src/mcpg/pg_search.py
+++ b/src/mcpg/pg_search.py
@@ -61,7 +61,6 @@ from __future__ import annotations
 import datetime as _datetime
 import json
 import math
-import re
 import time as _time
 from dataclasses import dataclass, field
 from typing import Any
@@ -69,12 +68,8 @@ from typing import Any
 from mcpg.database import Database
 from mcpg.errors import MCPgError
 from mcpg.extensions import extension_installed
+from mcpg.identifiers import IdentifierError, ensure_identifier
 from mcpg.sql import SqlDriver
-
-# Plain unquoted PostgreSQL identifier — same rule as turboquant /
-# vector_tuning. Anything that would require delimited quoting is
-# refused rather than parsed out of an agent string.
-_IDENTIFIER = re.compile(r"\A[A-Za-z_][A-Za-z0-9_]*\Z")
 
 
 class PgSearchError(MCPgError):
@@ -82,8 +77,12 @@ class PgSearchError(MCPgError):
 
 
 def _validate_identifier(name: str, kind: str) -> None:
-    if not _IDENTIFIER.match(name):
-        raise PgSearchError(f"invalid {kind} name: {name!r}")
+    # Accept any addressable identifier; _pg_quote_ident escapes it safely.
+    # Only empty / NUL / overlong names are refused.
+    try:
+        ensure_identifier(name, kind)
+    except IdentifierError as exc:
+        raise PgSearchError(str(exc)) from exc
 
 
 # Per §2.2 of the BM-0 investigation checkpoint, the ``bm25`` AM

--- a/src/mcpg/rag_efficiency.py
+++ b/src/mcpg/rag_efficiency.py
@@ -44,18 +44,14 @@ function — see ``docs/plans/rag-efficiency-suite.md``.
 from __future__ import annotations
 
 import math
-import re
 import time
 from dataclasses import dataclass, field
 from typing import Any
 
 from mcpg.errors import MCPgError
 from mcpg.extensions import extension_installed
+from mcpg.identifiers import IdentifierError, ensure_identifier, quote_identifier
 from mcpg.sql import SqlDriver
-
-# Reused from vector_tuning's identifier convention — refuse anything
-# that would require delimited quoting.
-_IDENTIFIER = re.compile(r"\A[A-Za-z_][A-Za-z0-9_]*\Z")
 
 # Reused cap from vector_tuning. Each sample run triggers
 # 1 + len(multipliers) queries, so even at the cap a run with the
@@ -108,12 +104,16 @@ class VectorEfficiencyError(MCPgError):
 
 
 def _validate_identifier(name: str, kind: str) -> None:
-    if not _IDENTIFIER.match(name):
-        raise VectorEfficiencyError(f"invalid {kind} name: {name!r}")
+    # Accept any addressable identifier (delimited names included); _quoted
+    # escapes it safely. Only empty / NUL / overlong names are refused.
+    try:
+        ensure_identifier(name, kind)
+    except IdentifierError as exc:
+        raise VectorEfficiencyError(str(exc)) from exc
 
 
 def _quoted(name: str) -> str:
-    return '"' + name.replace('"', '""') + '"'
+    return quote_identifier(name)
 
 
 # --- statistical helpers (pure Python) -------------------------------------

--- a/src/mcpg/redis_fdw.py
+++ b/src/mcpg/redis_fdw.py
@@ -56,6 +56,7 @@ _VALID_KEY_TYPES = frozenset({"hash", "list", "string", "set", "zset"})
 # ``allow_insecure_tls`` flag. Everything else must pass through TLS.
 _LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
 
+
 class RedisFdwError(MCPgError):
     """Raised when a redis_fdw operation cannot complete."""
 

--- a/src/mcpg/redis_fdw.py
+++ b/src/mcpg/redis_fdw.py
@@ -33,12 +33,13 @@ passed explicitly.
 from __future__ import annotations
 
 import ipaddress
-import re
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 
 from mcpg.errors import MCPgError
 from mcpg.extensions import extension_installed
+from mcpg.identifiers import IdentifierError, ensure_identifier
+from mcpg.identifiers import quote_identifier as _qi
 from mcpg.introspection import _parse_options
 from mcpg.secrets import SecretsProvider
 from mcpg.sql import SqlDriver
@@ -54,14 +55,6 @@ _VALID_KEY_TYPES = frozenset({"hash", "list", "string", "set", "zset"})
 # Loopback families: TLS may be disabled here without the explicit
 # ``allow_insecure_tls`` flag. Everything else must pass through TLS.
 _LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
-
-# Identifier validator — Postgres unquoted identifier shape. We use this
-# pattern (vs psycopg's Identifier escaping) because foreign-server /
-# user-mapping DDL is built up out of identifiers we trust *after this
-# check*; rejecting hostile inputs at the boundary is simpler than
-# escape-correctness everywhere downstream.
-_IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
-
 
 class RedisFdwError(MCPgError):
     """Raised when a redis_fdw operation cannot complete."""
@@ -340,15 +333,18 @@ async def get_redis_cache_stats(driver: SqlDriver, server: str) -> RedisCacheSta
 
 
 def _validate_identifier(label: str, value: str) -> str:
-    """Reject everything outside the ``[A-Za-z_][A-Za-z0-9_]*`` shape.
+    """Return ``value`` if it is an addressable identifier; raise otherwise.
 
     ``CREATE SERVER`` / ``CREATE USER MAPPING`` / ``CREATE FOREIGN TABLE``
-    DDL is built up of identifiers we can't bind. The allowlist is the
-    injection guard.
+    DDL is built up of identifiers we can't bind, so each is double-quoted
+    (embedded quotes doubled) at the splice site via :func:`_qi`. Any name
+    PostgreSQL supports through delimited quoting is accepted here; only the
+    empty string, an embedded NUL, or an over-63-byte name is rejected.
     """
-    if not _IDENT_RE.match(value):
-        raise RedisFdwError(f"{label} {value!r} is not a valid unquoted SQL identifier")
-    return value
+    try:
+        return ensure_identifier(value, label)
+    except IdentifierError as exc:
+        raise RedisFdwError(str(exc)) from exc
 
 
 def _validate_address(address: str) -> str:
@@ -401,7 +397,7 @@ async def create_redis_cache_server(
         raise RedisFdwError("redis_fdw extension is not installed; call enable_extension('redis_fdw') first")
     options = f"address '{address}', port '{port}', database '{database}', tls '{'true' if tls else 'false'}'"
     await driver.execute_query(
-        f'CREATE SERVER IF NOT EXISTS "{name}" FOREIGN DATA WRAPPER redis_fdw OPTIONS ({options})',
+        f"CREATE SERVER IF NOT EXISTS {_qi(name)} FOREIGN DATA WRAPPER redis_fdw OPTIONS ({options})",
         force_readonly=False,
     )
     return CreateRedisServerResult(
@@ -438,7 +434,7 @@ async def create_redis_user_mapping(
         user_clause = "PUBLIC"
     else:
         _validate_identifier("user name", user)
-        user_clause = f'"{user}"'
+        user_clause = _qi(user)
     if not secret_ref or not secret_ref.strip():
         raise RedisFdwError("secret_ref must reference a name in the configured secrets backend")
     password = secrets.get(secret_ref)
@@ -510,7 +506,7 @@ async def create_redis_cache_table(
         raise RedisFdwError("ttl_seconds must be a non-negative integer")
     if not await extension_installed(driver, _REDIS_FDW_NAME):
         raise RedisFdwError("redis_fdw extension is not installed; call enable_extension('redis_fdw') first")
-    columns_sql = ", ".join(f'"{n}" {t}' for n, t in decls)
+    columns_sql = ", ".join(f"{_qi(n)} {t}" for n, t in decls)
     options_parts = [f"tabletype '{key_type}'"]
     if key_prefix is not None:
         if any(ch in key_prefix for ch in "'\";\\\n\r"):
@@ -520,8 +516,8 @@ async def create_redis_cache_table(
         options_parts.append(f"ttl '{ttl_seconds}'")
     options_sql = ", ".join(options_parts)
     await driver.execute_query(
-        f'CREATE FOREIGN TABLE IF NOT EXISTS "{schema}"."{name}" ({columns_sql}) '
-        f'SERVER "{server}" OPTIONS ({options_sql})',
+        f"CREATE FOREIGN TABLE IF NOT EXISTS {_qi(schema)}.{_qi(name)} ({columns_sql}) "
+        f"SERVER {_qi(server)} OPTIONS ({options_sql})",
         force_readonly=False,
     )
     return CreateRedisCacheTableResult(
@@ -613,10 +609,10 @@ async def recommend_redis_cache_targets(
         table = row.cells["table_name"]
         stub = (
             f"-- redis_fdw cache stub for {schema}.{table}\n"
-            f'CREATE FOREIGN TABLE IF NOT EXISTS "{schema}"."{table}_cache" (\n'
+            f"CREATE FOREIGN TABLE IF NOT EXISTS {_qi(schema)}.{_qi(table + '_cache')} (\n"
             f"    key text,\n"
             f"    value text\n"
-            f') SERVER "{target_server}" OPTIONS (\n'
+            f") SERVER {_qi(target_server)} OPTIONS (\n"
             f"    tabletype 'hash',\n"
             f"    keyprefix '{schema}:{table}:'\n"
             f");"

--- a/src/mcpg/rls.py
+++ b/src/mcpg/rls.py
@@ -20,14 +20,12 @@ Safe by construction:
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass
 from typing import Any
 
 from mcpg.errors import MCPgError
+from mcpg.identifiers import IdentifierError, ensure_identifier, quote_identifier
 from mcpg.sql import SqlDriver
-
-_IDENTIFIER = re.compile(r"\A[A-Za-z_][A-Za-z0-9_]*\Z")
 
 DEFAULT_RLS_SAMPLE_SIZE = 25
 
@@ -37,8 +35,13 @@ class RLSError(MCPgError):
 
 
 def _check_identifier(value: str, kind: str) -> None:
-    if not _IDENTIFIER.match(value):
-        raise RLSError(f"invalid {kind} {value!r}; must match [A-Za-z_][A-Za-z0-9_]*")
+    # Accept any addressable identifier (schema / table / role names needing
+    # delimited quoting included); the splice sites quote them safely. Only
+    # empty / NUL / overlong names are refused.
+    try:
+        ensure_identifier(value, kind)
+    except IdentifierError as exc:
+        raise RLSError(str(exc)) from exc
 
 
 @dataclass(frozen=True)
@@ -154,10 +157,11 @@ async def test_rls_for_role(
         for row in policy_rows or []
     ]
 
-    # Now run the count + sample AS the role. Inline the validated
-    # identifiers — they've all been allowlist-checked.
-    qualified = f'"{schema}"."{table}"'
-    quoted_role = f'"{role}"'
+    # Now run the count + sample AS the role. Every identifier is quoted
+    # with embedded quotes doubled, so a name needing delimited quoting
+    # works and cannot break out of its identifier.
+    qualified = f"{quote_identifier(schema, 'schema')}.{quote_identifier(table, 'table')}"
+    quoted_role = quote_identifier(role, "role")
 
     # Count + sample issued as separate queries inside the role
     # context. The driver wraps each call in its own transaction; we

--- a/src/mcpg/tenancy.py
+++ b/src/mcpg/tenancy.py
@@ -36,7 +36,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import re
 from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any
 
@@ -44,13 +43,11 @@ from mcp.server.context import CallNext, HandlerResult, ServerMiddleware, Server
 from psycopg.rows import dict_row
 
 from mcpg.errors import MCPgError
+from mcpg.identifiers import IdentifierError, ensure_identifier, quote_identifier
 from mcpg.sql import SqlDriver
 
 logger = logging.getLogger(__name__)
 
-# Mirrors the validator in mcpg.config — duplicated here so this
-# module has no import-cycle on Settings.
-_ROLE_IDENTIFIER = re.compile(r"\A[A-Za-z_][A-Za-z0-9_]*\Z")
 
 # Per-request override, set once per inbound request by
 # TenantRoleContextMiddleware (stdio: never set, so it stays at its default
@@ -71,10 +68,17 @@ class TenancyError(MCPgError, ValueError):
 
 
 def validate_role(role: str) -> str:
-    """Return ``role`` unchanged if safe; raise otherwise."""
-    if not _ROLE_IDENTIFIER.match(role):
-        raise TenancyError(f"role name {role!r} must match [A-Za-z_][A-Za-z0-9_]*")
-    return role
+    """Return ``role`` unchanged if it is an addressable identifier; raise otherwise.
+
+    Accepts any role name PostgreSQL supports through delimited quoting
+    (hyphens, spaces, mixed case); the ``SET LOCAL ROLE`` splice quotes it
+    with embedded quotes doubled, so it cannot break out. Only the empty
+    string, an embedded NUL, or an over-63-byte name is rejected.
+    """
+    try:
+        return ensure_identifier(role, "role")
+    except IdentifierError as exc:
+        raise TenancyError(str(exc)) from exc
 
 
 def resolve_role(default: str | None) -> str | None:
@@ -212,7 +216,7 @@ async def _execute_with_role(  # noqa: C901
     """
     # Defence-in-depth — role is already validated at config / middleware,
     # but a misconfigured caller could still pass an unvalidated string.
-    validate_role(role)
+    quoted_role = quote_identifier(validate_role(role), "role")
     transaction_started = False
     try:
         async with connection.cursor(row_factory=dict_row) as cursor:
@@ -222,7 +226,7 @@ async def _execute_with_role(  # noqa: C901
                 await cursor.execute("BEGIN")
             transaction_started = True
 
-            await cursor.execute(f'SET LOCAL ROLE "{role}"')
+            await cursor.execute(f"SET LOCAL ROLE {quoted_role}")
 
             if params:
                 await cursor.execute(query, params)

--- a/src/mcpg/test_data.py
+++ b/src/mcpg/test_data.py
@@ -26,17 +26,16 @@ Scope:
 from __future__ import annotations
 
 import random
-import re
 import string
 import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 
 from mcpg.errors import MCPgError
+from mcpg.identifiers import IdentifierError, ensure_identifier
+from mcpg.identifiers import quote_identifier as _qi
 from mcpg.introspection import ColumnInfo, describe_table
 from mcpg.sql import SqlDriver
-
-_IDENTIFIER = re.compile(r"\A[A-Za-z_][A-Za-z0-9_]*\Z")
 
 DEFAULT_ROW_COUNT = 10
 HARD_ROW_CAP = 10_000
@@ -70,8 +69,12 @@ class GeneratedDataset:
 
 
 def _check_identifier(value: str, kind: str) -> None:
-    if not _IDENTIFIER.match(value):
-        raise TestDataError(f"invalid {kind} {value!r}; must match [A-Za-z_][A-Za-z0-9_]*")
+    # Accept any addressable identifier; splices quote it via _qi. Only
+    # empty / NUL / overlong names are rejected.
+    try:
+        ensure_identifier(value, kind)
+    except IdentifierError as exc:
+        raise TestDataError(str(exc)) from exc
 
 
 def _quote_literal(value: object) -> str:
@@ -207,11 +210,11 @@ async def generate_test_data(
             f"no columns of {schema}.{table!r} have generator support; skipped types: " + ", ".join(skipped)
         )
 
-    column_list = ", ".join(f'"{c.name}"' for c in target_columns)
+    column_list = ", ".join(_qi(c.name) for c in target_columns)
     statements: list[str] = []
     for _ in range(rows):
         values = [_format_column_value(col, rng) for col in target_columns]
-        statements.append(f'INSERT INTO "{schema}"."{table}" ({column_list}) VALUES ({", ".join(values)})')
+        statements.append(f"INSERT INTO {_qi(schema)}.{_qi(table)} ({column_list}) VALUES ({', '.join(values)})")
 
     return GeneratedDataset(
         schema=schema,

--- a/src/mcpg/test_row_factory.py
+++ b/src/mcpg/test_row_factory.py
@@ -52,7 +52,6 @@ Security posture
 from __future__ import annotations
 
 import random
-import re
 import string
 import uuid
 from collections.abc import Callable
@@ -60,10 +59,10 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 
 from mcpg.errors import MCPgError
+from mcpg.identifiers import IdentifierError, ensure_identifier
+from mcpg.identifiers import quote_identifier as _qi
 from mcpg.introspection import ColumnInfo, describe_table
 from mcpg.sql import SqlDriver
-
-_IDENTIFIER = re.compile(r"\A[A-Za-z_][A-Za-z0-9_]*\Z")
 
 
 class TestRowFactoryError(MCPgError):
@@ -116,8 +115,12 @@ class GeneratedTestRow:
 
 
 def _check_identifier(value: str, kind: str) -> None:
-    if not _IDENTIFIER.match(value):
-        raise TestRowFactoryError(f"invalid {kind} {value!r}; must match [A-Za-z_][A-Za-z0-9_]*")
+    # Accept any addressable identifier; splices quote it via _qi. Only
+    # empty / NUL / overlong names are rejected.
+    try:
+        ensure_identifier(value, kind)
+    except IdentifierError as exc:
+        raise TestRowFactoryError(str(exc)) from exc
 
 
 def _quote_literal(value: object) -> str:
@@ -353,9 +356,9 @@ async def _sample_fk_row(
     mapping each referenced column to its sampled cell value.
     """
     # Identifiers were validated by the caller — safe to interpolate.
-    col_list = ", ".join(f'"{c}"' for c in ref_columns)
+    col_list = ", ".join(_qi(c) for c in ref_columns)
     rows = await driver.execute_query(
-        f'SELECT {col_list} FROM "{ref_schema}"."{ref_table}" LIMIT 1',
+        f"SELECT {col_list} FROM {_qi(ref_schema)}.{_qi(ref_table)} LIMIT 1",
         force_readonly=True,
     )
     if not rows:
@@ -476,7 +479,7 @@ async def generate_test_row_for(  # noqa: C901
                             heuristic=f"fk → {ref_schema}.{ref_table} empty, column nullable",
                         )
                     )
-                    insert_cols.append(f'"{col.name}"')
+                    insert_cols.append(_qi(col.name))
                     insert_vals.append("NULL")
                     continue
                 raise TestRowFactoryError(
@@ -491,7 +494,7 @@ async def generate_test_row_for(  # noqa: C901
                     heuristic=f"fk → {ref_schema}.{ref_table}.{ref_column} sampled",
                 )
             )
-            insert_cols.append(f'"{col.name}"')
+            insert_cols.append(_qi(col.name))
             insert_vals.append(literal)
             continue
 
@@ -510,7 +513,7 @@ async def generate_test_row_for(  # noqa: C901
                 column_fills.append(
                     ColumnFill(name=col.name, sql_literal="NULL", heuristic="unsupported type, column nullable")
                 )
-                insert_cols.append(f'"{col.name}"')
+                insert_cols.append(_qi(col.name))
                 insert_vals.append("NULL")
                 continue
             raise TestRowFactoryError(
@@ -519,16 +522,17 @@ async def generate_test_row_for(  # noqa: C901
         value, heuristic = synth
         literal = _quote_literal(value)
         column_fills.append(ColumnFill(name=col.name, sql_literal=literal, heuristic=heuristic))
-        insert_cols.append(f'"{col.name}"')
+        insert_cols.append(_qi(col.name))
         insert_vals.append(literal)
 
     if not insert_cols:
         # Every column was skipped (entirely generated table). Emit
         # the DEFAULT VALUES form rather than a syntactically-bad
         # empty INSERT.
-        insert_sql = f'INSERT INTO "{schema}"."{table}" DEFAULT VALUES'
+        insert_sql = f"INSERT INTO {_qi(schema)}.{_qi(table)} DEFAULT VALUES"
     else:
-        insert_sql = f'INSERT INTO "{schema}"."{table}" ({", ".join(insert_cols)}) VALUES ({", ".join(insert_vals)})'
+        relation = f"{_qi(schema)}.{_qi(table)}"
+        insert_sql = f"INSERT INTO {relation} ({', '.join(insert_cols)}) VALUES ({', '.join(insert_vals)})"
 
     return GeneratedTestRow(schema=schema, table=table, columns=column_fills, insert_sql=insert_sql)
 

--- a/src/mcpg/textsearch.py
+++ b/src/mcpg/textsearch.py
@@ -21,6 +21,7 @@ from typing import Any
 
 from mcpg.errors import MCPgError
 from mcpg.extensions import extension_installed
+from mcpg.identifiers import IdentifierError, ensure_identifier, quote_identifier
 from mcpg.sql import SqlDriver
 
 _IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
@@ -141,15 +142,38 @@ class GeoSearchResult:
 
 
 def _checked(name: str, kind: str) -> str:
-    """Validate a SQL identifier and return it unchanged, or raise."""
+    """Validate a value against the strict plain-identifier allowlist.
+
+    Kept strict on purpose: its remaining caller embeds the value inside a
+    single-quoted SQL *string literal* (a ``regconfig`` name passed to
+    ``to_tsvector('<config>', …)``), where the plain-identifier allowlist —
+    which forbids the ``'`` that could close the literal — is the safety
+    boundary. Identifier arguments do not go through here; they are quoted
+    by :func:`_quoted`.
+    """
     if not _IDENTIFIER.match(name):
         raise SearchError(f"invalid {kind} name: {name!r}")
     return name
 
 
+def _ensure_identifier(name: str, kind: str) -> str:
+    """Pre-validate an identifier leniently, returning it unchanged.
+
+    Accepts any addressable PostgreSQL identifier (delimited names
+    included); the actual SQL splice quotes it via :func:`_quoted`.
+    """
+    try:
+        return ensure_identifier(name, kind)
+    except IdentifierError as exc:
+        raise SearchError(str(exc)) from exc
+
+
 def _quoted(name: str, kind: str) -> str:
-    """Validate a SQL identifier and return it double-quoted."""
-    return f'"{_checked(name, kind)}"'
+    """Return a SQL identifier safely double-quoted (embedded quotes doubled)."""
+    try:
+        return quote_identifier(name, kind)
+    except IdentifierError as exc:
+        raise SearchError(str(exc)) from exc
 
 
 async def fuzzy_search(
@@ -848,10 +872,10 @@ async def recommend_vector_quantization(
     doesn't justify the migration.
 
     Requires ``vector`` (pgvector) installed; when absent, returns
-    an empty list. Schema name is validated; only plain identifiers
-    accepted.
+    an empty list. The schema name is accepted as any addressable
+    identifier and quoted safely where it reaches SQL.
     """
-    _checked(schema, "schema")
+    _ensure_identifier(schema, "schema")
     if not await extension_installed(driver, "vector"):
         return []
 

--- a/src/mcpg/timescaledb.py
+++ b/src/mcpg/timescaledb.py
@@ -20,9 +20,10 @@ from dataclasses import dataclass
 
 from mcpg.errors import MCPgError
 from mcpg.extensions import extension_installed
+from mcpg.identifiers import IdentifierError, ensure_identifier
+from mcpg.identifiers import quote_identifier as _qi
 from mcpg.sql import SqlDriver
 
-_IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
 # A whitelist of intervals we'll inline into SQL. Validated against this
 # pattern then passed as a SQL literal (TimescaleDB takes interval
 # expressions as positional args, not bound params).
@@ -36,8 +37,29 @@ class TimescaleError(MCPgError):
 
 
 def _check_identifier(name: str, kind: str) -> None:
-    if not _IDENTIFIER.match(name):
-        raise TimescaleError(f"invalid {kind} name: {name!r}")
+    # Accept any addressable identifier; it is quoted (and, where it lands
+    # inside a string literal, single-quote-escaped) at each splice site.
+    # Only empty / NUL / overlong names are rejected.
+    try:
+        ensure_identifier(name, kind)
+    except IdentifierError as exc:
+        raise TimescaleError(str(exc)) from exc
+
+
+def _sql_str_literal(text: str) -> str:
+    """Return ``text`` as a single-quoted SQL string literal (quotes doubled)."""
+    return "'" + text.replace("'", "''") + "'"
+
+
+def _regclass_literal(schema: str, table: str) -> str:
+    """Return ``'"schema"."table"'`` — a quoted relation inside a string literal.
+
+    TimescaleDB's ``create_hypertable`` / ``add_*_policy`` take the relation
+    as a ``regclass`` *text* argument, so the double-quoted identifier is
+    itself wrapped in a single-quoted literal; both layers are escaped
+    (``"`` doubled by :func:`quote_identifier`, ``'`` doubled here).
+    """
+    return _sql_str_literal(f"{_qi(schema)}.{_qi(table)}")
 
 
 def _check_interval(value: str) -> None:
@@ -198,7 +220,7 @@ async def create_hypertable(
     # name reaches regclass with its case preserved — unquoted identifiers
     # passed to functions that cast to regclass are folded to lowercase.
     sql = (
-        f"SELECT create_hypertable('\"{schema}\".\"{table}\"', '{time_column}', "
+        f"SELECT create_hypertable({_regclass_literal(schema, table)}, {_sql_str_literal(time_column)}, "
         f"chunk_time_interval => INTERVAL '{chunk_time_interval}', "
         f"if_not_exists => {inex}) AS result"
     )
@@ -228,9 +250,9 @@ async def add_compression_policy(
         return TimescaleWriteResult(
             available=False, function="add_compression_policy", details="timescaledb extension is not installed"
         )
-    await driver.execute_query(f'ALTER TABLE "{schema}"."{table}" SET (timescaledb.compress = TRUE)')
+    await driver.execute_query(f"ALTER TABLE {_qi(schema)}.{_qi(table)} SET (timescaledb.compress = TRUE)")
     rows = await driver.execute_query(
-        f"SELECT add_compression_policy('\"{schema}\".\"{table}\"', INTERVAL '{compress_after}') AS job_id"
+        f"SELECT add_compression_policy({_regclass_literal(schema, table)}, INTERVAL '{compress_after}') AS job_id"
     )
     detail = f"job_id={rows[0].cells['job_id']}" if rows else "policy added"
     return TimescaleWriteResult(available=True, function="add_compression_policy", details=detail)
@@ -252,7 +274,7 @@ async def add_retention_policy(
             available=False, function="add_retention_policy", details="timescaledb extension is not installed"
         )
     rows = await driver.execute_query(
-        f"SELECT add_retention_policy('\"{schema}\".\"{table}\"', INTERVAL '{drop_after}') AS job_id"
+        f"SELECT add_retention_policy({_regclass_literal(schema, table)}, INTERVAL '{drop_after}') AS job_id"
     )
     detail = f"job_id={rows[0].cells['job_id']}" if rows else "policy added"
     return TimescaleWriteResult(available=True, function="add_retention_policy", details=detail)

--- a/src/mcpg/turboquant.py
+++ b/src/mcpg/turboquant.py
@@ -53,7 +53,6 @@ from __future__ import annotations
 
 import datetime
 import json
-import re
 import time
 from dataclasses import dataclass, field
 from typing import Any
@@ -61,12 +60,8 @@ from typing import Any
 from mcpg.database import Database
 from mcpg.errors import MCPgError
 from mcpg.extensions import extension_installed
+from mcpg.identifiers import IdentifierError, ensure_identifier
 from mcpg.sql import SqlDriver
-
-# Plain unquoted PostgreSQL identifier — matches the rule used by
-# vector_tuning. Anything that would require delimited quoting at the
-# catalog level is refused rather than parsed out of an agent string.
-_IDENTIFIER = re.compile(r"\A[A-Za-z_][A-Za-z0-9_]*\Z")
 
 
 class TurboQuantError(MCPgError):
@@ -74,8 +69,12 @@ class TurboQuantError(MCPgError):
 
 
 def _validate_identifier(name: str, kind: str) -> None:
-    if not _IDENTIFIER.match(name):
-        raise TurboQuantError(f"invalid {kind} name: {name!r}")
+    # Accept any addressable identifier; _pg_quote_ident escapes it safely.
+    # Only empty / NUL / overlong names are refused.
+    try:
+        ensure_identifier(name, kind)
+    except IdentifierError as exc:
+        raise TurboQuantError(str(exc)) from exc
 
 
 def _pg_quote_ident(name: str) -> str:
@@ -454,8 +453,9 @@ async def list_turboquant_indexes(driver: SqlDriver) -> list[TurboQuantIndexInfo
 async def get_turboquant_index_metadata(driver: SqlDriver, schema: str, index: str) -> TurboQuantIndexInfo:
     """Fetch the metadata payload for a single turboquant index.
 
-    Identifier validation (``_IDENTIFIER``) runs before any SQL is built,
-    so the schema / index strings cannot drive arbitrary catalog lookups.
+    Identifier validation runs before any SQL is built and every name is
+    quoted via ``_pg_quote_ident``, so the schema / index strings cannot
+    drive arbitrary catalog lookups.
 
     Raises:
         TurboQuantError: extension is not installed, the schema / index

--- a/src/mcpg/vector_ops.py
+++ b/src/mcpg/vector_ops.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import math
 import random
-import re
 from collections.abc import Callable
 from dataclasses import dataclass, replace
 from typing import Any
@@ -26,9 +25,8 @@ from typing import Any
 from mcpg import introspection
 from mcpg.errors import MCPgError
 from mcpg.extensions import extension_installed
+from mcpg.identifiers import IdentifierError, ensure_identifier, quote_identifier
 from mcpg.sql import SqlDriver
-
-_IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
 
 # Default sample size when the caller doesn't pass one. Chosen so the
 # tool is cheap on big tables (a few MB of vectors) while still giving
@@ -110,13 +108,19 @@ class DistanceMetricRecommendation:
 
 
 def _checked(name: str, kind: str) -> str:
-    if not _IDENTIFIER.match(name):
-        raise VectorOpsError(f"invalid {kind} name: {name!r}")
-    return name
+    # Accept any addressable identifier (delimited names included); the
+    # splice sites quote it via _quoted. Only empty / NUL / overlong refused.
+    try:
+        return ensure_identifier(name, kind)
+    except IdentifierError as exc:
+        raise VectorOpsError(str(exc)) from exc
 
 
 def _quoted(name: str, kind: str) -> str:
-    return f'"{_checked(name, kind)}"'
+    try:
+        return quote_identifier(name, kind)
+    except IdentifierError as exc:
+        raise VectorOpsError(str(exc)) from exc
 
 
 # pgvector distance operators, shared across the analytics tools so the

--- a/src/mcpg/vector_tuning.py
+++ b/src/mcpg/vector_tuning.py
@@ -16,11 +16,11 @@ when it is absent.
 from __future__ import annotations
 
 import math
-import re
 from dataclasses import dataclass
 
 from mcpg.errors import MCPgError
 from mcpg.extensions import extension_installed
+from mcpg.identifiers import IdentifierError, quote_identifier
 from mcpg.introspection import describe_table
 from mcpg.sql import SqlDriver
 
@@ -45,22 +45,22 @@ _TRUTH_ORDER = {"l2": "ASC", "cosine": "ASC", "inner_product": "DESC"}
 # accidental DoS via a runaway sample_size argument.
 _MAX_SAMPLE_SIZE = 100
 
-# Plain unquoted PostgreSQL identifier — letters, digits, underscores,
-# starting with a letter or underscore. We refuse anything that requires
-# quoting at the catalog level (delimited identifiers, case-sensitive
-# names) rather than try to parse them out of an agent's string.
-_IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
-
-
 class VectorTuningError(MCPgError):
     """Raised when a pgvector tuning operation cannot complete."""
 
 
 def _quoted(name: str, kind: str) -> str:
-    """Validate a SQL identifier against the allowlist and return it double-quoted."""
-    if not _IDENTIFIER.match(name):
-        raise VectorTuningError(f"invalid {kind} name: {name!r}")
-    return f'"{name}"'
+    """Return a SQL identifier safely double-quoted.
+
+    Accepts any actual PostgreSQL identifier — including names that need
+    delimited quoting (hyphens, mixed case) — and doubles embedded quotes
+    so the value can't break out. Only empty / NUL / over-63-byte names are
+    rejected. See :func:`mcpg.identifiers.quote_identifier`.
+    """
+    try:
+        return quote_identifier(name, kind)
+    except IdentifierError as exc:
+        raise VectorTuningError(str(exc)) from exc
 
 
 @dataclass(frozen=True)

--- a/src/mcpg/vector_tuning.py
+++ b/src/mcpg/vector_tuning.py
@@ -45,6 +45,7 @@ _TRUTH_ORDER = {"l2": "ASC", "cosine": "ASC", "inner_product": "DESC"}
 # accidental DoS via a runaway sample_size argument.
 _MAX_SAMPLE_SIZE = 100
 
+
 class VectorTuningError(MCPgError):
     """Raised when a pgvector tuning operation cannot complete."""
 

--- a/tests/unit/test_composite.py
+++ b/tests/unit/test_composite.py
@@ -22,12 +22,16 @@ from mcpg.server import create_server
 _SETTINGS = load_settings({"MCPG_DATABASE_URL": "postgresql://u:p@localhost/db"})
 
 
-def test_check_identifier_rejects_unsafe_names() -> None:
+def test_check_identifier_accepts_delimited_names_rejects_empty_and_nul() -> None:
+    # Names needing delimited quoting now pass the check (the splice site
+    # quotes them safely); only empty / NUL / overlong names are refused.
     _check_identifier("widget", "table")
+    _check_identifier('w"; DROP', "table")
+    _check_identifier("with space", "schema")
     with pytest.raises(CompositeError, match="invalid table"):
-        _check_identifier('w"; DROP', "table")
+        _check_identifier("", "table")
     with pytest.raises(CompositeError, match="invalid schema"):
-        _check_identifier("with space", "schema")
+        _check_identifier("with\x00nul", "schema")
 
 
 def test_pk_columns_extracts_from_primary_key_definition() -> None:
@@ -145,11 +149,13 @@ async def test_cache_hit_ratio_handles_null_aggregates() -> None:
 # --- summarize_table --------------------------------------------------
 
 
-async def test_summarize_table_rejects_unsafe_identifiers() -> None:
+async def test_summarize_table_rejects_empty_or_nul_identifiers() -> None:
     driver = FakeRoutingDriver({})
 
     with pytest.raises(CompositeError, match="invalid"):
-        await summarize_table(driver, 'app"; DROP', "widget")  # type: ignore[arg-type]
+        await summarize_table(driver, "", "widget")  # type: ignore[arg-type]
+    with pytest.raises(CompositeError, match="invalid"):
+        await summarize_table(driver, "app", "wid\x00get")  # type: ignore[arg-type]
 
 
 async def test_summarize_table_rejects_negative_sample_rows() -> None:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -208,9 +208,16 @@ def test_default_role_defaults_to_none_and_parses_when_set() -> None:
     assert settings.default_role == "app_reader"
 
 
-def test_default_role_rejects_unsafe_identifiers() -> None:
+def test_default_role_accepts_delimited_role_names() -> None:
+    # Role names needing delimited quoting are legal in PostgreSQL and are
+    # quoted safely where SET LOCAL ROLE is issued, so config accepts them.
+    settings = load_settings({"MCPG_DATABASE_URL": _DB_URL, "MCPG_DEFAULT_ROLE": "role-with-dash"})
+    assert settings.default_role == "role-with-dash"
+
+
+def test_default_role_rejects_non_addressable_identifiers() -> None:
     with pytest.raises(ConfigError, match="MCPG_DEFAULT_ROLE"):
-        load_settings({"MCPG_DATABASE_URL": _DB_URL, "MCPG_DEFAULT_ROLE": '"; DROP USER alice'})
+        load_settings({"MCPG_DATABASE_URL": _DB_URL, "MCPG_DEFAULT_ROLE": "bad\x00role"})
 
 
 def test_default_role_rejects_blank_string() -> None:
@@ -226,9 +233,11 @@ def test_allowed_roles_defaults_to_empty_tuple_and_parses_comma_list() -> None:
     assert settings.allowed_roles == ("tenant_a", "tenant_b", "tenant_c")
 
 
-def test_allowed_roles_rejects_unsafe_identifiers_in_the_list() -> None:
+def test_allowed_roles_accepts_delimited_names_rejects_non_addressable() -> None:
+    settings = load_settings({"MCPG_DATABASE_URL": _DB_URL, "MCPG_ALLOWED_ROLES": "tenant_a, bad-name"})
+    assert settings.allowed_roles == ("tenant_a", "bad-name")
     with pytest.raises(ConfigError, match="MCPG_ALLOWED_ROLES"):
-        load_settings({"MCPG_DATABASE_URL": _DB_URL, "MCPG_ALLOWED_ROLES": "tenant_a, bad-name"})
+        load_settings({"MCPG_DATABASE_URL": _DB_URL, "MCPG_ALLOWED_ROLES": "tenant_a, bad\x00name"})
 
 
 def test_default_role_must_appear_in_allowed_roles_when_both_set() -> None:

--- a/tests/unit/test_data_movement.py
+++ b/tests/unit/test_data_movement.py
@@ -171,11 +171,26 @@ async def test_export_table_builds_a_safe_select_against_quoted_identifiers() ->
     assert any('"app"."widget"' in sql or "app.widget" in sql for sql in sqls)
 
 
-async def test_export_table_rejects_invalid_identifier_characters() -> None:
+async def test_export_table_safely_escapes_embedded_quotes() -> None:
+    # A name carrying a double quote is no longer rejected — it's escaped
+    # (doubled) so it stays one identifier and can't break out into a
+    # second statement. Issue-#329 class: valid delimited identifiers work.
+    driver = FakeDriver([{"id": 1}])
+    await export_table(driver, 'app"; DROP TABLE x; --', "widget")  # type: ignore[arg-type]
+    sqls = [call[0] for call in driver.calls]
+    # The embedded quote is doubled; the raw break-out sequence (a lone
+    # quote immediately followed by ;) never appears in the emitted SQL.
+    assert any('"app""; DROP TABLE x; --"' in sql for sql in sqls)
+    # The unescaped break-out (a single quote right before `; DROP`) is gone.
+    assert not any('app"; DROP' in sql for sql in sqls)
+
+
+@pytest.mark.parametrize("bad", ["", "\x00", "sch\x00ema"])
+async def test_export_table_rejects_empty_or_nul(bad: str) -> None:
     with pytest.raises(ExportError, match="invalid schema name"):
-        await export_table(FakeDriver(), 'app"; DROP TABLE x; --', "widget")  # type: ignore[arg-type]
+        await export_table(FakeDriver(), bad, "widget")  # type: ignore[arg-type]
     with pytest.raises(ExportError, match="invalid table name"):
-        await export_table(FakeDriver(), "app", "widget; DROP")  # type: ignore[arg-type]
+        await export_table(FakeDriver(), "app", bad)  # type: ignore[arg-type]
 
 
 # --- module exports + tool wiring -----------------------------------------
@@ -711,7 +726,7 @@ async def test_copy_table_pipes_pg_dump_into_pg_restore_with_separate_envs(
     assert dump_call["env"]["PGHOST"] == "srchost"
     assert dump_call["env"]["PGDATABASE"] == "srcdb"
     assert dump_call["env"]["PGPASSWORD"] == "srcpw"
-    assert "--table=app.widget" in dump_call["argv"]
+    assert '--table="app"."widget"' in dump_call["argv"]
     # The archive bytes flow into pg_restore's stdin verbatim.
     assert restore_call["binary"] == "pg_restore"
     assert restore_call["env"]["PGHOST"] == "dsthost"
@@ -787,12 +802,50 @@ async def test_copy_table_rejects_when_neither_schema_nor_data_requested() -> No
         )
 
 
-async def test_copy_table_rejects_unsafe_identifiers() -> None:
+async def test_copy_table_encodes_quoted_names_as_literal_table_patterns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A schema/table needing delimited quoting is encoded as a literal
+    # pg_dump --table pattern (each half double-quoted) rather than being
+    # rejected; metacharacters can't expand and an embedded quote is doubled.
+    captured: list[list[str]] = []
+
+    async def fake_run(binary: str, *argv: str, **kwargs: object) -> SubprocessResult:
+        captured.append(list(argv))
+        return SubprocessResult(
+            binary=binary,
+            argv=list(argv),
+            exit_code=0,
+            stdout=b"",
+            stderr=b"",
+            output_bytes=0,
+            output_truncated=False,
+            timed_out=False,
+            env_redacted={},
+        )
+
+    monkeypatch.setattr("mcpg.data_movement.run_pg_binary", fake_run)
+    await copy_table_between_databases(
+        "postgresql://u@h/src",
+        "postgresql://u@h/dst",
+        "adm-pgbench",
+        'wid"get',
+        include_schema=True,
+        include_data=True,
+        timeout_sec=10,
+        max_output_bytes=4096,
+    )
+    dump_argv = captured[0]
+    assert '--table="adm-pgbench"."wid""get"' in dump_argv
+
+
+@pytest.mark.parametrize("bad", ["", "\x00"])
+async def test_copy_table_rejects_empty_or_nul_names(bad: str) -> None:
     with pytest.raises(ShellError, match="invalid schema name"):
         await copy_table_between_databases(
             "postgresql://u@h/src",
             "postgresql://u@h/dst",
-            "app; DROP",
+            bad,
             "widget",
             include_schema=True,
             include_data=True,
@@ -804,7 +857,7 @@ async def test_copy_table_rejects_unsafe_identifiers() -> None:
             "postgresql://u@h/src",
             "postgresql://u@h/dst",
             "app",
-            'widget"; --',
+            bad,
             include_schema=True,
             include_data=True,
             timeout_sec=10,
@@ -992,14 +1045,24 @@ async def test_import_csv_rejects_empty_column_list() -> None:
         await import_csv(FakeDatabase(FakeDriver()), "app", "widget", "x\n", columns=[])  # type: ignore[arg-type]
 
 
-async def test_import_csv_rejects_unsafe_identifiers() -> None:
+async def test_import_csv_safely_escapes_quoted_identifiers() -> None:
+    # Names needing delimited quoting (hyphens, spaces, embedded quotes) are
+    # accepted and double-quoted safely in the COPY statement.
+    db = FakeDatabase(FakeDriver())
+    await import_csv(db, "adm-pgbench", 'wid"get', "x\n", columns=["a col"])  # type: ignore[arg-type]
+    copy_sql = db.copy_calls[-1][0]
+    assert 'COPY "adm-pgbench"."wid""get" ("a col")' in copy_sql
+
+
+@pytest.mark.parametrize("bad", ["", "\x00"])
+async def test_import_csv_rejects_empty_or_nul_identifiers(bad: str) -> None:
     db = FakeDatabase(FakeDriver())
     with pytest.raises(ImportDataError, match="invalid schema name"):
-        await import_csv(db, "app; DROP", "widget", "x\n")  # type: ignore[arg-type]
+        await import_csv(db, bad, "widget", "x\n")  # type: ignore[arg-type]
     with pytest.raises(ImportDataError, match="invalid table name"):
-        await import_csv(db, "app", 'widget"; --', "x\n")  # type: ignore[arg-type]
+        await import_csv(db, "app", bad, "x\n")  # type: ignore[arg-type]
     with pytest.raises(ImportDataError, match="invalid column name"):
-        await import_csv(db, "app", "widget", "x\n", columns=["bad name"])  # type: ignore[arg-type]
+        await import_csv(db, "app", "widget", "x\n", columns=[bad])  # type: ignore[arg-type]
 
 
 async def test_import_csv_rejects_dangerous_delimiters() -> None:
@@ -1106,10 +1169,20 @@ async def test_import_json_rejects_non_object_rows() -> None:
         await import_json(db, "app", "widget", json.dumps([[1, 2], [3, 4]]))  # type: ignore[arg-type]
 
 
-async def test_import_json_rejects_unsafe_identifiers() -> None:
+async def test_import_json_safely_escapes_quoted_identifiers() -> None:
+    db = FakeDatabase(FakeDriver())
+    await import_json(db, "adm-pgbench", 'wid"get', json.dumps([{"a-col": 1}]))  # type: ignore[arg-type]
+    insert_sql = db.execute_many_calls[-1][0]
+    assert 'INSERT INTO "adm-pgbench"."wid""get" ("a-col")' in insert_sql
+
+
+@pytest.mark.parametrize("bad", ["", "\x00"])
+async def test_import_json_rejects_empty_or_nul_identifiers(bad: str) -> None:
     db = FakeDatabase(FakeDriver())
     with pytest.raises(ImportDataError, match="invalid schema name"):
-        await import_json(db, "app; DROP", "widget", "[]")  # type: ignore[arg-type]
+        await import_json(db, bad, "widget", "[]")  # type: ignore[arg-type]
+    with pytest.raises(ImportDataError, match="invalid table name"):
+        await import_json(db, "app", bad, "[]")  # type: ignore[arg-type]
 
 
 async def test_import_json_falls_back_to_input_length_when_rowcount_is_negative() -> None:
@@ -1248,10 +1321,18 @@ async def test_import_vectors_rejects_unknown_format() -> None:
         await import_vectors(db, "app", "docs", "embedding", "[]", format="parquet")  # type: ignore[arg-type]
 
 
-async def test_import_vectors_rejects_unsafe_identifiers() -> None:
+async def test_import_vectors_safely_escapes_quoted_identifiers() -> None:
+    db = FakeDatabase(FakeRoutingDriver(_vector_routes(dimension=2)))
+    await import_vectors(db, "adm-pgbench", "docs", "embedding", json.dumps([{"embedding": [0.1, 0.2]}]))  # type: ignore[arg-type]
+    insert_sql = db.execute_many_calls[-1][0]
+    assert 'INSERT INTO "adm-pgbench"."docs" ("embedding")' in insert_sql
+
+
+@pytest.mark.parametrize("bad", ["", "\x00"])
+async def test_import_vectors_rejects_empty_or_nul_identifiers(bad: str) -> None:
     db = FakeDatabase(FakeRoutingDriver(_vector_routes(dimension=2)))
     with pytest.raises(ImportDataError, match="invalid table"):
-        await import_vectors(db, "app", 'docs"; DROP TABLE x', "embedding", "[]")  # type: ignore[arg-type]
+        await import_vectors(db, "app", bad, "embedding", "[]")  # type: ignore[arg-type]
 
 
 async def test_import_vectors_rejects_null_embedding_row() -> None:

--- a/tests/unit/test_data_movement.py
+++ b/tests/unit/test_data_movement.py
@@ -351,8 +351,10 @@ async def test_dump_database_schemas_emits_one_schema_flag_per_entry(
 
     argv = captured["argv"]
     assert isinstance(argv, list)
-    assert "--schema=public" in argv
-    assert "--schema=app" in argv
+    # Each schema name is encoded as a double-quoted literal pg_dump pattern
+    # so metacharacters can't expand and case is preserved.
+    assert '--schema="public"' in argv
+    assert '--schema="app"' in argv
 
 
 async def test_dump_database_default_schemas_none_emits_no_schema_flag(
@@ -387,8 +389,28 @@ async def test_dump_database_default_schemas_none_emits_no_schema_flag(
     assert not any(a.startswith("--schema=") for a in argv)
 
 
-async def test_dump_database_rejects_invalid_schema_name_without_running_pg_dump(
+def _fake_run_capturing(captured: dict[str, object]):
+    async def fake_run(binary: str, *argv: str, **kwargs: object) -> SubprocessResult:
+        captured["argv"] = list(argv)
+        return SubprocessResult(
+            binary=binary,
+            argv=list(argv),
+            exit_code=0,
+            stdout=b"-- PostgreSQL database dump\n",
+            stderr=b"",
+            output_bytes=29,
+            output_truncated=False,
+            timed_out=False,
+            env_redacted={},
+        )
+
+    return fake_run
+
+
+@pytest.mark.parametrize("bad_name", ["", "\x00", "sch\x00ema"])
+async def test_dump_database_rejects_empty_or_nul_schema_name_without_running_pg_dump(
     monkeypatch: pytest.MonkeyPatch,
+    bad_name: str,
 ) -> None:
     called = False
 
@@ -404,9 +426,52 @@ async def test_dump_database_rejects_invalid_schema_name_without_running_pg_dump
             "postgresql://u:p@h:5432/db",
             timeout_sec=10,
             max_output_bytes=1024,
-            schemas=["public", "bad;name"],
+            schemas=["public", bad_name],
         )
     assert called is False
+
+
+@pytest.mark.parametrize(
+    ("schema_name", "expected_flag"),
+    [
+        # A hyphenated schema name — the case from issue #329 — must reach
+        # pg_dump quoted rather than being rejected up-front.
+        ("adm-pgbench", '--schema="adm-pgbench"'),
+        # Spaces and mixed case are legal quoted identifiers; quoting also
+        # preserves case (an unquoted pg_dump pattern folds to lowercase).
+        ("My Schema", '--schema="My Schema"'),
+        ("MixedCase", '--schema="MixedCase"'),
+        # An embedded double quote is doubled per pg_dump's pattern-quoting
+        # rules, so it matches the literal quote in the schema name.
+        ('weird"name', '--schema="weird""name"'),
+        # Pattern metacharacters are neutralised by the surrounding quotes —
+        # they must match literally, never expand as wildcards / classes.
+        ("wild*card", '--schema="wild*card"'),
+        ("q?mark", '--schema="q?mark"'),
+        ("class[abc]", '--schema="class[abc]"'),
+        # A semicolon is harmless in argv (no shell) and now accepted as a
+        # literal schema-name character.
+        ("bad;name", '--schema="bad;name"'),
+    ],
+)
+async def test_dump_database_encodes_quoted_schema_names_as_literal_patterns(
+    monkeypatch: pytest.MonkeyPatch,
+    schema_name: str,
+    expected_flag: str,
+) -> None:
+    captured: dict[str, object] = {}
+    monkeypatch.setattr("mcpg.data_movement.run_pg_binary", _fake_run_capturing(captured))
+
+    await dump_database(
+        "postgresql://u:p@h:5432/db",
+        timeout_sec=10,
+        max_output_bytes=1024,
+        schemas=[schema_name],
+    )
+
+    argv = captured["argv"]
+    assert isinstance(argv, list)
+    assert expected_flag in argv
 
 
 # --- tool wiring: dump_database is shell-gated ----------------------------

--- a/tests/unit/test_http_runtime.py
+++ b/tests/unit/test_http_runtime.py
@@ -437,10 +437,13 @@ def test_tenant_role_middleware_returns_403_when_role_has_invalid_characters() -
         sent_messages.append(message)
 
     middleware = _TenantRoleMiddleware(inner)
+    # A NUL byte is not an addressable identifier, so the role header is
+    # rejected. (A role needing delimited quoting, e.g. "my-role", is now
+    # accepted and quoted safely at the SET LOCAL ROLE splice.)
     scope = {
         "type": "http",
         "path": "/",
-        "headers": [(b"x-mcpg-role", b'"; DROP USER alice; --')],
+        "headers": [(b"x-mcpg-role", b"ro\x00le")],
     }
 
     import asyncio
@@ -956,7 +959,7 @@ async def test_oidc_middleware_sets_and_resets_role_from_claim() -> None:
 async def test_oidc_middleware_rejects_unsafe_role_identifier() -> None:
     from mcpg.http_runtime import _OIDCAuthMiddleware
 
-    mw = _OIDCAuthMiddleware(None, verifier=_FakeVerifier(role='"; DROP USER alice; --'))  # type: ignore[arg-type]
+    mw = _OIDCAuthMiddleware(None, verifier=_FakeVerifier(role="ro\x00le"))  # type: ignore[arg-type]
     sent = await _drive_get(mw, auth=b"Bearer tok")
 
     starts = [m for m in sent if m["type"] == "http.response.start"]

--- a/tests/unit/test_identifiers.py
+++ b/tests/unit/test_identifiers.py
@@ -1,0 +1,95 @@
+"""Adversarial tests for the shared SQL identifier quoting helper.
+
+`quote_identifier` replaces the per-module `[A-Za-z_][A-Za-z0-9_]*`
+validators that used to double as MCPg's injection defense. The bar here
+is that value passed by callers can never break out of the quoted
+identifier, while every name PostgreSQL supports through delimited quoting
+still round-trips.
+"""
+
+import pytest
+
+from mcpg.identifiers import (
+    MAX_IDENTIFIER_BYTES,
+    IdentifierError,
+    ensure_identifier,
+    quote_identifier,
+)
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        # Plain identifiers are quoted but otherwise unchanged.
+        ("public", '"public"'),
+        ("my_table", '"my_table"'),
+        # The issue #329 case and its siblings — names that need delimited
+        # quoting, all preserved literally and case-sensitively.
+        ("adm-pgbench", '"adm-pgbench"'),
+        ("My Schema", '"My Schema"'),
+        ("MixedCase", '"MixedCase"'),
+        ("naïve", '"naïve"'),
+        # Reserved words are fine once quoted.
+        ("select", '"select"'),
+        ("order", '"order"'),
+    ],
+)
+def test_quote_identifier_preserves_valid_names(name: str, expected: str) -> None:
+    assert quote_identifier(name) == expected
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        # A single embedded double quote is doubled.
+        ('weird"name', '"weird""name"'),
+        # The classic break-out attempt: doubling neutralises it, so the
+        # whole thing stays one identifier rather than closing early.
+        ('a";DROP TABLE t;--', '"a"";DROP TABLE t;--"'),
+        # Several quotes, including adjacent ones.
+        ('""', '""""""'),
+        ('a"b"c', '"a""b""c"'),
+    ],
+)
+def test_quote_identifier_escapes_embedded_quotes(name: str, expected: str) -> None:
+    quoted = quote_identifier(name)
+    assert quoted == expected
+    # The escaped form has balanced, even quoting: stripping the outer pair
+    # and collapsing doubled quotes recovers the original name exactly.
+    inner = quoted[1:-1]
+    assert inner.replace('""', '\x00').count('"') == 0
+    assert inner.replace('""', '"') == name
+
+
+@pytest.mark.parametrize("bad", ["", "\x00", "abc\x00def"])
+def test_quote_identifier_rejects_empty_and_nul(bad: str) -> None:
+    with pytest.raises(IdentifierError, match="invalid identifier name"):
+        quote_identifier(bad)
+
+
+def test_quote_identifier_rejects_overlong_name() -> None:
+    too_long = "a" * (MAX_IDENTIFIER_BYTES + 1)
+    with pytest.raises(IdentifierError, match="63-byte"):
+        quote_identifier(too_long)
+    # Exactly at the limit is fine.
+    assert quote_identifier("a" * MAX_IDENTIFIER_BYTES) == '"' + "a" * MAX_IDENTIFIER_BYTES + '"'
+
+
+def test_quote_identifier_counts_bytes_not_codepoints() -> None:
+    # A 4-byte emoji: 16 of them = 64 bytes > 63, rejected even though it is
+    # only 16 code points.
+    assert len(("😀" * 16).encode("utf-8")) == 64
+    with pytest.raises(IdentifierError, match="63-byte"):
+        quote_identifier("😀" * 16)
+
+
+def test_kind_appears_in_error_message() -> None:
+    with pytest.raises(IdentifierError, match="invalid schema name"):
+        quote_identifier("", "schema")
+    with pytest.raises(IdentifierError, match="invalid column name"):
+        ensure_identifier("x" * 100, "column")
+
+
+def test_ensure_identifier_passes_names_through_unquoted() -> None:
+    assert ensure_identifier("adm-pgbench") == "adm-pgbench"
+    assert ensure_identifier("public") == "public"

--- a/tests/unit/test_identifiers.py
+++ b/tests/unit/test_identifiers.py
@@ -57,7 +57,7 @@ def test_quote_identifier_escapes_embedded_quotes(name: str, expected: str) -> N
     # The escaped form has balanced, even quoting: stripping the outer pair
     # and collapsing doubled quotes recovers the original name exactly.
     inner = quoted[1:-1]
-    assert inner.replace('""', '\x00').count('"') == 0
+    assert inner.replace('""', "\x00").count('"') == 0
     assert inner.replace('""', '"') == name
 
 

--- a/tests/unit/test_listen.py
+++ b/tests/unit/test_listen.py
@@ -140,10 +140,12 @@ async def test_second_subscribe_on_same_channel_does_not_re_listen() -> None:
 async def test_subscribe_rejects_unsafe_channel_names() -> None:
     manager, _ = _manager_with_fake_conn()
     try:
+        # Channel names needing delimited quoting are accepted (quoted
+        # safely in LISTEN); only empty / NUL / overlong names are rejected.
         with pytest.raises(ListenError, match="invalid channel name"):
-            await manager.subscribe('orders"; DROP TABLE x; --')
+            await manager.subscribe("")
         with pytest.raises(ListenError, match="invalid channel name"):
-            await manager.subscribe("with space")
+            await manager.subscribe("with\x00nul")
     finally:
         await manager.close()
 

--- a/tests/unit/test_logical_replication.py
+++ b/tests/unit/test_logical_replication.py
@@ -63,7 +63,7 @@ async def test_create_publication_rejects_invalid_publication_name() -> None:
     with pytest.raises(LogicalReplicationError, match="invalid publication"):
         await create_publication(
             db,  # type: ignore[arg-type]
-            name='pub"; DROP TABLE x; --',
+            name="",
             all_tables=True,
         )
 
@@ -78,14 +78,17 @@ async def test_create_publication_rejects_unqualified_table_name() -> None:
         )
 
 
-async def test_create_publication_rejects_injection_in_table_name() -> None:
+async def test_create_publication_safely_escapes_quoted_table_name() -> None:
+    # A table name needing delimited quoting is accepted and double-quoted
+    # (embedded quotes doubled) rather than rejected — it can't break out.
     db = FakeDatabase(FakeDriver())
-    with pytest.raises(LogicalReplicationError, match="invalid"):
-        await create_publication(
-            db,  # type: ignore[arg-type]
-            name="bad",
-            tables=('public.t"; DROP TABLE x; --',),
-        )
+    result = await create_publication(
+        db,  # type: ignore[arg-type]
+        name="bad",
+        tables=('public.wid"get',),
+    )
+    assert '"public"."wid""get"' in result.executed_sql
+    assert 'wid"get' not in result.executed_sql.replace('""', "")
 
 
 async def test_create_publication_surfaces_driver_failure_as_typed_error() -> None:
@@ -140,7 +143,7 @@ async def test_drop_publication_with_if_exists_and_cascade() -> None:
 async def test_drop_publication_rejects_invalid_name() -> None:
     db = FakeDatabase(FakeDriver())
     with pytest.raises(LogicalReplicationError):
-        await drop_publication(db, name="0bad")  # type: ignore[arg-type]
+        await drop_publication(db, name="")  # type: ignore[arg-type]
 
 
 # ---------------------------------------------------------------------------
@@ -219,7 +222,7 @@ async def test_create_subscription_rejects_invalid_publication_name() -> None:
             db,
             name="x",
             connection_string="host=p",
-            publications=('pub"; DROP TABLE y',),
+            publications=("",),
         )
 
 
@@ -257,7 +260,7 @@ async def test_drop_subscription_if_exists() -> None:
 async def test_drop_subscription_rejects_invalid_name() -> None:
     db = FakeDatabase(FakeDriver())
     with pytest.raises(LogicalReplicationError):
-        await drop_subscription(db, name=" bad name ")  # type: ignore[arg-type]
+        await drop_subscription(db, name="")  # type: ignore[arg-type]
 
 
 async def test_drop_subscription_surfaces_driver_failure() -> None:

--- a/tests/unit/test_migrations.py
+++ b/tests/unit/test_migrations.py
@@ -33,13 +33,16 @@ def test_check_identifier_accepts_plain_names() -> None:
     _check_identifier("a1b2c3", "table")
 
 
-def test_check_identifier_rejects_quoted_or_unsafe_names() -> None:
+def test_check_identifier_accepts_delimited_names_rejects_non_addressable() -> None:
+    # Names needing delimited quoting are accepted (splices quote them via
+    # _qi); only empty / NUL / overlong names are rejected.
+    _check_identifier('w"; DROP', "table")
+    _check_identifier("with space", "schema")
+    _check_identifier("1starts_with_digit", "schema")
     with pytest.raises(MigrationError, match="invalid table"):
-        _check_identifier('w"; DROP', "table")
+        _check_identifier("", "table")
     with pytest.raises(MigrationError, match="invalid schema"):
-        _check_identifier("with space", "schema")
-    with pytest.raises(MigrationError, match="invalid schema"):
-        _check_identifier("1starts_with_digit", "schema")
+        _check_identifier("with\x00nul", "schema")
 
 
 def test_make_migration_id_strips_unsafe_chars_and_appends_timestamp() -> None:
@@ -189,7 +192,7 @@ async def test_prepare_migration_rejects_unsafe_target_schema() -> None:
         await prepare_migration(
             FakeDriver(),  # type: ignore[arg-type]
             name="bad",
-            target_schema='app"; DROP TABLE x; --',
+            target_schema="app\x00evil",
             candidate_sql="ALTER TABLE w ADD c int",
         )
 
@@ -273,7 +276,7 @@ async def test_validate_migration_rejects_unsafe_target_schema() -> None:
     with pytest.raises(MigrationError, match="invalid target_schema"):
         await validate_migration(
             FakeDriver(),  # type: ignore[arg-type]
-            target_schema='app"; DROP TABLE x; --',
+            target_schema="app\x00evil",
             candidate_sql="ALTER TABLE w ADD c int",
         )
 
@@ -330,7 +333,7 @@ async def test_validate_migration_schema_rejects_unsafe_target_schema() -> None:
     with pytest.raises(MigrationError, match="invalid target_schema"):
         await validate_migration_schema(
             FakeDriver(),  # type: ignore[arg-type]
-            target_schema='app"; DROP TABLE x; --',
+            target_schema="app\x00evil",
             reference_schema="ref",
             candidate_sql="ALTER TABLE w ADD c int",
         )
@@ -343,6 +346,6 @@ async def test_validate_migration_schema_rejects_unsafe_reference_schema() -> No
         await validate_migration_schema(
             FakeDriver(),  # type: ignore[arg-type]
             target_schema="app",
-            reference_schema='ref"; DROP TABLE x; --',
+            reference_schema="ref\x00evil",
             candidate_sql="ALTER TABLE w ADD c int",
         )

--- a/tests/unit/test_pg_search.py
+++ b/tests/unit/test_pg_search.py
@@ -271,11 +271,10 @@ async def test_get_pg_search_index_metadata_returns_parsed_info() -> None:
 @pytest.mark.parametrize(
     ("schema", "index"),
     [
-        ("public; DROP TABLE x", "docs_bm25_idx"),
-        ("public", "docs_bm25_idx; --"),
         ("", "docs"),
         ("public", ""),
-        ("123bad", "docs"),
+        ("sch\x00ema", "docs"),
+        ("public", "id\x00x"),
     ],
 )
 async def test_get_pg_search_index_metadata_validates_identifiers(schema: str, index: str) -> None:
@@ -534,7 +533,7 @@ async def test_pg_search_run_multi_column_validates_each_identifier() -> None:
             "docs",
             "rust",
             "id",
-            columns=["body", "bad; name"],
+            columns=["body", "bad\x00name"],
             limit=5,
         )
 
@@ -595,12 +594,10 @@ async def test_pg_search_run_limit_validation(bad_limit: object) -> None:
 @pytest.mark.parametrize(
     ("schema", "table", "key_field"),
     [
-        ("public; DROP TABLE x", "docs", "id"),
-        ("public", "docs; --", "id"),
-        ("public", "docs", "id'; DROP"),
         ("", "docs", "id"),
         ("public", "", "id"),
         ("public", "docs", ""),
+        ("sch\x00", "docs", "id"),
     ],
 )
 async def test_pg_search_run_identifier_validation(schema: str, table: str, key_field: str) -> None:
@@ -668,7 +665,7 @@ async def test_pg_search_more_like_this_validates_identifiers() -> None:
 
     with pytest.raises(PgSearchError, match="invalid"):
         await pg_search_more_like_this(  # type: ignore[arg-type]
-            driver, "bad; schema", "docs", 42, "id", limit=10
+            driver, "bad\x00schema", "docs", 42, "id", limit=10
         )
 
 
@@ -1256,10 +1253,10 @@ async def test_hybrid_bm25_vector_search_rejects_bad_k(bad_k: object) -> None:
 @pytest.mark.parametrize(
     ("schema", "table", "key_field", "vector_column"),
     [
-        ("public; --", "docs", "id", "embedding"),
-        ("public", "docs; DROP", "id", "embedding"),
-        ("public", "docs", "id'or'1", "embedding"),
-        ("public", "docs", "id", "embedding); --"),
+        ("", "docs", "id", "embedding"),
+        ("public", "", "id", "embedding"),
+        ("public", "docs", "", "embedding"),
+        ("public", "docs", "id", "emb\x00"),
     ],
 )
 async def test_hybrid_bm25_vector_search_identifier_validation(
@@ -1471,12 +1468,12 @@ async def test_create_pg_search_index_option_validation(kwarg: str, value: objec
 @pytest.mark.parametrize(
     "kwargs",
     [
-        {"schema": "public; DROP"},
-        {"table": "docs'; --"},
+        {"schema": "sch\x00ema"},
+        {"table": "d\x00ocs"},
         {"index_name": ""},
-        {"key_field": "id'or'1"},
+        {"key_field": "k\x00ey"},
         {"columns": []},
-        {"columns": ["good", "bad; --"]},
+        {"columns": ["good", "ba\x00d"]},
         {"columns": "id"},  # not a list
     ],
 )
@@ -1568,7 +1565,7 @@ async def test_reindex_pg_search_index_omits_concurrently_when_disabled() -> Non
 async def test_reindex_pg_search_index_rejects_unsafe_identifiers() -> None:
     db = FakeDatabase(FakeRoutingDriver({"pg_extension": [{"present": 1}]}))  # type: ignore[arg-type]
     with pytest.raises(PgSearchError, match="invalid"):
-        await reindex_pg_search_index(db, "public; DROP", "docs_bm25_idx")  # type: ignore[arg-type]
+        await reindex_pg_search_index(db, "sch\x00ema", "docs_bm25_idx")  # type: ignore[arg-type]
 
 
 async def test_create_pg_search_index_wraps_driver_failure_as_pg_search_error() -> None:

--- a/tests/unit/test_rag_efficiency.py
+++ b/tests/unit/test_rag_efficiency.py
@@ -340,7 +340,10 @@ async def test_analyze_rejects_unsafe_identifiers(field: str) -> None:
         "column": "embedding",
         "id_column": "id",
     }
-    kwargs[field] = "bad; DROP"
+    # A name needing delimited quoting (e.g. "bad; DROP") is now accepted and
+    # safely quoted; only names that aren't addressable identifiers at all —
+    # the empty string / an embedded NUL — are rejected.
+    kwargs[field] = ""
     with pytest.raises(VectorEfficiencyError, match="invalid"):
         await analyze_vector_search_efficiency(driver, **kwargs)  # type: ignore[arg-type]
 

--- a/tests/unit/test_redis_fdw.py
+++ b/tests/unit/test_redis_fdw.py
@@ -168,8 +168,10 @@ async def test_create_server_emits_create_server_with_options() -> None:
 
 async def test_create_server_rejects_bad_identifier() -> None:
     driver = FakeRoutingDriver({"FROM pg_extension WHERE extname": [{"present": 1}]})
-    with pytest.raises(RedisFdwError, match="not a valid unquoted SQL identifier"):
-        await create_redis_cache_server(driver, name="redis; DROP", address="redis.internal")  # type: ignore[arg-type]
+    # A name needing delimited quoting is accepted and quoted safely; only
+    # empty / NUL / overlong names are rejected.
+    with pytest.raises(RedisFdwError, match="invalid"):
+        await create_redis_cache_server(driver, name="redis\x00drop", address="redis.internal")  # type: ignore[arg-type]
 
 
 async def test_create_server_rejects_address_with_quotes() -> None:
@@ -267,7 +269,7 @@ async def test_create_user_mapping_validates_user_identifier() -> None:
         await create_redis_user_mapping(
             driver,  # type: ignore[arg-type]
             server="redis_primary",
-            user="bad; user",
+            user="bad\x00user",
             secret_ref="P",
             secrets=secrets,  # type: ignore[arg-type]
         )

--- a/tests/unit/test_rls.py
+++ b/tests/unit/test_rls.py
@@ -19,7 +19,7 @@ async def test_test_rls_for_role_rejects_unsafe_role_name() -> None:
             FakeRoutingDriver({}),  # type: ignore[arg-type]
             schema="app",
             table="orders",
-            role='"; DROP USER alice',
+            role="ro\x00le",
         )
 
 
@@ -27,7 +27,7 @@ async def test_test_rls_for_role_rejects_unsafe_schema() -> None:
     with pytest.raises(RLSError, match="invalid schema"):
         await run_rls_test(
             FakeRoutingDriver({}),  # type: ignore[arg-type]
-            schema='app"; DROP TABLE x',
+            schema="",
             table="orders",
             role="readonly",
         )

--- a/tests/unit/test_tenancy.py
+++ b/tests/unit/test_tenancy.py
@@ -24,18 +24,25 @@ def test_validate_role_accepts_safe_identifiers() -> None:
 
 
 @pytest.mark.parametrize(
-    "bad",
+    "role",
     [
-        "",
-        '"; DROP USER alice',
+        # Roles needing delimited quoting are legal in PostgreSQL and are now
+        # accepted — validate_role returns them unchanged; the SET LOCAL ROLE
+        # splice quotes them (embedded quotes doubled) so they can't inject.
         "role-with-dash",
         "role with space",
         "1starts_with_digit",
         "weird$char",
         "role; DROP USER alice",
+        '"; DROP USER alice',
     ],
 )
-def test_validate_role_rejects_unsafe_identifiers(bad: str) -> None:
+def test_validate_role_accepts_delimited_role_names(role: str) -> None:
+    assert validate_role(role) == role
+
+
+@pytest.mark.parametrize("bad", ["", "\x00", "role\x00x", "a" * 64])
+def test_validate_role_rejects_non_addressable_names(bad: str) -> None:
     with pytest.raises(TenancyError):
         validate_role(bad)
 

--- a/tests/unit/test_test_data.py
+++ b/tests/unit/test_test_data.py
@@ -29,7 +29,7 @@ async def test_generate_test_data_rejects_unsafe_schema() -> None:
     with pytest.raises(TestDataError, match="invalid schema"):
         await generate_test_data(
             FakeRoutingDriver({}),  # type: ignore[arg-type]
-            schema='public"; DROP TABLE x',
+            schema="pub\x00lic",
             table="widget",
         )
 

--- a/tests/unit/test_test_row_factory.py
+++ b/tests/unit/test_test_row_factory.py
@@ -47,13 +47,13 @@ def _full_routes(
 async def test_rejects_invalid_schema_name() -> None:
     driver = FakeRoutingDriver({})
     with pytest.raises(TestRowFactoryError, match="schema"):
-        await generate_test_row_for(driver, "bad; DROP", "t")  # type: ignore[arg-type]
+        await generate_test_row_for(driver, "bad\x00schema", "t")  # type: ignore[arg-type]
 
 
 async def test_rejects_invalid_table_name() -> None:
     driver = FakeRoutingDriver({})
     with pytest.raises(TestRowFactoryError, match="table"):
-        await generate_test_row_for(driver, "public", '"; DROP TABLE x; --')  # type: ignore[arg-type]
+        await generate_test_row_for(driver, "public", "")  # type: ignore[arg-type]
 
 
 async def test_errors_when_table_has_no_columns() -> None:

--- a/tests/unit/test_textsearch.py
+++ b/tests/unit/test_textsearch.py
@@ -64,7 +64,7 @@ async def test_fuzzy_search_binds_the_term_threshold_and_limit_as_parameters() -
     assert search_call[1] == ["bob", "bob", 0.4, 7]
 
 
-@pytest.mark.parametrize("bad", ["users; DROP TABLE x", 'a"b', "1leading_digit", "has space"])
+@pytest.mark.parametrize("bad", ["", "\x00"])
 async def test_fuzzy_search_rejects_invalid_identifiers(bad: str) -> None:
     driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
 
@@ -132,7 +132,7 @@ async def test_full_text_search_binds_the_query_and_limit_as_parameters() -> Non
     assert driver.calls[0][1] == ["cat or dog", "cat or dog", 5]
 
 
-@pytest.mark.parametrize("bad", ["posts; DROP TABLE x", 'a"b', "1bad"])
+@pytest.mark.parametrize("bad", ["", "\x00"])
 async def test_full_text_search_rejects_invalid_identifiers(bad: str) -> None:
     with pytest.raises(SearchError, match="invalid"):
         await full_text_search(FakeDriver(), bad, "posts", "body", "cat")
@@ -198,7 +198,7 @@ async def test_vector_search_rejects_an_unknown_metric() -> None:
         await vector_search(driver, "app", "docs", "embedding", [1.0], metric="manhattan")  # type: ignore[arg-type]
 
 
-@pytest.mark.parametrize("bad", ["docs; DROP TABLE x", 'a"b', "1bad"])
+@pytest.mark.parametrize("bad", ["", "\x00"])
 async def test_vector_search_rejects_invalid_identifiers(bad: str) -> None:
     driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
 
@@ -457,7 +457,7 @@ async def test_geo_search_rejects_invalid_identifiers() -> None:
     driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
 
     with pytest.raises(SearchError, match="invalid"):
-        await geo_search(driver, "places; DROP", "places", "location", 1.0, 2.0)  # type: ignore[arg-type]
+        await geo_search(driver, "", "places", "location", 1.0, 2.0)  # type: ignore[arg-type]
 
 
 async def test_geo_search_tool_is_callable_from_a_client() -> None:
@@ -759,7 +759,7 @@ async def test_recommend_vector_quantization_rejects_unsafe_schema_names() -> No
     driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
 
     with pytest.raises(SearchError, match="invalid"):
-        await recommend_vector_quantization(driver, 'app"; DROP TABLE x; --')  # type: ignore[arg-type]
+        await recommend_vector_quantization(driver, "")  # type: ignore[arg-type]
 
 
 async def test_recommend_vector_quantization_tool_is_callable_from_a_client() -> None:

--- a/tests/unit/test_timescaledb.py
+++ b/tests/unit/test_timescaledb.py
@@ -20,10 +20,15 @@ from mcpg.timescaledb import (
 )
 
 
-def test_check_identifier_rejects_unsafe_names() -> None:
+def test_check_identifier_accepts_delimited_names_rejects_non_addressable() -> None:
+    # Delimited names are accepted (quoted safely at the splice); only
+    # empty / NUL / overlong names are rejected.
     _check_identifier("widget", "table")
+    _check_identifier('w"; DROP', "table")
     with pytest.raises(TimescaleError, match="invalid table"):
-        _check_identifier('w"; DROP', "table")
+        _check_identifier("", "table")
+    with pytest.raises(TimescaleError, match="invalid table"):
+        _check_identifier("w\x00t", "table")
 
 
 def test_check_interval_accepts_common_timescaledb_intervals() -> None:
@@ -94,7 +99,7 @@ async def test_list_chunks_rejects_unsafe_identifiers() -> None:
     driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
 
     with pytest.raises(TimescaleError, match="invalid"):
-        await list_chunks(driver, 'app"; DROP', "metrics")  # type: ignore[arg-type]
+        await list_chunks(driver, "app\x00evil", "metrics")  # type: ignore[arg-type]
 
 
 async def test_create_hypertable_reports_unavailable_without_timescaledb() -> None:
@@ -111,9 +116,9 @@ async def test_create_hypertable_validates_inputs() -> None:
     driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
 
     with pytest.raises(TimescaleError, match="invalid table"):
-        await create_hypertable(driver, "public", 'm"; DROP', "time")  # type: ignore[arg-type]
+        await create_hypertable(driver, "public", "m\x00t", "time")  # type: ignore[arg-type]
     with pytest.raises(TimescaleError, match="invalid time_column"):
-        await create_hypertable(driver, "public", "metrics", 'tcol"; DROP')  # type: ignore[arg-type]
+        await create_hypertable(driver, "public", "metrics", "tc\x00ol")  # type: ignore[arg-type]
     with pytest.raises(TimescaleError, match="invalid interval"):
         await create_hypertable(
             driver,  # type: ignore[arg-type]

--- a/tests/unit/test_turboquant.py
+++ b/tests/unit/test_turboquant.py
@@ -248,12 +248,10 @@ async def test_get_turboquant_index_metadata_raises_when_no_match() -> None:
 @pytest.mark.parametrize(
     ("schema", "index"),
     [
-        ("public; DROP", "idx"),
-        ("public", "idx; DROP"),
         ("", "idx"),
         ("public", ""),
-        ("public.embeddings", "idx"),
-        ("public", "idx-name"),
+        ("sch\x00ema", "idx"),
+        ("public", "id\x00x"),
     ],
 )
 async def test_get_turboquant_index_metadata_rejects_unsafe_identifiers(schema: str, index: str) -> None:
@@ -328,7 +326,7 @@ async def test_get_turboquant_heap_stats_falls_back_to_alternate_key() -> None:
 
 @pytest.mark.parametrize(
     ("schema", "index"),
-    [("public", "idx; DROP"), ("../etc/passwd", "idx")],
+    [("", "idx"), ("public", "id\x00x")],
 )
 async def test_get_turboquant_heap_stats_rejects_unsafe_identifiers(schema: str, index: str) -> None:
     driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
@@ -654,12 +652,10 @@ async def test_maintain_turboquant_index_raises_when_index_is_not_turboquant() -
 @pytest.mark.parametrize(
     ("schema", "index"),
     [
-        ("public; DROP", "idx"),
-        ("public", "idx; DROP"),
         ("", "idx"),
         ("public", ""),
-        ("public.embeddings", "idx"),
-        ("public", "idx-name"),
+        ("sch\x00ema", "idx"),
+        ("public", "id\x00x"),
     ],
 )
 async def test_maintain_turboquant_index_rejects_unsafe_identifiers(schema: str, index: str) -> None:
@@ -798,7 +794,7 @@ async def test_create_turboquant_index_rejects_unsafe_identifiers(field: str) ->
         "index_name": "idx",
         "metric": "cosine",
     }
-    kwargs[field] = "bad; DROP TABLE x"
+    kwargs[field] = ""
     with pytest.raises(TurboQuantError, match="invalid"):
         await create_turboquant_index(db, **kwargs)  # type: ignore[arg-type]
 
@@ -1046,7 +1042,7 @@ async def test_turboquant_approx_candidates_rejects_unsafe_identifiers(field: st
         "metric": "cosine",
         "candidate_limit": 10,
     }
-    kwargs[field] = "bad; DROP"
+    kwargs[field] = ""
     with pytest.raises(TurboQuantError, match="invalid"):
         await turboquant_approx_candidates(driver, **kwargs)  # type: ignore[arg-type]
 

--- a/tests/unit/test_vector_ops.py
+++ b/tests/unit/test_vector_ops.py
@@ -295,7 +295,7 @@ async def test_analyze_distance_metric_rejects_oversized_sample_size() -> None:
         await analyze_distance_metric(driver, "app", "docs", "embedding", sample_size=10_000_000)  # type: ignore[arg-type]
 
 
-@pytest.mark.parametrize("bad", ['docs"; DROP TABLE x', "1bad", "a-b"])
+@pytest.mark.parametrize("bad", ["", "\x00"])
 async def test_analyze_distance_metric_rejects_unsafe_identifiers(bad: str) -> None:
     driver = FakeRoutingDriver({"pg_extension": [{"present": 1}]})
 
@@ -596,7 +596,7 @@ async def test_cross_table_similarity_raises_when_source_row_has_unparseable_emb
         )
 
 
-@pytest.mark.parametrize("bad", ['x"; DROP TABLE y', "1bad", "a-b"])
+@pytest.mark.parametrize("bad", ["", "\x00"])
 async def test_cross_table_similarity_rejects_unsafe_identifiers(bad: str) -> None:
     driver = FakeParamRoutingDriver(_xt_routes())
     with pytest.raises(VectorOpsError, match="invalid"):
@@ -891,7 +891,7 @@ async def test_cluster_vectors_validates_arguments(kwargs: dict[str, object], ma
         await cluster_vectors(driver, "app", "docs", "embedding", **kwargs)  # type: ignore[arg-type]
 
 
-@pytest.mark.parametrize("bad", ['x"; DROP TABLE y', "1bad", "a-b"])
+@pytest.mark.parametrize("bad", ["", "\x00"])
 async def test_cluster_vectors_rejects_unsafe_identifiers(bad: str) -> None:
     driver = FakeParamRoutingDriver(_cluster_routes())
     with pytest.raises(VectorOpsError, match="invalid"):
@@ -1227,7 +1227,7 @@ async def test_detect_vector_outliers_validates_arguments(kwargs: dict[str, obje
         await detect_vector_outliers(driver, "app", "docs", "embedding", **kwargs)  # type: ignore[arg-type]
 
 
-@pytest.mark.parametrize("bad", ["bad name", "ta;ble", "1abc", '"x"'])
+@pytest.mark.parametrize("bad", ["", "\x00"])
 async def test_detect_vector_outliers_rejects_unsafe_identifiers(bad: str) -> None:
     driver = FakeParamRoutingDriver(_cluster_routes())
     with pytest.raises(VectorOpsError, match="invalid"):
@@ -1556,7 +1556,7 @@ async def test_monitor_embedding_drift_validates_arguments(kwargs: dict[str, obj
         await monitor_embedding_drift(driver, "app", "docs", "embedding", "created_at", **base_kwargs)  # type: ignore[arg-type]
 
 
-@pytest.mark.parametrize("bad", ["bad name", "ta;ble", "1abc", '"x"'])
+@pytest.mark.parametrize("bad", ["", "\x00"])
 async def test_monitor_embedding_drift_rejects_unsafe_identifiers(bad: str) -> None:
     driver = FakeParamRoutingDriver(_drift_routes())
     with pytest.raises(VectorOpsError, match="invalid"):
@@ -2047,7 +2047,7 @@ async def test_retrieve_with_context_rejects_unsafe_identifier() -> None:
         await retrieve_with_context(
             driver,  # type: ignore[arg-type]
             schema="public",
-            table="posts; DROP",
+            table="",
             embedding_column="embedding",
             query_vector=[0.1, 0.2, 0.3],
         )

--- a/tests/unit/test_vector_tuning.py
+++ b/tests/unit/test_vector_tuning.py
@@ -278,8 +278,8 @@ async def test_vector_recall_at_k_caps_sample_size_to_prevent_dos() -> None:
 
 
 async def test_tune_vector_index_rejects_invalid_identifier_characters() -> None:
-    # Identifier injection guard — anything not matching the [A-Za-z_][...]
-    # allowlist is rejected before the SQL is built.
+    # Names needing delimited quoting are accepted and safely quoted; only
+    # empty / NUL / overlong names are rejected before the SQL is built.
     driver = FakeRoutingDriver(
         {
             "pg_extension": [{"present": 1}],
@@ -288,13 +288,13 @@ async def test_tune_vector_index_rejects_invalid_identifier_characters() -> None
         }
     )
     with pytest.raises(VectorTuningError, match="invalid schema name"):
-        await tune_vector_index(driver, 'app"; DROP TABLE x; --', "docs", "embedding")  # type: ignore[arg-type]
+        await tune_vector_index(driver, "", "docs", "embedding")  # type: ignore[arg-type]
 
 
 async def test_vector_recall_at_k_rejects_invalid_identifier_characters() -> None:
     driver = FakeRoutingDriver({"pg_extension": [{"present": 1}], "WHERE": []})
     with pytest.raises(VectorTuningError, match="invalid id_column name"):
-        await vector_recall_at_k(driver, "app", "docs", "embedding", 'id"; DROP TABLE x; --')  # type: ignore[arg-type]
+        await vector_recall_at_k(driver, "app", "docs", "embedding", "id\x00col")  # type: ignore[arg-type]
 
 
 # --- tool wiring -----------------------------------------------------------
@@ -486,7 +486,7 @@ async def test_migrate_vector_to_halfvec_with_no_indexes_emits_only_alter() -> N
 async def test_migrate_vector_to_halfvec_rejects_unsafe_identifiers() -> None:
     driver = FakeRoutingDriver(_halfvec_routes())
     with pytest.raises(VectorTuningError, match="invalid schema name"):
-        await migrate_vector_to_halfvec(driver, 'app"; DROP TABLE x; --', "docs", "embedding")  # type: ignore[arg-type]
+        await migrate_vector_to_halfvec(driver, "", "docs", "embedding")  # type: ignore[arg-type]
 
 
 async def test_migrate_vector_to_halfvec_tool_is_callable_from_a_client() -> None:


### PR DESCRIPTION
## Summary

Bug-fix release resolving the project's first user-reported issue, #329:
`dump_database` rejected valid PostgreSQL schema names (e.g. `adm-pgbench`)
that need delimited-identifier quoting. On inspection, ~20 other tools
shared the same over-strict `[A-Za-z_][A-Za-z0-9_]*` allowlist.

- New `mcpg.identifiers` module: `quote_identifier` / `ensure_identifier`,
  an escape-based (doubled-quote) SQL identifier quoter replacing the
  copy-pasted plain-identifier regex. Adversarial test suite added
  (`tests/unit/test_identifiers.py`).
- Migrated every affected call site: data movement (`dump_database`,
  `export_table`, `import_csv`/`import_json`/`import_vectors`,
  `copy_table_between_databases`), the pgvector suites, `textsearch`,
  `composite`, RLS/tenancy/config roles, logical replication, migrations,
  test-data generators, `redis_fdw`, LISTEN/NOTIFY, TimescaleDB.
  Deliberately left strict where the name isn't a PG identifier (AGE
  labels, ORM code generators, SQL/PGQ, the `regconfig` literal).
- `__version__` → 0.8.2 (single source), MCPB bundle + `server.json`
  synced, `CHANGELOG.md` + `docs/release-notes-0.8.2.md` added.
- No tool-surface change (254/256 tools, unchanged), no contract-snapshot
  drift, no breaking changes, no configuration changes.

## Verification (re-run locally on this branch before opening the PR)

- `ruff check` / `ruff format --check`: clean
- `mypy src/mcpg`: clean (110 source files)
- `bandit -r src/mcpg --skip B101,B608,B110 -ll`: clean
- `pip-audit --strict --no-deps`: no known vulnerabilities
- Full unit suite: **3027 passed, 115 skipped**, 0 failed
- `tests/contract/test_doc_tables.py` (doc-drift guard): 3 passed
- `python -m build && twine check dist/*`: both artifacts PASSED
- No merge conflicts with `origin/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Release MCPg 0.8.2 with safe PostgreSQL identifier quoting and broader support for valid delimited object names without changing the tool surface or contracts.

New Features:
- Add shared SQL identifier quoting that supports valid PostgreSQL delimited names while safely escaping embedded quotes.

Bug Fixes:
- Allow dump, copy, and SQL-based tools to operate on valid PostgreSQL names containing hyphens, spaces, mixed case, and other characters previously rejected by strict validation.
- Prevent pg_dump pattern metacharacters and embedded quotes from being interpreted as unintended matches.

Enhancements:
- Apply consistent identifier validation and quoting across data movement, vector, search, replication, migration, tenancy, test-data, FDW, notification, RLS, and TimescaleDB functionality while retaining strict validation where names are not PostgreSQL identifiers.

Build:
- Synchronize the project, MCPB bundle, and server metadata versions to 0.8.2.

Documentation:
- Add the v0.8.2 changelog and release notes and update the architecture module map and release index.

Tests:
- Add adversarial coverage for identifier escaping, PostgreSQL byte-length limits, and newly supported delimited names across affected tools.

Chores:
- Bump the package version to 0.8.2.